### PR TITLE
Don't try to use MIPS32 asm macros on MIPS64

### DIFF
--- a/include/polarssl/bn_mul.h
+++ b/include/polarssl/bn_mul.h
@@ -770,7 +770,7 @@
     );
 #endif /* Alpha */
 
-#if defined(__mips__)
+#if defined(__mips__) && !defined(__mips64__)
 
 #define MULADDC_INIT            \
     asm(                        \


### PR DESCRIPTION
The MIPS32 bn_mul asm code causes segfaults on MIPS64 and failing
tests. Until someone has time to fix this up, MIPS64 platforms should
fall back to the C implementation (which works fine).
