### PR TITLE
FIX: threading definitions when POLARSSL_THREADING_C is disabled

### DIFF
--- a/dist/mbedtls.me
+++ b/dist/mbedtls.me
@@ -1,0 +1,23 @@
+/*
+    mbedtls.me -- MakeMe file for MbedTLS
+ */
+
+Me.load({
+    blend: [ 'osdep' ],
+
+    targets: {
+        libmbedtls: {
+            type: 'lib',
+            static: true,
+            headers: [ '*.h' ],
+            depends: [ 'osdep' ],
+            sources: [ 'mbedtlsLib.c' ],
+            '-compiler': [
+                '-Wall',
+                '-Wshorten-64-to-32',
+                '-W3',
+            ],
+            ifdef: [ 'mbedtls' ],
+        }
+	}
+})

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -81,6 +81,7 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 void mbedtls_threading_free_alt( void );
 #endif /* MBEDTLS_THREADING_ALT */
 
+#if defined(POLARSSL_THREADING_C)
 /*
  * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
  *
@@ -96,6 +97,7 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif
 
 #ifdef __cplusplus
 }

--- a/library/net.c
+++ b/library/net.c
@@ -319,7 +319,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
         /* UDP: wait for a message, but keep it in the queue */
         char buf[1] = { 0 };
 
-        ret = recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
+        ret = (int) recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
                         (struct sockaddr *) &client_addr, &n );
 
 #if defined(_WIN32)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "mbedtls",
+    "title": "Mbedtls",
+    "description": "Mbedtls SSL Stack",
+    "version": "1.3.11",
+    "license": "GPLv2",
+    "keywords": [
+        "mbedtls",
+        "ssl",
+        "tls"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/ARMmbed/mbedtls.git"
+    },
+    "files": [
+        "dist/"
+    ],
+    "pak": {
+        "import": true,
+        "origin": "ARMmbed/mbedtls"
+    }
+}
+


### PR DESCRIPTION
This pull request fixes threading.h when used in single threaded applications. It protects definitions with 
POLARSSL_THREADING_C.

## Details:

The threading.h defines the following regardless of whether POLARSSL_THREADING_C is defined:

```
/*
 * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
 *
 * All these functions are expected to work or the result will be undefined.
 */
extern void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t *mutex );
extern void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t *mutex );
extern int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t *mutex );
extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );

/*
 * Global mutexes
 */
extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
```