### PR TITLE
build: Makefile: misc cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,18 @@ OLDPREFIX=polarssl_
 
 .SILENT:
 
-all:
-	cd library  && $(MAKE) all && cd ..
-	cd programs && $(MAKE) all && cd ..
-	cd tests    && $(MAKE) all && cd ..
+all:	programs tests
 
-no_test:
-	cd library  && $(MAKE) all && cd ..
-	cd programs && $(MAKE) all && cd ..
+no_test:	programs
+
+programs:	lib
+	$(MAKE) -C programs
 
 lib:
-	cd library  && $(MAKE) all && cd ..
+	$(MAKE) -C library
+
+tests:	lib
+	$(MAKE) -C tests
 
 install:
 	mkdir -p $(DESTDIR)/include/polarssl
@@ -51,13 +52,13 @@ uninstall:
 	done
 
 clean:
-	cd library  && $(MAKE) clean && cd ..
-	cd programs && $(MAKE) clean && cd ..
-	cd tests    && $(MAKE) clean && cd ..
+	$(MAKE) -C library clean
+	$(MAKE) -C programs clean
+	$(MAKE) -C tests clean
 	find . \( -name \*.gcno -o -name \*.gcda -o -name *.info \) -exec rm {} +
 
-check: lib
-	( cd tests && $(MAKE) && $(MAKE) check )
+check: tests
+	$(MAKE) -C tests check
 
 test-ref-configs:
 	tests/scripts/test-ref-configs.pl

--- a/library/Makefile
+++ b/library/Makefile
@@ -25,10 +25,7 @@ endif
 
 # To compile as a shared library:
 ifdef SHARED
-# all code is position-indep with mingw, avoid warning about useless flag
-ifndef WINDOWS_BUILD
 LOCAL_CFLAGS += -fPIC -fpic
-endif
 endif
 
 SOEXT=so.8

--- a/library/Makefile
+++ b/library/Makefile
@@ -1,11 +1,10 @@
 
 # Also see "include/polarssl/config.h"
 
-# To compile on MinGW: add "-lws2_32" to LDFLAGS or define WINDOWS in your
-# environment
-#
 CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
 OFLAGS	= -O2
+LDFLAGS ?=
+LOCAL_LDFLAGS =
 
 ifdef DEBUG
 CFLAGS += -g3
@@ -26,7 +25,7 @@ endif
 ifdef SHARED
 # all code is position-indep with mingw, avoid warning about useless flag
 ifndef WINDOWS_BUILD
-CFLAGS += -fPIC
+LOCAL_CFLAGS += -fPIC
 endif
 endif
 
@@ -39,7 +38,6 @@ DLEXT=so
 # Windows shared library extension:
 ifdef WINDOWS_BUILD
 DLEXT=dll
-LDFLAGS += -lws2_32
 endif
 
 OBJS=	aes.o		aesni.o		arc4.o			\
@@ -114,7 +112,7 @@ endif
 
 libmbedtls.$(SOEXT): $(OBJS)
 	echo "  LD    $@"
-	$(CC) ${LDFLAGS} -shared -Wl,-soname,$@ -o $@ $(OBJS)
+	$(CC) -shared -Wl,-soname,$@ $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS)
 
 libmbedtls.so: libmbedtls.$(SOEXT)
 	echo "  LN    $@ -> libmbedtls.$(SOEXT)"
@@ -122,11 +120,11 @@ libmbedtls.so: libmbedtls.$(SOEXT)
 
 libmbedtls.dylib: $(OBJS)
 	echo "  LD    $@"
-	$(CC) ${LDFLAGS} -dynamiclib -o $@ $(OBJS)
+	$(CC) -dynamiclib $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS)
 
 libmbedtls.dll: $(OBJS)
 	echo "  LD    $@"
-	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS) -lws2_32 -lwinmm -lgdi32
+	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS) -lws2_32 -lwinmm -lgdi32 $(LOCAL_LDFLAGS) $(LDFLAGS)
 
 .c.o:
 	echo "  CC    $<"

--- a/library/Makefile
+++ b/library/Makefile
@@ -1,13 +1,15 @@
 
 # Also see "include/polarssl/config.h"
 
-CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
-OFLAGS	= -O2
+CFLAGS	?= -O2
+WARNING_CFLAGS ?=  -Wall -W -Wdeclaration-after-statement
 LDFLAGS ?=
+
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS =
 
 ifdef DEBUG
-CFLAGS += -g3
+LOCAL_CFLAGS += -g3
 endif
 
 # MicroBlaze specific options:
@@ -25,7 +27,7 @@ endif
 ifdef SHARED
 # all code is position-indep with mingw, avoid warning about useless flag
 ifndef WINDOWS_BUILD
-LOCAL_CFLAGS += -fPIC
+LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
@@ -128,7 +130,7 @@ libmbedtls.dll: $(OBJS)
 
 .c.o:
 	echo "  CC    $<"
-	$(CC) $(CFLAGS) $(OFLAGS) -c $<
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -c $<
 
 clean:
 ifndef WINDOWS

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -2,13 +2,15 @@
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
-CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
-OFLAGS	= -O2
+CFLAGS	?= -O2
+WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement
 LDFLAGS ?=
+
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = -L../library -lmbedtls$(SHARED_SUFFIX)
 
 ifdef DEBUG
-CFLAGS += -g3
+LOCAL_CFLAGS += -g3
 endif
 
 #
@@ -72,191 +74,191 @@ all: $(APPS)
 
 aes/aescrypt2$(EXEXT): aes/aescrypt2.c ../library/libmbedtls.a
 	echo   "  CC    aes/aescrypt2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) aes/aescrypt2.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/aescrypt2.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c ../library/libmbedtls.a
 	echo   "  CC    aes/crypt_and_hash.c"
-	$(CC) $(CFLAGS) $(OFLAGS) aes/crypt_and_hash.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) aes/crypt_and_hash.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/hello$(EXEXT): hash/hello.c ../library/libmbedtls.a
 	echo   "  CC    hash/hello.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/hello.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/hello.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/generic_sum$(EXEXT): hash/generic_sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/generic_sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/generic_sum.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/generic_sum.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/md5sum$(EXEXT): hash/md5sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/md5sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/md5sum.c      $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/md5sum.c      $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/sha1sum$(EXEXT): hash/sha1sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha1sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/sha1sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/sha1sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/sha2sum$(EXEXT): hash/sha2sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha2sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/sha2sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) hash/sha2sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_client$(EXEXT): pkey/dh_client.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_genprime$(EXEXT): pkey/dh_genprime.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_genprime.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_genprime.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_genprime.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_server$(EXEXT): pkey/dh_server.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/dh_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/ecdsa$(EXEXT): pkey/ecdsa.c ../library/libmbedtls.a
 	echo   "  CC    pkey/ecdsa.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/ecdsa.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/ecdsa.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/gen_key$(EXEXT): pkey/gen_key.c ../library/libmbedtls.a
 	echo   "  CC    pkey/gen_key.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/gen_key.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/gen_key.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/key_app$(EXEXT): pkey/key_app.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/key_app_writer$(EXEXT): pkey/key_app_writer.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app_writer.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app_writer.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/key_app_writer.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/mpi_demo$(EXEXT): pkey/mpi_demo.c ../library/libmbedtls.a
 	echo   "  CC    pkey/mpi_demo.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/mpi_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/mpi_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_decrypt$(EXEXT): pkey/pk_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_decrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_encrypt$(EXEXT): pkey/pk_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_encrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_sign$(EXEXT): pkey/pk_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_sign.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_verify$(EXEXT): pkey/pk_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_verify.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/pk_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_genkey$(EXEXT): pkey/rsa_genkey.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_genkey.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_genkey.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_genkey.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_sign$(EXEXT): pkey/rsa_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_verify$(EXEXT): pkey/rsa_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_sign_pss$(EXEXT): pkey/rsa_sign_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign_pss.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign_pss.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_sign_pss.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify_pss.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify_pss.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_verify_pss.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_decrypt$(EXEXT): pkey/rsa_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_decrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_encrypt$(EXEXT): pkey/rsa_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_encrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) pkey/rsa_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_entropy$(EXEXT): random/gen_entropy.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_entropy.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_entropy.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_entropy.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_random_havege$(EXEXT): random/gen_random_havege.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_havege.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_havege.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_havege.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_random_ctr_drbg$(EXEXT): random/gen_random_ctr_drbg.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_ctr_drbg.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_ctr_drbg.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) random/gen_random_ctr_drbg.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_client1$(EXEXT): ssl/ssl_client1.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client1.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client1.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client1.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_client2$(EXEXT): ssl/ssl_client2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client2.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_client2.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_server$(EXEXT): ssl/ssl_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server2.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_server2.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_fork_server$(EXEXT): ssl/ssl_fork_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_fork_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_fork_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_fork_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_pthread_server$(EXEXT): ssl/ssl_pthread_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_pthread_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_pthread_server.c   $(LOCAL_LDFLAGS) -lpthread  $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_pthread_server.c   $(LOCAL_LDFLAGS) -lpthread  $(LDFLAGS) -o $@
 
 ssl/ssl_mail_client$(EXEXT): ssl/ssl_mail_client.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_mail_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_mail_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/ssl_mail_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/mini_client$(EXEXT): ssl/mini_client.c ../library/libmbedtls.a
 	echo   "  CC    ssl/mini_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/mini_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) ssl/mini_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/ssl_cert_test$(EXEXT): test/ssl_cert_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_cert_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_cert_test.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/ssl_cert_test.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/benchmark$(EXEXT): test/benchmark.c ../library/libmbedtls.a
 	echo   "  CC    test/benchmark.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/benchmark.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/benchmark.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/selftest$(EXEXT): test/selftest.c ../library/libmbedtls.a
 	echo   "  CC    test/selftest.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/selftest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/selftest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/ssl_test$(EXEXT): test/ssl_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_test.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/ssl_test.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/o_p_test$(EXEXT): test/o_p_test.c ../library/libmbedtls.a
 	echo   "  CC    test/o_p_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/o_p_test.c    $(LOCAL_LDFLAGS) -lssl -lcrypto  $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) test/o_p_test.c    $(LOCAL_LDFLAGS) -lssl -lcrypto  $(LDFLAGS) -o $@
 
 util/pem2der$(EXEXT): util/pem2der.c ../library/libmbedtls.a
 	echo   "  CC    util/pem2der.c"
-	$(CC) $(CFLAGS) $(OFLAGS) util/pem2der.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/pem2der.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 util/strerror$(EXEXT): util/strerror.c ../library/libmbedtls.a
 	echo   "  CC    util/strerror.c"
-	$(CC) $(CFLAGS) $(OFLAGS) util/strerror.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) util/strerror.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/cert_app$(EXEXT): x509/cert_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/crl_app$(EXEXT): x509/crl_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/crl_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/crl_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/crl_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/cert_req$(EXEXT): x509/cert_req.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_req.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_req.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) x509/cert_req.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -1,11 +1,11 @@
 
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
-# To compile on MinGW: add "-lws2_32" to LDFLAGS or define WINDOWS in your env
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
 OFLAGS	= -O2
-LDFLAGS	+= -L../library -lmbedtls$(SHARED_SUFFIX) $(SYS_LDFLAGS)
+LDFLAGS ?=
+LOCAL_LDFLAGS = -L../library -lmbedtls$(SHARED_SUFFIX)
 
 ifdef DEBUG
 CFLAGS += -g3
@@ -22,7 +22,7 @@ endif
 ifdef WINDOWS_BUILD
 DLEXT=dll
 EXEXT=.exe
-LDFLAGS += -lws2_32
+LOCAL_LDFLAGS += -lws2_32
 ifdef SHARED
 SHARED_SUFFIX=.$(DLEXT)
 endif
@@ -30,7 +30,7 @@ endif
 
 # Zlib shared library extensions:
 ifdef ZLIB
-LDFLAGS += -lz
+LOCAL_LDFLAGS += -lz
 endif
 
 APPS =	aes/aescrypt2$(EXEXT)		aes/crypt_and_hash$(EXEXT)	\
@@ -72,191 +72,191 @@ all: $(APPS)
 
 aes/aescrypt2$(EXEXT): aes/aescrypt2.c ../library/libmbedtls.a
 	echo   "  CC    aes/aescrypt2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) aes/aescrypt2.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) aes/aescrypt2.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c ../library/libmbedtls.a
 	echo   "  CC    aes/crypt_and_hash.c"
-	$(CC) $(CFLAGS) $(OFLAGS) aes/crypt_and_hash.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) aes/crypt_and_hash.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/hello$(EXEXT): hash/hello.c ../library/libmbedtls.a
 	echo   "  CC    hash/hello.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/hello.c       $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) hash/hello.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/generic_sum$(EXEXT): hash/generic_sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/generic_sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/generic_sum.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) hash/generic_sum.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/md5sum$(EXEXT): hash/md5sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/md5sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/md5sum.c      $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) hash/md5sum.c      $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/sha1sum$(EXEXT): hash/sha1sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha1sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/sha1sum.c     $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) hash/sha1sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 hash/sha2sum$(EXEXT): hash/sha2sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha2sum.c"
-	$(CC) $(CFLAGS) $(OFLAGS) hash/sha2sum.c     $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) hash/sha2sum.c     $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_client$(EXEXT): pkey/dh_client.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_client.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_genprime$(EXEXT): pkey/dh_genprime.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_genprime.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_genprime.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_genprime.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/dh_server$(EXEXT): pkey/dh_server.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_server.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/ecdsa$(EXEXT): pkey/ecdsa.c ../library/libmbedtls.a
 	echo   "  CC    pkey/ecdsa.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/ecdsa.c       $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/ecdsa.c       $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/gen_key$(EXEXT): pkey/gen_key.c ../library/libmbedtls.a
 	echo   "  CC    pkey/gen_key.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/gen_key.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/gen_key.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/key_app$(EXEXT): pkey/key_app.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/key_app_writer$(EXEXT): pkey/key_app_writer.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app_writer.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app_writer.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app_writer.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/mpi_demo$(EXEXT): pkey/mpi_demo.c ../library/libmbedtls.a
 	echo   "  CC    pkey/mpi_demo.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/mpi_demo.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/mpi_demo.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_decrypt$(EXEXT): pkey/pk_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_decrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_decrypt.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_encrypt$(EXEXT): pkey/pk_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_encrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_encrypt.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_sign$(EXEXT): pkey/pk_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_sign.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_sign.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/pk_verify$(EXEXT): pkey/pk_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_verify.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_verify.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_genkey$(EXEXT): pkey/rsa_genkey.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_genkey.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_genkey.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_genkey.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_sign$(EXEXT): pkey/rsa_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_verify$(EXEXT): pkey/rsa_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_sign_pss$(EXEXT): pkey/rsa_sign_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign_pss.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign_pss.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign_pss.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify_pss.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify_pss.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify_pss.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_decrypt$(EXEXT): pkey/rsa_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_decrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_decrypt.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_decrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 pkey/rsa_encrypt$(EXEXT): pkey/rsa_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_encrypt.c"
-	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_encrypt.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_encrypt.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_entropy$(EXEXT): random/gen_entropy.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_entropy.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_entropy.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) random/gen_entropy.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_random_havege$(EXEXT): random/gen_random_havege.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_havege.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_havege.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_havege.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 random/gen_random_ctr_drbg$(EXEXT): random/gen_random_ctr_drbg.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_ctr_drbg.c"
-	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_ctr_drbg.c $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_ctr_drbg.c $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_client1$(EXEXT): ssl/ssl_client1.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client1.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client1.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client1.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_client2$(EXEXT): ssl/ssl_client2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client2.c  $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client2.c  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_server$(EXEXT): ssl/ssl_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server2.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server2.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server2.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_fork_server$(EXEXT): ssl/ssl_fork_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_fork_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_fork_server.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_fork_server.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/ssl_pthread_server$(EXEXT): ssl/ssl_pthread_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_pthread_server.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_pthread_server.c   $(LDFLAGS) -o $@ -lpthread
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_pthread_server.c   $(LOCAL_LDFLAGS) -lpthread  $(LDFLAGS) -o $@
 
 ssl/ssl_mail_client$(EXEXT): ssl/ssl_mail_client.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_mail_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_mail_client.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_mail_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 ssl/mini_client$(EXEXT): ssl/mini_client.c ../library/libmbedtls.a
 	echo   "  CC    ssl/mini_client.c"
-	$(CC) $(CFLAGS) $(OFLAGS) ssl/mini_client.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) ssl/mini_client.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/ssl_cert_test$(EXEXT): test/ssl_cert_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_cert_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_cert_test.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_cert_test.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/benchmark$(EXEXT): test/benchmark.c ../library/libmbedtls.a
 	echo   "  CC    test/benchmark.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/benchmark.c   $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) test/benchmark.c   $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/selftest$(EXEXT): test/selftest.c ../library/libmbedtls.a
 	echo   "  CC    test/selftest.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/selftest.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) test/selftest.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/ssl_test$(EXEXT): test/ssl_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_test.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_test.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test/o_p_test$(EXEXT): test/o_p_test.c ../library/libmbedtls.a
 	echo   "  CC    test/o_p_test.c"
-	$(CC) $(CFLAGS) $(OFLAGS) test/o_p_test.c    $(LDFLAGS) -o $@ -lssl -lcrypto
+	$(CC) $(CFLAGS) $(OFLAGS) test/o_p_test.c    $(LOCAL_LDFLAGS) -lssl -lcrypto  $(LDFLAGS) -o $@
 
 util/pem2der$(EXEXT): util/pem2der.c ../library/libmbedtls.a
 	echo   "  CC    util/pem2der.c"
-	$(CC) $(CFLAGS) $(OFLAGS) util/pem2der.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) util/pem2der.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 util/strerror$(EXEXT): util/strerror.c ../library/libmbedtls.a
 	echo   "  CC    util/strerror.c"
-	$(CC) $(CFLAGS) $(OFLAGS) util/strerror.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) util/strerror.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/cert_app$(EXEXT): x509/cert_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_app.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/crl_app$(EXEXT): x509/crl_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/crl_app.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/crl_app.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) x509/crl_app.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 x509/cert_req$(EXEXT): x509/cert_req.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_req.c"
-	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_req.c    $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_req.c    $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,11 +2,11 @@
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
-CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement \
-			-Wno-unused-function -Wno-unused-value
-
-OFLAGS	= -O2
+CFLAGS	?= -O2
+WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -Wno-unused-function -Wno-unused-value
 LDFLAGS ?=
+
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = -L../library -lmbedtls$(SHARED_SUFFIX)
 DLEXT=so
 
@@ -19,7 +19,7 @@ CHECK_PRELOAD= LD_PRELOAD=../library/libmbedtls.$(DLEXT)
 endif
 
 ifdef DEBUG
-CFLAGS += -g3
+LOCAL_CFLAGS += -g3
 endif
 
 #
@@ -189,231 +189,231 @@ test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_sui
 
 test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.cbc$(EXEXT): test_suite_aes.cbc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.cfb$(EXEXT): test_suite_aes.cfb.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.rest$(EXEXT): test_suite_aes.rest.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_arc4$(EXEXT): test_suite_arc4.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_asn1write$(EXEXT): test_suite_asn1write.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_base64$(EXEXT): test_suite_base64.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_blowfish$(EXEXT): test_suite_blowfish.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_camellia$(EXEXT): test_suite_camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ccm$(EXEXT): test_suite_ccm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.aes$(EXEXT): test_suite_cipher.aes.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.arc4$(EXEXT): test_suite_cipher.arc4.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.ccm$(EXEXT): test_suite_cipher.ccm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.gcm$(EXEXT): test_suite_cipher.gcm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.blowfish$(EXEXT): test_suite_cipher.blowfish.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.camellia$(EXEXT): test_suite_cipher.camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.des$(EXEXT): test_suite_cipher.des.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.null$(EXEXT): test_suite_cipher.null.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.padding$(EXEXT): test_suite_cipher.padding.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ctr_drbg$(EXEXT): test_suite_ctr_drbg.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_des$(EXEXT): test_suite_des.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_dhm$(EXEXT): test_suite_dhm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecdh$(EXEXT): test_suite_ecdh.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecdsa$(EXEXT): test_suite_ecdsa.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecp$(EXEXT): test_suite_ecp.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_entropy$(EXEXT): test_suite_entropy.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_error$(EXEXT): test_suite_error.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes128_de$(EXEXT): test_suite_gcm.aes128_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes192_de$(EXEXT): test_suite_gcm.aes192_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes256_de$(EXEXT): test_suite_gcm.aes256_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes128_en$(EXEXT): test_suite_gcm.aes128_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes192_en$(EXEXT): test_suite_gcm.aes192_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes256_en$(EXEXT): test_suite_gcm.aes256_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.camellia$(EXEXT): test_suite_gcm.camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.misc$(EXEXT): test_suite_hmac_drbg.misc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.no_reseed$(EXEXT): test_suite_hmac_drbg.no_reseed.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.nopr$(EXEXT): test_suite_hmac_drbg.nopr.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.pr$(EXEXT): test_suite_hmac_drbg.pr.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_shax$(EXEXT): test_suite_hmac_shax.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_md$(EXEXT): test_suite_md.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_mdx$(EXEXT): test_suite_mdx.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_memory_buffer_alloc$(EXEXT): test_suite_memory_buffer_alloc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_mpi$(EXEXT): test_suite_mpi.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pbkdf2$(EXEXT): test_suite_pbkdf2.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pem$(EXEXT): test_suite_pem.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkcs1_v21$(EXEXT): test_suite_pkcs1_v21.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkcs5$(EXEXT): test_suite_pkcs5.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkparse$(EXEXT): test_suite_pkparse.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkwrite$(EXEXT): test_suite_pkwrite.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pk$(EXEXT): test_suite_pk.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_rsa$(EXEXT): test_suite_rsa.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_shax$(EXEXT): test_suite_shax.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_x509parse$(EXEXT): test_suite_x509parse.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_x509write$(EXEXT): test_suite_x509write.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_xtea$(EXEXT): test_suite_xtea.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_debug$(EXEXT): test_suite_debug.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_version$(EXEXT): test_suite_version.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,13 +1,13 @@
 
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
-# To compile on MinGW: add "-lws2_32" to LDFLAGS or define WINDOWS in your env
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement \
 			-Wno-unused-function -Wno-unused-value
 
 OFLAGS	= -O2
-LDFLAGS	+= -L../library -lmbedtls$(SHARED_SUFFIX) $(SYS_LDFLAGS)
+LDFLAGS ?=
+LOCAL_LDFLAGS = -L../library -lmbedtls$(SHARED_SUFFIX)
 DLEXT=so
 
 ifndef SHARED
@@ -33,7 +33,7 @@ endif
 ifdef WINDOWS_BUILD
 DLEXT=dll
 EXEXT=.exe
-LDFLAGS += -lws2_32
+LOCAL_LDFLAGS += -lws2_32
 ifdef SHARED
 SHARED_SUFFIX=.$(DLEXT)
 endif
@@ -41,7 +41,7 @@ endif
 
 # Zlib shared library extensions:
 ifdef ZLIB
-LDFLAGS += -lz
+LOCAL_LDFLAGS += -lz
 endif
 
 APPS =	test_suite_aes.ecb$(EXEXT)	test_suite_aes.cbc$(EXEXT)	\
@@ -189,231 +189,231 @@ test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_sui
 
 test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.cbc$(EXEXT): test_suite_aes.cbc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.cfb$(EXEXT): test_suite_aes.cfb.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_aes.rest$(EXEXT): test_suite_aes.rest.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_arc4$(EXEXT): test_suite_arc4.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_asn1write$(EXEXT): test_suite_asn1write.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_base64$(EXEXT): test_suite_base64.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_blowfish$(EXEXT): test_suite_blowfish.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_camellia$(EXEXT): test_suite_camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ccm$(EXEXT): test_suite_ccm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.aes$(EXEXT): test_suite_cipher.aes.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.arc4$(EXEXT): test_suite_cipher.arc4.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.ccm$(EXEXT): test_suite_cipher.ccm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.gcm$(EXEXT): test_suite_cipher.gcm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.blowfish$(EXEXT): test_suite_cipher.blowfish.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.camellia$(EXEXT): test_suite_cipher.camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.des$(EXEXT): test_suite_cipher.des.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.null$(EXEXT): test_suite_cipher.null.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_cipher.padding$(EXEXT): test_suite_cipher.padding.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ctr_drbg$(EXEXT): test_suite_ctr_drbg.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_des$(EXEXT): test_suite_des.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_dhm$(EXEXT): test_suite_dhm.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecdh$(EXEXT): test_suite_ecdh.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecdsa$(EXEXT): test_suite_ecdsa.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_ecp$(EXEXT): test_suite_ecp.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_entropy$(EXEXT): test_suite_entropy.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_error$(EXEXT): test_suite_error.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes128_de$(EXEXT): test_suite_gcm.aes128_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes192_de$(EXEXT): test_suite_gcm.aes192_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes256_de$(EXEXT): test_suite_gcm.aes256_de.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes128_en$(EXEXT): test_suite_gcm.aes128_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes192_en$(EXEXT): test_suite_gcm.aes192_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.aes256_en$(EXEXT): test_suite_gcm.aes256_en.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_gcm.camellia$(EXEXT): test_suite_gcm.camellia.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.misc$(EXEXT): test_suite_hmac_drbg.misc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.no_reseed$(EXEXT): test_suite_hmac_drbg.no_reseed.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.nopr$(EXEXT): test_suite_hmac_drbg.nopr.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_drbg.pr$(EXEXT): test_suite_hmac_drbg.pr.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_hmac_shax$(EXEXT): test_suite_hmac_shax.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_md$(EXEXT): test_suite_md.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_mdx$(EXEXT): test_suite_mdx.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_memory_buffer_alloc$(EXEXT): test_suite_memory_buffer_alloc.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_mpi$(EXEXT): test_suite_mpi.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pbkdf2$(EXEXT): test_suite_pbkdf2.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pem$(EXEXT): test_suite_pem.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkcs1_v21$(EXEXT): test_suite_pkcs1_v21.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkcs5$(EXEXT): test_suite_pkcs5.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkparse$(EXEXT): test_suite_pkparse.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pkwrite$(EXEXT): test_suite_pkwrite.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_pk$(EXEXT): test_suite_pk.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_rsa$(EXEXT): test_suite_rsa.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_shax$(EXEXT): test_suite_shax.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_x509parse$(EXEXT): test_suite_x509parse.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_x509write$(EXEXT): test_suite_x509write.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_xtea$(EXEXT): test_suite_xtea.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_debug$(EXEXT): test_suite_debug.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 test_suite_version$(EXEXT): test_suite_version.c $(DEP)
 	echo   "  CC    	$<"
-	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -433,7 +433,7 @@ ifndef WINDOWS
 		RESULT=`$(CHECK_PRELOAD) ./$${i} | grep -v 'PASS$$' | grep -v -- '----' | grep -v '^$$'`;	\
 		PASSED=`echo $$RESULT |grep PASSED`; 								\
 		echo "   $$RESULT";													\
-		if [ "$$PASSED" == "" ];											\
+		if [ "$$PASSED" = "" ];											\
 		then																\
 			echo "**** Failed ***************";								\
 			RETURN=1;														\


### PR DESCRIPTION
Few years ago I offered help to apply autotools build to polarssl and was rejected, autoconf/automake/libtool are the best tools available for multiplatform/crosscompile build environment. Writing standalone Makefiles is not easy, especially when the consumer are packagers that relay on some practice.

I still recommend autotools build system over anything else (including cmake) to enable flexibility required for such important infra library.

I got a request to help cross compile on Windows and post that fix, attached are some more to make the build closer to comply with best practice, I hope this will be sufficient at this point.

Thank you,