### PR TITLE
Make config check include for configs examples more consistent

### DIFF
--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -80,6 +80,6 @@
  */
 #define MBEDTLS_SSL_MAX_CONTENT_LEN             512
 
-#include "check_config.h"
+#include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-picocoin.h
+++ b/configs/config-picocoin.h
@@ -66,6 +66,6 @@
 #define MBEDTLS_SHA1_C
 #define MBEDTLS_SHA256_C
 
-#include "check_config.h"
+#include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
This way all config examples work when used like described in the README