### PR TITLE
Remove excessive condition

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2585,7 +2585,6 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
         dn_size = crt->subject_raw.len;
 
         if( end < p ||
-            (size_t)( end - p ) < dn_size ||
             (size_t)( end - p ) < 2 + dn_size )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "skipping CAs: buffer too short" ) );


### PR DESCRIPTION
If `< dn_size` is true, `< 2 + dn_size` is also true, so we get into if body. 
If `< dn_size` is false, but `< 2 + dn_size` is true, we also get into if body.
The only case when we pass is length `>= 2 + dn_size`, so `< dn_size` check can be dropped.