### PR TITLE
Fix compile bug: incompatible declaration of polarssl_exit in platform.c

### DIFF
--- a/library/platform.c
+++ b/library/platform.c
@@ -154,7 +154,7 @@ static void platform_exit_uninit( int status )
 #define POLARSSL_PLATFORM_STD_EXIT   platform_exit_uninit
 #endif /* !POLARSSL_PLATFORM_STD_EXIT */
 
-int (*polarssl_exit)( int status ) = POLARSSL_PLATFORM_STD_EXIT;
+void (*polarssl_exit)( int status ) = POLARSSL_PLATFORM_STD_EXIT;
 
 int platform_set_exit( void (*exit_func)( int status ) )
 {


### PR DESCRIPTION
This causes a compile-time error: 

platform.c(157): error:  #147: declaration is incompatible with "void (*polarssl_exit)(int)" (declared at line 179 of "platform.h")