### PR TITLE
fix multiple definition

### DIFF
--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include <polarssl/ctr_drbg.h>
 
-int test_offset;
+extern int test_offset;
 int entropy_func( void *data, unsigned char *buf, size_t len )
 {
     unsigned char *p = (unsigned char *) data;


### PR DESCRIPTION
Build tests failed caused by multiple definition of test_offset

```
../library/libpolarssl.a(ctr_drbg.c.o): In function `_GLOBAL__sub_D_00099_0_ctr_drbg_init_entropy_len':
/polarssl/library/ctr_drbg.c:456: multiple definition of `test_offset'
CMakeFiles/test_suite_ctr_drbg.dir/test_suite_ctr_drbg.c.o:/polarssl/build/tests/test_suite_ctr_drbg.c:11: first defined here
```
