### PR TITLE
Fix WSAStartup return value check.

### DIFF
--- a/library/net.c
+++ b/library/net.c
@@ -146,7 +146,7 @@ static int net_prepare( void )
 
     if( wsa_init_done == 0 )
     {
-        if( WSAStartup( MAKEWORD(2,0), &wsaData ) == SOCKET_ERROR )
+        if( WSAStartup( MAKEWORD(2,0), &wsaData ) != 0 )
             return( POLARSSL_ERR_NET_SOCKET_FAILED );
 
         wsa_init_done = 1;


### PR DESCRIPTION
SOCKET_ERROR was not a valid return value.
WSAStartup returns 0 on success, so check that instead.
(for details check http://msdn.microsoft.com/en-us/library/windows/desktop/ms742213 )
