### PR TITLE
Fixed potential null dereference when record splitting is enabled.

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4844,6 +4844,7 @@ int ssl_write( ssl_context *ssl, const unsigned char *buf, size_t len )
     if( ssl->split_done == SSL_CBC_RECORD_SPLITTING_DISABLED ||
         len <= 1 ||
         ssl->minor_ver > SSL_MINOR_VERSION_1 ||
+        ssl->transform_out == NULL ||
         cipher_get_cipher_mode( &ssl->transform_out->cipher_ctx_enc )
                                 != POLARSSL_MODE_CBC )
     {


### PR DESCRIPTION
Found by some OpenWrt users that are reporting problems with OpenVPN (in client mode):
https://dev.openwrt.org/ticket/19101