### PR TITLE
dhm addons and fixes for ssh library based on polarssl

### DIFF
--- a/include/polarssl/dhm.h
+++ b/include/polarssl/dhm.h
@@ -41,6 +41,7 @@
 #define POLARSSL_ERR_DHM_INVALID_FORMAT                    -0x3380  /**< The ASN.1 data is not formatted correctly. */
 #define POLARSSL_ERR_DHM_MALLOC_FAILED                     -0x3400  /**< Allocation of memory failed. */
 #define POLARSSL_ERR_DHM_FILE_IO_ERROR                     -0x3480  /**< Read/write of file failed. */
+#define POLARSSL_ERR_DHM_BUFFER_TOO_SMALL                  -0x3500  /**< The buffer is too small to write to. */
 
 /**
  * RFC 2409 defines a number of standardized Diffie-Hellman groups
@@ -189,6 +190,7 @@ int dhm_read_params( dhm_context *ctx,
  * \param x_size   private value size in bytes
  * \param output   destination buffer
  * \param olen     number of chars written
+ * \param osize    size of the output buffer
  * \param f_rng    RNG function
  * \param p_rng    RNG parameter
  *
@@ -199,7 +201,7 @@ int dhm_read_params( dhm_context *ctx,
  * \return         0 if successful, or an POLARSSL_ERR_DHM_XXX error code
  */
 int dhm_make_params( dhm_context *ctx, int x_size,
-                     unsigned char *output, size_t *olen,
+                     unsigned char *output, size_t *olen, size_t osize,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
 

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -134,12 +134,12 @@ int dhm_read_params( dhm_context *ctx,
  * Setup and write the ServerKeyExchange parameters
  */
 int dhm_make_params( dhm_context *ctx, int x_size,
-                     unsigned char *output, size_t *olen,
+                     unsigned char *output, size_t *olen, size_t osize,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng )
 {
     int ret, count = 0;
-    size_t n1, n2, n3;
+    size_t n, n1, n2, n3;
     unsigned char *p;
 
     if( mpi_cmp_int( &ctx->P, 0 ) == 0 )
@@ -180,6 +180,11 @@ int dhm_make_params( dhm_context *ctx, int x_size,
     n1 = mpi_size( &ctx->P  );
     n2 = mpi_size( &ctx->G  );
     n3 = mpi_size( &ctx->GX );
+
+    n = (n1 + 2) + (n2 + 2) + (n3 + 2);
+
+    if( osize < n )
+        return( POLARSSL_ERR_DHM_BUFFER_TOO_SMALL );
 
     p = output;
     DHM_MPI_EXPORT( &ctx->P , n1 );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2145,6 +2145,7 @@ static int ssl_write_server_key_exchange( ssl_context *ssl )
     defined(POLARSSL_KEY_EXCHANGE_ECDHE_PSK_ENABLED) ||                     \
     defined(POLARSSL_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     unsigned char *p = ssl->out_msg + 4;
+    size_t p_len = ssl->out_msglen - 4;
     unsigned char *dig_signed = p;
     size_t dig_signed_len = 0, len;
     ((void) dig_signed);
@@ -2217,7 +2218,7 @@ static int ssl_write_server_key_exchange( ssl_context *ssl )
         if( ( ret = dhm_make_params( &ssl->handshake->dhm_ctx,
                                       (int) mpi_size( &ssl->handshake->dhm_ctx.P ),
                                       p,
-                                      &len, ssl->f_rng, ssl->p_rng ) ) != 0 )
+                                      &len, p_len, ssl->f_rng, ssl->p_rng ) ) != 0 )
         {
             SSL_DEBUG_RET( 1, "dhm_make_params", ret );
             return( ret );

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -178,7 +178,7 @@ int main( int argc, char *argv[] )
 
     memset( buf, 0, sizeof( buf ) );
 
-    if( ( ret = dhm_make_params( &dhm, (int) mpi_size( &dhm.P ), buf, &n,
+    if( ( ret = dhm_make_params( &dhm, (int) mpi_size( &dhm.P ), buf, &n, 2048,
                                  ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
         printf( " failed\n  ! dhm_make_params returned %d\n\n", ret );

--- a/tests/suites/test_suite_dhm.function
+++ b/tests/suites/test_suite_dhm.function
@@ -44,7 +44,7 @@ void dhm_do_dhm( int radix_P, char *input_P,
     /*
      * First key exchange
      */
-    TEST_ASSERT( dhm_make_params( &ctx_srv, x_size, ske, &ske_len, &rnd_pseudo_rand, &rnd_info ) == 0 );
+    TEST_ASSERT( dhm_make_params( &ctx_srv, x_size, ske, &ske_len, 1000, &rnd_pseudo_rand, &rnd_info ) == 0 );
     ske[ske_len++] = 0;
     ske[ske_len++] = 0;
     TEST_ASSERT( dhm_read_params( &ctx_cli, &p, ske + ske_len ) == 0 );
@@ -77,7 +77,7 @@ void dhm_do_dhm( int radix_P, char *input_P,
     sec_srv_len = 1000;
     p = ske;
 
-    TEST_ASSERT( dhm_make_params( &ctx_srv, x_size, ske, &ske_len, &rnd_pseudo_rand, &rnd_info ) == 0 );
+    TEST_ASSERT( dhm_make_params( &ctx_srv, x_size, ske, &ske_len, 1000, &rnd_pseudo_rand, &rnd_info ) == 0 );
     ske[ske_len++] = 0;
     ske[ske_len++] = 0;
     TEST_ASSERT( dhm_read_params( &ctx_cli, &p, ske + ske_len ) == 0 );


### PR DESCRIPTION
First patch adds one more MODP group which is required by SSH RFC, I thought it would be nice to have it in polarssl as well.

IMHO polarssl should check the length of the output buffer in dhm before writing into it. Second patch in the series addresses that problem. Before patching all other functions in dhm I would like to get your feedback on this problem.
