### PR TITLE
Fix cross-compiling for Windows on '*nix'

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,10 +95,10 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/data_files" target)
 
     if (NOT EXISTS ${link})
-        if (UNIX)
-            set(command ln -s ${target} ${link})
-        else()
+        if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
             set(command cmd.exe /c mklink ${link} ${target})
+        else()
+            set(command ln -s ${target} ${link})
         endif()
 
         execute_process(COMMAND ${command}


### PR DESCRIPTION
When creating a symlink, use the host system instead of the target system to select the command to create the symlink.

This fixes cross compiling on a Linux host for a Windows target for me. I don't have a Windows build environment available, so I did not test this fix on a Windows host.
