### PR TITLE
Fix single threaded builds

### DIFF
--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -81,6 +81,7 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 void mbedtls_threading_free_alt( void );
 #endif /* MBEDTLS_THREADING_ALT */
 
+#if defined(MBEDTLS_THREADING_C)
 /*
  * The function pointers for mutex_init, mutex_free, mutex_ and mutex_unlock
  *
@@ -96,6 +97,7 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The definitions of mutexes in threading.h are not protected by 

    #if defined(MBEDTLS_THREADING_C)

this breaks single threaded builds.