### PR TITLE
Fix build with cc from Apple LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(POLARSSL C)
 
 enable_testing()
 
-string(REGEX MATCH "clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER}")
+string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER_ID}")
 
 if(CMAKE_COMPILER_IS_GNUCC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -W -Wdeclaration-after-statement")


### PR DESCRIPTION
On Xcode 4.x and above (I tested Xcode 4.6.3 on 10.7.5 and Xcode 5.5.1 on 10.9.2), cmake (2.8.12.2, whether from MacPorts or from clang.org, FWIW) is detecting /usr/bin/cc as Clang, but CMAKE_COMPILER_IS_CLANG is not getting set, so the tests aren't being built. (There may have been other build problems as well, but the fact that the tests weren't being built was by far the most obvious problem.)

Checking the compiler ID detected by cmake, rather than the name of the command used to invoke the compiler, fixes this.
