### PR TITLE
Config option for SHA-256 based entropy accumulator

### DIFF
--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -601,6 +601,23 @@
 //#define POLARSSL_NO_PLATFORM_ENTROPY
 
 /**
+ * \def POLARSSL_ENTROPY_SHA256
+ *
+ * Use the SHA-256 based entropy accumulator instead of the SHA-512 based.
+ *
+ * Module:  library/entropy.c
+ *
+ * Requires: POLARSSL_SHA256_C
+ *
+ * On 32-bit systems SHA-256 can be much faster than SHA-512. Use this option
+ * if you have performance concerns.
+ *
+ * This option will be automatically selected, if define POLARSSL_SHA256_C
+ * but not define POLARSSL_SHA512_C.
+ */
+//#define POLARSSL_ENTROPY_SHA256
+
+/**
  * \def POLARSSL_MEMORY_DEBUG
  *
  * Enable debugging of buffer allocator memory issues. Automatically prints
@@ -1261,23 +1278,6 @@
  * This module provides a generic entropy pool
  */
 #define POLARSSL_ENTROPY_C
-
-/**
- * \def POLARSSL_ENTROPY_SHA256_ACCUMULATOR
- *
- * Use the SHA-256 based entropy accumulator instead of the SHA-512 based.
- *
- * Module:  library/entropy.c
- *
- * Requires: POLARSSL_SHA256_C
- *
- * On 32-bit systems SHA-256 can be much faster than SHA-512. Use this option
- * if you have performance concerns.
- *
- * This option will be automatically selected, if you have defined
- * POLARSSL_SHA256_C but not POLARSSL_SHA512_C.
- */
-//#define POLARSSL_ENTROPY_SHA256_ACCUMULATOR
 
 /**
  * \def POLARSSL_ERROR_C
@@ -2008,8 +2008,8 @@
 #error "CTR_DRBG_ENTROPY_LEN value too high"
 #endif
 #if defined(POLARSSL_ENTROPY_C) && \
-    defined(POLARSSL_ENTROPY_SHA256_ACCUMULATOR) && !defined(POLARSSL_SHA256_C)
-#error "POLARSSL_ENTROPY_SHA256_ACCUMULATOR defined, but not all prerequisites"
+    defined(POLARSSL_ENTROPY_SHA256) && !defined(POLARSSL_SHA256_C)
+#error "POLARSSL_ENTROPY_SHA256 defined, but not all prerequisites"
 #endif
 
 #if defined(POLARSSL_GCM_C) && (                                        \

--- a/include/polarssl/ctr_drbg.h
+++ b/include/polarssl/ctr_drbg.h
@@ -30,7 +30,6 @@
 #include <string.h>
 
 #include "aes.h"
-#include "entropy.h"
 
 #define POLARSSL_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED        -0x0034  /**< The entropy source failed. */
 #define POLARSSL_ERR_CTR_DRBG_REQUEST_TOO_BIG              -0x0036  /**< Too many random requested in single call. */
@@ -44,7 +43,7 @@
                                             /**< The seed length (counter + AES key)            */
 
 #if !defined(POLARSSL_CONFIG_OPTIONS)
-#if defined(POLARSSL_ENTROPY_SHA512_ACCUMULATOR)
+#if defined(POLARSSL_SHA512_C) && !defined(POLARSSL_ENTROPY_SHA256)
 #define CTR_DRBG_ENTROPY_LEN        48      /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */
 #else
 #define CTR_DRBG_ENTROPY_LEN        32      /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */

--- a/include/polarssl/entropy.h
+++ b/include/polarssl/entropy.h
@@ -31,14 +31,12 @@
 
 #include "config.h"
 
-#if defined(POLARSSL_SHA512_C) && !defined(POLARSSL_ENTROPY_SHA256_ACCUMULATOR)
+#if defined(POLARSSL_SHA512_C) && !defined(POLARSSL_ENTROPY_SHA256)
 #include "sha512.h"
 #define POLARSSL_ENTROPY_SHA512_ACCUMULATOR
 #else
 #if defined(POLARSSL_SHA256_C)
-#if !defined(POLARSSL_ENTROPY_SHA256_ACCUMULATOR)
 #define POLARSSL_ENTROPY_SHA256_ACCUMULATOR
-#endif
 #include "sha256.h"
 #endif
 #endif


### PR DESCRIPTION
Lets the user specify the SHA-256 based entropy accumulator even if SHA-512 is defined.
