### PR TITLE
Fix installation of shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 	cp -r include/polarssl $(DESTDIR)/include
 	
 	mkdir -p $(DESTDIR)/lib
-	cp library/libpolarssl.* library/libmbedtls.* $(DESTDIR)/lib
+	cp -d library/libpolarssl.* library/libmbedtls.* $(DESTDIR)/lib
 	
 	mkdir -p $(DESTDIR)/bin
 	for p in programs/*/* ; do              \


### PR DESCRIPTION
Install currently breaks symbolic links!

Using cp -d make sure symolic links are preserved. See result below.

The content of library directory:
$ make SHARED=1 && ls -l library/lib*.so*
lrwxrwxrwx 1 gael gael     15 avril 27 12:44 library/libmbedtls.so -> libmbedtls.so.8
-rwxrwxr-x 1 gael gael 597675 avril 27 12:44 library/libmbedtls.so.8
lrwxrwxrwx 1 gael gael     13 avril 27 12:44 library/libpolarssl.so -> libmbedtls.so

The content of the output lib directory at install (without the fix):
$ make install DESTDIR=$PWD/_install-no-fix && ls -l _install-no-fix/lib/
-rw-rw-r-- 1 gael gael 898192 avril 27 12:45 libmbedtls.a
-rwxrwxr-x 1 gael gael 597675 avril 27 12:45 libmbedtls.so
-rwxrwxr-x 1 gael gael 597675 avril 27 12:45 libmbedtls.so.8
-rw-rw-r-- 1 gael gael 898192 avril 27 12:45 libpolarssl.a
-rwxrwxr-x 1 gael gael 597675 avril 27 12:45 libpolarssl.so

The content of the output lib directory at install with the fix:
$ make install DESTDIR=$PWD/_install && ls -l _install/lib/
-rw-rw-r-- 1 gael gael 898192 avril 27 12:46 libmbedtls.a
lrwxrwxrwx 1 gael gael     15 avril 27 12:46 libmbedtls.so -> libmbedtls.so.8
-rwxrwxr-x 1 gael gael 597675 avril 27 12:46 libmbedtls.so.8
lrwxrwxrwx 1 gael gael     12 avril 27 12:46 libpolarssl.a -> libmbedtls.a
lrwxrwxrwx 1 gael gael     13 avril 27 12:46 libpolarssl.so -> libmbedtls.so