### PR TITLE
fix minor bug in path_cnt checks

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1771,7 +1771,7 @@ static int x509_crt_verify_top(
                 void *p_vrfy )
 {
     int ret;
-    int ca_flags = 0, check_path_cnt = path_cnt + 1;
+    int ca_flags = 0, check_path_cnt;
     unsigned char hash[POLARSSL_MD_MAX_SIZE];
     const md_info_t *md_info;
 
@@ -1802,8 +1802,10 @@ static int x509_crt_verify_top(
         if( x509_crt_check_parent( child, trust_ca, 1, path_cnt == 0 ) != 0 )
             continue;
 
+        check_path_cnt = path_cnt + 1;
+
         /*
-         * Reduce path_len to check against if top of the chain is
+         * Reduce check_path_cnt to check against if top of the chain is
          * the same as the trusted CA
          */
         if( child->subject_raw.len == trust_ca->subject_raw.len &&


### PR DESCRIPTION
What do you think, is this a bug or not? I don't think it's dangerous, you'd need to have two CAs in the `trust_ca` list with the same subject name, but I think it counts as unintended behaviour that should be fixed.

Noticed during code review.

Commit comment: If the top certificate occurs twice in trust_ca (for example) it would not be good for the second instance to be checked with check_path_cnt reduced twice!