### PR TITLE
Windows CE time support

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -52,7 +52,11 @@
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+#include <windows.h>
+#else
 #include <time.h>
+#endif /* WINCE */
 #endif
 
 /*

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -61,6 +61,7 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
 #if defined(MBEDTLS_HAVE_TIME)
     time_t t;
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
 #endif /* MBEDTLS_HAVE_TIME */
@@ -83,8 +84,9 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
-    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+        GetSystemTime(&st);
+        SystemTimeToFileTime(&st, &ft);
+        t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = time( NULL );
 #endif /* WINCE */
@@ -151,6 +153,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
     time_t t, oldest = 0;
     mbedtls_ssl_cache_entry *old = NULL;
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
 #endif /* MBEDTLS_HAVE_TIME */
@@ -168,7 +171,8 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = time( NULL );
@@ -181,8 +185,9 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
-    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+        GetSystemTime(&st);
+        SystemTimeToFileTime(&st, &ft);
+        t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = time( NULL );
 #endif /* WINCE */

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -59,8 +59,12 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
 {
     int ret = 1;
 #if defined(MBEDTLS_HAVE_TIME)
-    time_t t = time( NULL );
-#endif
+    time_t t;
+#if defined(WINCE)
+    FILETIME ft;
+#endif /* WINCE */
+#endif /* MBEDTLS_HAVE_TIME */
+
     mbedtls_ssl_cache_context *cache = (mbedtls_ssl_cache_context *) data;
     mbedtls_ssl_cache_entry *cur, *entry;
 
@@ -78,6 +82,12 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
         cur = cur->next;
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
+    t = time( NULL );
+#endif /* WINCE */
         if( cache->timeout != 0 &&
             (int) ( t - entry->timestamp ) > cache->timeout )
             continue;
@@ -138,9 +148,12 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
 {
     int ret = 1;
 #if defined(MBEDTLS_HAVE_TIME)
-    time_t t = time( NULL ), oldest = 0;
+    time_t t, oldest = 0;
     mbedtls_ssl_cache_entry *old = NULL;
-#endif
+#if defined(WINCE)
+    FILETIME ft;
+#endif /* WINCE */
+#endif /* MBEDTLS_HAVE_TIME */
     mbedtls_ssl_cache_context *cache = (mbedtls_ssl_cache_context *) data;
     mbedtls_ssl_cache_entry *cur, *prv;
     int count = 0;
@@ -153,11 +166,26 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
     cur = cache->chain;
     prv = NULL;
 
+#if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
+    t = time( NULL );
+#endif /* WINCE */
+#endif /* MBEDTLS_HAVE_TIME */
+
     while( cur != NULL )
     {
         count++;
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
+    t = time( NULL );
+#endif /* WINCE */
         if( cache->timeout != 0 &&
             (int) ( t - cur->timestamp ) > cache->timeout )
         {

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -662,6 +662,7 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
     unsigned char *p = ssl->handshake->randbytes;
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
     time_t t;
@@ -680,7 +681,8 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = time( NULL );
@@ -1398,6 +1400,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
     uint32_t t;
 #endif
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
 
@@ -1596,7 +1599,8 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         ssl->handshake->resume = 0;
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     ssl->session_negotiate->start = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     ssl->session_negotiate->start = time( NULL );

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -166,6 +166,7 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
     unsigned long t;
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
 #endif /* MBEDTLS_HAVE_TIME */
@@ -178,7 +179,8 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     t = (unsigned long)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = (unsigned long) time( NULL );
@@ -223,6 +225,7 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     mbedtls_ssl_cookie_ctx *ctx = (mbedtls_ssl_cookie_ctx *) p_ctx;
     unsigned long cur_time, cookie_time;
 #if defined(MBEDTLS_HAVE_TIME) && defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* MBEDTLS_HAVE_TIME && WINCE */
 
@@ -256,11 +259,13 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     cur_time = (unsigned long)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     cur_time = (unsigned long) time( NULL );
 #endif /* WINCE */
+
 #else
     cur_time = ctx->serial;
 #endif

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -164,6 +164,11 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
     int ret;
     mbedtls_ssl_cookie_ctx *ctx = (mbedtls_ssl_cookie_ctx *) p_ctx;
     unsigned long t;
+#if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    FILETIME ft;
+#endif /* WINCE */
+#endif /* MBEDTLS_HAVE_TIME */
 
     if( ctx == NULL || cli_id == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -172,7 +177,12 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    t = (unsigned long)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
     t = (unsigned long) time( NULL );
+#endif /* WINCE */
 #else
     t = ctx->serial++;
 #endif
@@ -212,6 +222,9 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     unsigned char *p = ref_hmac;
     mbedtls_ssl_cookie_ctx *ctx = (mbedtls_ssl_cookie_ctx *) p_ctx;
     unsigned long cur_time, cookie_time;
+#if defined(MBEDTLS_HAVE_TIME) && defined(WINCE)
+    FILETIME ft;
+#endif /* MBEDTLS_HAVE_TIME && WINCE */
 
     if( ctx == NULL || cli_id == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -242,7 +255,12 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
         return( -1 );
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    cur_time = (unsigned long)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
     cur_time = (unsigned long) time( NULL );
+#endif /* WINCE */
 #else
     cur_time = ctx->serial;
 #endif

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -45,10 +45,6 @@
 #define mbedtls_free       free
 #endif
 
-#if defined(MBEDTLS_HAVE_TIME)
-#include <time.h>
-#endif
-
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
@@ -2211,6 +2207,9 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_HAVE_TIME)
     time_t t;
+#if defined(WINCE)
+    FILETIME ft;
+#endif /* WINCE */
 #endif
     int ret;
     size_t olen, ext_len = 0, n;
@@ -2253,7 +2252,12 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
                         buf[4], buf[5] ) );
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+    GetSystemTimeAsFileTime(&ft);
+    t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
     t = time( NULL );
+#endif /* WINCE */
     *p++ = (unsigned char)( t >> 24 );
     *p++ = (unsigned char)( t >> 16 );
     *p++ = (unsigned char)( t >>  8 );
@@ -2302,7 +2306,12 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
         ssl->state++;
 
 #if defined(MBEDTLS_HAVE_TIME)
+#if defined(WINCE)
+        GetSystemTimeAsFileTime(&ft);
+        ssl->session_negotiate->start = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
+#else
         ssl->session_negotiate->start = time( NULL );
+#endif /* WINCE */
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2208,6 +2208,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_HAVE_TIME)
     time_t t;
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
 #endif /* WINCE */
 #endif
@@ -2253,7 +2254,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     t = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     t = time( NULL );
@@ -2307,7 +2309,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
-        GetSystemTimeAsFileTime(&ft);
+        GetSystemTime(&st);
+        SystemTimeToFileTime(&st, &ft);
         ssl->session_negotiate->start = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
         ssl->session_negotiate->start = time( NULL );

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -70,8 +70,10 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
 
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(WINCE)
+    SYSTEMTIME st;
     FILETIME ft;
-    GetSystemTimeAsFileTime(&ft);
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
     key->generation_time = (uint32_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
     key->generation_time = (uint32_t) time( NULL );
@@ -106,8 +108,10 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
     {
         uint32_t current_time, key_time;
 #if defined(WINCE)
+        SYSTEMTIME st;
         FILETIME ft;
-        GetSystemTimeAsFileTime(&ft);
+        GetSystemTime(&st);
+        SystemTimeToFileTime(&st, &ft);
         current_time = (uint32_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
         current_time = (uint32_t) time( NULL );
@@ -466,8 +470,10 @@ int mbedtls_ssl_ticket_parse( void *p_ticket,
         /* Check for expiration */
         time_t current_time;
 #if defined(WINCE)
+        SYSTEMTIME st;
         FILETIME ft;
-        GetSystemTimeAsFileTime(&ft);
+        GetSystemTime(&st);
+        SystemTimeToFileTime(&st, &ft);
         current_time = (time_t)( ( *( ( DWORDLONG* ) &ft ) / 10000000) - 11644473600LL);
 #else
         current_time = time( NULL );


### PR DESCRIPTION
Added windows CE implementation for current time (time()).

The following code snippet (or similar) has been added to a number of places in the library.

```
#if defined(WINCE)
   SYSTEMTIME st;
   FILETIME ft;
   GetSystemTime(&st);
   SystemTimeToFileTime(&st, &ft);
   time = (time_t)( ( *((DWORDLONG*)&ft) / 10000000) - 11644473600LL);
#else
   time = time( NULL );
#endif /* WINCE */
```

Background:
Since older windows CE versions does not support higher TLS protocol versions than 1.0, mbedTLS is good choice to use instead of windows standard ssl library. A problem is that mbedTLS not is compliant with windows time.h. This fix solves that issue by replacing time() with GetSystemTime() for windows CE.

Github Issue: #411 "time() replacement for older windows CE" 
ARM Internal Ref: IOTSSL-618
