### PR TITLE
Lets the user provide his / her own timing implementation.

### DIFF
--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -1745,6 +1745,17 @@
 #define POLARSSL_TIMING_C
 
 /**
+ * \def POLARSSL_TIMING_ALT
+ *
+ * Provide your own alternate timing implementation.
+ *
+ * Requires: POLARSSL_TIMING_C
+ *
+ * Uncomment this to allow your own alternate timing implementation.
+ */
+//#define POLARSSL_TIMING_ALT
+
+/**
  * \def POLARSSL_VERSION_C
  *
  * Enable run-time version information.

--- a/library/timing.c
+++ b/library/timing.c
@@ -25,7 +25,7 @@
 
 #include "polarssl/config.h"
 
-#if defined(POLARSSL_TIMING_C)
+#if defined(POLARSSL_TIMING_C) && !defined(POLARSSL_TIMING_ALT)
 
 #include "polarssl/timing.h"
 


### PR DESCRIPTION
One more config #define that comes in handy for embedded folks...
