### PR TITLE
Fix sensitive data not being cleared from memory by memset.

### DIFF
--- a/include/polarssl/secure_memzero.h
+++ b/include/polarssl/secure_memzero.h
@@ -1,0 +1,56 @@
+/**
+ * \file secure_memzero.h
+ *
+ * \brief Securely memset memory to zero.
+ *
+ *  Copyright (C) 2006-2014, Brainspark B.V.
+ *
+ *  This file is part of PolarSSL (http://www.polarssl.org)
+ *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
+ *
+ *  All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef POLARSSL_SECURE_MEMZERO_H
+#define POLARSSL_SECURE_MEMZERO_H
+
+#include <string.h>
+
+#if defined(_MSC_VER) && !defined(inline)
+#define inline _inline
+#else
+#if defined(__ARMCC_VERSION) && !defined(inline)
+#define inline __inline
+#endif /* __ARMCC_VERSION */
+#endif /*_MSC_VER */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void *secure_memzero(void *v, size_t n)
+{
+    volatile unsigned char *p = (volatile unsigned char *)v;
+    while (n--)
+        *p++ = 0;
+    return v;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* secure_memzero.h */

--- a/library/aes.c
+++ b/library/aes.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_AES_C)
 
 #include "polarssl/aes.h"
+#include "polarssl/secure_memzero.h"
 #if defined(POLARSSL_PADLOCK_C)
 #include "polarssl/padlock.h"
 #endif
@@ -643,7 +644,7 @@ int aes_setkey_dec( aes_context *ctx, const unsigned char *key,
 #if defined(POLARSSL_AESNI_C) && defined(POLARSSL_HAVE_X86_64)
 done:
 #endif
-    memset( &cty, 0, sizeof( aes_context ) );
+    secure_memzero( &cty, sizeof( aes_context ) );
 
     return( 0 );
 }

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_CAMELLIA_C)
 
 #include "polarssl/camellia.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
@@ -469,7 +470,7 @@ int camellia_setkey_dec( camellia_context *ctx, const unsigned char *key,
     *RK++ = *SK++;
     *RK++ = *SK++;
 
-    memset( &cty, 0, sizeof( camellia_context ) );
+    secure_memzero( &cty, sizeof( camellia_context ) );
 
     return( 0 );
 }

--- a/library/des.c
+++ b/library/des.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_DES_C)
 
 #include "polarssl/des.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
@@ -519,7 +520,7 @@ int des3_set2key_enc( des3_context *ctx,
     uint32_t sk[96];
 
     des3_set2key( ctx->sk, sk, key );
-    memset( sk,  0, sizeof( sk ) );
+    secure_memzero( sk, sizeof( sk ) );
 
     return( 0 );
 }
@@ -533,7 +534,7 @@ int des3_set2key_dec( des3_context *ctx,
     uint32_t sk[96];
 
     des3_set2key( sk, ctx->sk, key );
-    memset( sk,  0, sizeof( sk ) );
+    secure_memzero( sk, sizeof( sk ) );
 
     return( 0 );
 }
@@ -570,7 +571,7 @@ int des3_set3key_enc( des3_context *ctx,
     uint32_t sk[96];
 
     des3_set3key( ctx->sk, sk, key );
-    memset( sk, 0, sizeof( sk ) );
+    secure_memzero( sk, sizeof( sk ) );
 
     return( 0 );
 }
@@ -584,7 +585,7 @@ int des3_set3key_dec( des3_context *ctx,
     uint32_t sk[96];
 
     des3_set3key( sk, ctx->sk, key );
-    memset( sk, 0, sizeof( sk ) );
+    secure_memzero( sk, sizeof( sk ) );
 
     return( 0 );
 }

--- a/library/md2.c
+++ b/library/md2.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_MD2_C)
 
 #include "polarssl/md2.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -188,7 +189,7 @@ void md2( const unsigned char *input, size_t ilen, unsigned char output[16] )
     md2_update( &ctx, input, ilen );
     md2_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md2_context ) );
+    secure_memzero( &ctx, sizeof( md2_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -212,7 +213,7 @@ int md2_file( const char *path, unsigned char output[16] )
 
     md2_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md2_context ) );
+    secure_memzero( &ctx, sizeof( md2_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -303,7 +304,7 @@ void md2_hmac( const unsigned char *key, size_t keylen,
     md2_hmac_update( &ctx, input, ilen );
     md2_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md2_context ) );
+    secure_memzero( &ctx, sizeof( md2_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/md4.c
+++ b/library/md4.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_MD4_C)
 
 #include "polarssl/md4.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -284,7 +285,7 @@ void md4( const unsigned char *input, size_t ilen, unsigned char output[16] )
     md4_update( &ctx, input, ilen );
     md4_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md4_context ) );
+    secure_memzero( &ctx, sizeof( md4_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -308,7 +309,7 @@ int md4_file( const char *path, unsigned char output[16] )
 
     md4_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md4_context ) );
+    secure_memzero( &ctx, sizeof( md4_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -399,7 +400,7 @@ void md4_hmac( const unsigned char *key, size_t keylen,
     md4_hmac_update( &ctx, input, ilen );
     md4_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md4_context ) );
+    secure_memzero( &ctx, sizeof( md4_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/md5.c
+++ b/library/md5.c
@@ -37,6 +37,7 @@
 #if defined(POLARSSL_MD5_C)
 
 #include "polarssl/md5.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -301,7 +302,7 @@ void md5( const unsigned char *input, size_t ilen, unsigned char output[16] )
     md5_update( &ctx, input, ilen );
     md5_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md5_context ) );
+    secure_memzero( &ctx, sizeof( md5_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -325,7 +326,7 @@ int md5_file( const char *path, unsigned char output[16] )
 
     md5_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md5_context ) );
+    secure_memzero( &ctx, sizeof( md5_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -366,7 +367,7 @@ void md5_hmac_starts( md5_context *ctx, const unsigned char *key,
     md5_starts( ctx );
     md5_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    secure_memzero( sum, sizeof( sum ) );
 }
 
 /*
@@ -391,7 +392,7 @@ void md5_hmac_finish( md5_context *ctx, unsigned char output[16] )
     md5_update( ctx, tmpbuf, 16 );
     md5_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    secure_memzero( tmpbuf, sizeof( tmpbuf ) );
 }
 
 /*
@@ -416,7 +417,7 @@ void md5_hmac( const unsigned char *key, size_t keylen,
     md5_hmac_update( &ctx, input, ilen );
     md5_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( md5_context ) );
+    secure_memzero( &ctx, sizeof( md5_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/pem.c
+++ b/library/pem.c
@@ -36,6 +36,7 @@
 #include "polarssl/aes.h"
 #include "polarssl/md5.h"
 #include "polarssl/cipher.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
@@ -121,8 +122,8 @@ static void pem_pbkdf1( unsigned char *key, size_t keylen,
 
     memcpy( key + 16, md5sum, use_len );
 
-    memset( &md5_ctx, 0, sizeof(  md5_ctx ) );
-    memset( md5sum, 0, 16 );
+    secure_memzero( &md5_ctx, sizeof(  md5_ctx ) );
+    secure_memzero( md5sum, 16 );
 }
 
 #if defined(POLARSSL_DES_C)
@@ -142,8 +143,8 @@ static void pem_des_decrypt( unsigned char des_iv[8],
     des_crypt_cbc( &des_ctx, DES_DECRYPT, buflen,
                      des_iv, buf, buf );
 
-    memset( &des_ctx, 0, sizeof( des_ctx ) );
-    memset( des_key, 0, 8 );
+    secure_memzero( &des_ctx, sizeof( des_ctx ) );
+    secure_memzero( des_key, 8 );
 }
 
 /*
@@ -162,8 +163,8 @@ static void pem_des3_decrypt( unsigned char des3_iv[8],
     des3_crypt_cbc( &des3_ctx, DES_DECRYPT, buflen,
                      des3_iv, buf, buf );
 
-    memset( &des3_ctx, 0, sizeof( des3_ctx ) );
-    memset( des3_key, 0, 24 );
+    secure_memzero( &des3_ctx, sizeof( des3_ctx ) );
+    secure_memzero( des3_key, 24 );
 }
 #endif /* POLARSSL_DES_C */
 
@@ -184,8 +185,8 @@ static void pem_aes_decrypt( unsigned char aes_iv[16], unsigned int keylen,
     aes_crypt_cbc( &aes_ctx, AES_DECRYPT, buflen,
                      aes_iv, buf, buf );
 
-    memset( &aes_ctx, 0, sizeof( aes_ctx ) );
-    memset( aes_key, 0, keylen );
+    secure_memzero( &aes_ctx, sizeof( aes_ctx ) );
+    secure_memzero( aes_key, keylen );
 }
 #endif /* POLARSSL_AES_C */
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -38,6 +38,7 @@
 #if defined(POLARSSL_RIPEMD160_C)
 
 #include "polarssl/ripemd160.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -363,7 +364,7 @@ void ripemd160( const unsigned char *input, size_t ilen,
     ripemd160_update( &ctx, input, ilen );
     ripemd160_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( ripemd160_context ) );
+    secure_memzero( &ctx, sizeof( ripemd160_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -387,7 +388,7 @@ int ripemd160_file( const char *path, unsigned char output[20] )
 
     ripemd160_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( ripemd160_context ) );
+    secure_memzero( &ctx, sizeof( ripemd160_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -428,7 +429,7 @@ void ripemd160_hmac_starts( ripemd160_context *ctx,
     ripemd160_starts( ctx );
     ripemd160_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    secure_memzero( sum, sizeof( sum ) );
 }
 
 /*
@@ -453,7 +454,7 @@ void ripemd160_hmac_finish( ripemd160_context *ctx, unsigned char output[20] )
     ripemd160_update( ctx, tmpbuf, 20 );
     ripemd160_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    secure_memzero( tmpbuf, sizeof( tmpbuf ) );
 }
 
 /*
@@ -478,7 +479,7 @@ void ripemd160_hmac( const unsigned char *key, size_t keylen,
     ripemd160_hmac_update( &ctx, input, ilen );
     ripemd160_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( ripemd160_context ) );
+    secure_memzero( &ctx, sizeof( ripemd160_context ) );
 }
 
 

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -37,6 +37,7 @@
 #if defined(POLARSSL_SHA1_C)
 
 #include "polarssl/sha1.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -334,7 +335,7 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] )
     sha1_update( &ctx, input, ilen );
     sha1_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha1_context ) );
+    secure_memzero( &ctx, sizeof( sha1_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -358,7 +359,7 @@ int sha1_file( const char *path, unsigned char output[20] )
 
     sha1_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha1_context ) );
+    secure_memzero( &ctx, sizeof( sha1_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -399,7 +400,7 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
     sha1_starts( ctx );
     sha1_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    secure_memzero( sum, sizeof( sum ) );
 }
 
 /*
@@ -424,7 +425,7 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] )
     sha1_update( ctx, tmpbuf, 20 );
     sha1_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    secure_memzero( tmpbuf, sizeof( tmpbuf ) );
 }
 
 /*
@@ -449,7 +450,7 @@ void sha1_hmac( const unsigned char *key, size_t keylen,
     sha1_hmac_update( &ctx, input, ilen );
     sha1_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha1_context ) );
+    secure_memzero( &ctx, sizeof( sha1_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -37,6 +37,7 @@
 #if defined(POLARSSL_SHA256_C)
 
 #include "polarssl/sha256.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -337,7 +338,7 @@ void sha256( const unsigned char *input, size_t ilen,
     sha256_update( &ctx, input, ilen );
     sha256_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha256_context ) );
+    secure_memzero( &ctx, sizeof( sha256_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -361,7 +362,7 @@ int sha256_file( const char *path, unsigned char output[32], int is224 )
 
     sha256_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha256_context ) );
+    secure_memzero( &ctx, sizeof( sha256_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -402,7 +403,7 @@ void sha256_hmac_starts( sha256_context *ctx, const unsigned char *key,
     sha256_starts( ctx, is224 );
     sha256_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    secure_memzero( sum, sizeof( sum ) );
 }
 
 /*
@@ -431,7 +432,7 @@ void sha256_hmac_finish( sha256_context *ctx, unsigned char output[32] )
     sha256_update( ctx, tmpbuf, hlen );
     sha256_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    secure_memzero( tmpbuf, sizeof( tmpbuf ) );
 }
 
 /*
@@ -456,7 +457,7 @@ void sha256_hmac( const unsigned char *key, size_t keylen,
     sha256_hmac_update( &ctx, input, ilen );
     sha256_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha256_context ) );
+    secure_memzero( &ctx, sizeof( sha256_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -37,6 +37,7 @@
 #if defined(POLARSSL_SHA512_C)
 
 #include "polarssl/sha512.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_FS_IO) || defined(POLARSSL_SELF_TEST)
 #include <stdio.h>
@@ -335,7 +336,7 @@ void sha512( const unsigned char *input, size_t ilen,
     sha512_update( &ctx, input, ilen );
     sha512_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha512_context ) );
+    secure_memzero( &ctx, sizeof( sha512_context ) );
 }
 
 #if defined(POLARSSL_FS_IO)
@@ -359,7 +360,7 @@ int sha512_file( const char *path, unsigned char output[64], int is384 )
 
     sha512_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha512_context ) );
+    secure_memzero( &ctx, sizeof( sha512_context ) );
 
     if( ferror( f ) != 0 )
     {
@@ -400,7 +401,7 @@ void sha512_hmac_starts( sha512_context *ctx, const unsigned char *key,
     sha512_starts( ctx, is384 );
     sha512_update( ctx, ctx->ipad, 128 );
 
-    memset( sum, 0, sizeof( sum ) );
+    secure_memzero( sum, sizeof( sum ) );
 }
 
 /*
@@ -429,7 +430,7 @@ void sha512_hmac_finish( sha512_context *ctx, unsigned char output[64] )
     sha512_update( ctx, tmpbuf, hlen );
     sha512_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    secure_memzero( tmpbuf, sizeof( tmpbuf ) );
 }
 
 /*
@@ -454,7 +455,7 @@ void sha512_hmac( const unsigned char *key, size_t keylen,
     sha512_hmac_update( &ctx, input, ilen );
     sha512_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha512_context ) );
+    secure_memzero( &ctx, sizeof( sha512_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -36,6 +36,7 @@
 #if defined(POLARSSL_ECP_C)
 #include "polarssl/ecp.h"
 #endif
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
@@ -337,7 +338,7 @@ static int ssl_parse_ticket( ssl_context *ssl,
 
     ssl_session_free( ssl->session_negotiate );
     memcpy( ssl->session_negotiate, &session, sizeof( ssl_session ) );
-    memset( &session, 0, sizeof( ssl_session ) );
+    secure_memzero( &session, sizeof( ssl_session ) );
 
     return( 0 );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -41,6 +41,7 @@
 
 #include "polarssl/debug.h"
 #include "polarssl/ssl.h"
+#include "polarssl/secure_memzero.h"
 
 #if defined(POLARSSL_X509_CRT_PARSE_C) && \
     defined(POLARSSL_X509_CHECK_EXTENDED_KEY_USAGE)
@@ -175,11 +176,11 @@ static int ssl3_prf( const unsigned char *secret, size_t slen,
         md5_finish( &md5, dstbuf + i * 16 );
     }
 
-    memset( &md5,  0, sizeof( md5  ) );
-    memset( &sha1, 0, sizeof( sha1 ) );
+    secure_memzero( &md5,  sizeof( md5  ) );
+    secure_memzero( &sha1, sizeof( sha1 ) );
 
-    memset( padding, 0, sizeof( padding ) );
-    memset( sha1sum, 0, sizeof( sha1sum ) );
+    secure_memzero( padding, sizeof( padding ) );
+    secure_memzero( sha1sum, sizeof( sha1sum ) );
 
     return( 0 );
 }
@@ -241,8 +242,8 @@ static int tls1_prf( const unsigned char *secret, size_t slen,
             dstbuf[i + j] = (unsigned char)( dstbuf[i + j] ^ h_i[j] );
     }
 
-    memset( tmp, 0, sizeof( tmp ) );
-    memset( h_i, 0, sizeof( h_i ) );
+    secure_memzero( tmp, sizeof( tmp ) );
+    secure_memzero( h_i, sizeof( h_i ) );
 
     return( 0 );
 }
@@ -284,8 +285,8 @@ static int tls_prf_sha256( const unsigned char *secret, size_t slen,
             dstbuf[i + j]  = h_i[j];
     }
 
-    memset( tmp, 0, sizeof( tmp ) );
-    memset( h_i, 0, sizeof( h_i ) );
+    secure_memzero( tmp, sizeof( tmp ) );
+    secure_memzero( h_i, sizeof( h_i ) );
 
     return( 0 );
 }
@@ -326,8 +327,8 @@ static int tls_prf_sha384( const unsigned char *secret, size_t slen,
             dstbuf[i + j]  = h_i[j];
     }
 
-    memset( tmp, 0, sizeof( tmp ) );
-    memset( h_i, 0, sizeof( h_i ) );
+    secure_memzero( tmp, sizeof( tmp ) );
+    secure_memzero( h_i, sizeof( h_i ) );
 
     return( 0 );
 }
@@ -477,7 +478,7 @@ int ssl_derive_keys( ssl_context *ssl )
     memcpy( tmp, handshake->randbytes, 64 );
     memcpy( handshake->randbytes, tmp + 32, 32 );
     memcpy( handshake->randbytes + 32, tmp, 32 );
-    memset( tmp, 0, sizeof( tmp ) );
+    secure_memzero( tmp, sizeof( tmp ) );
 
     /*
      *  SSLv3:
@@ -698,7 +699,7 @@ int ssl_derive_keys( ssl_context *ssl )
     }
 #endif /* POLARSSL_CIPHER_MODE_CBC */
 
-    memset( keyblk, 0, sizeof( keyblk ) );
+    secure_memzero( keyblk, sizeof( keyblk ) );
 
 #if defined(POLARSSL_ZLIB_SUPPORT)
     // Initialize compression
@@ -2985,12 +2986,12 @@ static void ssl_calc_finished_ssl(
 
     SSL_DEBUG_BUF( 3, "calc finished result", buf, 36 );
 
-    memset(  &md5, 0, sizeof(  md5_context ) );
-    memset( &sha1, 0, sizeof( sha1_context ) );
+    secure_memzero(  &md5, sizeof(  md5_context ) );
+    secure_memzero( &sha1, sizeof( sha1_context ) );
 
-    memset(  padbuf, 0, sizeof(  padbuf ) );
-    memset(  md5sum, 0, sizeof(  md5sum ) );
-    memset( sha1sum, 0, sizeof( sha1sum ) );
+    secure_memzero(  padbuf, sizeof(  padbuf ) );
+    secure_memzero(  md5sum, sizeof(  md5sum ) );
+    secure_memzero( sha1sum, sizeof( sha1sum ) );
 
     SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
 }
@@ -3043,10 +3044,10 @@ static void ssl_calc_finished_tls(
 
     SSL_DEBUG_BUF( 3, "calc finished result", buf, len );
 
-    memset(  &md5, 0, sizeof(  md5_context ) );
-    memset( &sha1, 0, sizeof( sha1_context ) );
+    secure_memzero(  &md5, sizeof(  md5_context ) );
+    secure_memzero( &sha1, sizeof( sha1_context ) );
 
-    memset(  padbuf, 0, sizeof(  padbuf ) );
+    secure_memzero(  padbuf, sizeof(  padbuf ) );
 
     SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
 }
@@ -3092,9 +3093,9 @@ static void ssl_calc_finished_tls_sha256(
 
     SSL_DEBUG_BUF( 3, "calc finished result", buf, len );
 
-    memset( &sha256, 0, sizeof( sha256_context ) );
+    secure_memzero( &sha256, sizeof( sha256_context ) );
 
-    memset(  padbuf, 0, sizeof(  padbuf ) );
+    secure_memzero(  padbuf, sizeof(  padbuf ) );
 
     SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
 }
@@ -3139,9 +3140,9 @@ static void ssl_calc_finished_tls_sha384(
 
     SSL_DEBUG_BUF( 3, "calc finished result", buf, len );
 
-    memset( &sha512, 0, sizeof( sha512_context ) );
+    secure_memzero( &sha512, sizeof( sha512_context ) );
 
-    memset(  padbuf, 0, sizeof(  padbuf ) );
+    secure_memzero(  padbuf, sizeof(  padbuf ) );
 
     SSL_DEBUG_MSG( 2, ( "<= calc  finished" ) );
 }

--- a/visualc/VS2010/PolarSSL.vcxproj
+++ b/visualc/VS2010/PolarSSL.vcxproj
@@ -191,6 +191,7 @@
     <ClInclude Include="..\..\include\polarssl\platform.h" />
     <ClInclude Include="..\..\include\polarssl\ripemd160.h" />
     <ClInclude Include="..\..\include\polarssl\rsa.h" />
+    <ClInclude Include="..\..\include\polarssl\secure_memzero.h" />
     <ClInclude Include="..\..\include\polarssl\sha1.h" />
     <ClInclude Include="..\..\include\polarssl\sha256.h" />
     <ClInclude Include="..\..\include\polarssl\sha512.h" />

--- a/visualc/VS6/polarssl.dsp
+++ b/visualc/VS6/polarssl.dsp
@@ -557,6 +557,10 @@ SOURCE=..\..\include\polarssl\rsa.h
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\include\polarssl\secure_memzero.h
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\include\polarssl\sha1.h
 # End Source File
 # Begin Source File


### PR DESCRIPTION
The compiler will optimize away memset calls for memory locations that
are not 'used' anymore after the memset. ( see: http://goo.gl/y8311 )
Implement secure_memzero function that is guaranteed to zero the
memory location and use it in all critical cases.
