### PR TITLE
Fix yotta dependencies

### DIFF
--- a/yotta/data/module.json
+++ b/yotta/data/module.json
@@ -10,9 +10,9 @@
     ],
     "dependencies": {},
     "targetDependencies": {
-        "mbed": { "cmsis-core": "~0.2.3" }
+        "mbed": { "cmsis-core": "~0.4.0" }
     },
     "testTargetDependencies": {
-        "mbed": { "sockets": "~0.5.0" }
+        "mbed": { "sockets": "~0.6.0" }
     }
 }


### PR DESCRIPTION
Recent changes in various repositories broke the build of the yotta
module again :( This change fixes the build. Build tested with
frdm-k64f-gcc. I didn't update the yotta version number because I
don't know what is your policy with regards to version changes.