### PR TITLE
Write key : correct output_buf[] size.

### DIFF
--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -319,7 +319,7 @@ int pk_write_pubkey_pem( pk_context *key, unsigned char *buf, size_t size )
 int pk_write_key_pem( pk_context *key, unsigned char *buf, size_t size )
 {
     int ret;
-    unsigned char output_buf[4096];
+    unsigned char output_buf[8192];
     const char *begin, *end;
     size_t olen = 0;
 


### PR DESCRIPTION
This array size prevents the creation of keyfile.key with the "gen_key rsa_keysize=8192" command, because pk_write_key_der generates more than 4096 characters when keysize >~ 7200 bits. A size of 8192 will be sufficient for the current limit of 8192 bits for RSA keys.
