### PR TITLE
Fix building of mbedtls on RHEL/CentOS 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 if(UNIX)
     ADD_CUSTOM_TARGET(apidoc
         COMMAND mkdir -p apidoc
-        COMMAND cp include/mbedtls/config.h include/mbedtls/config.h.bak
+        COMMAND cp -p include/mbedtls/config.h include/mbedtls/config.h.bak
         COMMAND scripts/config.pl realfull
         COMMAND doxygen doxygen/mbedtls.doxyfile
         COMMAND mv include/mbedtls/config.h.bak include/mbedtls/config.h

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ lcov:
 
 apidoc:
 	mkdir -p apidoc
-	cp include/mbedtls/config.h include/mbedtls/config.h.bak
+	cp -p include/mbedtls/config.h include/mbedtls/config.h.bak
 	scripts/config.pl realfull
 	doxygen doxygen/mbedtls.doxyfile
 	mv include/mbedtls/config.h.bak include/mbedtls/config.h


### PR DESCRIPTION
Fix building of mbedtls on RHEL/CentOS 5: When include/mbedtls/config.h is copied to include/mbedtls/config.h.bak, the timestamp changes - and when it's copied back, the timestamp changes again. Running "make apidoc" afterwards detects the timestamp change, rebuilds the library (which removes the symlinks at least partially), and finally the symlink libmbedtls.so is missing. This solves #391.