### PR TITLE
fix const-ness of argument to mbedtls_ssl_conf_cert_profile

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1381,7 +1381,7 @@ void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
  * \param profile  Profile to use
  */
 void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
-                                    mbedtls_x509_crt_profile *profile );
+                                    const mbedtls_x509_crt_profile *profile );
 
 /**
  * \brief          Set the data required to verify peer certificate

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5372,7 +5372,7 @@ void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
-                                    mbedtls_x509_crt_profile *profile )
+                                    const mbedtls_x509_crt_profile *profile )
 {
     conf->cert_profile = profile;
 }


### PR DESCRIPTION
Otherwise, it's impossible to pass in a pointer to `mbedtls_x509_crt_profile_next`!