### PR TITLE
fix for #279 (inline keyword must not be macroized when building C++ code)

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -51,6 +51,14 @@
 #endif
 #endif /* _WIN32 */
 
+#if !defined(MBEDTLS_INLINE)
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) )
+#define MBEDTLS_INLINE __inline
+#else
+#define MBEDTLS_INLINE inline
+#endif
+#endif
+
 #if defined(TARGET_LIKE_MBED) && \
     ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
 #error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -52,7 +52,9 @@
 #endif /* _WIN32 */
 
 #if !defined(MBEDTLS_INLINE)
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) )
+#if defined(__cplusplus)
+#define MBEDTLS_INLINE inline
+#elif ( defined(__ARMCC_VERSION) || defined(_MSC_VER) )
 #define MBEDTLS_INLINE __inline
 #else
 #define MBEDTLS_INLINE inline

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -46,10 +46,6 @@
 #define MBEDTLS_CIPHER_MODE_STREAM
 #endif
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 #define MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE            -0x6080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA                 -0x6100  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_CIPHER_ALLOC_FAILED                   -0x6180  /**< Failed to allocate memory. */
@@ -325,7 +321,7 @@ int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_in
  * \return              size of the cipher's blocks, or 0 if ctx has not been
  *                      initialised.
  */
-static inline unsigned int mbedtls_cipher_get_block_size( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE unsigned int mbedtls_cipher_get_block_size( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return 0;
@@ -342,7 +338,7 @@ static inline unsigned int mbedtls_cipher_get_block_size( const mbedtls_cipher_c
  * \return              mode of operation, or MBEDTLS_MODE_NONE if ctx
  *                      has not been initialised.
  */
-static inline mbedtls_cipher_mode_t mbedtls_cipher_get_cipher_mode( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE mbedtls_cipher_mode_t mbedtls_cipher_get_cipher_mode( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return MBEDTLS_MODE_NONE;
@@ -359,7 +355,7 @@ static inline mbedtls_cipher_mode_t mbedtls_cipher_get_cipher_mode( const mbedtl
  *                      (0 for ciphers not using IV/NONCE).
  *                      If IV has already been set: actual size.
  */
-static inline int mbedtls_cipher_get_iv_size( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE int mbedtls_cipher_get_iv_size( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return 0;
@@ -378,7 +374,7 @@ static inline int mbedtls_cipher_get_iv_size( const mbedtls_cipher_context_t *ct
  * \return              type of the cipher, or MBEDTLS_CIPHER_NONE if ctx has
  *                      not been initialised.
  */
-static inline mbedtls_cipher_type_t mbedtls_cipher_get_type( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE mbedtls_cipher_type_t mbedtls_cipher_get_type( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return MBEDTLS_CIPHER_NONE;
@@ -393,7 +389,7 @@ static inline mbedtls_cipher_type_t mbedtls_cipher_get_type( const mbedtls_ciphe
  *
  * \return              name of the cipher, or NULL if ctx was not initialised.
  */
-static inline const char *mbedtls_cipher_get_name( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE const char *mbedtls_cipher_get_name( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return 0;
@@ -410,7 +406,7 @@ static inline const char *mbedtls_cipher_get_name( const mbedtls_cipher_context_
  *                      MBEDTLS_KEY_LENGTH_NONE if ctx has not been
  *                      initialised.
  */
-static inline int mbedtls_cipher_get_key_bitlen( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE int mbedtls_cipher_get_key_bitlen( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return MBEDTLS_KEY_LENGTH_NONE;
@@ -427,7 +423,7 @@ static inline int mbedtls_cipher_get_key_bitlen( const mbedtls_cipher_context_t 
  *                      or MBEDTLS_OPERATION_NONE if ctx has not been
  *                      initialised.
  */
-static inline mbedtls_operation_t mbedtls_cipher_get_operation( const mbedtls_cipher_context_t *ctx )
+static MBEDTLS_INLINE mbedtls_operation_t mbedtls_cipher_get_operation( const mbedtls_cipher_context_t *ctx )
 {
     if( NULL == ctx || NULL == ctx->cipher_info )
         return MBEDTLS_OPERATION_NONE;

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -89,6 +89,17 @@
 #define MBEDTLS_HAVE_TIME_DATE
 
 /**
+ * \def MBEDTLS_INLINE
+ *
+ * Compiler inline keyword.
+ *
+ * If undefined, check_config.h defines an appropriate per platform value.
+ *
+ * An empty definition may be used to disable explicit inlining.
+ */
+//#define MBEDTLS_INLINE inline
+
+/**
  * \def MBEDTLS_PLATFORM_MEMORY
  *
  * Enable the memory allocation layer.

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -27,10 +27,6 @@
 
 #include <stddef.h>
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -132,7 +132,7 @@ typedef struct
  * \warning You must make sure the PK context actually holds an RSA context
  * before using this function!
  */
-static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
+static MBEDTLS_INLINE mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
 {
     return( (mbedtls_rsa_context *) (pk).pk_ctx );
 }
@@ -145,7 +145,7 @@ static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
  * \warning You must make sure the PK context actually holds an EC context
  * before using this function!
  */
-static inline mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context pk )
+static MBEDTLS_INLINE mbedtls_ecp_keypair *mbedtls_pk_ec( const mbedtls_pk_context pk )
 {
     return( (mbedtls_ecp_keypair *) (pk).pk_ctx );
 }
@@ -236,7 +236,7 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx );
  *
  * \return          Key length in bytes, or 0 on error
  */
-static inline size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
+static MBEDTLS_INLINE size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
 {
     return( ( mbedtls_pk_get_bitlen( ctx ) + 7 ) / 8 );
 }

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -37,10 +37,6 @@
 
 #include <pkcs11-helper-1.0/pkcs11h-certificate.h>
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -139,7 +135,7 @@ int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
 /**
  * SSL/TLS wrappers for PKCS#11 functions
  */
-static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx, int mode, size_t *olen,
+static MBEDTLS_INLINE int mbedtls_ssl_pkcs11_decrypt( void *ctx, int mode, size_t *olen,
                         const unsigned char *input, unsigned char *output,
                         size_t output_max_len )
 {
@@ -147,7 +143,7 @@ static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx, int mode, size_t *olen,
                            output_max_len );
 }
 
-static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
+static MBEDTLS_INLINE int mbedtls_ssl_pkcs11_sign( void *ctx,
                      int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                      int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
                      const unsigned char *hash, unsigned char *sig )
@@ -158,7 +154,7 @@ static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
                         hashlen, hash, sig );
 }
 
-static inline size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
+static MBEDTLS_INLINE size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
 {
     return ( (mbedtls_pkcs11_context *) ctx )->len;
 }

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -41,10 +41,6 @@
 #include "sha512.h"
 #endif
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 /* Determine minimum supported version */
 #define MBEDTLS_SSL_MIN_MAJOR_VERSION           MBEDTLS_SSL_MAJOR_VERSION_3
 
@@ -382,7 +378,7 @@ int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
 #endif
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
-static inline mbedtls_pk_context *mbedtls_ssl_own_key( mbedtls_ssl_context *ssl )
+static MBEDTLS_INLINE mbedtls_pk_context *mbedtls_ssl_own_key( mbedtls_ssl_context *ssl )
 {
     mbedtls_ssl_key_cert *key_cert;
 
@@ -394,7 +390,7 @@ static inline mbedtls_pk_context *mbedtls_ssl_own_key( mbedtls_ssl_context *ssl 
     return( key_cert == NULL ? NULL : key_cert->key );
 }
 
-static inline mbedtls_x509_crt *mbedtls_ssl_own_cert( mbedtls_ssl_context *ssl )
+static MBEDTLS_INLINE mbedtls_x509_crt *mbedtls_ssl_own_cert( mbedtls_ssl_context *ssl )
 {
     mbedtls_ssl_key_cert *key_cert;
 
@@ -426,7 +422,7 @@ void mbedtls_ssl_write_version( int major, int minor, int transport,
 void mbedtls_ssl_read_version( int *major, int *minor, int transport,
                        const unsigned char ver[2] );
 
-static inline size_t mbedtls_ssl_hdr_len( const mbedtls_ssl_context *ssl )
+static MBEDTLS_INLINE size_t mbedtls_ssl_hdr_len( const mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -437,7 +433,7 @@ static inline size_t mbedtls_ssl_hdr_len( const mbedtls_ssl_context *ssl )
     return( 5 );
 }
 
-static inline size_t mbedtls_ssl_hs_hdr_len( const mbedtls_ssl_context *ssl )
+static MBEDTLS_INLINE size_t mbedtls_ssl_hs_hdr_len( const mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -461,7 +457,7 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 #endif
 
 /* constant-time buffer comparison */
-static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
+static MBEDTLS_INLINE int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
 {
     size_t i;
     const unsigned char *A = (const unsigned char *) a;

--- a/library/debug.c
+++ b/library/debug.c
@@ -42,10 +42,6 @@
 #define mbedtls_snprintf    snprintf
 #endif
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 #define DEBUG_BUF_SIZE      512
 
 static int debug_threshold = 0;
@@ -58,7 +54,7 @@ void mbedtls_debug_set_threshold( int threshold )
 /*
  * All calls to f_dbg must be made via this function
  */
-static inline void debug_send_line( const mbedtls_ssl_context *ssl, int level,
+static MBEDTLS_INLINE void debug_send_line( const mbedtls_ssl_context *ssl, int level,
                                     const char *file, int line,
                                     const char *str )
 {

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -62,10 +62,6 @@
 #define mbedtls_free       free
 #endif
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
@@ -253,7 +249,7 @@ const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_name( const char *name
 /*
  * Get the type of a curve
  */
-static inline ecp_curve_type ecp_get_type( const mbedtls_ecp_group *grp )
+static MBEDTLS_INLINE ecp_curve_type ecp_get_type( const mbedtls_ecp_group *grp )
 {
     if( grp->G.X.p == NULL )
         return( ECP_TYPE_NONE );

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -31,10 +31,6 @@
 
 #include <string.h>
 
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && !defined(inline)
-#define inline __inline
-#endif
-
 /*
  * Conversion macros for embedded constants:
  * build lists of mbedtls_mpi_uint's from lists of unsigned char's grouped by 8, 4 or 2
@@ -550,7 +546,7 @@ static const mbedtls_mpi_uint brainpoolP512r1_n[] = {
  * Create an MPI from embedded constants
  * (assumes len is an exact multiple of sizeof mbedtls_mpi_uint)
  */
-static inline void ecp_mpi_load( mbedtls_mpi *X, const mbedtls_mpi_uint *p, size_t len )
+static MBEDTLS_INLINE void ecp_mpi_load( mbedtls_mpi *X, const mbedtls_mpi_uint *p, size_t len )
 {
     X->s = 1;
     X->n = len / sizeof( mbedtls_mpi_uint );
@@ -560,7 +556,7 @@ static inline void ecp_mpi_load( mbedtls_mpi *X, const mbedtls_mpi_uint *p, size
 /*
  * Set an MPI to static value 1
  */
-static inline void ecp_mpi_set1( mbedtls_mpi *X )
+static MBEDTLS_INLINE void ecp_mpi_set1( mbedtls_mpi *X )
 {
     static mbedtls_mpi_uint one[] = { 1 };
     X->s = 1;
@@ -795,7 +791,7 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id )
  */
 
 /* Add 64-bit chunks (dst += src) and update carry */
-static inline void add64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *src, mbedtls_mpi_uint *carry )
+static MBEDTLS_INLINE void add64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *src, mbedtls_mpi_uint *carry )
 {
     unsigned char i;
     mbedtls_mpi_uint c = 0;
@@ -808,7 +804,7 @@ static inline void add64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *src, mbedtls_
 }
 
 /* Add carry to a 64-bit chunk and update carry */
-static inline void carry64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *carry )
+static MBEDTLS_INLINE void carry64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *carry )
 {
     unsigned char i;
     for( i = 0; i < 8 / sizeof( mbedtls_mpi_uint ); i++, dst++ )
@@ -899,13 +895,13 @@ cleanup:
 /*
  * Helpers for addition and subtraction of chunks, with signed carry.
  */
-static inline void add32( uint32_t *dst, uint32_t src, signed char *carry )
+static MBEDTLS_INLINE void add32( uint32_t *dst, uint32_t src, signed char *carry )
 {
     *dst += src;
     *carry += ( *dst < src );
 }
 
-static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
+static MBEDTLS_INLINE void sub32( uint32_t *dst, uint32_t src, signed char *carry )
 {
     *carry -= ( *dst < src );
     *dst -= src;
@@ -952,7 +948,7 @@ static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
  * If the result is negative, we get it in the form
  * c * 2^(bits + 32) + N, with c negative and N positive shorter than 'bits'
  */
-static inline int fix_negative( mbedtls_mpi *N, signed char c, mbedtls_mpi *C, size_t bits )
+static MBEDTLS_INLINE int fix_negative( mbedtls_mpi *N, signed char c, mbedtls_mpi *C, size_t bits )
 {
     int ret;
 
@@ -1206,7 +1202,7 @@ cleanup:
  */
 #define P_KOBLITZ_MAX   ( 256 / 8 / sizeof( mbedtls_mpi_uint ) )  // Max limbs in P
 #define P_KOBLITZ_R     ( 8 / sizeof( mbedtls_mpi_uint ) )        // Limbs in R
-static inline int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t p_limbs,
+static MBEDTLS_INLINE int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t p_limbs,
                                    size_t adjust, size_t shift, mbedtls_mpi_uint mask )
 {
     int ret;

--- a/library/pk.c
+++ b/library/pk.c
@@ -157,7 +157,7 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 /*
  * Helper for mbedtls_pk_sign and mbedtls_pk_verify
  */
-static inline int pk_hashlen_helper( mbedtls_md_type_t md_alg, size_t *hash_len )
+static MBEDTLS_INLINE int pk_hashlen_helper( mbedtls_md_type_t md_alg, size_t *hash_len )
 {
     const mbedtls_md_info_t *md_info;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -60,7 +60,7 @@ static void mbedtls_zeroize( void *v, size_t n ) {
 }
 
 /* Length of the "epoch" field in the record header */
-static inline size_t ssl_ep_len( const mbedtls_ssl_context *ssl )
+static MBEDTLS_INLINE size_t ssl_ep_len( const mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
@@ -3179,7 +3179,7 @@ static void ssl_dtls_replay_reset( mbedtls_ssl_context *ssl )
     ssl->in_window = 0;
 }
 
-static inline uint64_t ssl_load_six_bytes( unsigned char *buf )
+static MBEDTLS_INLINE uint64_t ssl_load_six_bytes( unsigned char *buf )
 {
     return( ( (uint64_t) buf[0] << 40 ) |
             ( (uint64_t) buf[1] << 32 ) |

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -45,6 +45,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_HAVE_TIME_DATE)
     "MBEDTLS_HAVE_TIME_DATE",
 #endif /* MBEDTLS_HAVE_TIME_DATE */
+#if defined(MBEDTLS_INLINE)
+    "MBEDTLS_INLINE",
+#endif /* MBEDTLS_INLINE */
 #if defined(MBEDTLS_PLATFORM_MEMORY)
     "MBEDTLS_PLATFORM_MEMORY",
 #endif /* MBEDTLS_PLATFORM_MEMORY */


### PR DESCRIPTION
Adds a configurable macro for the inline keyword, later defined as 'inline' for C++.