### PR TITLE
Fix for memory leak in RSA-SSA signing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,8 +13,10 @@ Bugfix
    * Fix bug in certificate validation that caused valid chains to be rejected
      when the first intermediate certificate has pathLenConstraint=0. Found by
      Nicholas Wilson. Introduced in mbed TLS 2.2.0. #280
+   * Removed potential leak in mbedtls_rsa_rsassa_pkcs1_v15_sign(), found by 
+     JayaraghavendranK. #372
 
-Changes
+Change
    * To avoid dropping an entire DTLS datagram if a single record in a datagram
      is invalid, we now only drop the record and look at subsequent records (if
      any are presemt) in the same datagram to avoid interoperability issues.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1086,9 +1086,15 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
      * temporary buffer and check it before returning it.
      */
     sig_try = mbedtls_calloc( 1, ctx->len );
-    verif   = mbedtls_calloc( 1, ctx->len );
-    if( sig_try == NULL || verif == NULL )
+    if( sig_try == NULL )
         return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
+    verif   = mbedtls_calloc( 1, ctx->len );
+    if( verif == NULL )
+    {
+        mbedtls_free( sig_try );
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+    }
 
     MBEDTLS_MPI_CHK( mbedtls_rsa_private( ctx, f_rng, p_rng, sig, sig_try ) );
     MBEDTLS_MPI_CHK( mbedtls_rsa_public( ctx, sig_try, verif ) );


### PR DESCRIPTION
Fix in mbedtls_rsa_rsassa_pkcs1_v15_sign() in rsa.c. Github bug #372 