### PR TITLE
Fix symlink command for cross compiling

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/data_files" target)
 
     if (NOT EXISTS ${link})
-        if (UNIX)
+        if (CMAKE_HOST_UNIX)
             set(command ln -s ${target} ${link})
         else()
             set(command cmd.exe /c mklink ${link} ${target})


### PR DESCRIPTION
```
Check for the host system to determine which command
should be used to create a symlink. Otherwise symlinking
will fail when cross compiling polarssl on a unix host for
windows.
```
