### PR TITLE
Two fixes for bn_mul PowerPC asm code on OS X

### DIFF
--- a/include/polarssl/bn_mul.h
+++ b/include/polarssl/bn_mul.h
@@ -285,7 +285,6 @@
 
 #endif /* MC68000 */
 
-#if defined(__powerpc__)   || defined(__ppc__)
 #if defined(__powerpc64__) || defined(__ppc64__)
 
 #if defined(__MACH__) && defined(__APPLE__)
@@ -375,7 +374,7 @@
 
 #endif /* __MACH__ && __APPLE__ */
 
-#else /* PPC32 */
+#elif defined(__powerpc__) || defined(__ppc__) /* end PPC64/begin PPC32  */
 
 #if defined(__MACH__) && defined(__APPLE__)
 /* Apple gcc + Apple cctools assembler (i.e. a typical Xcode toolchain with
@@ -464,7 +463,6 @@
 #endif /* __MACH__ && __APPLE__ */
 
 #endif /* PPC32 */
-#endif /* PPC64 */
 
 #if defined(__sparc__) && defined(__sparc64__)
 


### PR DESCRIPTION
Two fixes:
1. I'm not sure if this is the fault of Apple's gcc, or Apple's assembler, or both, but when targeting PPC32 or PPC64 it's treating semicolons as comment delimiters even for inline assembly. (Incidentally, this only happens when targeting PPC, not Intel.) Without any \n's in the inline assembly macros, everything after the first instruction in MULADDC_INIT ends up being commented out. (This is a regression that was introduced in PolarSSL 1.3.4, in commit 02d800c15160b1e8dc26e405e41c1ae91d38dcd2, but I fixed the new code rather than reverting to the old code.)
2. The #if defined... checks for PPC32 vs PPC64 were incorrect. Specifically, for OS X **ppc64** is only defined when targeting PPC64, and **ppc** is _only defined when targeting PPC32_. Since the **ppc64** check was nested inside the **ppc** check, the PPC64 asm code was not being used at all on OS X.

On my PPC32 OS X systems, the test suite of vanilla PolarSSL 1.3.7 fails 6 tests and appears to enter infinite loops on 7 others (out of 52 total). With these changes applied, all 52 tests pass. I also tested a PPC32 Linux system to make sure these changes did not cause a regression there; with or without these changes, all 52 tests pass on that system. I currently don't have any PPC64 systems, but I cross-compiled to OS X PPC64 and used otool (the OS X equivalent to objdump) to check the output emitted by the toolchain for bignum.c.o, to check whether the first problem affected PPC64 as well as PPC32 -- and that's how I stumbled into the second problem.
