### PR TITLE
FIX: compiling on vxworks

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 /* padlock.c and aesni.c rely on these values! */
 #define MBEDTLS_AES_ENCRYPT     1

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if defined(MBEDTLS_FS_IO)
 #include <stdio.h>

--- a/include/mbedtls/blowfish.h
+++ b/include/mbedtls/blowfish.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_BLOWFISH_ENCRYPT     1
 #define MBEDTLS_BLOWFISH_DECRYPT     0

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_CAMELLIA_ENCRYPT     1
 #define MBEDTLS_CAMELLIA_DECRYPT     0

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_DES_ENCRYPT     1
 #define MBEDTLS_DES_DECRYPT     0

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -25,7 +25,9 @@
 
 #include "cipher.h"
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_GCM_ENCRYPT     1
 #define MBEDTLS_GCM_DECRYPT     0

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_MD4_ALT)
 // Regular implementation

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_MD5_ALT)
 // Regular implementation

--- a/include/mbedtls/net.h
+++ b/include/mbedtls/net.h
@@ -32,7 +32,9 @@
 #include "ssl.h"
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_ERR_NET_SOCKET_FAILED                     -0x0042  /**< Failed to open a socket. */
 #define MBEDTLS_ERR_NET_CONNECT_FAILED                    -0x0044  /**< The connection to the given server / port failed. */

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -42,7 +42,9 @@
 #define MBEDTLS_HAVE_X86
 #endif
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_PADLOCK_RNG 0x000C
 #define MBEDTLS_PADLOCK_ACE 0x00C0

--- a/include/mbedtls/pkcs5.h
+++ b/include/mbedtls/pkcs5.h
@@ -29,7 +29,9 @@
 #include "md.h"
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA                  -0x2f80  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_PKCS5_INVALID_FORMAT                  -0x2f00  /**< Unexpected ASN.1 data. */

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_RIPEMD160_ALT)
 // Regular implementation

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_SHA1_ALT)
 // Regular implementation

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_SHA256_ALT)
 // Regular implementation

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if !defined(MBEDTLS_SHA512_ALT)
 // Regular implementation

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -33,7 +33,9 @@
 // Regular implementation
 //
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/xtea.h
+++ b/include/mbedtls/xtea.h
@@ -30,7 +30,9 @@
 #endif
 
 #include <stddef.h>
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #define MBEDTLS_XTEA_ENCRYPT     1
 #define MBEDTLS_XTEA_DECRYPT     0

--- a/library/base64.c
+++ b/library/base64.c
@@ -29,7 +29,9 @@
 
 #include "mbedtls/base64.h"
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 #include <string.h>

--- a/library/net.c
+++ b/library/net.c
@@ -64,7 +64,9 @@ static int wsa_init_done = 0;
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#if !VXWORKS
 #include <sys/time.h>
+#endif
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
@@ -86,7 +88,9 @@ static int wsa_init_done = 0;
 
 #include <time.h>
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 /*
  * Prepare for using the sockets interface
@@ -203,7 +207,11 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
 
         n = 1;
         if( setsockopt( ctx->fd, SOL_SOCKET, SO_REUSEADDR,
+#if VXWORKS
+                        (char *) &n, sizeof( n ) ) != 0 )
+#else
                         (const char *) &n, sizeof( n ) ) != 0 )
+#endif
         {
             close( ctx->fd );
             ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
@@ -358,8 +366,13 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
                          (struct sockaddr *) &local_addr, &n ) != 0 ||
             ( bind_ctx->fd = (int) socket( local_addr.ss_family,
                                            SOCK_DGRAM, IPPROTO_UDP ) ) < 0 ||
+#if VXWORKS
+            setsockopt( bind_ctx->fd, SOL_SOCKET, SO_REUSEADDR,
+                        (char *) &one, sizeof( one ) ) != 0 )
+#else
             setsockopt( bind_ctx->fd, SOL_SOCKET, SO_REUSEADDR,
                         (const char *) &one, sizeof( one ) ) != 0 )
+#endif
         {
             return( MBEDTLS_ERR_NET_SOCKET_FAILED );
         }
@@ -533,7 +546,11 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
+#if VXWORKS
+    ret = (int) write( fd, (char*) buf, len );
+#else
     ret = (int) write( fd, buf, len );
+#endif
 
     if( ret < 0 )
     {

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -41,7 +41,9 @@
 #define mbedtls_free       free
 #endif
 
+#if !VXWORKS
 #include <stdint.h>
+#endif
 
 #if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>

--- a/library/timing.c
+++ b/library/timing.c
@@ -56,7 +56,9 @@ struct _hr_time
 
 #include <unistd.h>
 #include <sys/types.h>
+#if !VXWORKS
 #include <sys/time.h>
+#endif
 #include <signal.h>
 #include <time.h>
 


### PR DESCRIPTION
Changes to get the software to compile on VxWorks.

* VxWorks does not have stdint.h
* Different casting requirements for setsockopt and write