### PR TITLE
Fix file descriptor leaks

### DIFF
--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -356,7 +356,10 @@ int ctr_drbg_write_seed_file( ctr_drbg_context *ctx, const char *path )
         return( POLARSSL_ERR_CTR_DRBG_FILE_IO_ERROR );
 
     if( ( ret = ctr_drbg_random( ctx, buf, CTR_DRBG_MAX_INPUT ) ) != 0 )
+    {
+        fclose( f );
         return( ret );
+    }
 
     if( fwrite( buf, 1, CTR_DRBG_MAX_INPUT, f ) != CTR_DRBG_MAX_INPUT )
     {
@@ -382,7 +385,10 @@ int ctr_drbg_update_seed_file( ctr_drbg_context *ctx, const char *path )
     fseek( f, 0, SEEK_SET );
 
     if( n > CTR_DRBG_MAX_INPUT )
+    {
+        fclose( f );
         return( POLARSSL_ERR_CTR_DRBG_INPUT_TOO_BIG );
+    }
 
     if( fread( buf, 1, n, f ) != n )
     {

--- a/library/x509parse.c
+++ b/library/x509parse.c
@@ -1845,7 +1845,10 @@ int load_file( const char *path, unsigned char **buf, size_t *n )
     fseek( f, 0, SEEK_SET );
 
     if( ( *buf = (unsigned char *) malloc( *n + 1 ) ) == NULL )
+    {
+        fclose ( f );
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
+    }
 
     if( fread( *buf, 1, *n, f ) != *n )
     {
@@ -1956,7 +1959,10 @@ cleanup:
         i = stat( entry_name, &sb );
 
         if( i == -1 )
+        {
+            closedir( dir );
             return( POLARSSL_ERR_X509_FILE_IO_ERROR );
+        }
 
         if( !S_ISREG( sb.st_mode ) )
             continue;


### PR DESCRIPTION
Fix file descriptor leaks in case of error in:
- library/x509parse.c: load_file() and x509parse_crtpath()
- library/ctr_drbg.c: ctr_drbg_write_seed_file() and ctr_drbg_update_seed_file()
