### PR TITLE
Remove unused variable in mpi_mul_hlp

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1103,7 +1103,7 @@ __attribute__ ((noinline))
 #endif
 void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mpi_uint b )
 {
-    mbedtls_mpi_uint c = 0, t = 0;
+    mbedtls_mpi_uint c = 0;
 
 #if defined(MULADDC_HUIT)
     for( ; i >= 8; i -= 8 )
@@ -1153,8 +1153,6 @@ void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mp
         MULADDC_STOP
     }
 #endif /* MULADDC_HUIT */
-
-    t++;
 
     do {
         *d += c; c = ( *d < c ); d++;


### PR DESCRIPTION
Probably left there from previous versions, seems not to be used anymore.