### PR TITLE
[ASN.1] Add support of negative values and values larger than 128

### DIFF
--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -204,25 +204,65 @@ int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val )
 {
     int ret;
     size_t len = 0;
+    size_t val_buf_len = 0;
+    unsigned char val_buf[8]; // consider that size of int <= 64 bit
 
-    // TODO negative values and values larger than 128
-    // DER format assumes 2s complement for numbers, so the leftmost bit
-    // should be 0 for positive numbers and 1 for negative numbers.
-    //
+    const int one_const = 1;
+    const int is_bigendian = (*(char*)&one_const) == 0;
+
+    const unsigned char * begin = is_bigendian ?
+            (const unsigned char *)&val :
+            (const unsigned char *)&val + sizeof(val) - 1;
+
+    const unsigned char * end = is_bigendian ?
+            (const unsigned char *)&val + sizeof(val) :
+            (const unsigned char *)&val - 1;
+
+    const int inc = is_bigendian ? +1 : -1;
+
+    const unsigned char * prev = begin;
+    const unsigned char * curr = begin + inc;
+    int is_trim_finished = 0;
+    size_t trimed_cnt = 0;
+
     if( *p - start < 1 )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-    len += 1;
-    *--(*p) = val;
-
-    if( val > 0 && **p & 0x80 )
+    for(; curr != end; curr += inc )
     {
-        if( *p - start < 1 )
-            return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+        if( !is_trim_finished )
+        {
+            const int is_ones_leading =
+                    ( *prev == 0xFF ) && ( ( *curr & 0x80 ) == 0x80 );
+            const int is_zeros_leading =
+                    ( *prev == 0x00 ) && ( ( *curr & 0x80 ) == 0x00 );
+            if( is_ones_leading || is_zeros_leading )
+            {
+                ++trimed_cnt;
+            }
+            else
+            {
+                is_trim_finished = 1;
+            }
+        }
 
-        *--(*p) = 0x00;
-        len += 1;
+        if( is_trim_finished )
+        { // Not else for previous 'if' statement
+            val_buf[val_buf_len++] = *prev;
+        }
+
+        prev = curr;
     }
+
+    /* process integer last byte */
+    val_buf[val_buf_len++] = *prev;
+
+    if( *p - start < (int)val_buf_len )
+        return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+
+    *p -= val_buf_len;
+    len += val_buf_len;
+    memcpy( *p, val_buf, val_buf_len );
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( p, start, MBEDTLS_ASN1_INTEGER ) );

--- a/tests/suites/test_suite_asn1write.data
+++ b/tests/suites/test_suite_asn1write.data
@@ -48,3 +48,27 @@ mbedtls_asn1_write_ia5_string:"ABC":"":3:MBEDTLS_ERR_ASN1_BUF_TOO_SMALL
 
 ASN.1 Write IA5 String #5 (Buffer too small for string)
 mbedtls_asn1_write_ia5_string:"ABC":"":2:MBEDTLS_ERR_ASN1_BUF_TOO_SMALL
+
+ASN.1 Write Integer #0 (Zero)
+mbedtls_asn1_write_int:0:"020100":3:3
+
+ASN.1 Write Integer #1 (Small positive)
+mbedtls_asn1_write_int:123:"02017B":3:3
+
+ASN.1 Write Integer #2 (Big positive)
+mbedtls_asn1_write_int:305419896:"020412345678":6:6
+
+ASN.1 Write Integer #3 (Small negative)
+mbedtls_asn1_write_int:-16:"0201F0":3:3
+
+ASN.1 Write Integer #4 (Big negative)
+mbedtls_asn1_write_int:-231451016:"0204F2345678":6:6
+
+ASN.1 Write Integer #5 (Buffer too small for tag)
+mbedtls_asn1_write_int:-231451016:"0204F2345678":5:MBEDTLS_ERR_ASN1_BUF_TOO_SMALL
+
+ASN.1 Write Integer #6 (Buffer too small for len)
+mbedtls_asn1_write_int:-231451016:"0204F2345678":4:MBEDTLS_ERR_ASN1_BUF_TOO_SMALL
+
+ASN.1 Write Integer #7 (Buffer too small for integer)
+mbedtls_asn1_write_int:-231451016:"0204F2345678":3:MBEDTLS_ERR_ASN1_BUF_TOO_SMALL

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -82,3 +82,38 @@ void mbedtls_asn1_write_ia5_string( char *str, char *hex_asn1,
     }
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_asn1_write_int( int val, char *hex_asn1,
+                            int buf_len, int result )
+{
+    int ret;
+    unsigned char buf[150];
+    unsigned char asn1[150] = { 0 };
+    size_t asn1_len, i;
+    unsigned char *p;
+
+    memset( buf, GUARD_VAL, sizeof( buf ) );
+
+    asn1_len = unhexify( asn1, hex_asn1 );
+
+    p = buf + GUARD_LEN + buf_len;
+
+    ret = mbedtls_asn1_write_int( &p, buf + GUARD_LEN, val );
+
+    /* Check for buffer overwrite on both sides */
+    for( i = 0; i < GUARD_LEN; i++ )
+    {
+        TEST_ASSERT( buf[i] == GUARD_VAL );
+        TEST_ASSERT( buf[GUARD_LEN + buf_len + i] == GUARD_VAL );
+    }
+
+    if( result >= 0 )
+    {
+        TEST_ASSERT( (size_t) ret == asn1_len );
+        TEST_ASSERT( p + asn1_len == buf + GUARD_LEN + buf_len );
+
+        TEST_ASSERT( memcmp( p, asn1, asn1_len ) == 0 );
+    }
+}
+/* END_CASE */


### PR DESCRIPTION
Implement TODO: negative values and values larger than 128 DER format assumes 2s complement for numbers, so the leftmost bit should be 0 for positive numbers and 1 for negative numbers.
