### PR TITLE
mbedtls_mpi_copy optimization

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -200,7 +200,13 @@ int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y )
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, i ) );
 
-    memset( X->p, 0, X->n * ciL );
+    if( X->n > i )
+    {
+        // clear only unused limbs
+        // used ones will be overwritten by following memcpy()
+        memset( X->p + i, 0, ( X->n - i ) * ciL );
+    }
+    
     memcpy( X->p, Y->p, i * ciL );
 
 cleanup:


### PR DESCRIPTION
In most cases we can avoid (or minimize impact of) clearing entire number in `mbedtls_mpi_copy`.

Test shows that in about 60% of cases clearing is not needed at all (the whole number is overwritten), and in other cases less than a half of a number should be cleared. We can save some resources by clearing only required part of a number.
