### PR TITLE
Initialize all the things

### DIFF
--- a/include/polarssl/asn1.h
+++ b/include/polarssl/asn1.h
@@ -92,7 +92,7 @@
 /* \} addtogroup asn1_module */
 
 /** Returns the size of the binary string, without the trailing \\0 */
-#define OID_SIZE(x) (sizeof(x) - 1)
+#define OID_SIZE(x) (sizeof( x ) - 1)
 
 /**
  * Compares an asn1_buf structure to a reference OID.

--- a/include/polarssl/platform.h
+++ b/include/polarssl/platform.h
@@ -60,6 +60,9 @@ extern "C" {
 #if !defined(POLARSSL_PLATFORM_STD_MALLOC)
 #define POLARSSL_PLATFORM_STD_MALLOC   malloc /**< Default allocator to use */
 #endif
+#if !defined(POLARSSL_PLATFORM_STD_CALLOC)
+#define POLARSSL_PLATFORM_STD_CALLOC   calloc /**< Default calloc to use */
+#endif
 #if !defined(POLARSSL_PLATFORM_STD_FREE)
 #define POLARSSL_PLATFORM_STD_FREE       free /**< Default free to use */
 #endif
@@ -72,16 +75,18 @@ extern "C" {
 /* \} name SECTION: Module settings */
 
 /*
- * The function pointers for malloc and free
+ * The function pointers for malloc, calloc, and free
  */
 #if defined(POLARSSL_PLATFORM_MEMORY)
 extern void * (*polarssl_malloc)( size_t len );
+extern void * (*polatssl_calloc)( size_t count, size_t size );
 extern void (*polarssl_free)( void *ptr );
 
 /**
  * \brief   Set your own memory implementation function pointers
  *
  * \param malloc_func   the malloc function implementation
+ * \param calloc_func   the calloc function implementation
  * \param free_func     the free function implementation
  *
  * \return              0 if successful
@@ -90,6 +95,7 @@ int platform_set_malloc_free( void * (*malloc_func)( size_t ),
                               void (*free_func)( void * ) );
 #else /* POLARSSL_PLATFORM_ENTROPY */
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif /* POLARSSL_PLATFORM_ENTROPY */
 

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -275,8 +275,6 @@ int asn1_get_sequence_of( unsigned char **p,
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
 
-            memset( cur->next, 0, sizeof( asn1_sequence ) );
-
             cur = cur->next;
         }
     }

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -38,7 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -270,7 +270,7 @@ int asn1_get_sequence_of( unsigned char **p,
         /* Allocate and assign next pointer */
         if( *p < end )
         {
-            cur->next = polarssl_calloc(1, sizeof(asn1_sequence));
+            cur->next = polarssl_calloc( 1, sizeof(asn1_sequence) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -38,6 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -269,7 +270,7 @@ int asn1_get_sequence_of( unsigned char **p,
         /* Allocate and assign next pointer */
         if( *p < end )
         {
-            cur->next = polarssl_malloc( sizeof( asn1_sequence ) );
+            cur->next = polarssl_calloc(1, sizeof(asn1_sequence));
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -270,7 +270,7 @@ int asn1_get_sequence_of( unsigned char **p,
         /* Allocate and assign next pointer */
         if( *p < end )
         {
-            cur->next = polarssl_calloc( 1, sizeof(asn1_sequence) );
+            cur->next = polarssl_calloc( 1, sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
@@ -315,7 +315,7 @@ int asn1_get_alg( unsigned char **p,
 
     if( *p == end )
     {
-        polarssl_zeroize( params, sizeof(asn1_buf) );
+        polarssl_zeroize( params, sizeof( asn1_buf ) );
         return( 0 );
     }
 
@@ -341,7 +341,7 @@ int asn1_get_alg_null( unsigned char **p,
     int ret;
     asn1_buf params;
 
-    memset( &params, 0, sizeof(asn1_buf) );
+    memset( &params, 0, sizeof( asn1_buf ) );
 
     if( ( ret = asn1_get_alg( p, end, alg, &params ) ) != 0 )
         return( ret );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -35,6 +35,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -311,7 +312,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
     {
         // Add new entry if not present yet based on OID
         //
-        if( ( cur = polarssl_malloc( sizeof(asn1_named_data) ) ) == NULL )
+        if( ( cur = polarssl_calloc(1, sizeof(asn1_named_data))) == NULL )
             return( NULL );
 
         memset( cur, 0, sizeof(asn1_named_data) );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -318,7 +318,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         memset( cur, 0, sizeof( asn1_named_data ) );
 
         cur->oid.len = oid_len;
-        cur->oid.p = polarssl_malloc( oid_len );
+        cur->oid.p = polarssl_calloc(1, oid_len);
         if( cur->oid.p == NULL )
         {
             polarssl_free( cur );
@@ -328,7 +328,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         memcpy( cur->oid.p, oid, oid_len );
 
         cur->val.len = val_len;
-        cur->val.p = polarssl_malloc( val_len );
+        cur->val.p = polarssl_calloc(1, val_len);
         if( cur->val.p == NULL )
         {
             polarssl_free( cur->oid.p );
@@ -347,7 +347,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         cur->val.p = NULL;
 
         cur->val.len = val_len;
-        cur->val.p = polarssl_malloc( val_len );
+        cur->val.p = polarssl_calloc(1, val_len);
         if( cur->val.p == NULL )
         {
             polarssl_free( cur->oid.p );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -315,8 +315,6 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         if( ( cur = polarssl_calloc( 1, sizeof( asn1_named_data ) ) ) == NULL )
             return( NULL );
 
-        memset( cur, 0, sizeof( asn1_named_data ) );
-
         cur->oid.len = oid_len;
         cur->oid.p = polarssl_calloc( 1, oid_len );
         if( cur->oid.p == NULL )

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -312,10 +312,10 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
     {
         // Add new entry if not present yet based on OID
         //
-        if( ( cur = polarssl_calloc( 1, sizeof(asn1_named_data) ) ) == NULL )
+        if( ( cur = polarssl_calloc( 1, sizeof( asn1_named_data ) ) ) == NULL )
             return( NULL );
 
-        memset( cur, 0, sizeof(asn1_named_data) );
+        memset( cur, 0, sizeof( asn1_named_data ) );
 
         cur->oid.len = oid_len;
         cur->oid.p = polarssl_malloc( oid_len );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -318,7 +318,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         memset( cur, 0, sizeof( asn1_named_data ) );
 
         cur->oid.len = oid_len;
-        cur->oid.p = polarssl_calloc(1, oid_len);
+        cur->oid.p = polarssl_calloc( 1, oid_len );
         if( cur->oid.p == NULL )
         {
             polarssl_free( cur );
@@ -328,7 +328,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         memcpy( cur->oid.p, oid, oid_len );
 
         cur->val.len = val_len;
-        cur->val.p = polarssl_calloc(1, val_len);
+        cur->val.p = polarssl_calloc( 1, val_len );
         if( cur->val.p == NULL )
         {
             polarssl_free( cur->oid.p );
@@ -347,7 +347,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
         cur->val.p = NULL;
 
         cur->val.len = val_len;
-        cur->val.p = polarssl_calloc(1, val_len);
+        cur->val.p = polarssl_calloc( 1, val_len );
         if( cur->val.p == NULL )
         {
             polarssl_free( cur->oid.p );

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -35,7 +35,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -312,7 +312,7 @@ asn1_named_data *asn1_store_named_data( asn1_named_data **head,
     {
         // Add new entry if not present yet based on OID
         //
-        if( ( cur = polarssl_calloc(1, sizeof(asn1_named_data))) == NULL )
+        if( ( cur = polarssl_calloc( 1, sizeof(asn1_named_data) ) ) == NULL )
             return( NULL );
 
         memset( cur, 0, sizeof(asn1_named_data) );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -111,8 +111,6 @@ int mpi_grow( mpi *X, size_t nblimbs )
         if( ( p = polarssl_calloc( nblimbs, ciL ) ) == NULL )
             return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
-        memset( p, 0, nblimbs * ciL );
-
         if( X->p != NULL )
         {
             memcpy( p, X->p, X->n * ciL );
@@ -150,8 +148,6 @@ int mpi_shrink( mpi *X, size_t nblimbs )
 
     if( ( p = polarssl_calloc( i, ciL ) ) == NULL )
         return( POLARSSL_ERR_MPI_MALLOC_FAILED );
-
-    memset( p, 0, i * ciL );
 
     if( X->p != NULL )
     {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -43,7 +43,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -108,7 +108,7 @@ int mpi_grow( mpi *X, size_t nblimbs )
 
     if( X->n < nblimbs )
     {
-        if( ( p = polarssl_calloc(nblimbs, ciL)) == NULL )
+        if( ( p = polarssl_calloc( nblimbs, ciL ) ) == NULL )
             return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
         memset( p, 0, nblimbs * ciL );
@@ -148,7 +148,7 @@ int mpi_shrink( mpi *X, size_t nblimbs )
     if( i < nblimbs )
         i = nblimbs;
 
-    if( ( p = polarssl_calloc(i, ciL)) == NULL )
+    if( ( p = polarssl_calloc( i, ciL ) ) == NULL )
         return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
     memset( p, 0, i * ciL );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -54,7 +54,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
 
-#define ciL    (sizeof(t_uint))         /* chars in limb  */
+#define ciL    (sizeof( t_uint) )         /* chars in limb  */
 #define biL    (ciL << 3)               /* bits  in limb  */
 #define biH    (ciL << 2)               /* half limb size */
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -43,6 +43,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -107,7 +108,7 @@ int mpi_grow( mpi *X, size_t nblimbs )
 
     if( X->n < nblimbs )
     {
-        if( ( p = polarssl_malloc( nblimbs * ciL ) ) == NULL )
+        if( ( p = polarssl_calloc(nblimbs, ciL)) == NULL )
             return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
         memset( p, 0, nblimbs * ciL );
@@ -147,7 +148,7 @@ int mpi_shrink( mpi *X, size_t nblimbs )
     if( i < nblimbs )
         i = nblimbs;
 
-    if( ( p = polarssl_malloc( i * ciL ) ) == NULL )
+    if( ( p = polarssl_calloc(i, ciL)) == NULL )
         return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
     memset( p, 0, i * ciL );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -54,7 +54,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
 
-#define ciL    (sizeof( t_uint) )         /* chars in limb  */
+#define ciL    (sizeof( t_uint ))       /* chars in limb  */
 #define biL    (ciL << 3)               /* bits  in limb  */
 #define biH    (ciL << 2)               /* half limb size */
 

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -349,7 +349,7 @@ int camellia_setkey_enc( camellia_context *ctx, const unsigned char *key,
     RK = ctx->rk;
 
     memset( t, 0, 64 );
-    memset( RK, 0, sizeof(ctx->rk) );
+    memset( RK, 0, sizeof( ctx->rk ) );
 
     switch( keysize )
     {
@@ -379,7 +379,7 @@ int camellia_setkey_enc( camellia_context *ctx, const unsigned char *key,
      * Key storage in KC
      * Order: KL, KR, KA, KB
      */
-    memset( KC, 0, sizeof(KC) );
+    memset( KC, 0, sizeof( KC ) );
 
     /* Store KL, KR */
     for( i = 0; i < 8; i++ )

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -135,7 +135,7 @@ void cipher_free( cipher_context_t *ctx )
     if( ctx->cipher_ctx )
         ctx->cipher_info->base->ctx_free_func( ctx->cipher_ctx );
 
-    polarssl_zeroize( ctx, sizeof(cipher_context_t) );
+    polarssl_zeroize( ctx, sizeof( cipher_context_t ) );
 }
 
 int cipher_init_ctx( cipher_context_t *ctx, const cipher_info_t *cipher_info )

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -66,7 +66,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -76,7 +76,7 @@
 /* shared by all GCM ciphers */
 static void *gcm_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(gcm_context));
+    return polarssl_calloc( 1, sizeof(gcm_context) );
 }
 
 static void gcm_ctx_free( void *ctx )
@@ -90,7 +90,7 @@ static void gcm_ctx_free( void *ctx )
 /* shared by all CCM ciphers */
 static void *ccm_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(ccm_context));
+    return polarssl_calloc( 1, sizeof(ccm_context) );
 }
 
 static void ccm_ctx_free( void *ctx )
@@ -180,7 +180,7 @@ static int aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * aes_ctx_alloc( void )
 {
-    aes_context *aes = polarssl_calloc(1, sizeof(aes_context));
+    aes_context *aes = polarssl_calloc( 1, sizeof(aes_context) );
 
     if( aes == NULL )
         return( NULL );
@@ -542,7 +542,7 @@ static int camellia_setkey_enc_wrap( void *ctx, const unsigned char *key,
 static void * camellia_ctx_alloc( void )
 {
     camellia_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(camellia_context));
+    ctx = polarssl_calloc( 1, sizeof(camellia_context) );
 
     if( ctx == NULL )
         return( NULL );
@@ -923,7 +923,7 @@ static int des3_set3key_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * des_ctx_alloc( void )
 {
-    des_context *des = polarssl_calloc(1, sizeof(des_context));
+    des_context *des = polarssl_calloc( 1, sizeof(des_context) );
 
     if( des == NULL )
         return( NULL );
@@ -942,7 +942,7 @@ static void des_ctx_free( void *ctx )
 static void * des3_ctx_alloc( void )
 {
     des3_context *des3;
-    des3 = polarssl_calloc(1, sizeof(des3_context));
+    des3 = polarssl_calloc( 1, sizeof(des3_context) );
 
     if( des3 == NULL )
         return( NULL );
@@ -1146,7 +1146,7 @@ static int blowfish_setkey_wrap( void *ctx, const unsigned char *key,
 static void * blowfish_ctx_alloc( void )
 {
     blowfish_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(blowfish_context));
+    ctx = polarssl_calloc( 1, sizeof(blowfish_context) );
 
     if( ctx == NULL )
         return( NULL );
@@ -1248,7 +1248,7 @@ static int arc4_setkey_wrap( void *ctx, const unsigned char *key,
 static void * arc4_ctx_alloc( void )
 {
     arc4_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(arc4_context));
+    ctx = polarssl_calloc( 1, sizeof(arc4_context) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -76,7 +76,7 @@
 /* shared by all GCM ciphers */
 static void *gcm_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(gcm_context) );
+    return polarssl_calloc( 1, sizeof( gcm_context ) );
 }
 
 static void gcm_ctx_free( void *ctx )
@@ -90,7 +90,7 @@ static void gcm_ctx_free( void *ctx )
 /* shared by all CCM ciphers */
 static void *ccm_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(ccm_context) );
+    return polarssl_calloc( 1, sizeof( ccm_context ) );
 }
 
 static void ccm_ctx_free( void *ctx )
@@ -180,7 +180,7 @@ static int aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * aes_ctx_alloc( void )
 {
-    aes_context *aes = polarssl_calloc( 1, sizeof(aes_context) );
+    aes_context *aes = polarssl_calloc( 1, sizeof( aes_context ) );
 
     if( aes == NULL )
         return( NULL );
@@ -542,7 +542,7 @@ static int camellia_setkey_enc_wrap( void *ctx, const unsigned char *key,
 static void * camellia_ctx_alloc( void )
 {
     camellia_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(camellia_context) );
+    ctx = polarssl_calloc( 1, sizeof( camellia_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -923,7 +923,7 @@ static int des3_set3key_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * des_ctx_alloc( void )
 {
-    des_context *des = polarssl_calloc( 1, sizeof(des_context) );
+    des_context *des = polarssl_calloc( 1, sizeof( des_context ) );
 
     if( des == NULL )
         return( NULL );
@@ -942,7 +942,7 @@ static void des_ctx_free( void *ctx )
 static void * des3_ctx_alloc( void )
 {
     des3_context *des3;
-    des3 = polarssl_calloc( 1, sizeof(des3_context) );
+    des3 = polarssl_calloc( 1, sizeof( des3_context ) );
 
     if( des3 == NULL )
         return( NULL );
@@ -1146,7 +1146,7 @@ static int blowfish_setkey_wrap( void *ctx, const unsigned char *key,
 static void * blowfish_ctx_alloc( void )
 {
     blowfish_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(blowfish_context) );
+    ctx = polarssl_calloc( 1, sizeof( blowfish_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -1248,7 +1248,7 @@ static int arc4_setkey_wrap( void *ctx, const unsigned char *key,
 static void * arc4_ctx_alloc( void )
 {
     arc4_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(arc4_context) );
+    ctx = polarssl_calloc( 1, sizeof( arc4_context ) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -66,6 +66,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -75,7 +76,7 @@
 /* shared by all GCM ciphers */
 static void *gcm_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( gcm_context ) );
+    return polarssl_calloc(1, sizeof(gcm_context));
 }
 
 static void gcm_ctx_free( void *ctx )
@@ -89,7 +90,7 @@ static void gcm_ctx_free( void *ctx )
 /* shared by all CCM ciphers */
 static void *ccm_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( ccm_context ) );
+    return polarssl_calloc(1, sizeof(ccm_context));
 }
 
 static void ccm_ctx_free( void *ctx )
@@ -179,7 +180,7 @@ static int aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * aes_ctx_alloc( void )
 {
-    aes_context *aes = polarssl_malloc( sizeof( aes_context ) );
+    aes_context *aes = polarssl_calloc(1, sizeof(aes_context));
 
     if( aes == NULL )
         return( NULL );
@@ -541,7 +542,7 @@ static int camellia_setkey_enc_wrap( void *ctx, const unsigned char *key,
 static void * camellia_ctx_alloc( void )
 {
     camellia_context *ctx;
-    ctx = polarssl_malloc( sizeof( camellia_context ) );
+    ctx = polarssl_calloc(1, sizeof(camellia_context));
 
     if( ctx == NULL )
         return( NULL );
@@ -922,7 +923,7 @@ static int des3_set3key_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * des_ctx_alloc( void )
 {
-    des_context *des = polarssl_malloc( sizeof( des_context ) );
+    des_context *des = polarssl_calloc(1, sizeof(des_context));
 
     if( des == NULL )
         return( NULL );
@@ -941,7 +942,7 @@ static void des_ctx_free( void *ctx )
 static void * des3_ctx_alloc( void )
 {
     des3_context *des3;
-    des3 = polarssl_malloc( sizeof( des3_context ) );
+    des3 = polarssl_calloc(1, sizeof(des3_context));
 
     if( des3 == NULL )
         return( NULL );
@@ -1145,7 +1146,7 @@ static int blowfish_setkey_wrap( void *ctx, const unsigned char *key,
 static void * blowfish_ctx_alloc( void )
 {
     blowfish_context *ctx;
-    ctx = polarssl_malloc( sizeof( blowfish_context ) );
+    ctx = polarssl_calloc(1, sizeof(blowfish_context));
 
     if( ctx == NULL )
         return( NULL );
@@ -1247,7 +1248,7 @@ static int arc4_setkey_wrap( void *ctx, const unsigned char *key,
 static void * arc4_ctx_alloc( void )
 {
     arc4_context *ctx;
-    ctx = polarssl_malloc( sizeof( arc4_context ) );
+    ctx = polarssl_calloc(1, sizeof(arc4_context));
 
     if( ctx == NULL )
         return( NULL );

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -65,7 +65,7 @@ int ctr_drbg_init_entropy_len(
     int ret;
     unsigned char key[CTR_DRBG_KEYSIZE];
 
-    memset( ctx, 0, sizeof(ctr_drbg_context) );
+    memset( ctx, 0, sizeof( ctr_drbg_context ) );
     memset( key, 0, CTR_DRBG_KEYSIZE );
 
     aes_init( &ctx->aes_ctx );

--- a/library/debug.c
+++ b/library/debug.c
@@ -210,7 +210,7 @@ void debug_print_mpi( const ssl_context *ssl, int level,
         if( X->p[n] != 0 )
             break;
 
-    for( j = ( sizeof(t_uint) << 3 ) - 1; j >= 0; j-- )
+    for( j = ( sizeof( t_uint ) << 3 ) - 1; j >= 0; j-- )
         if( ( ( X->p[n] >> j ) & 1 ) != 0 )
             break;
 
@@ -218,7 +218,7 @@ void debug_print_mpi( const ssl_context *ssl, int level,
         idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
 
     snprintf( str + idx, maxlen - idx, "value of '%s' (%d bits) is:\n",
-              text, (int) ( ( n * ( sizeof(t_uint) << 3 ) ) + j + 1 ) );
+              text, (int) ( ( n * ( sizeof( t_uint ) << 3 ) ) + j + 1 ) );
 
     str[maxlen] = '\0';
     ssl->f_dbg( ssl->p_dbg, level, str );

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -505,7 +506,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_calloc( 1, *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( POLARSSL_ERR_DHM_MALLOC_FAILED );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -56,7 +56,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -813,7 +813,7 @@ static int ecp_normalize_jac_many( const ecp_group *grp,
     if( t_len < 2 )
         return( ecp_normalize_jac( grp, *T ) );
 
-    if( ( c = polarssl_calloc(t_len, sizeof(mpi))) == NULL )
+    if( ( c = polarssl_calloc( t_len, sizeof(mpi) ) ) == NULL )
         return( POLARSSL_ERR_ECP_MALLOC_FAILED );
 
     mpi_init( &u ); mpi_init( &Zi ); mpi_init( &ZZi );
@@ -1416,7 +1416,7 @@ static int ecp_mul_comb( ecp_group *grp, ecp_point *R,
 
     if( T == NULL )
     {
-        T = polarssl_calloc(pre_len, sizeof(ecp_point));
+        T = polarssl_calloc( pre_len, sizeof(ecp_point) );
         if( T == NULL )
         {
             ret = POLARSSL_ERR_ECP_MALLOC_FAILED;

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -56,6 +56,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -812,7 +813,7 @@ static int ecp_normalize_jac_many( const ecp_group *grp,
     if( t_len < 2 )
         return( ecp_normalize_jac( grp, *T ) );
 
-    if( ( c = polarssl_malloc( t_len * sizeof( mpi ) ) ) == NULL )
+    if( ( c = polarssl_calloc(t_len, sizeof(mpi))) == NULL )
         return( POLARSSL_ERR_ECP_MALLOC_FAILED );
 
     mpi_init( &u ); mpi_init( &Zi ); mpi_init( &ZZi );
@@ -1415,7 +1416,7 @@ static int ecp_mul_comb( ecp_group *grp, ecp_point *R,
 
     if( T == NULL )
     {
-        T = polarssl_malloc( pre_len * sizeof( ecp_point ) );
+        T = polarssl_calloc(pre_len, sizeof(ecp_point));
         if( T == NULL )
         {
             ret = POLARSSL_ERR_ECP_MALLOC_FAILED;

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -813,7 +813,7 @@ static int ecp_normalize_jac_many( const ecp_group *grp,
     if( t_len < 2 )
         return( ecp_normalize_jac( grp, *T ) );
 
-    if( ( c = polarssl_calloc( t_len, sizeof(mpi) ) ) == NULL )
+    if( ( c = polarssl_calloc( t_len, sizeof( mpi ) ) ) == NULL )
         return( POLARSSL_ERR_ECP_MALLOC_FAILED );
 
     mpi_init( &u ); mpi_init( &Zi ); mpi_init( &ZZi );
@@ -1416,7 +1416,7 @@ static int ecp_mul_comb( ecp_group *grp, ecp_point *R,
 
     if( T == NULL )
     {
-        T = polarssl_calloc( pre_len, sizeof(ecp_point) );
+        T = polarssl_calloc( pre_len, sizeof( ecp_point ) );
         if( T == NULL )
         {
             ret = POLARSSL_ERR_ECP_MALLOC_FAILED;

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -973,10 +973,10 @@ static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
     uint32_t cur;                                           \
     size_t i = 0, bits = b;                                 \
     mpi C;                                                  \
-    t_uint Cp[ b / 8 / sizeof(  t_uint ) + 1 ];               \
+    t_uint Cp[ b / 8 / sizeof( t_uint ) + 1 ];              \
                                                             \
     C.s = 1;                                                \
-    C.n = b / 8 / sizeof(  t_uint ) + 1;                      \
+    C.n = b / 8 / sizeof( t_uint ) + 1;                     \
     C.p = Cp;                                               \
     memset( Cp, 0, C.n * sizeof( t_uint ) );                \
                                                             \

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -973,10 +973,10 @@ static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
     uint32_t cur;                                           \
     size_t i = 0, bits = b;                                 \
     mpi C;                                                  \
-    t_uint Cp[ b / 8 / sizeof( t_uint) + 1 ];               \
+    t_uint Cp[ b / 8 / sizeof(  t_uint ) + 1 ];               \
                                                             \
     C.s = 1;                                                \
-    C.n = b / 8 / sizeof( t_uint) + 1;                      \
+    C.n = b / 8 / sizeof(  t_uint ) + 1;                      \
     C.p = Cp;                                               \
     memset( Cp, 0, C.n * sizeof( t_uint ) );                \
                                                             \

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -48,7 +48,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
 
 void entropy_init( entropy_context *ctx )
 {
-    memset( ctx, 0, sizeof(entropy_context) );
+    memset( ctx, 0, sizeof( entropy_context ) );
 
 #if defined(POLARSSL_THREADING_C)
     polarssl_mutex_init( &ctx->mutex );

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -146,11 +146,11 @@ int hardclock_poll( void *data,
     ((void) data);
     *olen = 0;
 
-    if( len < sizeof(unsigned long) )
+    if( len < sizeof( unsigned long ) )
         return( 0 );
 
-    memcpy( output, &timer, sizeof(unsigned long) );
-    *olen = sizeof(unsigned long);
+    memcpy( output, &timer, sizeof( unsigned long ) );
+    *olen = sizeof( unsigned long );
 
     return( 0 );
 }

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -152,7 +152,7 @@ int gcm_init( gcm_context *ctx, cipher_id_t cipher, const unsigned char *key,
     int ret;
     const cipher_info_t *cipher_info;
 
-    memset( ctx, 0, sizeof(gcm_context) );
+    memset( ctx, 0, sizeof( gcm_context ) );
 
     cipher_init( &ctx->cipher_ctx );
 
@@ -271,8 +271,8 @@ int gcm_starts( gcm_context *ctx,
         return( POLARSSL_ERR_GCM_BAD_INPUT );
     }
 
-    memset( ctx->y, 0x00, sizeof(ctx->y) );
-    memset( ctx->buf, 0x00, sizeof(ctx->buf) );
+    memset( ctx->y, 0x00, sizeof( ctx->y ) );
+    memset( ctx->buf, 0x00, sizeof( ctx->buf ) );
 
     ctx->mode = mode;
     ctx->len = 0;

--- a/library/havege.c
+++ b/library/havege.c
@@ -223,8 +223,8 @@ int havege_random( void *p_rng, unsigned char *buf, size_t len )
     while( len > 0 )
     {
         use_len = len;
-        if( use_len > sizeof(int) )
-            use_len = sizeof(int);
+        if( use_len > sizeof( int ) )
+            use_len = sizeof( int );
 
         if( hs->offset[1] >= COLLECT_SIZE )
             havege_fill( hs );

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -66,7 +66,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -130,7 +130,7 @@ static void md2_hmac_reset_wrap( void *ctx )
 
 static void * md2_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(md2_context));
+    return polarssl_calloc( 1, sizeof(md2_context) );
 }
 
 static void md2_ctx_free( void *ctx )
@@ -220,7 +220,7 @@ static void md4_hmac_reset_wrap( void *ctx )
 
 static void *md4_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(md4_context));
+    return polarssl_calloc( 1, sizeof(md4_context) );
 }
 
 static void md4_ctx_free( void *ctx )
@@ -308,7 +308,7 @@ static void md5_hmac_reset_wrap( void *ctx )
 
 static void * md5_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(md5_context));
+    return polarssl_calloc( 1, sizeof(md5_context) );
 }
 
 static void md5_ctx_free( void *ctx )
@@ -397,7 +397,7 @@ static void ripemd160_hmac_reset_wrap( void *ctx )
 static void * ripemd160_ctx_alloc( void )
 {
     ripemd160_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(ripemd160_context));
+    ctx = polarssl_calloc( 1, sizeof(ripemd160_context) );
 
     if( ctx == NULL )
         return( NULL );
@@ -493,7 +493,7 @@ static void sha1_hmac_reset_wrap( void *ctx )
 static void * sha1_ctx_alloc( void )
 {
     sha1_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(sha1_context));
+    ctx = polarssl_calloc( 1, sizeof(sha1_context) );
 
     if( ctx == NULL )
         return( NULL );
@@ -604,7 +604,7 @@ static void sha224_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha224_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(sha256_context));
+    return polarssl_calloc( 1, sizeof(sha256_context) );
 }
 
 static void sha224_ctx_free( void *ctx )
@@ -702,7 +702,7 @@ static void sha256_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha256_ctx_alloc( void )
 {
     sha256_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(sha256_context));
+    ctx = polarssl_calloc( 1, sizeof(sha256_context) );
 
     if( ctx == NULL )
         return( NULL );
@@ -810,7 +810,7 @@ static void sha384_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha384_ctx_alloc( void )
 {
-    return polarssl_calloc(1, sizeof(sha512_context));
+    return polarssl_calloc( 1, sizeof(sha512_context) );
 }
 
 static void sha384_ctx_free( void *ctx )
@@ -908,7 +908,7 @@ static void sha512_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha512_ctx_alloc( void )
 {
     sha512_context *ctx;
-    ctx = polarssl_calloc(1, sizeof(sha512_context));
+    ctx = polarssl_calloc( 1, sizeof(sha512_context) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -66,6 +66,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -129,7 +130,7 @@ static void md2_hmac_reset_wrap( void *ctx )
 
 static void * md2_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( md2_context ) );
+    return polarssl_calloc(1, sizeof(md2_context));
 }
 
 static void md2_ctx_free( void *ctx )
@@ -219,7 +220,7 @@ static void md4_hmac_reset_wrap( void *ctx )
 
 static void *md4_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( md4_context ) );
+    return polarssl_calloc(1, sizeof(md4_context));
 }
 
 static void md4_ctx_free( void *ctx )
@@ -307,7 +308,7 @@ static void md5_hmac_reset_wrap( void *ctx )
 
 static void * md5_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( md5_context ) );
+    return polarssl_calloc(1, sizeof(md5_context));
 }
 
 static void md5_ctx_free( void *ctx )
@@ -396,7 +397,7 @@ static void ripemd160_hmac_reset_wrap( void *ctx )
 static void * ripemd160_ctx_alloc( void )
 {
     ripemd160_context *ctx;
-    ctx = polarssl_malloc( sizeof( ripemd160_context ) );
+    ctx = polarssl_calloc(1, sizeof(ripemd160_context));
 
     if( ctx == NULL )
         return( NULL );
@@ -492,7 +493,7 @@ static void sha1_hmac_reset_wrap( void *ctx )
 static void * sha1_ctx_alloc( void )
 {
     sha1_context *ctx;
-    ctx = polarssl_malloc( sizeof( sha1_context ) );
+    ctx = polarssl_calloc(1, sizeof(sha1_context));
 
     if( ctx == NULL )
         return( NULL );
@@ -603,7 +604,7 @@ static void sha224_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha224_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( sha256_context ) );
+    return polarssl_calloc(1, sizeof(sha256_context));
 }
 
 static void sha224_ctx_free( void *ctx )
@@ -701,7 +702,7 @@ static void sha256_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha256_ctx_alloc( void )
 {
     sha256_context *ctx;
-    ctx = polarssl_malloc( sizeof( sha256_context ) );
+    ctx = polarssl_calloc(1, sizeof(sha256_context));
 
     if( ctx == NULL )
         return( NULL );
@@ -809,7 +810,7 @@ static void sha384_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha384_ctx_alloc( void )
 {
-    return polarssl_malloc( sizeof( sha512_context ) );
+    return polarssl_calloc(1, sizeof(sha512_context));
 }
 
 static void sha384_ctx_free( void *ctx )
@@ -907,7 +908,7 @@ static void sha512_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha512_ctx_alloc( void )
 {
     sha512_context *ctx;
-    ctx = polarssl_malloc( sizeof( sha512_context ) );
+    ctx = polarssl_calloc(1, sizeof(sha512_context));
 
     if( ctx == NULL )
         return( NULL );

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -130,7 +130,7 @@ static void md2_hmac_reset_wrap( void *ctx )
 
 static void * md2_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(md2_context) );
+    return polarssl_calloc( 1, sizeof( md2_context ) );
 }
 
 static void md2_ctx_free( void *ctx )
@@ -220,7 +220,7 @@ static void md4_hmac_reset_wrap( void *ctx )
 
 static void *md4_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(md4_context) );
+    return polarssl_calloc( 1, sizeof( md4_context ) );
 }
 
 static void md4_ctx_free( void *ctx )
@@ -308,7 +308,7 @@ static void md5_hmac_reset_wrap( void *ctx )
 
 static void * md5_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(md5_context) );
+    return polarssl_calloc( 1, sizeof( md5_context ) );
 }
 
 static void md5_ctx_free( void *ctx )
@@ -397,7 +397,7 @@ static void ripemd160_hmac_reset_wrap( void *ctx )
 static void * ripemd160_ctx_alloc( void )
 {
     ripemd160_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(ripemd160_context) );
+    ctx = polarssl_calloc( 1, sizeof( ripemd160_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -493,7 +493,7 @@ static void sha1_hmac_reset_wrap( void *ctx )
 static void * sha1_ctx_alloc( void )
 {
     sha1_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(sha1_context) );
+    ctx = polarssl_calloc( 1, sizeof( sha1_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -604,7 +604,7 @@ static void sha224_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha224_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(sha256_context) );
+    return polarssl_calloc( 1, sizeof( sha256_context ) );
 }
 
 static void sha224_ctx_free( void *ctx )
@@ -702,7 +702,7 @@ static void sha256_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha256_ctx_alloc( void )
 {
     sha256_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(sha256_context) );
+    ctx = polarssl_calloc( 1, sizeof( sha256_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -810,7 +810,7 @@ static void sha384_hmac_wrap( const unsigned char *key, size_t keylen,
 
 static void * sha384_ctx_alloc( void )
 {
-    return polarssl_calloc( 1, sizeof(sha512_context) );
+    return polarssl_calloc( 1, sizeof( sha512_context ) );
 }
 
 static void sha384_ctx_free( void *ctx )
@@ -908,7 +908,7 @@ static void sha512_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha512_ctx_alloc( void )
 {
     sha512_context *ctx;
-    ctx = polarssl_calloc( 1, sizeof(sha512_context) );
+    ctx = polarssl_calloc( 1, sizeof( sha512_context ) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -631,9 +631,9 @@ int memory_buffer_alloc_self_test( int verbose )
 
     memory_buffer_alloc_init( buf, sizeof( buf ) );
 
-    p = polarssl_calloc(1, 1);
-    q = polarssl_calloc(1, 128);
-    r = polarssl_calloc(1, 16);
+    p = polarssl_calloc( 1, 1 );
+    q = polarssl_calloc( 1, 128 );
+    r = polarssl_calloc( 1, 16 );
 
     TEST_ASSERT( check_pointer( p ) == 0 &&
                  check_pointer( q ) == 0 &&
@@ -660,9 +660,9 @@ int memory_buffer_alloc_self_test( int verbose )
 
     TEST_ASSERT( heap.buf + heap.len == end );
 
-    p = polarssl_calloc(1, 1);
-    q = polarssl_calloc(1, 128);
-    r = polarssl_calloc(1, 16);
+    p = polarssl_calloc( 1, 1 );
+    q = polarssl_calloc( 1, 128 );
+    r = polarssl_calloc( 1, 16 );
 
     TEST_ASSERT( check_pointer( p ) == 0 &&
                  check_pointer( q ) == 0 &&
@@ -687,19 +687,19 @@ int memory_buffer_alloc_self_test( int verbose )
     p = polarssl_malloc( sizeof( buf ) - sizeof( memory_header ) );
 
     TEST_ASSERT( check_pointer( p ) == 0 );
-    TEST_ASSERT(polarssl_calloc(1, 1) == NULL );
+    TEST_ASSERT( polarssl_calloc( 1, 1 ) == NULL );
 
     polarssl_free( p );
 
     p = polarssl_malloc( sizeof( buf ) - 2 * sizeof( memory_header ) - 16 );
-    q = polarssl_calloc(1, 16);
+    q = polarssl_calloc( 1, 16 );
 
     TEST_ASSERT( check_pointer( p ) == 0 && check_pointer( q ) == 0 );
-    TEST_ASSERT(polarssl_calloc(1, 1) == NULL );
+    TEST_ASSERT( polarssl_calloc( 1, 1 ) == NULL );
 
     polarssl_free( q );
 
-    TEST_ASSERT(polarssl_calloc(1, 17) == NULL );
+    TEST_ASSERT( polarssl_calloc( 1, 17 ) == NULL );
 
     polarssl_free( p );
 

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -631,9 +631,9 @@ int memory_buffer_alloc_self_test( int verbose )
 
     memory_buffer_alloc_init( buf, sizeof( buf ) );
 
-    p = polarssl_malloc( 1 );
-    q = polarssl_malloc( 128 );
-    r = polarssl_malloc( 16 );
+    p = polarssl_calloc(1, 1);
+    q = polarssl_calloc(1, 128);
+    r = polarssl_calloc(1, 16);
 
     TEST_ASSERT( check_pointer( p ) == 0 &&
                  check_pointer( q ) == 0 &&
@@ -660,9 +660,9 @@ int memory_buffer_alloc_self_test( int verbose )
 
     TEST_ASSERT( heap.buf + heap.len == end );
 
-    p = polarssl_malloc( 1 );
-    q = polarssl_malloc( 128 );
-    r = polarssl_malloc( 16 );
+    p = polarssl_calloc(1, 1);
+    q = polarssl_calloc(1, 128);
+    r = polarssl_calloc(1, 16);
 
     TEST_ASSERT( check_pointer( p ) == 0 &&
                  check_pointer( q ) == 0 &&
@@ -687,19 +687,19 @@ int memory_buffer_alloc_self_test( int verbose )
     p = polarssl_malloc( sizeof( buf ) - sizeof( memory_header ) );
 
     TEST_ASSERT( check_pointer( p ) == 0 );
-    TEST_ASSERT( polarssl_malloc( 1 ) == NULL );
+    TEST_ASSERT(polarssl_calloc(1, 1) == NULL );
 
     polarssl_free( p );
 
     p = polarssl_malloc( sizeof( buf ) - 2 * sizeof( memory_header ) - 16 );
-    q = polarssl_malloc( 16 );
+    q = polarssl_calloc(1, 16);
 
     TEST_ASSERT( check_pointer( p ) == 0 && check_pointer( q ) == 0 );
-    TEST_ASSERT( polarssl_malloc( 1 ) == NULL );
+    TEST_ASSERT(polarssl_calloc(1, 1) == NULL );
 
     polarssl_free( q );
 
-    TEST_ASSERT( polarssl_malloc( 17 ) == NULL );
+    TEST_ASSERT(polarssl_calloc(1, 17) == NULL );
 
     polarssl_free( p );
 

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -283,7 +283,7 @@ static void *buffer_alloc_malloc( size_t len )
 
     // Found location, split block if > memory_header + 4 room left
     //
-    if( cur->size - len < sizeof(memory_header) +
+    if( cur->size - len < sizeof( memory_header ) +
                           POLARSSL_MEMORY_ALIGN_MULTIPLE )
     {
         cur->alloc = 1;
@@ -315,13 +315,13 @@ static void *buffer_alloc_malloc( size_t len )
         if( ( heap.verify & MEMORY_VERIFY_ALLOC ) && verify_chain() != 0 )
             exit( 1 );
 
-        return( ( (unsigned char *) cur ) + sizeof(memory_header) );
+        return( ( (unsigned char *) cur ) + sizeof( memory_header ) );
     }
 
-    p = ( (unsigned char *) cur ) + sizeof(memory_header) + len;
+    p = ( (unsigned char *) cur ) + sizeof( memory_header ) + len;
     new = (memory_header *) p;
 
-    new->size = cur->size - len - sizeof(memory_header);
+    new->size = cur->size - len - sizeof( memory_header );
     new->alloc = 0;
     new->prev = cur;
     new->next = cur->next;
@@ -370,7 +370,7 @@ static void *buffer_alloc_malloc( size_t len )
     if( ( heap.verify & MEMORY_VERIFY_ALLOC ) && verify_chain() != 0 )
         exit( 1 );
 
-    return( ( (unsigned char *) cur ) + sizeof(memory_header) );
+    return( ( (unsigned char *) cur ) + sizeof( memory_header ) );
 }
 
 static void buffer_alloc_free( void *ptr )
@@ -390,7 +390,7 @@ static void buffer_alloc_free( void *ptr )
         exit( 1 );
     }
 
-    p -= sizeof(memory_header);
+    p -= sizeof( memory_header );
     hdr = (memory_header *) p;
 
     if( verify_header( hdr ) != 0 )
@@ -419,7 +419,7 @@ static void buffer_alloc_free( void *ptr )
 #if defined(POLARSSL_MEMORY_DEBUG)
         heap.header_count--;
 #endif
-        hdr->prev->size += sizeof(memory_header) + hdr->size;
+        hdr->prev->size += sizeof( memory_header ) + hdr->size;
         hdr->prev->next = hdr->next;
         old = hdr;
         hdr = hdr->prev;
@@ -430,7 +430,7 @@ static void buffer_alloc_free( void *ptr )
 #if defined(POLARSSL_MEMORY_BACKTRACE)
         free( old->trace );
 #endif
-        memset( old, 0, sizeof(memory_header) );
+        memset( old, 0, sizeof( memory_header ) );
     }
 
     // Regroup with block after
@@ -440,7 +440,7 @@ static void buffer_alloc_free( void *ptr )
 #if defined(POLARSSL_MEMORY_DEBUG)
         heap.header_count--;
 #endif
-        hdr->size += sizeof(memory_header) + hdr->next->size;
+        hdr->size += sizeof( memory_header ) + hdr->next->size;
         old = hdr->next;
         hdr->next = hdr->next->next;
 
@@ -472,7 +472,7 @@ static void buffer_alloc_free( void *ptr )
 #if defined(POLARSSL_MEMORY_BACKTRACE)
         free( old->trace );
 #endif
-        memset( old, 0, sizeof(memory_header) );
+        memset( old, 0, sizeof( memory_header ) );
     }
 
     // Prepend to free_list if we have not merged
@@ -547,7 +547,7 @@ static void buffer_alloc_free_mutexed( void *ptr )
 
 int memory_buffer_alloc_init( unsigned char *buf, size_t len )
 {
-    memset( &heap, 0, sizeof(buffer_alloc_ctx) );
+    memset( &heap, 0, sizeof( buffer_alloc_ctx ) );
     memset( buf, 0, len );
 
 #if defined(POLARSSL_THREADING_C)
@@ -571,7 +571,7 @@ int memory_buffer_alloc_init( unsigned char *buf, size_t len )
     heap.len = len;
 
     heap.first = (memory_header *) buf;
-    heap.first->size = len - sizeof(memory_header);
+    heap.first->size = len - sizeof( memory_header );
     heap.first->magic1 = MAGIC1;
     heap.first->magic2 = MAGIC2;
     heap.first_free = heap.first;
@@ -583,7 +583,7 @@ void memory_buffer_alloc_free()
 #if defined(POLARSSL_THREADING_C)
     polarssl_mutex_free( &heap.mutex );
 #endif
-    polarssl_zeroize( &heap, sizeof(buffer_alloc_ctx) );
+    polarssl_zeroize( &heap, sizeof( buffer_alloc_ctx ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)

--- a/library/pem.c
+++ b/library/pem.c
@@ -38,6 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -319,7 +320,7 @@ int pem_read_buffer( pem_context *ctx, const char *header, const char *footer,
     if( ret == POLARSSL_ERR_BASE64_INVALID_CHARACTER )
         return( POLARSSL_ERR_PEM_INVALID_DATA + ret );
 
-    if( ( buf = polarssl_malloc( len ) ) == NULL )
+    if( ( buf = polarssl_calloc(1, len)) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_decode( buf, &len, s1, s2 - s1 ) ) != 0 )
@@ -405,7 +406,7 @@ int pem_write_buffer( const char *header, const char *footer,
         return( POLARSSL_ERR_BASE64_BUFFER_TOO_SMALL );
     }
 
-    if( ( encode_buf = polarssl_malloc( use_len ) ) == NULL )
+    if( ( encode_buf = polarssl_calloc(1, use_len)) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_encode( encode_buf, &use_len, der_data,

--- a/library/pem.c
+++ b/library/pem.c
@@ -38,7 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -320,7 +320,7 @@ int pem_read_buffer( pem_context *ctx, const char *header, const char *footer,
     if( ret == POLARSSL_ERR_BASE64_INVALID_CHARACTER )
         return( POLARSSL_ERR_PEM_INVALID_DATA + ret );
 
-    if( ( buf = polarssl_calloc(1, len)) == NULL )
+    if( ( buf = polarssl_calloc( 1, len )) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_decode( buf, &len, s1, s2 - s1 ) ) != 0 )
@@ -406,7 +406,7 @@ int pem_write_buffer( const char *header, const char *footer,
         return( POLARSSL_ERR_BASE64_BUFFER_TOO_SMALL );
     }
 
-    if( ( encode_buf = polarssl_calloc(1, use_len)) == NULL )
+    if( ( encode_buf = polarssl_calloc( 1, use_len )) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_encode( encode_buf, &use_len, der_data,

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -46,6 +46,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -131,7 +132,7 @@ static int rsa_check_pair_wrap( const void *pub, const void *prv )
 
 static void *rsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_malloc( sizeof( rsa_context ) );
+    void *ctx = polarssl_calloc(1, sizeof(rsa_context));
 
     if( ctx != NULL )
         rsa_init( (rsa_context *) ctx, 0, 0 );
@@ -247,7 +248,7 @@ static int eckey_check_pair( const void *pub, const void *prv )
 
 static void *eckey_alloc_wrap( void )
 {
-    void *ctx = polarssl_malloc( sizeof( ecp_keypair ) );
+    void *ctx = polarssl_calloc(1, sizeof(ecp_keypair));
 
     if( ctx != NULL )
         ecp_keypair_init( ctx );
@@ -357,7 +358,7 @@ static int ecdsa_sign_wrap( void *ctx, md_type_t md_alg,
 
 static void *ecdsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_malloc( sizeof( ecdsa_context ) );
+    void *ctx = polarssl_calloc(1, sizeof(ecdsa_context));
 
     if( ctx != NULL )
         ecdsa_init( (ecdsa_context *) ctx );
@@ -465,7 +466,7 @@ static int rsa_alt_check_pair( const void *pub, const void *prv )
 
 static void *rsa_alt_alloc_wrap( void )
 {
-    void *ctx = polarssl_malloc( sizeof( rsa_alt_context ) );
+    void *ctx = polarssl_calloc(1, sizeof(rsa_alt_context));
 
     if( ctx != NULL )
         memset( ctx, 0, sizeof( rsa_alt_context ) );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -132,7 +132,7 @@ static int rsa_check_pair_wrap( const void *pub, const void *prv )
 
 static void *rsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc( 1, sizeof(rsa_context) );
+    void *ctx = polarssl_calloc( 1, sizeof( rsa_context ) );
 
     if( ctx != NULL )
         rsa_init( (rsa_context *) ctx, 0, 0 );
@@ -248,7 +248,7 @@ static int eckey_check_pair( const void *pub, const void *prv )
 
 static void *eckey_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc( 1, sizeof(ecp_keypair) );
+    void *ctx = polarssl_calloc( 1, sizeof( ecp_keypair ) );
 
     if( ctx != NULL )
         ecp_keypair_init( ctx );
@@ -358,7 +358,7 @@ static int ecdsa_sign_wrap( void *ctx, md_type_t md_alg,
 
 static void *ecdsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc( 1, sizeof(ecdsa_context) );
+    void *ctx = polarssl_calloc( 1, sizeof( ecdsa_context ) );
 
     if( ctx != NULL )
         ecdsa_init( (ecdsa_context *) ctx );
@@ -466,7 +466,7 @@ static int rsa_alt_check_pair( const void *pub, const void *prv )
 
 static void *rsa_alt_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc( 1, sizeof(rsa_alt_context) );
+    void *ctx = polarssl_calloc( 1, sizeof( rsa_alt_context ) );
 
     if( ctx != NULL )
         memset( ctx, 0, sizeof( rsa_alt_context ) );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -46,7 +46,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -132,7 +132,7 @@ static int rsa_check_pair_wrap( const void *pub, const void *prv )
 
 static void *rsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc(1, sizeof(rsa_context));
+    void *ctx = polarssl_calloc( 1, sizeof(rsa_context) );
 
     if( ctx != NULL )
         rsa_init( (rsa_context *) ctx, 0, 0 );
@@ -248,7 +248,7 @@ static int eckey_check_pair( const void *pub, const void *prv )
 
 static void *eckey_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc(1, sizeof(ecp_keypair));
+    void *ctx = polarssl_calloc( 1, sizeof(ecp_keypair) );
 
     if( ctx != NULL )
         ecp_keypair_init( ctx );
@@ -358,7 +358,7 @@ static int ecdsa_sign_wrap( void *ctx, md_type_t md_alg,
 
 static void *ecdsa_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc(1, sizeof(ecdsa_context));
+    void *ctx = polarssl_calloc( 1, sizeof(ecdsa_context) );
 
     if( ctx != NULL )
         ecdsa_init( (ecdsa_context *) ctx );
@@ -466,7 +466,7 @@ static int rsa_alt_check_pair( const void *pub, const void *prv )
 
 static void *rsa_alt_alloc_wrap( void )
 {
-    void *ctx = polarssl_calloc(1, sizeof(rsa_alt_context));
+    void *ctx = polarssl_calloc( 1, sizeof(rsa_alt_context) );
 
     if( ctx != NULL )
         memset( ctx, 0, sizeof( rsa_alt_context ) );

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -36,7 +36,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -59,7 +59,7 @@ int pkcs11_x509_cert_init( x509_crt *cert, pkcs11h_certificate_t pkcs11_cert )
         goto cleanup;
     }
 
-    cert_blob = polarssl_calloc(1, cert_blob_size);
+    cert_blob = polarssl_calloc( 1, cert_blob_size );
     if( NULL == cert_blob )
     {
         ret = 4;

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -36,6 +36,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -58,7 +59,7 @@ int pkcs11_x509_cert_init( x509_crt *cert, pkcs11h_certificate_t pkcs11_cert )
         goto cleanup;
     }
 
-    cert_blob = polarssl_malloc( cert_blob_size );
+    cert_blob = polarssl_calloc(1, cert_blob_size);
     if( NULL == cert_blob )
     {
         ret = 4;

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -95,8 +95,8 @@ static int pkcs12_pbe_derive_key_iv( asn1_buf *pbe_params, md_type_t md_type,
     size_t i;
     unsigned char unipwd[258];
 
-    memset( &salt, 0, sizeof(asn1_buf) );
-    memset( &unipwd, 0, sizeof(unipwd) );
+    memset( &salt, 0, sizeof( asn1_buf ) );
+    memset( &unipwd, 0, sizeof( unipwd ) );
 
     if( ( ret = pkcs12_parse_pbe_params( pbe_params, &salt,
                                          &iterations ) ) != 0 )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -56,6 +56,7 @@
 #else
 #include <stdlib.h>
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -87,7 +88,7 @@ int pk_load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_calloc( 1, *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( POLARSSL_ERR_PK_MALLOC_FAILED );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -542,7 +542,7 @@ static int pk_get_pk_alg( unsigned char **p,
     int ret;
     asn1_buf alg_oid;
 
-    memset( params, 0, sizeof(asn1_buf) );
+    memset( params, 0, sizeof( asn1_buf ) );
 
     if( ( ret = asn1_get_alg( p, end, &alg_oid, params ) ) != 0 )
         return( POLARSSL_ERR_PK_INVALID_ALG + ret );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -381,13 +381,13 @@ int pk_write_pubkey_pem( pk_context *key, unsigned char *buf, size_t size )
     size_t olen = 0;
 
     if( ( ret = pk_write_pubkey_der( key, output_buf,
-                                     sizeof(output_buf) ) ) < 0 )
+                                     sizeof( output_buf ) ) ) < 0 )
     {
         return( ret );
     }
 
     if( ( ret = pem_write_buffer( PEM_BEGIN_PUBLIC_KEY, PEM_END_PUBLIC_KEY,
-                                  output_buf + sizeof(output_buf) - ret,
+                                  output_buf + sizeof( output_buf ) - ret,
                                   ret, buf, size, &olen ) ) != 0 )
     {
         return( ret );
@@ -403,7 +403,7 @@ int pk_write_key_pem( pk_context *key, unsigned char *buf, size_t size )
     const char *begin, *end;
     size_t olen = 0;
 
-    if( ( ret = pk_write_key_der( key, output_buf, sizeof(output_buf) ) ) < 0 )
+    if( ( ret = pk_write_key_der( key, output_buf, sizeof( output_buf ) ) ) < 0 )
         return( ret );
 
 #if defined(POLARSSL_RSA_C)
@@ -425,7 +425,7 @@ int pk_write_key_pem( pk_context *key, unsigned char *buf, size_t size )
         return( POLARSSL_ERR_PK_FEATURE_UNAVAILABLE );
 
     if( ( ret = pem_write_buffer( begin, end,
-                                  output_buf + sizeof(output_buf) - ret,
+                                  output_buf + sizeof( output_buf ) - ret,
                                   ret, buf, size, &olen ) ) != 0 )
     {
         return( ret );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1604,7 +1604,7 @@ int rsa_self_test( int verbose )
 
     if( rsa_pkcs1_decrypt( &rsa, myrand, NULL, RSA_PRIVATE, &len,
                            rsa_ciphertext, rsa_decrypted,
-                           sizeof(rsa_decrypted) ) != 0 )
+                           sizeof( rsa_decrypted ) ) != 0 )
     {
         if( verbose != 0 )
             polarssl_printf( "failed\n" );

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -103,8 +103,7 @@ int ssl_cache_get( void *data, ssl_session *session )
          */
         if( entry->peer_cert.p != NULL )
         {
-            if( ( session->peer_cert = polarssl_malloc(
-                                 sizeof(x509_crt) ) ) == NULL )
+            if( ( session->peer_cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL )
             {
                 ret = 1;
                 goto exit;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -38,6 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -221,7 +222,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
             /*
              * max_entries not reached, create new entry
              */
-            cur = polarssl_malloc( sizeof(ssl_cache_entry) );
+            cur = polarssl_calloc(1, sizeof(ssl_cache_entry));
             if( cur == NULL )
             {
                 ret = 1;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -259,7 +259,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
      */
     if( session->peer_cert != NULL )
     {
-        cur->peer_cert.p = polarssl_malloc( session->peer_cert->raw.len );
+        cur->peer_cert.p = polarssl_calloc( 1, session->peer_cert->raw.len );
         if( cur->peer_cert.p == NULL )
         {
             ret = 1;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -229,8 +229,6 @@ int ssl_cache_set( void *data, const ssl_session *session )
                 goto exit;
             }
 
-            memset( cur, 0, sizeof( ssl_cache_entry ) );
-
             if( prv == NULL )
                 cache->chain = cur;
             else

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -103,7 +103,8 @@ int ssl_cache_get( void *data, ssl_session *session )
          */
         if( entry->peer_cert.p != NULL )
         {
-            if( ( session->peer_cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL )
+            session->peer_cert = polarssl_calloc( 1, sizeof( x509_crt ) );
+            if( session->peer_cert == NULL )
             {
                 ret = 1;
                 goto exit;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -222,14 +222,14 @@ int ssl_cache_set( void *data, const ssl_session *session )
             /*
              * max_entries not reached, create new entry
              */
-            cur = polarssl_calloc( 1, sizeof(ssl_cache_entry) );
+            cur = polarssl_calloc( 1, sizeof( ssl_cache_entry ) );
             if( cur == NULL )
             {
                 ret = 1;
                 goto exit;
             }
 
-            memset( cur, 0, sizeof(ssl_cache_entry) );
+            memset( cur, 0, sizeof( ssl_cache_entry ) );
 
             if( prv == NULL )
                 cache->chain = cur;
@@ -251,7 +251,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
     if( cur->peer_cert.p != NULL )
     {
         polarssl_free( cur->peer_cert.p );
-        memset( &cur->peer_cert, 0, sizeof(x509_buf) );
+        memset( &cur->peer_cert, 0, sizeof( x509_buf ) );
     }
 
     /*

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -38,7 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -222,7 +222,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
             /*
              * max_entries not reached, create new entry
              */
-            cur = polarssl_calloc(1, sizeof(ssl_cache_entry));
+            cur = polarssl_calloc( 1, sizeof(ssl_cache_entry) );
             if( cur == NULL )
             {
                 ret = 1;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -35,7 +35,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -2710,7 +2710,7 @@ static int ssl_parse_new_session_ticket( ssl_context *ssl )
     ssl->session_negotiate->ticket = NULL;
     ssl->session_negotiate->ticket_len = 0;
 
-    if( ( ticket = polarssl_calloc(1, ticket_len)) == NULL )
+    if( ( ticket = polarssl_calloc( 1, ticket_len ) ) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "ticket malloc failed" ) );
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -35,6 +35,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -2709,7 +2710,7 @@ static int ssl_parse_new_session_ticket( ssl_context *ssl )
     ssl->session_negotiate->ticket = NULL;
     ssl->session_negotiate->ticket_len = 0;
 
-    if( ( ticket = polarssl_malloc( ticket_len ) ) == NULL )
+    if( ( ticket = polarssl_calloc(1, ticket_len)) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "ticket malloc failed" ) );
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -140,7 +140,7 @@ static int ssl_load_session( ssl_session *session,
         if( p + cert_len > end )
             return( POLARSSL_ERR_SSL_BAD_INPUT_DATA );
 
-        session->peer_cert = polarssl_malloc( sizeof( x509_crt ) );
+        session->peer_cert = polarssl_calloc(1, sizeof(x509_crt));
 
         if( session->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -38,7 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -543,7 +543,7 @@ static int ssl_parse_supported_elliptic_curves( ssl_context *ssl,
     if( our_size > POLARSSL_ECP_DP_MAX )
         our_size = POLARSSL_ECP_DP_MAX;
 
-    if( ( curves = polarssl_calloc(our_size, sizeof(*curves))) == NULL )
+    if( ( curves = polarssl_calloc( our_size, sizeof(*curves) ) ) == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
     /* explicit void pointer cast for buggy MS compiler */

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -140,7 +140,7 @@ static int ssl_load_session( ssl_session *session,
         if( p + cert_len > end )
             return( POLARSSL_ERR_SSL_BAD_INPUT_DATA );
 
-        session->peer_cert = polarssl_calloc(1, sizeof(x509_crt));
+        session->peer_cert = polarssl_calloc( 1, sizeof(x509_crt) );
 
         if( session->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -546,8 +546,6 @@ static int ssl_parse_supported_elliptic_curves( ssl_context *ssl,
     if( ( curves = polarssl_calloc( our_size, sizeof( *curves ) ) ) == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    /* explicit void pointer cast for buggy MS compiler */
-    memset( (void *) curves, 0, our_size * sizeof( *curves ) );
     ssl->handshake->curves = curves;
 
     p = buf + 2;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -38,6 +38,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -542,7 +543,7 @@ static int ssl_parse_supported_elliptic_curves( ssl_context *ssl,
     if( our_size > POLARSSL_ECP_DP_MAX )
         our_size = POLARSSL_ECP_DP_MAX;
 
-    if( ( curves = polarssl_malloc( our_size * sizeof( *curves ) ) ) == NULL )
+    if( ( curves = polarssl_calloc(our_size, sizeof(*curves))) == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
     /* explicit void pointer cast for buggy MS compiler */

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -57,7 +57,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
 
 /*
  * Serialize a session in the following format:
- *  0   .   n-1     session structure, n = sizeof(ssl_session)
+ *  0   .   n-1     session structure, n = sizeof( ssl_session )
  *  n   .   n+2     peer_cert length = m (0 if no certificate)
  *  n+3 .   n+2+m   peer cert ASN.1
  *
@@ -140,7 +140,7 @@ static int ssl_load_session( ssl_session *session,
         if( p + cert_len > end )
             return( POLARSSL_ERR_SSL_BAD_INPUT_DATA );
 
-        session->peer_cert = polarssl_calloc( 1, sizeof(x509_crt) );
+        session->peer_cert = polarssl_calloc( 1, sizeof( x509_crt ) );
 
         if( session->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
@@ -543,7 +543,7 @@ static int ssl_parse_supported_elliptic_curves( ssl_context *ssl,
     if( our_size > POLARSSL_ECP_DP_MAX )
         our_size = POLARSSL_ECP_DP_MAX;
 
-    if( ( curves = polarssl_calloc( our_size, sizeof(*curves) ) ) == NULL )
+    if( ( curves = polarssl_calloc( our_size, sizeof( *curves ) ) ) == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
     /* explicit void pointer cast for buggy MS compiler */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -48,6 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -92,7 +93,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
     {
         int ret;
 
-        dst->peer_cert = polarssl_malloc( sizeof(x509_crt) );
+        dst->peer_cert = polarssl_calloc(1, sizeof(x509_crt));
         if( dst->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -2747,8 +2748,7 @@ int ssl_parse_certificate( ssl_context *ssl )
         polarssl_free( ssl->session_negotiate->peer_cert );
     }
 
-    if( ( ssl->session_negotiate->peer_cert = polarssl_malloc(
-                    sizeof( x509_crt ) ) ) == NULL )
+    if( ( ssl->session_negotiate->peer_cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",
                        sizeof( x509_crt ) ) );
@@ -3544,17 +3544,17 @@ static int ssl_handshake_init( ssl_context *ssl )
      */
     if( ssl->transform_negotiate == NULL )
     {
-        ssl->transform_negotiate = polarssl_malloc( sizeof(ssl_transform) );
+        ssl->transform_negotiate = polarssl_calloc(1, sizeof(ssl_transform));
     }
 
     if( ssl->session_negotiate == NULL )
     {
-        ssl->session_negotiate = polarssl_malloc( sizeof(ssl_session) );
+        ssl->session_negotiate = polarssl_calloc(1, sizeof(ssl_session));
     }
 
     if( ssl->handshake == NULL )
     {
-        ssl->handshake = polarssl_malloc( sizeof(ssl_handshake_params) );
+        ssl->handshake = polarssl_calloc(1, sizeof(ssl_handshake_params));
     }
 
     /* All pointers should exist and can be directly freed without issue */
@@ -3779,7 +3779,7 @@ static int ssl_ticket_keys_init( ssl_context *ssl )
     if( ssl->ticket_keys != NULL )
         return( 0 );
 
-    tkeys = polarssl_malloc( sizeof(ssl_ticket_keys) );
+    tkeys = polarssl_calloc(1, sizeof(ssl_ticket_keys));
     if( tkeys == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -3936,7 +3936,7 @@ static ssl_key_cert *ssl_add_key_cert( ssl_context *ssl )
 {
     ssl_key_cert *key_cert, *last;
 
-    key_cert = polarssl_malloc( sizeof(ssl_key_cert) );
+    key_cert = polarssl_calloc(1, sizeof(ssl_key_cert));
     if( key_cert == NULL )
         return( NULL );
 
@@ -3992,7 +3992,7 @@ int ssl_set_own_cert_rsa( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_malloc( sizeof(pk_context) );
+    key_cert->key = polarssl_calloc(1, sizeof(pk_context));
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4024,7 +4024,7 @@ int ssl_set_own_cert_alt( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_malloc( sizeof(pk_context) );
+    key_cert->key = polarssl_calloc(1, sizeof(pk_context));
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -796,7 +796,7 @@ int ssl_derive_keys( ssl_context *ssl )
         if( ssl->compress_buf == NULL )
         {
             SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );
-            ssl->compress_buf = polarssl_calloc(1, SSL_BUFFER_LEN);
+            ssl->compress_buf = polarssl_calloc( 1, SSL_BUFFER_LEN );
             if( ssl->compress_buf == NULL )
             {
                 SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3653,9 +3653,6 @@ int ssl_init( ssl_context *ssl )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
     }
 
-    memset( ssl-> in_ctr, 0, SSL_BUFFER_LEN );
-    memset( ssl->out_ctr, 0, SSL_BUFFER_LEN );
-
 #if defined(POLARSSL_SSL_ENCRYPT_THEN_MAC)
     ssl->encrypt_then_mac = SSL_ETM_ENABLED;
 #endif
@@ -3941,8 +3938,6 @@ static ssl_key_cert *ssl_add_key_cert( ssl_context *ssl )
     key_cert = polarssl_calloc( 1, sizeof( ssl_key_cert ) );
     if( key_cert == NULL )
         return( NULL );
-
-    memset( key_cert, 0, sizeof( ssl_key_cert ) );
 
     /* Append the new key_cert to the (possibly empty) current list */
     if( ssl->key_cert == NULL )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -796,7 +796,7 @@ int ssl_derive_keys( ssl_context *ssl )
         if( ssl->compress_buf == NULL )
         {
             SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );
-            ssl->compress_buf = polarssl_malloc( SSL_BUFFER_LEN );
+            ssl->compress_buf = polarssl_calloc(1, SSL_BUFFER_LEN);
             if( ssl->compress_buf == NULL )
             {
                 SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -93,7 +93,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
     {
         int ret;
 
-        dst->peer_cert = polarssl_calloc( 1, sizeof(x509_crt) );
+        dst->peer_cert = polarssl_calloc( 1, sizeof( x509_crt ) );
         if( dst->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -509,7 +509,7 @@ int ssl_derive_keys( ssl_context *ssl )
                             handshake->randbytes, 64, session->master, 48 );
 
 
-        polarssl_zeroize( handshake->premaster, sizeof(handshake->premaster) );
+        polarssl_zeroize( handshake->premaster, sizeof( handshake->premaster ) );
     }
     else
         SSL_DEBUG_MSG( 3, ( "no premaster (session resumed)" ) );
@@ -835,8 +835,8 @@ void ssl_calc_verify_ssl( ssl_context *ssl, unsigned char hash[36] )
 
     SSL_DEBUG_MSG( 2, ( "=> calc verify ssl" ) );
 
-    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof(md5_context)  );
-    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof(sha1_context) );
+    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof( md5_context )  );
+    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof( sha1_context ) );
 
     memset( pad_1, 0x36, 48 );
     memset( pad_2, 0x5C, 48 );
@@ -879,8 +879,8 @@ void ssl_calc_verify_tls( ssl_context *ssl, unsigned char hash[36] )
 
     SSL_DEBUG_MSG( 2, ( "=> calc verify tls" ) );
 
-    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof(md5_context)  );
-    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof(sha1_context) );
+    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof( md5_context )  );
+    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof( sha1_context ) );
 
      md5_finish( &md5,  hash );
     sha1_finish( &sha1, hash + 16 );
@@ -903,7 +903,7 @@ void ssl_calc_verify_tls_sha256( ssl_context *ssl, unsigned char hash[32] )
 
     SSL_DEBUG_MSG( 2, ( "=> calc verify sha256" ) );
 
-    memcpy( &sha256, &ssl->handshake->fin_sha256, sizeof(sha256_context) );
+    memcpy( &sha256, &ssl->handshake->fin_sha256, sizeof( sha256_context ) );
     sha256_finish( &sha256, hash );
 
     SSL_DEBUG_BUF( 3, "calculated verify result", hash, 32 );
@@ -922,7 +922,7 @@ void ssl_calc_verify_tls_sha384( ssl_context *ssl, unsigned char hash[48] )
 
     SSL_DEBUG_MSG( 2, ( "=> calc verify sha384" ) );
 
-    memcpy( &sha512, &ssl->handshake->fin_sha512, sizeof(sha512_context) );
+    memcpy( &sha512, &ssl->handshake->fin_sha512, sizeof( sha512_context ) );
     sha512_finish( &sha512, hash );
 
     SSL_DEBUG_BUF( 3, "calculated verify result", hash, 48 );
@@ -2749,7 +2749,7 @@ int ssl_parse_certificate( ssl_context *ssl )
     }
 
     if( ( ssl->session_negotiate->peer_cert =
-              polarssl_calloc( 1, sizeof(x509_crt) ) ) == NULL )
+              polarssl_calloc( 1, sizeof( x509_crt ) ) ) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",
                        sizeof( x509_crt ) ) );
@@ -3029,8 +3029,8 @@ static void ssl_calc_finished_ssl(
 
     SSL_DEBUG_MSG( 2, ( "=> calc  finished ssl" ) );
 
-    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof(md5_context)  );
-    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof(sha1_context) );
+    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof( md5_context )  );
+    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof( sha1_context ) );
 
     /*
      * SSLv3:
@@ -3109,8 +3109,8 @@ static void ssl_calc_finished_tls(
 
     SSL_DEBUG_MSG( 2, ( "=> calc  finished tls" ) );
 
-    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof(md5_context)  );
-    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof(sha1_context) );
+    memcpy( &md5 , &ssl->handshake->fin_md5 , sizeof( md5_context )  );
+    memcpy( &sha1, &ssl->handshake->fin_sha1, sizeof( sha1_context ) );
 
     /*
      * TLSv1:
@@ -3165,7 +3165,7 @@ static void ssl_calc_finished_tls_sha256(
 
     SSL_DEBUG_MSG( 2, ( "=> calc  finished tls sha256" ) );
 
-    memcpy( &sha256, &ssl->handshake->fin_sha256, sizeof(sha256_context) );
+    memcpy( &sha256, &ssl->handshake->fin_sha256, sizeof( sha256_context ) );
 
     /*
      * TLSv1.2:
@@ -3212,7 +3212,7 @@ static void ssl_calc_finished_tls_sha384(
 
     SSL_DEBUG_MSG( 2, ( "=> calc  finished tls sha384" ) );
 
-    memcpy( &sha512, &ssl->handshake->fin_sha512, sizeof(sha512_context) );
+    memcpy( &sha512, &ssl->handshake->fin_sha512, sizeof( sha512_context ) );
 
     /*
      * TLSv1.2:
@@ -3515,7 +3515,7 @@ static void ssl_handshake_params_init( ssl_handshake_params *handshake )
 
 static void ssl_transform_init( ssl_transform *transform )
 {
-    memset( transform, 0, sizeof(ssl_transform) );
+    memset( transform, 0, sizeof( ssl_transform ) );
 
     cipher_init( &transform->cipher_ctx_enc );
     cipher_init( &transform->cipher_ctx_dec );
@@ -3526,7 +3526,7 @@ static void ssl_transform_init( ssl_transform *transform )
 
 void ssl_session_init( ssl_session *session )
 {
-    memset( session, 0, sizeof(ssl_session) );
+    memset( session, 0, sizeof( ssl_session ) );
 }
 
 static int ssl_handshake_init( ssl_context *ssl )
@@ -3546,17 +3546,17 @@ static int ssl_handshake_init( ssl_context *ssl )
     if( ssl->transform_negotiate == NULL )
     {
         ssl->transform_negotiate =
-            polarssl_calloc( 1, sizeof(ssl_transform) );
+            polarssl_calloc( 1, sizeof( ssl_transform ) );
     }
 
     if( ssl->session_negotiate == NULL )
     {
-        ssl->session_negotiate = polarssl_calloc( 1, sizeof(ssl_session) );
+        ssl->session_negotiate = polarssl_calloc( 1, sizeof( ssl_session ) );
     }
 
     if( ssl->handshake == NULL )
     {
-        ssl->handshake = polarssl_calloc( 1, sizeof(ssl_handshake_params) );
+        ssl->handshake = polarssl_calloc( 1, sizeof( ssl_handshake_params ) );
     }
 
     /* All pointers should exist and can be directly freed without issue */
@@ -3766,7 +3766,7 @@ static void ssl_ticket_keys_free( ssl_ticket_keys *tkeys )
     aes_free( &tkeys->enc );
     aes_free( &tkeys->dec );
 
-    polarssl_zeroize( tkeys, sizeof(ssl_ticket_keys) );
+    polarssl_zeroize( tkeys, sizeof( ssl_ticket_keys ) );
 }
 
 /*
@@ -3781,7 +3781,7 @@ static int ssl_ticket_keys_init( ssl_context *ssl )
     if( ssl->ticket_keys != NULL )
         return( 0 );
 
-    tkeys = polarssl_calloc( 1, sizeof(ssl_ticket_keys) );
+    tkeys = polarssl_calloc( 1, sizeof( ssl_ticket_keys ) );
     if( tkeys == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -3938,7 +3938,7 @@ static ssl_key_cert *ssl_add_key_cert( ssl_context *ssl )
 {
     ssl_key_cert *key_cert, *last;
 
-    key_cert = polarssl_calloc( 1, sizeof(ssl_key_cert) );
+    key_cert = polarssl_calloc( 1, sizeof( ssl_key_cert ) );
     if( key_cert == NULL )
         return( NULL );
 
@@ -3994,7 +3994,7 @@ int ssl_set_own_cert_rsa( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_calloc( 1, sizeof(pk_context) );
+    key_cert->key = polarssl_calloc( 1, sizeof( pk_context ) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4026,7 +4026,7 @@ int ssl_set_own_cert_alt( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_calloc( 1, sizeof(pk_context) );
+    key_cert->key = polarssl_calloc( 1, sizeof( pk_context ) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -112,7 +112,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
 #if defined(POLARSSL_SSL_SESSION_TICKETS)
     if( src->ticket != NULL )
     {
-        dst->ticket = polarssl_malloc( src->ticket_len );
+        dst->ticket = polarssl_calloc( 1, src->ticket_len );
         if( dst->ticket == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4062,8 +4062,8 @@ int ssl_set_psk( ssl_context *ssl, const unsigned char *psk, size_t psk_len,
     ssl->psk_len = psk_len;
     ssl->psk_identity_len = psk_identity_len;
 
-    ssl->psk = polarssl_malloc( ssl->psk_len );
-    ssl->psk_identity = polarssl_malloc( ssl->psk_identity_len );
+    ssl->psk = polarssl_calloc( 1, ssl->psk_len );
+    ssl->psk_identity = polarssl_calloc( 1, ssl->psk_identity_len );
 
     if( ssl->psk == NULL || ssl->psk_identity == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
@@ -4145,7 +4145,7 @@ int ssl_set_hostname( ssl_context *ssl, const char *hostname )
     if( ssl->hostname_len + 1 == 0 )
         return( POLARSSL_ERR_SSL_BAD_INPUT_DATA );
 
-    ssl->hostname = polarssl_malloc( ssl->hostname_len + 1 );
+    ssl->hostname = polarssl_calloc( 1, ssl->hostname_len + 1 );
 
     if( ssl->hostname == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3629,7 +3629,7 @@ int ssl_init( ssl_context *ssl )
     /*
      * Prepare base structures
      */
-    ssl->in_ctr = polarssl_malloc( len );
+    ssl->in_ctr = polarssl_calloc(1, len);
     ssl->in_hdr = ssl->in_ctr +  8;
     ssl->in_iv  = ssl->in_ctr + 13;
     ssl->in_msg = ssl->in_ctr + 13;
@@ -3640,7 +3640,7 @@ int ssl_init( ssl_context *ssl )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
     }
 
-    ssl->out_ctr = polarssl_malloc( len );
+    ssl->out_ctr = polarssl_calloc(1, len);
     ssl->out_hdr = ssl->out_ctr +  8;
     ssl->out_iv  = ssl->out_ctr + 13;
     ssl->out_msg = ssl->out_ctr + 13;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3629,7 +3629,7 @@ int ssl_init( ssl_context *ssl )
     /*
      * Prepare base structures
      */
-    ssl->in_ctr = polarssl_calloc(1, len);
+    ssl->in_ctr = polarssl_calloc( 1, len );
     ssl->in_hdr = ssl->in_ctr +  8;
     ssl->in_iv  = ssl->in_ctr + 13;
     ssl->in_msg = ssl->in_ctr + 13;
@@ -3640,7 +3640,7 @@ int ssl_init( ssl_context *ssl )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
     }
 
-    ssl->out_ctr = polarssl_calloc(1, len);
+    ssl->out_ctr = polarssl_calloc( 1, len );
     ssl->out_hdr = ssl->out_ctr +  8;
     ssl->out_iv  = ssl->out_ctr + 13;
     ssl->out_msg = ssl->out_ctr + 13;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -48,7 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -93,7 +93,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
     {
         int ret;
 
-        dst->peer_cert = polarssl_calloc(1, sizeof(x509_crt));
+        dst->peer_cert = polarssl_calloc( 1, sizeof(x509_crt) );
         if( dst->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -2748,7 +2748,8 @@ int ssl_parse_certificate( ssl_context *ssl )
         polarssl_free( ssl->session_negotiate->peer_cert );
     }
 
-    if( ( ssl->session_negotiate->peer_cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL )
+    if( ( ssl->session_negotiate->peer_cert =
+              polarssl_calloc( 1, sizeof(x509_crt) ) ) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",
                        sizeof( x509_crt ) ) );
@@ -3544,17 +3545,18 @@ static int ssl_handshake_init( ssl_context *ssl )
      */
     if( ssl->transform_negotiate == NULL )
     {
-        ssl->transform_negotiate = polarssl_calloc(1, sizeof(ssl_transform));
+        ssl->transform_negotiate =
+            polarssl_calloc( 1, sizeof(ssl_transform) );
     }
 
     if( ssl->session_negotiate == NULL )
     {
-        ssl->session_negotiate = polarssl_calloc(1, sizeof(ssl_session));
+        ssl->session_negotiate = polarssl_calloc( 1, sizeof(ssl_session) );
     }
 
     if( ssl->handshake == NULL )
     {
-        ssl->handshake = polarssl_calloc(1, sizeof(ssl_handshake_params));
+        ssl->handshake = polarssl_calloc( 1, sizeof(ssl_handshake_params) );
     }
 
     /* All pointers should exist and can be directly freed without issue */
@@ -3779,7 +3781,7 @@ static int ssl_ticket_keys_init( ssl_context *ssl )
     if( ssl->ticket_keys != NULL )
         return( 0 );
 
-    tkeys = polarssl_calloc(1, sizeof(ssl_ticket_keys));
+    tkeys = polarssl_calloc( 1, sizeof(ssl_ticket_keys) );
     if( tkeys == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -3936,7 +3938,7 @@ static ssl_key_cert *ssl_add_key_cert( ssl_context *ssl )
 {
     ssl_key_cert *key_cert, *last;
 
-    key_cert = polarssl_calloc(1, sizeof(ssl_key_cert));
+    key_cert = polarssl_calloc( 1, sizeof(ssl_key_cert) );
     if( key_cert == NULL )
         return( NULL );
 
@@ -3992,7 +3994,7 @@ int ssl_set_own_cert_rsa( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_calloc(1, sizeof(pk_context));
+    key_cert->key = polarssl_calloc( 1, sizeof(pk_context) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4024,7 +4026,7 @@ int ssl_set_own_cert_alt( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = polarssl_calloc(1, sizeof(pk_context));
+    key_cert->key = polarssl_calloc( 1, sizeof(pk_context) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -50,6 +50,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -445,7 +446,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
             /* Mark this item as being only one in a set */
             cur->next_merged = 1;
 
-            cur->next = polarssl_malloc( sizeof( x509_name ) );
+            cur->next = polarssl_calloc(1, sizeof(x509_name));
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -461,7 +462,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
         if( *p == end )
             return( 0 );
 
-        cur->next = polarssl_malloc( sizeof( x509_name ) );
+        cur->next = polarssl_calloc(1, sizeof(x509_name));
 
         if( cur->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -583,7 +584,7 @@ int x509_get_sig_alg( const x509_buf *sig_oid, const x509_buf *sig_params,
     {
         pk_rsassa_pss_options *pss_opts;
 
-        pss_opts = polarssl_malloc( sizeof( pk_rsassa_pss_options ) );
+        pss_opts = polarssl_calloc(1, sizeof(pk_rsassa_pss_options));
         if( pss_opts == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -446,7 +446,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
             /* Mark this item as being only one in a set */
             cur->next_merged = 1;
 
-            cur->next = polarssl_calloc( 1, sizeof(x509_name) );
+            cur->next = polarssl_calloc( 1, sizeof( x509_name ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -462,7 +462,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
         if( *p == end )
             return( 0 );
 
-        cur->next = polarssl_calloc( 1, sizeof(x509_name) );
+        cur->next = polarssl_calloc( 1, sizeof( x509_name ) );
 
         if( cur->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -584,7 +584,7 @@ int x509_get_sig_alg( const x509_buf *sig_oid, const x509_buf *sig_params,
     {
         pk_rsassa_pss_options *pss_opts;
 
-        pss_opts = polarssl_calloc( 1, sizeof(pk_rsassa_pss_options) );
+        pss_opts = polarssl_calloc( 1, sizeof( pk_rsassa_pss_options ) );
         if( pss_opts == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -50,7 +50,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -446,7 +446,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
             /* Mark this item as being only one in a set */
             cur->next_merged = 1;
 
-            cur->next = polarssl_calloc(1, sizeof(x509_name));
+            cur->next = polarssl_calloc( 1, sizeof(x509_name) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -462,7 +462,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
         if( *p == end )
             return( 0 );
 
-        cur->next = polarssl_calloc(1, sizeof(x509_name));
+        cur->next = polarssl_calloc( 1, sizeof(x509_name) );
 
         if( cur->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -584,7 +584,7 @@ int x509_get_sig_alg( const x509_buf *sig_oid, const x509_buf *sig_params,
     {
         pk_rsassa_pss_options *pss_opts;
 
-        pss_opts = polarssl_calloc(1, sizeof(pk_rsassa_pss_options));
+        pss_opts = polarssl_calloc( 1, sizeof(pk_rsassa_pss_options) );
         if( pss_opts == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -451,8 +451,6 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
-            memset( cur->next, 0, sizeof( x509_name ) );
-
             cur = cur->next;
         }
 
@@ -466,8 +464,6 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
 
         if( cur->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
-
-        memset( cur->next, 0, sizeof( x509_name ) );
 
         cur = cur->next;
     }

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -293,7 +293,7 @@ int x509_crl_parse_der( x509_crl *chain,
     /*
      * Copy raw DER-encoded CRL
      */
-    if( ( p = polarssl_malloc( buflen ) ) == NULL )
+    if( ( p = polarssl_calloc(1, buflen)) == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -241,7 +241,6 @@ static int x509_get_entries( unsigned char **p,
             if( cur_entry->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
-            memset( cur_entry->next, 0, sizeof( x509_crl_entry ) );
             cur_entry = cur_entry->next;
         }
     }

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -236,7 +236,7 @@ static int x509_get_entries( unsigned char **p,
 
         if( *p < end )
         {
-            cur_entry->next = polarssl_calloc( 1, sizeof(x509_crl_entry) );
+            cur_entry->next = polarssl_calloc( 1, sizeof( x509_crl_entry ) );
 
             if( cur_entry->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -278,7 +278,7 @@ int x509_crl_parse_der( x509_crl *chain,
 
     if( crl->version != 0 && crl->next == NULL )
     {
-        crl->next = polarssl_calloc( 1, sizeof(x509_crl) );
+        crl->next = polarssl_calloc( 1, sizeof( x509_crl ) );
 
         if( crl->next == NULL )
         {
@@ -696,7 +696,7 @@ int x509_crl_info( char *buf, size_t size, const char *prefix,
  */
 void x509_crl_init( x509_crl *crl )
 {
-    memset( crl, 0, sizeof(x509_crl) );
+    memset( crl, 0, sizeof( x509_crl ) );
 }
 
 /*

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -48,6 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -235,7 +236,7 @@ static int x509_get_entries( unsigned char **p,
 
         if( *p < end )
         {
-            cur_entry->next = polarssl_malloc( sizeof( x509_crl_entry ) );
+            cur_entry->next = polarssl_calloc(1, sizeof(x509_crl_entry));
 
             if( cur_entry->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -277,7 +278,7 @@ int x509_crl_parse_der( x509_crl *chain,
 
     if( crl->version != 0 && crl->next == NULL )
     {
-        crl->next = polarssl_malloc( sizeof( x509_crl ) );
+        crl->next = polarssl_calloc(1, sizeof(x509_crl));
 
         if( crl->next == NULL )
         {

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -293,7 +293,7 @@ int x509_crl_parse_der( x509_crl *chain,
     /*
      * Copy raw DER-encoded CRL
      */
-    if( ( p = polarssl_calloc(1, buflen)) == NULL )
+    if( ( p = polarssl_calloc( 1, buflen ) ) == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -48,7 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -236,7 +236,7 @@ static int x509_get_entries( unsigned char **p,
 
         if( *p < end )
         {
-            cur_entry->next = polarssl_calloc(1, sizeof(x509_crl_entry));
+            cur_entry->next = polarssl_calloc( 1, sizeof(x509_crl_entry) );
 
             if( cur_entry->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -278,7 +278,7 @@ int x509_crl_parse_der( x509_crl *chain,
 
     if( crl->version != 0 && crl->next == NULL )
     {
-        crl->next = polarssl_calloc(1, sizeof(x509_crl));
+        crl->next = polarssl_calloc( 1, sizeof(x509_crl) );
 
         if( crl->next == NULL )
         {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -357,7 +357,7 @@ static int x509_get_subject_alt_name( unsigned char **p,
             if( cur->next != NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS );
 
-            cur->next = polarssl_calloc( 1, sizeof(asn1_sequence) );
+            cur->next = polarssl_calloc( 1, sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS +
@@ -807,7 +807,7 @@ int x509_crt_parse_der( x509_crt *chain, const unsigned char *buf,
      */
     if( crt->version != 0 && crt->next == NULL )
     {
-        crt->next = polarssl_calloc( 1, sizeof(x509_crt) );
+        crt->next = polarssl_calloc( 1, sizeof( x509_crt ) );
 
         if( crt->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -978,7 +978,7 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
     if( len > MAX_PATH - 3 )
         return( POLARSSL_ERR_X509_BAD_INPUT_DATA );
 
-    memset( szDir, 0, sizeof(szDir) );
+    memset( szDir, 0, sizeof( szDir ) );
     memset( filename, 0, MAX_PATH );
     memcpy( filename, path, len );
     filename[len++] = '\\';
@@ -2013,7 +2013,7 @@ int x509_crt_verify( x509_crt *crt,
  */
 void x509_crt_init( x509_crt *crt )
 {
-    memset( crt, 0, sizeof(x509_crt) );
+    memset( crt, 0, sizeof( x509_crt ) );
 }
 
 /*

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -48,7 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -357,7 +357,7 @@ static int x509_get_subject_alt_name( unsigned char **p,
             if( cur->next != NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS );
 
-            cur->next = polarssl_calloc(1, sizeof(asn1_sequence));
+            cur->next = polarssl_calloc( 1, sizeof(asn1_sequence) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS +
@@ -807,7 +807,7 @@ int x509_crt_parse_der( x509_crt *chain, const unsigned char *buf,
      */
     if( crt->version != 0 && crt->next == NULL )
     {
-        crt->next = polarssl_calloc(1, sizeof(x509_crt));
+        crt->next = polarssl_calloc( 1, sizeof(x509_crt) );
 
         if( crt->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -363,7 +363,6 @@ static int x509_get_subject_alt_name( unsigned char **p,
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS +
                         POLARSSL_ERR_ASN1_MALLOC_FAILED );
 
-            memset( cur->next, 0, sizeof( asn1_sequence ) );
             cur = cur->next;
         }
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -550,7 +550,8 @@ static int x509_crt_parse_der_core( x509_crt *crt, const unsigned char *buf,
     if( crt == NULL || buf == NULL )
         return( POLARSSL_ERR_X509_BAD_INPUT_DATA );
 
-    p = polarssl_malloc( len = buflen );
+    len = buflen;
+    p = polarssl_calloc( 1, len );
 
     if( p == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -48,6 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -356,7 +357,7 @@ static int x509_get_subject_alt_name( unsigned char **p,
             if( cur->next != NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS );
 
-            cur->next = polarssl_malloc( sizeof( asn1_sequence ) );
+            cur->next = polarssl_calloc(1, sizeof(asn1_sequence));
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS +
@@ -806,7 +807,7 @@ int x509_crt_parse_der( x509_crt *chain, const unsigned char *buf,
      */
     if( crt->version != 0 && crt->next == NULL )
     {
-        crt->next = polarssl_malloc( sizeof( x509_crt ) );
+        crt->next = polarssl_calloc(1, sizeof(x509_crt));
 
         if( crt->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -421,7 +421,7 @@ int x509_csr_info( char *buf, size_t size, const char *prefix,
  */
 void x509_csr_init( x509_csr *csr )
 {
-    memset( csr, 0, sizeof(x509_csr) );
+    memset( csr, 0, sizeof( x509_csr ) );
 }
 
 /*

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -48,6 +48,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -110,7 +111,8 @@ int x509_csr_parse_der( x509_csr *csr,
     /*
      * first copy the raw DER data
      */
-    p = polarssl_malloc( len = buflen );
+    len = buflen;
+    p = polarssl_calloc( 1, len );
 
     if( p == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -50,7 +50,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
 
 void x509write_crt_init( x509write_cert *ctx )
 {
-    memset( ctx, 0, sizeof(x509write_cert) );
+    memset( ctx, 0, sizeof( x509write_cert ) );
 
     mpi_init( &ctx->serial );
     ctx->version = X509_CRT_VERSION_3;
@@ -64,7 +64,7 @@ void x509write_crt_free( x509write_cert *ctx )
     asn1_free_named_data_list( &ctx->issuer );
     asn1_free_named_data_list( &ctx->extensions );
 
-    polarssl_zeroize( ctx, sizeof(x509write_cert) );
+    polarssl_zeroize( ctx, sizeof( x509write_cert ) );
 }
 
 void x509write_crt_set_version( x509write_cert *ctx, int version )
@@ -139,10 +139,10 @@ int x509write_crt_set_basic_constraints( x509write_cert *ctx,
 {
     int ret;
     unsigned char buf[9];
-    unsigned char *c = buf + sizeof(buf);
+    unsigned char *c = buf + sizeof( buf );
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    memset( buf, 0, sizeof( buf ) );
 
     if( is_ca && max_pathlen > 127 )
         return( POLARSSL_ERR_X509_BAD_INPUT_DATA );
@@ -162,7 +162,7 @@ int x509write_crt_set_basic_constraints( x509write_cert *ctx,
 
     return x509write_crt_set_extension( ctx, OID_BASIC_CONSTRAINTS,
                                         OID_SIZE( OID_BASIC_CONSTRAINTS ),
-                                        0, buf + sizeof(buf) - len, len );
+                                        0, buf + sizeof( buf ) - len, len );
 }
 
 #if defined(POLARSSL_SHA1_C)
@@ -170,14 +170,14 @@ int x509write_crt_set_subject_key_identifier( x509write_cert *ctx )
 {
     int ret;
     unsigned char buf[POLARSSL_MPI_MAX_SIZE * 2 + 20]; /* tag, length + 2xMPI */
-    unsigned char *c = buf + sizeof(buf);
+    unsigned char *c = buf + sizeof( buf );
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    memset( buf, 0, sizeof( buf ) );
     ASN1_CHK_ADD( len, pk_write_pubkey( &c, buf, ctx->subject_key ) );
 
-    sha1( buf + sizeof(buf) - len, len, buf + sizeof(buf) - 20 );
-    c = buf + sizeof(buf) - 20;
+    sha1( buf + sizeof( buf ) - len, len, buf + sizeof( buf ) - 20 );
+    c = buf + sizeof( buf ) - 20;
     len = 20;
 
     ASN1_CHK_ADD( len, asn1_write_len( &c, buf, len ) );
@@ -185,21 +185,21 @@ int x509write_crt_set_subject_key_identifier( x509write_cert *ctx )
 
     return x509write_crt_set_extension( ctx, OID_SUBJECT_KEY_IDENTIFIER,
                                         OID_SIZE( OID_SUBJECT_KEY_IDENTIFIER ),
-                                        0, buf + sizeof(buf) - len, len );
+                                        0, buf + sizeof( buf ) - len, len );
 }
 
 int x509write_crt_set_authority_key_identifier( x509write_cert *ctx )
 {
     int ret;
     unsigned char buf[POLARSSL_MPI_MAX_SIZE * 2 + 20]; /* tag, length + 2xMPI */
-    unsigned char *c = buf + sizeof(buf);
+    unsigned char *c = buf + sizeof( buf );
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    memset( buf, 0, sizeof( buf ) );
     ASN1_CHK_ADD( len, pk_write_pubkey( &c, buf, ctx->issuer_key ) );
 
-    sha1( buf + sizeof(buf) - len, len, buf + sizeof(buf) - 20 );
-    c = buf + sizeof(buf) - 20;
+    sha1( buf + sizeof( buf ) - len, len, buf + sizeof( buf ) - 20 );
+    c = buf + sizeof( buf ) - 20;
     len = 20;
 
     ASN1_CHK_ADD( len, asn1_write_len( &c, buf, len ) );
@@ -211,7 +211,7 @@ int x509write_crt_set_authority_key_identifier( x509write_cert *ctx )
 
     return x509write_crt_set_extension( ctx, OID_AUTHORITY_KEY_IDENTIFIER,
                                    OID_SIZE( OID_AUTHORITY_KEY_IDENTIFIER ),
-                                   0, buf + sizeof(buf) - len, len );
+                                   0, buf + sizeof( buf ) - len, len );
 }
 #endif /* POLARSSL_SHA1_C */
 
@@ -429,14 +429,14 @@ int x509write_crt_pem( x509write_cert *crt, unsigned char *buf, size_t size,
     unsigned char output_buf[4096];
     size_t olen = 0;
 
-    if( ( ret = x509write_crt_der( crt, output_buf, sizeof(output_buf),
+    if( ( ret = x509write_crt_der( crt, output_buf, sizeof( output_buf ),
                                    f_rng, p_rng ) ) < 0 )
     {
         return( ret );
     }
 
     if( ( ret = pem_write_buffer( PEM_BEGIN_CRT, PEM_END_CRT,
-                                  output_buf + sizeof(output_buf) - ret,
+                                  output_buf + sizeof( output_buf ) - ret,
                                   ret, buf, size, &olen ) ) != 0 )
     {
         return( ret );

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -51,7 +51,7 @@ static void polarssl_zeroize( void *v, size_t n ) {
 
 void x509write_csr_init( x509write_csr *ctx )
 {
-    memset( ctx, 0, sizeof(x509write_csr) );
+    memset( ctx, 0, sizeof( x509write_csr ) );
 }
 
 void x509write_csr_free( x509write_csr *ctx )
@@ -59,7 +59,7 @@ void x509write_csr_free( x509write_csr *ctx )
     asn1_free_named_data_list( &ctx->subject );
     asn1_free_named_data_list( &ctx->extensions );
 
-    polarssl_zeroize( ctx, sizeof(x509write_csr) );
+    polarssl_zeroize( ctx, sizeof( x509write_csr ) );
 }
 
 void x509write_csr_set_md_alg( x509write_csr *ctx, md_type_t md_alg )
@@ -237,14 +237,14 @@ int x509write_csr_pem( x509write_csr *ctx, unsigned char *buf, size_t size,
     unsigned char output_buf[4096];
     size_t olen = 0;
 
-    if( ( ret = x509write_csr_der( ctx, output_buf, sizeof(output_buf),
+    if( ( ret = x509write_csr_der( ctx, output_buf, sizeof( output_buf ),
                                    f_rng, p_rng ) ) < 0 )
     {
         return( ret );
     }
 
     if( ( ret = pem_write_buffer( PEM_BEGIN_CSR, PEM_END_CSR,
-                                  output_buf + sizeof(output_buf) - ret,
+                                  output_buf + sizeof( output_buf ) - ret,
                                   ret, buf, size, &olen ) ) != 0 )
     {
         return( ret );

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -86,7 +86,7 @@ void xtea_setup( xtea_context *ctx, const unsigned char key[16] )
 {
     int i;
 
-    memset( ctx, 0, sizeof(xtea_context) );
+    memset( ctx, 0, sizeof( xtea_context ) );
 
     for( i = 0; i < 4; i++ )
     {

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -116,10 +116,10 @@ int main( int argc, char *argv[] )
     }
 
     mode = atoi( argv[1] );
-    memset(IV, 0, sizeof(IV));
-    memset(key, 0, sizeof(key));
-    memset(digest, 0, sizeof(digest));
-    memset(buffer, 0, sizeof(buffer));
+    memset(IV, 0, sizeof( IV) );
+    memset(key, 0, sizeof( key) );
+    memset(digest, 0, sizeof( digest) );
+    memset(buffer, 0, sizeof( buffer) );
 
     if( mode != MODE_ENCRYPT && mode != MODE_DECRYPT )
     {

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -116,10 +116,10 @@ int main( int argc, char *argv[] )
     }
 
     mode = atoi( argv[1] );
-    memset(IV, 0, sizeof( IV) );
-    memset(key, 0, sizeof( key) );
-    memset(digest, 0, sizeof( digest) );
-    memset(buffer, 0, sizeof( buffer) );
+    memset( IV, 0, sizeof( IV ) );
+    memset( key, 0, sizeof( key ) );
+    memset( digest, 0, sizeof( digest ) );
+    memset( buffer, 0, sizeof( buffer ) );
 
     if( mode != MODE_ENCRYPT && mode != MODE_DECRYPT )
     {

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -151,7 +151,7 @@ static int write_private_key( pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len;
+        c = output_buf + sizeof( output_buf ) - len;
     }
 
     if( ( f = fopen( output_file, "wb" ) ) == NULL )

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -95,7 +95,7 @@ int main( int argc, char *argv[] )
      * Set to sane values
      */
     pk_init( &pk );
-    memset( buf, 0, sizeof(buf) );
+    memset( buf, 0, sizeof( buf ) );
 
     if( argc == 0 )
     {
@@ -153,7 +153,7 @@ int main( int argc, char *argv[] )
                 polarssl_printf( " failed\n  !  fopen returned NULL\n" );
                 goto exit;
             }
-            if( fgets( buf, sizeof(buf), f ) == NULL )
+            if( fgets( buf, sizeof( buf ), f ) == NULL )
             {
                 fclose( f );
                 polarssl_printf( "Error: fgets() failed to retrieve password\n" );
@@ -267,7 +267,7 @@ int main( int argc, char *argv[] )
 exit:
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, buf, sizeof(buf) );
+    polarssl_strerror( ret, buf, sizeof( buf ) );
     polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -111,7 +111,7 @@ static int write_public_key( pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof( output_buf ) - len - 1;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )
@@ -153,7 +153,7 @@ static int write_private_key( pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof( output_buf ) - len - 1;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )
@@ -286,7 +286,7 @@ int main( int argc, char *argv[] )
 
         if( ret != 0 )
         {
-            polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+            polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
             polarssl_printf( " failed\n  !  pk_parse_keyfile returned -0x%04x - %s\n\n", -ret, buf );
             goto exit;
         }
@@ -339,7 +339,7 @@ int main( int argc, char *argv[] )
 
         if( ret != 0 )
         {
-            polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+            polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
             polarssl_printf( " failed\n  !  pk_parse_public_key returned -0x%04x - %s\n\n", -ret, buf );
             goto exit;
         }

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -129,7 +129,7 @@ int main( int argc, char *argv[] )
     polarssl_printf( "\n  . Decrypting the encrypted data" );
     fflush( stdout );
 
-    if( ( ret = pk_decrypt( &pk, buf, i, result, &olen, sizeof(result),
+    if( ( ret = pk_decrypt( &pk, buf, i, result, &olen, sizeof( result ),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
         polarssl_printf( " failed\n  ! pk_decrypt returned -0x%04x\n", -ret );
@@ -147,7 +147,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+    polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
     polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -118,7 +118,7 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     if( ( ret = pk_encrypt( &pk, input, strlen( argv[2] ),
-                            buf, &olen, sizeof(buf),
+                            buf, &olen, sizeof( buf ),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
         polarssl_printf( " failed\n  ! pk_encrypt returned -0x%04x\n", -ret );
@@ -148,7 +148,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+    polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
     polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -133,7 +133,7 @@ int main( int argc, char *argv[] )
     /*
      * Write the signature into <filename>-sig.txt
      */
-    snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
+    snprintf( filename, sizeof( filename ), "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {
@@ -158,7 +158,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+    polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
     polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -94,7 +94,7 @@ int main( int argc, char *argv[] )
      * Extract the signature from the text file
      */
     ret = 1;
-    snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
+    snprintf( filename, sizeof( filename ), "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
@@ -103,7 +103,7 @@ int main( int argc, char *argv[] )
     }
 
 
-    i = fread( buf, 1, sizeof(buf), f );
+    i = fread( buf, 1, sizeof( buf ), f );
 
     fclose( f );
 
@@ -135,7 +135,7 @@ exit:
     pk_free( &pk );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
+    polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
     polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -80,7 +80,7 @@ int main( int argc, char *argv[] )
         fwrite( buf, 1, sizeof( buf ), f );
 
         polarssl_printf( "Generating %ldkb of data in file '%s'... %04.1f" \
-                "%% done\r", (long)(sizeof(buf) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
+                "%% done\r", (long)(sizeof( buf ) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }
 

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -109,7 +109,7 @@ int main( int argc, char *argv[] )
         fwrite( buf, 1, sizeof( buf ), f );
 
         polarssl_printf( "Generating %ldkb of data in file '%s'... %04.1f" \
-                "%% done\r", (long)(sizeof(buf) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
+                "%% done\r", (long)(sizeof( buf ) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }
 

--- a/programs/random/gen_random_havege.c
+++ b/programs/random/gen_random_havege.c
@@ -85,7 +85,7 @@ int main( int argc, char *argv[] )
         fwrite( buf, sizeof( buf ), 1, f );
 
         polarssl_printf( "Generating %ldkb of data in file '%s'... %04.1f" \
-                "%% done\r", (long)(sizeof(buf) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
+                "%% done\r", (long)(sizeof( buf ) * k / 1024), argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1197,7 +1197,7 @@ send_request:
     polarssl_printf( "  > Write to server:" );
     fflush( stdout );
 
-    len = snprintf( (char *) buf, sizeof(buf) - 1, GET_REQUEST,
+    len = snprintf( (char *) buf, sizeof( buf ) - 1, GET_REQUEST,
                     opt.request_page );
     tail_len = strlen( GET_REQUEST_END );
 
@@ -1209,7 +1209,7 @@ send_request:
         len += opt.request_size - len - tail_len;
     }
 
-    strncpy( (char *) buf + len, GET_REQUEST_END, sizeof(buf) - len - 1 );
+    strncpy( (char *) buf + len, GET_REQUEST_END, sizeof( buf ) - len - 1 );
     len += tail_len;
 
     /* Truncate if request size is smaller than the "natural" size */

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -116,7 +116,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    memset( &ssl, 0, sizeof(ssl_context) );
+    memset( &ssl, 0, sizeof( ssl_context ) );
 
     entropy_init( &entropy );
     pk_init( &pkey );

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -137,7 +137,7 @@ static void *handle_ssl_connection( void *data )
     memset( &ssl, 0, sizeof( ssl_context ) );
     memset( &ctr_drbg, 0, sizeof( ctr_drbg_context ) );
 
-    snprintf( pers, sizeof(pers), "SSL Pthread Thread %d", thread_id );
+    snprintf( pers, sizeof( pers ), "SSL Pthread Thread %d", thread_id );
     polarssl_printf( "  [ #%d ]  Client FD %d\n", thread_id, client_fd );
     polarssl_printf( "  [ #%d ]  Seeding the random number generator...\n", thread_id );
 
@@ -343,7 +343,7 @@ static int thread_create( int client_fd )
         {
             polarssl_printf( "  [ main ]  Cleaning up thread %d\n", i );
             pthread_join(threads[i].thread, NULL );
-            memset( &threads[i], 0, sizeof(pthread_info_t) );
+            memset( &threads[i], 0, sizeof( pthread_info_t ) );
             break;
         }
     }
@@ -354,7 +354,7 @@ static int thread_create( int client_fd )
     /*
      * Fill thread-info for thread
      */
-    memcpy( &threads[i].data, &base_info, sizeof(base_info) );
+    memcpy( &threads[i].data, &base_info, sizeof( base_info ) );
     threads[i].active = 1;
     threads[i].data.client_fd = client_fd;
 
@@ -386,7 +386,7 @@ int main( int argc, char *argv[] )
     ((void) argv);
 
 #if defined(POLARSSL_MEMORY_BUFFER_ALLOC_C)
-    memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
+    memory_buffer_alloc_init( alloc_buf, sizeof( alloc_buf ) );
 #endif
 
 #if defined(POLARSSL_SSL_CACHE_C)
@@ -394,7 +394,7 @@ int main( int argc, char *argv[] )
     base_info.cache = &cache;
 #endif
 
-    memset( threads, 0, sizeof(threads) );
+    memset( threads, 0, sizeof( threads ) );
 
     polarssl_mutex_init( &debug_mutex );
 

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -108,7 +108,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    memset( &ssl, 0, sizeof(ssl_context) );
+    memset( &ssl, 0, sizeof( ssl_context ) );
 #if defined(POLARSSL_SSL_CACHE_C)
     ssl_cache_init( &cache );
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1695,7 +1695,7 @@ data_exchange:
             ori_len = ret;
             extra_len = ssl_get_bytes_avail( &ssl );
 
-            larger_buf = polarssl_malloc( ori_len + extra_len + 1 );
+            larger_buf = polarssl_calloc( 1, ori_len + extra_len + 1 );
             if( larger_buf == NULL )
             {
                 polarssl_printf( "  ! memory allocation failed\n" );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -32,7 +32,7 @@
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
-#define polarssl_calloc calloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -419,13 +419,14 @@ sni_entry *sni_parse( char *sni_string )
 
     while( p <= end )
     {
-        if( ( new = polarssl_calloc(1, sizeof(sni_entry))) == NULL )
+        if( ( new = polarssl_calloc( 1, sizeof( sni_entry ) ) ) == NULL )
             return( NULL );
 
         memset( new, 0, sizeof( sni_entry ) );
 
-        if( ( new->cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL ||
-            ( new->key = polarssl_calloc(1, sizeof(pk_context))) == NULL )
+        new->cert = polarssl_calloc( 1, sizeof( x509_crt ) );
+        new->key = polarssl_calloc( 1, sizeof( pk_context ) );
+        if( new->cert == NULL || new->key == NULL )
             return( NULL );
 
         x509_crt_init( new->cert );
@@ -558,7 +559,7 @@ psk_entry *psk_parse( char *psk_string )
 
     while( p <= end )
     {
-        if( ( new = polarssl_calloc(1, sizeof(psk_entry))) == NULL )
+        if( ( new = polarssl_calloc( 1, sizeof( psk_entry ) ) ) == NULL )
             return( NULL );
 
         memset( new, 0, sizeof( psk_entry ) );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -32,6 +32,7 @@
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
+#define polarssl_calloc calloc
 #define polarssl_free       free
 #endif
 
@@ -418,13 +419,13 @@ sni_entry *sni_parse( char *sni_string )
 
     while( p <= end )
     {
-        if( ( new = polarssl_malloc( sizeof( sni_entry ) ) ) == NULL )
+        if( ( new = polarssl_calloc(1, sizeof(sni_entry))) == NULL )
             return( NULL );
 
         memset( new, 0, sizeof( sni_entry ) );
 
-        if( ( new->cert = polarssl_malloc( sizeof( x509_crt ) ) ) == NULL ||
-            ( new->key = polarssl_malloc( sizeof( pk_context ) ) ) == NULL )
+        if( ( new->cert = polarssl_calloc(1, sizeof(x509_crt))) == NULL ||
+            ( new->key = polarssl_calloc(1, sizeof(pk_context))) == NULL )
             return( NULL );
 
         x509_crt_init( new->cert );
@@ -557,7 +558,7 @@ psk_entry *psk_parse( char *psk_string )
 
     while( p <= end )
     {
-        if( ( new = polarssl_malloc( sizeof( psk_entry ) ) ) == NULL )
+        if( ( new = polarssl_calloc(1, sizeof(psk_entry))) == NULL )
             return( NULL );
 
         memset( new, 0, sizeof( psk_entry ) );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -422,8 +422,6 @@ sni_entry *sni_parse( char *sni_string )
         if( ( new = polarssl_calloc( 1, sizeof( sni_entry ) ) ) == NULL )
             return( NULL );
 
-        memset( new, 0, sizeof( sni_entry ) );
-
         new->cert = polarssl_calloc( 1, sizeof( x509_crt ) );
         new->key = polarssl_calloc( 1, sizeof( pk_context ) );
         if( new->cert == NULL || new->key == NULL )
@@ -561,8 +559,6 @@ psk_entry *psk_parse( char *psk_string )
     {
         if( ( new = polarssl_calloc( 1, sizeof( psk_entry ) ) ) == NULL )
             return( NULL );
-
-        memset( new, 0, sizeof( psk_entry ) );
 
         GET_ITEM( new->name );
         GET_ITEM( key_hex );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -677,7 +677,7 @@ int main( int argc, char *argv[] )
     const int *list;
 
 #if defined(POLARSSL_MEMORY_BUFFER_ALLOC_C)
-    memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
+    memory_buffer_alloc_init( alloc_buf, sizeof( alloc_buf ) );
 #endif
 
     /*

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -90,8 +90,8 @@ static int myrand( void *rng_state, unsigned char *output, size_t len )
     while( len > 0 )
     {
         use_len = len;
-        if( use_len > sizeof(int) )
-            use_len = sizeof(int);
+        if( use_len > sizeof( int ) )
+            use_len = sizeof( int );
 
         rnd = rand();
         memcpy( output, &rnd, use_len );
@@ -613,7 +613,7 @@ int main( int argc, char *argv[] )
             ecdh_init( &ecdh );
 
             if( ecp_use_known_dp( &ecdh.grp, curve_info->grp_id ) != 0 ||
-                ecdh_make_public( &ecdh, &olen, buf, sizeof( buf),
+                ecdh_make_public( &ecdh, &olen, buf, sizeof(  buf ),
                                   myrand, NULL ) != 0 ||
                 ecp_copy( &ecdh.Qp, &ecdh.Q ) != 0 )
             {
@@ -623,7 +623,7 @@ int main( int argc, char *argv[] )
             snprintf( title, sizeof( title ), "ECDHE-%s",
                                               curve_info->name );
             TIME_PUBLIC( title, "handshake",
-                    ret |= ecdh_make_public( &ecdh, &olen, buf, sizeof( buf),
+                    ret |= ecdh_make_public( &ecdh, &olen, buf, sizeof(  buf ),
                                              myrand, NULL );
                     ret |= ecdh_calc_secret( &ecdh, &olen, buf, sizeof( buf ),
                                              myrand, NULL ) );

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -613,7 +613,7 @@ int main( int argc, char *argv[] )
             ecdh_init( &ecdh );
 
             if( ecp_use_known_dp( &ecdh.grp, curve_info->grp_id ) != 0 ||
-                ecdh_make_public( &ecdh, &olen, buf, sizeof(  buf ),
+                ecdh_make_public( &ecdh, &olen, buf, sizeof( buf ),
                                   myrand, NULL ) != 0 ||
                 ecp_copy( &ecdh.Qp, &ecdh.Q ) != 0 )
             {
@@ -623,7 +623,7 @@ int main( int argc, char *argv[] )
             snprintf( title, sizeof( title ), "ECDHE-%s",
                                               curve_info->name );
             TIME_PUBLIC( title, "handshake",
-                    ret |= ecdh_make_public( &ecdh, &olen, buf, sizeof(  buf ),
+                    ret |= ecdh_make_public( &ecdh, &olen, buf, sizeof( buf ),
                                              myrand, NULL );
                     ret |= ecdh_calc_secret( &ecdh, &olen, buf, sizeof( buf ),
                                              myrand, NULL ) );

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -84,7 +84,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SELF_TEST)
 
 #if defined(POLARSSL_MEMORY_BUFFER_ALLOC_C)
-    memory_buffer_alloc_init( buf, sizeof(buf) );
+    memory_buffer_alloc_init( buf, sizeof( buf ) );
 #endif
 
 #if defined(POLARSSL_MD2_C)

--- a/programs/test/ssl_test.c
+++ b/programs/test/ssl_test.c
@@ -32,6 +32,7 @@
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -295,12 +296,13 @@ static int ssl_test( struct options *opt )
         }
     }
 
-     read_buf = polarssl_malloc( opt->buffer_size );
-    write_buf = polarssl_malloc( opt->buffer_size );
+     read_buf = polarssl_calloc( 1, opt->buffer_size );
+    write_buf = polarssl_calloc( 1, opt->buffer_size );
 
     if( read_buf == NULL || write_buf == NULL )
     {
-        polarssl_printf( "  ! polarssl_malloc(%d bytes) failed\n\n", opt->buffer_size );
+        polarssl_printf( "  ! polarssl_calloc(1, %d bytes) failed\n\n",
+                         opt->buffer_size );
         goto exit;
     }
 

--- a/programs/test/ssl_test.c
+++ b/programs/test/ssl_test.c
@@ -175,7 +175,7 @@ static int ssl_test( struct options *opt )
     x509_crt srvcert;
     pk_context pkey;
 
-    memset( &ssl, 0, sizeof(ssl_context) );
+    memset( &ssl, 0, sizeof( ssl_context ) );
     entropy_init( &entropy );
     x509_crt_init( &srvcert );
     pk_init( &pkey );

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -31,6 +31,7 @@
 #else
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
+#define polarssl_calloc     calloc
 #define polarssl_free       free
 #endif
 
@@ -129,7 +130,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_calloc( 1, *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( -1 );

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -183,15 +183,15 @@ int main( int argc, char *argv[] )
     unsigned char *pem_buffer = NULL;
     unsigned char der_buffer[4096];
     char buf[1024];
-    size_t pem_size, der_size = sizeof(der_buffer);
+    size_t pem_size, der_size = sizeof( der_buffer );
     int i;
     char *p, *q;
 
     /*
      * Set to sane values
      */
-    memset( buf, 0, sizeof(buf) );
-    memset( der_buffer, 0, sizeof(der_buffer) );
+    memset( buf, 0, sizeof( buf ) );
+    memset( der_buffer, 0, sizeof( der_buffer ) );
 
     if( argc == 0 )
     {

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -184,7 +184,7 @@ int main( int argc, char *argv[] )
 #else
     /* Zeroize structure as CRL parsing is not supported and we have to pass
        it to the verify function */
-    memset( &cacrl, 0, sizeof(x509_crl) );
+    memset( &cacrl, 0, sizeof( x509_crl ) );
 #endif
     pk_init( &pkey );
 

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -415,7 +415,7 @@ int main( int argc, char *argv[] )
             goto exit;
         }
 
-        ret = x509_dn_gets( issuer_name, sizeof(issuer_name),
+        ret = x509_dn_gets( issuer_name, sizeof( issuer_name ),
                                  &issuer_crt.subject );
         if( ret < 0 )
         {
@@ -447,7 +447,7 @@ int main( int argc, char *argv[] )
             goto exit;
         }
 
-        ret = x509_dn_gets( subject_name, sizeof(subject_name),
+        ret = x509_dn_gets( subject_name, sizeof( subject_name ),
                                  &csr.subject );
         if( ret < 0 )
         {

--- a/scripts/calloc.cocci
+++ b/scripts/calloc.cocci
@@ -4,7 +4,17 @@ expression m, n;
 - polarssl_malloc(m * n)
 + polarssl_calloc(m, n)
 
-@define depends on malloc_mul@
+@malloc_sizeof@
+type T;
+@@
+- polarssl_malloc(sizeof(T))
++ polarssl_calloc(1, sizeof(T))
+
+@definition@
+@@
+  #define polarssl_calloc calloc
+
+@define depends on !definition && (malloc_mul || malloc_sizeof)@
 @@
   #define polarssl_malloc malloc
 + #define polarssl_calloc calloc

--- a/scripts/calloc.cocci
+++ b/scripts/calloc.cocci
@@ -16,12 +16,18 @@ constant C;
 - polarssl_malloc(C)
 + polarssl_calloc(1, C)
 
+@malloc_var@
+identifier x;
+@@
+- polarssl_malloc(x)
++ polarssl_calloc(1, x)
+
 @definition@
 @@
   #define polarssl_calloc calloc
 
 @define depends on !definition &&
-  (malloc_mul || malloc_sizeof || malloc_constant)@
+  (malloc_mul || malloc_sizeof || malloc_constant || malloc_var)@
 @@
   #define polarssl_malloc malloc
 + #define polarssl_calloc calloc

--- a/scripts/calloc.cocci
+++ b/scripts/calloc.cocci
@@ -1,0 +1,10 @@
+@malloc_mul@
+expression m, n;
+@@
+- polarssl_malloc(m * n)
++ polarssl_calloc(m, n)
+
+@define depends on malloc_mul@
+@@
+  #define polarssl_malloc malloc
++ #define polarssl_calloc calloc

--- a/scripts/calloc.cocci
+++ b/scripts/calloc.cocci
@@ -10,11 +10,18 @@ type T;
 - polarssl_malloc(sizeof(T))
 + polarssl_calloc(1, sizeof(T))
 
+@malloc_constant@
+constant C;
+@@
+- polarssl_malloc(C)
++ polarssl_calloc(1, C)
+
 @definition@
 @@
   #define polarssl_calloc calloc
 
-@define depends on !definition && (malloc_mul || malloc_sizeof)@
+@define depends on !definition &&
+  (malloc_mul || malloc_sizeof || malloc_constant)@
 @@
   #define polarssl_malloc malloc
 + #define polarssl_calloc calloc

--- a/scripts/rm-zero-after-calloc.cocci
+++ b/scripts/rm-zero-after-calloc.cocci
@@ -1,0 +1,6 @@
+@@
+expression x;
+@@
+  x = polarssl_calloc(...)
+  ...
+- memset(x, 0, ...);


### PR DESCRIPTION
In this branch I try to replace malloc with calloc as much as possible, to avoid uninitialized memory.

On Linux calloc returns immediately and the pages are zeroed when they are accessed, so the performance impact is minimal.

The changes build and all tests pass on OS X with Clang.