### PR TITLE
Windows Embedded Compact 2013 support

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -90,7 +90,12 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(WIN32)
+    if(WINCE)
+      set(libs ${libs} ws2)
+     	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUNICODE") 
+    else()
     set(libs ${libs} ws2_32)
+    endif(WINCE)
 endif(WIN32)
 
 if(USE_PKCS11_HELPER_LIBRARY)


### PR DESCRIPTION
Added support for Windows Embedded Compact 2013 and Visual Studio 2015.
Code can be built by defining 
%PROCESSOR% as arm or x86 and %SDKNAME% as the name of the Windows Embedded Compact 2013 SDK you plan to use for build.
and running:
cmake -DWINCE=TRUE -DCMAKE_SYSTEM_NAME=WindowsCE -DCMAKE_SYSTEM_VERSION=8.0 -DCMAKE_SYSTEM_PROCESSOR=%PROCESSOR% -DCMAKE_GENERATOR_TOOLSET=CE800 -DCMAKE_GENERATOR_PLATFORM=%SDKNAME% <targetfolder>
