### PR TITLE
Make debug_fmt() thread-safe

### DIFF
--- a/library/debug.c
+++ b/library/debug.c
@@ -66,7 +66,7 @@ void debug_set_threshold( int threshold )
 char *debug_fmt( const char *format, ... )
 {
     va_list argp;
-    static char str[512];
+    char str[512];
     int maxlen = sizeof( str ) - 1;
 
     va_start( argp, format );


### PR DESCRIPTION
As reported in this issue https://github.com/ARMmbed/mbedtls/issues/203 : debug_fmt() is using a static buffer which makes this function not thread-safe. Removing the static attribute should be enough.