### PR TITLE
Include explicit casts to prevent compiler warnings when building for iOS

### DIFF
--- a/include/polarssl/bn_mul.h
+++ b/include/polarssl/bn_mul.h
@@ -833,8 +833,8 @@
 
 #define MULADDC_CORE                    \
     r   = *(s++) * (t_udbl) b;          \
-    r0  = r;                            \
-    r1  = r >> biL;                     \
+    r0  = (t_uint)r;                    \
+    r1  = (t_uint)(r >> biL);           \
     r0 += c;  r1 += (r0 <  c);          \
     r0 += *d; r1 += (r0 < *d);          \
     c = r1; *(d++) = r0;

--- a/library/net.c
+++ b/library/net.c
@@ -497,7 +497,7 @@ void net_usleep( unsigned long usec )
 {
     struct timeval tv;
     tv.tv_sec  = 0;
-    tv.tv_usec = usec;
+    tv.tv_usec = (suseconds_t)usec;
     select( 0, NULL, NULL, NULL, &tv );
 }
 #endif /* POLARSSL_HAVE_TIME */
@@ -508,7 +508,7 @@ void net_usleep( unsigned long usec )
 int net_recv( void *ctx, unsigned char *buf, size_t len )
 {
     int fd = *((int *) ctx);
-    int ret = read( fd, buf, len );
+    int ret = (int)read( fd, buf, len );
 
     if( ret < 0 )
     {
@@ -539,7 +539,7 @@ int net_recv( void *ctx, unsigned char *buf, size_t len )
 int net_send( void *ctx, const unsigned char *buf, size_t len )
 {
     int fd = *((int *) ctx);
-    int ret = write( fd, buf, len );
+    int ret = (int)write( fd, buf, len );
 
     if( ret < 0 )
     {

--- a/library/pk.c
+++ b/library/pk.c
@@ -222,7 +222,7 @@ int pk_verify_ext( pk_type_t type, const void *options,
 
         ret = rsa_rsassa_pss_verify_ext( pk_rsa( *ctx ),
                 NULL, NULL, RSA_PUBLIC,
-                md_alg, hash_len, hash,
+                md_alg, (unsigned int)hash_len, hash,
                 pss_opts->mgf1_hash_id,
                 pss_opts->expected_salt_len,
                 sig );

--- a/library/timing.c
+++ b/library/timing.c
@@ -378,7 +378,7 @@ int timing_self_test( int verbose )
     {
         (void) get_timer( &hires, 1 );
 
-        m_sleep( 500 * secs );
+        m_sleep( (int)(500 * secs) );
 
         millisecs = get_timer( &hires, 0 );
 
@@ -401,7 +401,7 @@ int timing_self_test( int verbose )
     {
         (void) get_timer( &hires, 1 );
 
-        set_alarm( secs );
+        set_alarm( (int)secs );
         while( !alarmed )
             ;
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -876,7 +876,7 @@ int x509_sig_alg_gets( char *buf, size_t size, const x509_buf *sig_oid,
     ((void) sig_opts);
 #endif /* POLARSSL_X509_RSASSA_PSS_SUPPORT */
 
-    return( (int) size - n );
+    return( (int) (size - n) );
 }
 
 /*


### PR DESCRIPTION
These minor changes just add some explicit casts to suppress compiler warnings.
The only possible tricky one may be the cast to 'suseconds_t', since I don't know if the type name is like this on all supported platforms. The other casts should all be fine.
