### PR TITLE
Add helper function for faster squares calculation

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -890,7 +890,7 @@
 #endif /* C (longlong) */
 
 /* helper macro used by mpi_sqr_hlp */
-#if !defined(MUL_XY)
+#if defined(MBEDTLS_MPI_SQR) && !defined(MUL_XY)
 #if defined(MBEDTLS_HAVE_UDBL)
 
 #define MUL_XY(X, Y, r0, r1) \
@@ -930,6 +930,6 @@
 }
 
 #endif /* MBEDTLS_HAVE_UDBL */
-#endif /* MUL_XY */
+#endif /* MBEDTLS_MPI_SQR && !MUL_XY */
 
 #endif /* bn_mul.h */

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -889,4 +889,47 @@
 #endif /* C (generic)  */
 #endif /* C (longlong) */
 
+/* helper macro used by mpi_sqr_hlp */
+#if !defined(MUL_XY)
+#if defined(MBEDTLS_HAVE_UDBL)
+
+#define MUL_XY(X, Y, r0, r1) \
+{                                       \
+    mbedtls_t_udbl r;                   \
+                                        \
+    r  = (mbedtls_t_udbl) (X) * (Y);    \
+    r0 = (mbedtls_mpi_uint) r;          \
+    r1 = (mbedtls_mpi_uint)( r >> biL );\
+}
+
+#else /* MBEDTLS_HAVE_UDBL */
+
+#define MUL_XY(X, Y, r0, r1) \
+{                                       \
+    mbedtls_mpi_uint x0, y0, x1, y1, t; \
+                                        \
+    x0 = ( (X) << biH ) >> biH;         \
+    x1 = ( (X) >> biH );                \
+    y0 = ( (Y) << biH ) >> biH;         \
+    y1 = ( (Y) >> biH );                \
+                                        \
+    r0 = x0 * y0;                       \
+    r1 = x1 * y1;                       \
+                                        \
+    t = x0 * y1;                        \
+    r1 += (t >> biH);                   \
+    t <<= biH;                          \
+    r0 += t;                            \
+    r1 += (r0 < t);                     \
+                                        \
+    t = x1 * y0;                        \
+    r1 += (t >> biH);                   \
+    t <<= biH;                          \
+    r0 += t;                            \
+    r1 += (r0 < t);                     \
+}
+
+#endif /* MBEDTLS_HAVE_UDBL */
+#endif /* MUL_XY */
+
 #endif /* bn_mul.h */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2412,6 +2412,7 @@
  */
 
 /* MPI / BIGNUM options */
+//#define MBEDTLS_MPI_SQR                    1 /**< Use special function for sqaring. */ 
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum windows size used. */
 //#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1172,7 +1172,7 @@ static int mpi_sqr_hlp( mbedtls_mpi *X, const mbedtls_mpi *A )
     int ret;
     size_t n, k;
     mbedtls_mpi TA;
-    mbedtls_mpi_uint r0, r1;
+    mbedtls_mpi_uint r0, r1, tmp;
     mbedtls_mpi_uint d0 = 0, d1 = 0, d2 = 0;
 
     mbedtls_mpi_init( &TA );
@@ -1195,8 +1195,9 @@ static int mpi_sqr_hlp( mbedtls_mpi *X, const mbedtls_mpi *A )
     
 #define SQR_STEP_ADD \
     d0 += r0;                           \
+    tmp = d1;                           \
     d1 += r1 + (d0 < r0);               \
-    d2 += (d1 < r1);
+    d2 += (d1 < tmp);
     
 #define SQR_STEP_ADD_DBL \
     d2 += (r1 >> (biL - 1));            \

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1172,7 +1172,7 @@ static int mpi_sqr_hlp( mbedtls_mpi *X, const mbedtls_mpi *A )
     int ret;
     size_t n, k;
     mbedtls_mpi TA;
-    mbedtls_mpi_uint r0, r1, tmp;
+    mbedtls_mpi_uint r0, r1;
     mbedtls_mpi_uint d0 = 0, d1 = 0, d2 = 0;
 
     for( n = A->n; n > 0; n-- )
@@ -1202,9 +1202,10 @@ static int mpi_sqr_hlp( mbedtls_mpi *X, const mbedtls_mpi *A )
     
 #define SQR_STEP_ADD \
     d0 += r0;                           \
-    tmp = d1;                           \
-    d1 += r1 + (d0 < r0);               \
-    d2 += (d1 < tmp);
+    /* safe, can't overflow here: */    \
+    r1 += (d0 < r0);                    \
+    d1 += r1;                           \
+    d2 += (d1 < r1);
     
 #define SQR_STEP_ADD_DBL \
     d2 += (r1 >> (biL - 1));            \

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1162,6 +1162,8 @@ void mpi_mul_hlp( size_t i, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d, mbedtls_mp
     while( c != 0 );
 }
 
+#if defined(MBEDTLS_MPI_SQR)
+
 /*
  * Squarification helper: X = A * A
  */
@@ -1258,6 +1260,8 @@ cleanup:
     return( ret );
 }
 
+#endif /* MBEDTLS_MPI_SQR */
+
 /*
  * Baseline multiplication: X = A * B  (HAC 14.12)
  */
@@ -1267,10 +1271,12 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     size_t i, j;
     mbedtls_mpi TA, TB;
     
+#if defined(MBEDTLS_MPI_SQR)
     if( A == B )
     {
         return mpi_sqr_hlp( X, A );
     }
+#endif
     
     mbedtls_mpi_init( &TA ); mbedtls_mpi_init( &TB );
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1175,13 +1175,20 @@ static int mpi_sqr_hlp( mbedtls_mpi *X, const mbedtls_mpi *A )
     mbedtls_mpi_uint r0, r1, tmp;
     mbedtls_mpi_uint d0 = 0, d1 = 0, d2 = 0;
 
-    mbedtls_mpi_init( &TA );
-    
-    if( X == A ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TA, A ) ); A = &TA; }
-    
     for( n = A->n; n > 0; n-- )
         if( A->p[n - 1] != 0 )
             break;
+
+    if( n == 0 )
+    {
+        // final 'X->p[2 * n - 1] = d0' will fail if input has zero length
+        // check it from the start to be sure the number is valid
+        return mbedtls_mpi_lset( X, 0 );
+    }
+
+    mbedtls_mpi_init( &TA );
+    
+    if( X == A ) { MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &TA, A ) ); A = &TA; }
     
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, n * 2 ) );
     


### PR DESCRIPTION
Squares can be computed faster than just plain multiplication by not computing the same values twice. This patch adds squarification helper which is called from `mbedtls_mpi_mul_mpi` when `A == B` (turned off in config by default).

It gives about 5% speed boost for signing/verification (I've tested it on my ESP8266 for clearer results), compared to multiplication. 

Also might be optimized a bit by providing an assembler version of `MUL_XY` macro (similar to `MULADDC_CORE`) for limbs' multiplication.
