### PR TITLE
Fixed issues when compiling as shared library together with PKCS#11 helper

### DIFF
--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -709,8 +709,8 @@
  *
  * This module enables SSL/TLS PKCS #11 smartcard support.
  * Requires the presence of the PKCS#11 helper library (libpkcs11-helper)
-#define POLARSSL_PKCS11_C
  */
+#define POLARSSL_PKCS11_C
 
 /**
  * \def POLARSSL_RSA_C

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -50,6 +50,10 @@ if(WIN32)
 set(libs ws2_32)
 endif(WIN32)
 
+if(USE_PKCS11_HELPER_LIBRARY)
+    set(libs ${libs} pkcs11-helper)
+endif(USE_PKCS11_HELPER_LIBRARY)
+
 if(NOT USE_SHARED_POLARSSL_LIBRARY)
 
 add_library(polarssl STATIC ${src})


### PR DESCRIPTION
PKCS#11 support was not really available, due to the #define being inside
a comment block in include/polarssl/config.h.

In addition, it didn't link in pkcs11-helper at all, which would make it
fail later on when PolarSSL and PKCS#11 was enabled.  Causing a build
error later on.

Signed-off-by: David Sommerseth <davids@redhat.com>