### PR TITLE
Fix help message for cert_req/cert_write programs

### DIFF
--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -75,7 +75,7 @@ int main( void )
     "                          key_encipherment\n"      \
     "                          data_encipherment\n"     \
     "                          key_agreement\n"         \
-    "                          key_certificate_sign\n"  \
+    "                          key_cert_sign\n"  \
     "                          crl_sign\n"              \
     "    ns_cert_type=%%s     default: (empty)\n"       \
     "                        Comma-separated-list of values:\n"     \

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -115,7 +115,7 @@ int main( void )
     "                          key_encipherment\n"      \
     "                          data_encipherment\n"     \
     "                          key_agreement\n"         \
-    "                          key_certificate_sign\n"  \
+    "                          key_cert_sign\n"  \
     "                          crl_sign\n"              \
     "    ns_cert_type=%%s     default: (empty)\n"       \
     "                        Comma-separated-list of values:\n"     \


### PR DESCRIPTION
In cert_req and cert_write programs, "key_certificate_sign" is not an
allowed value for "key_usage" parameter. The correct value is
"key_cert_sign".

See https://github.com/ARMmbed/mbedtls/blob/development/programs/x509/cert_req.c#L208
and https://github.com/ARMmbed/mbedtls/blob/development/programs/x509/cert_write.c#L323.