### PR TITLE
Removing yt ls step in READMEs of examples

### DIFF
--- a/yotta/data/example-authcrypt/README.md
+++ b/yotta/data/example-authcrypt/README.md
@@ -28,27 +28,19 @@ To build and run this example the requirements below are necessary:
     yotta target frdm-k64f-gcc
     ```
 
-4. Check that there are no missing dependencies:
-
-    ```
-    $ yt ls
-    ```
-
-    If there are, yotta will list them in the terminal. Please install them before proceeding.
-
-5. Build mbedtls and the examples. This will take a long time if it is the first time:
+4. Build mbedtls and the examples. This will take a long time if it is the first time:
 
     ```
     $ yt build
     ```
 
-6. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-authcrypt.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
+5. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-authcrypt.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-7. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
+6. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
 
-8. Press the reset button on the board.
+7. Press the reset button on the board.
 
-9. The output in the terminal window should look like:
+8. The output in the terminal window should look like:
 
     ```
     {{timeout;10}}

--- a/yotta/data/example-benchmark/README.md
+++ b/yotta/data/example-benchmark/README.md
@@ -28,27 +28,19 @@ To build and run this example the requirements below are necessary:
     yotta target frdm-k64f-gcc
     ```
 
-4. Check that there are no missing dependencies:
-
-    ```
-    $ yt ls
-    ```
-
-    If there are, yotta will list them in the terminal. Please install them before proceeding.
-
-5. Build mbedtls and the examples. This will take a long time if it is the first time:
+4. Build mbedtls and the examples. This will take a long time if it is the first time:
 
     ```
     $ yt build
     ```
 
-6. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-benchmark.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
+5. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-benchmark.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-7. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
+6. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
 
-8. Press the reset button on the board.
+7. Press the reset button on the board.
 
-9. The output in the terminal window should look like:
+8. The output in the terminal window should look like:
 
     ```
     {{timeout;150}}

--- a/yotta/data/example-hashing/README.md
+++ b/yotta/data/example-hashing/README.md
@@ -28,27 +28,19 @@ To build and run this example the requirements below are necessary:
     yotta target frdm-k64f-gcc
     ```
 
-4. Check that there are no missing dependencies:
-
-    ```
-    $ yt ls
-    ```
-
-    If there are, yotta will list them in the terminal. Please install them before proceeding.
-
-5. Build mbedtls and the examples. This will take a long time if it is the first time:
+4. Build mbedtls and the examples. This will take a long time if it is the first time:
 
     ```
     $ yt build
     ```
 
-6. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-hashing.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
+5. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-hashing.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-7. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
+6. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
 
-8. Press the reset button on the board.
+7. Press the reset button on the board.
 
-9. The output in the terminal window should look like:
+8. The output in the terminal window should look like:
 
     ```
     {{timeout;10}}

--- a/yotta/data/example-selftest/README.md
+++ b/yotta/data/example-selftest/README.md
@@ -28,27 +28,19 @@ To build and run this example the requirements below are necessary:
     yotta target frdm-k64f-gcc
     ```
 
-4. Check that there are no missing dependencies:
-
-    ```
-    $ yt ls
-    ```
-
-    If there are, yotta will list them in the terminal. Please install them before proceeding.
-
-5. Build mbedtls and the examples. This will take a long time if it is the first time:
+4. Build mbedtls and the examples. This will take a long time if it is the first time:
 
     ```
     $ yt build
     ```
 
-6. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-selftest.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
+5. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-selftest.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-7. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
+6. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
 
-8. Press the reset button on the board.
+7. Press the reset button on the board.
 
-9. The output in the terminal window should look like:
+8. The output in the terminal window should look like:
 
     ```
     {{timeout;40}}

--- a/yotta/data/example-tls-client/README.md
+++ b/yotta/data/example-tls-client/README.md
@@ -34,27 +34,19 @@ To build and run this example the requirements below are necessary:
     yotta target frdm-k64f-gcc
     ```
 
-5. Check that there are no missing dependencies:
-
-    ```
-    $ yt ls
-    ```
-
-    If there are, yotta will list them in the terminal. Please install them before proceeding.
-
 5. Build mbedtls and the examples. This will take a long time if it is the first time:
 
     ```
     $ yt build
     ```
 
-7. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-tls-client.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
+6. Copy `build/frdm-k64f-gcc/test/mbedtls-test-example-tls-client.bin` to your mbed board and wait until the LED next to the USB port stops blinking.
 
-8. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
+7. Start the serial terminal emulator and connect to the virtual serial port presented by FRDM-K64F. For settings, use 115200 baud, 8N1, no flow control. **Warning:** for this example, the baud rate is not the default 9600, it is 115200.
 
-9. Press the reset button on the board.
+8. Press the reset button on the board.
 
-10. The output in the terminal window should look like:
+9. The output in the terminal window should look like:
 
     ```
     {timeout;120}}


### PR DESCRIPTION
This removes the yt ls steps from the example READMEs. It seems like an unnecessary step because yt build will install them any way. It currently doesn't provide the command needed to remedy missing dependencies (yt install), so if removing it entirely isn't the correct way to change the READMEs then info about yt install should be added.