### PR TITLE
Fix unused variable in AES selftest when CBC and CFB disabled

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1222,7 +1222,9 @@ int mbedtls_aes_self_test( int verbose )
     int ret = 0, i, j, u, v;
     unsigned char key[32];
     unsigned char buf[64];
+#if defined(MBEDTLS_CIPHER_MODE_CBC) || defined(MBEDTLS_CIPHER_MODE_CFB)
     unsigned char iv[16];
+#endif
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     unsigned char prv[16];
 #endif


### PR DESCRIPTION
This commit fixes following warning:

> CC:  aes.c
> aes.c: In function 'mbedtls_aes_self_test':
> aes.c:1225:19: error: unused variable 'iv' [-Werror=unused-variable]
>      unsigned char iv[16];
>                    ^
> cc1: all warnings being treated as errors