### PR TITLE
cert_write : fix "Destination buffer is too small" error

### DIFF
--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -189,11 +189,11 @@ int main( int argc, char *argv[] )
     mbedtls_pk_context *issuer_key = &loaded_issuer_key,
                 *subject_key = &loaded_subject_key;
     char buf[1024];
-    char issuer_name[128];
+    char issuer_name[256];
     int i;
     char *p, *q, *r;
 #if defined(MBEDTLS_X509_CSR_PARSE_C)
-    char subject_name[128];
+    char subject_name[256];
     mbedtls_x509_csr csr;
 #endif
     mbedtls_x509write_cert crt;


### PR DESCRIPTION
This commit fixes the `Destination buffer is too small` error returned
by `mbedtls_cert_write` command when the values of `subject_name` or
`issuer_name` parameters exceed 128 characters.

I have increased the size of these varaibles from 128 to 256 characters,
but I don't know if it's the best way to solve this issue...

Fixes #315.