### PR TITLE
Added more constant-time code / removed biases in the prime number generation routines.

### DIFF
--- a/library/rsa.c
+++ b/library/rsa.c
@@ -761,7 +761,7 @@ int rsa_rsaes_oaep_decrypt( rsa_context *ctx,
     for( i = 0; i < ilen - 2 * hlen - 2; i++ )
     {
         pad_done |= p[i];
-        pad_len += ( pad_done == 0 );
+        pad_len += ((pad_done | (unsigned char)-pad_done) >> 7) ^ 1;
     }
 
     p += pad_len;
@@ -835,8 +835,8 @@ int rsa_rsaes_pkcs1_v15_decrypt( rsa_context *ctx,
          * (minus one, for the 00 byte) */
         for( i = 0; i < ilen - 3; i++ )
         {
-            pad_done |= ( p[i] == 0 );
-            pad_count += ( pad_done == 0 );
+            pad_done  |= ((p[i] | (unsigned char)-p[i]) >> 7) ^ 1;
+            pad_count += ((pad_done | (unsigned char)-pad_done) >> 7) ^ 1;
         }
 
         p += pad_count;


### PR DESCRIPTION
This pull request brings two changes:

- I have improved the time- and flow- constantness of some parts of the code handling big integers;

- I have removed statistical biases in the prime generation routines, and implemented a rejection method instead, which is the proper way to do. Such biases might have devastating consequences in terms of security for certain public-key cryptosystems. Note that I don't claim any attack here: I am not an expert in this field of cryptanalysis. However, look at the paper of Aranha et al. *GLV/GLS Decomposition, Power Analysis, and Attacks on ECDSA Signatures With Single-Bit Nonce Bias* presented at ASIACRYPT'14 as well as the references therein to be convinced that biases are bad in cryptography.