### PR TITLE
Add function mbedtls_pkcs12_pbe_ext()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ script:
 - tests/scripts/key-exchanges.pl
 env:
   global:
-    secure: "barHldniAfXyoWOD/vcO+E6/Xm4fmcaUoC9BeKW+LwsHqlDMLvugaJnmLXkSpkbYhVL61Hzf3bo0KPJn88AFc5Rkf8oYHPjH4adMnVXkf3B9ghHCgznqHsAH3choo6tnPxaFgOwOYmLGb382nQxfE5lUdvnM/W/psQjWt66A1+k="
+    secure: "h8SbQY2B7QC6rg6EtUgRgV2sgUf58QYdStdgA8wbKluoz1Km7Q0bgtdcpnyFrfOK84G4yJQifNW3OohBnqfjCmQNsVBYHExMTEqzcDVCYLV0eFdDHf3SJnp4wJYQ21ZXpzinZYww8lOhyMSjaoi9vnxZGbJyLW6Y/Zwa68KTSbc="
 
 addons:
   coverity_scan:
     project:
-      name: "ARMmbed/mbedtls"
-    notification_email: p.j.bakker@polarssl.org
+      name: "VirgilSecurity/mbedtls"
+    notification_email: sseroshtan@virgilsecurity.com
     build_command_prepend:
     build_command: make
     branch_pattern: coverity_scan

--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -85,6 +85,31 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 const unsigned char *pwd,  size_t pwdlen,
                 const unsigned char *input, size_t len,
                 unsigned char *output );
+/**
+ * \brief            PKCS12 Password Based function (encryption / decryption)
+ *                   for cipher-based and mbedtls_md-based PBE's
+ *
+ *                   Added output parameter that return actual number of bytes
+ *                   written to the output buffer
+ *
+ * \param pbe_params an ASN1 buffer containing the pkcs-12PbeParams structure
+ * \param mode       either MBEDTLS_PKCS12_PBE_ENCRYPT or MBEDTLS_PKCS12_PBE_DECRYPT
+ * \param cipher_type the cipher used
+ * \param md_type     the mbedtls_md used
+ * \param pwd        the password used (may be NULL if no password is used)
+ * \param pwdlen     length of the password (may be 0)
+ * \param input      the input data
+ * \param len        data length
+ * \param output     the output buffer
+ * \param olen       actual number of bytes written to output
+ *
+ * \return           0 if successful, or a MBEDTLS_ERR_XXX code
+ */
+int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params, int mode,
+                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
+                const unsigned char *pwd,  size_t pwdlen,
+                const unsigned char *input, size_t len,
+                unsigned char *output, size_t *olen );
 
 /**
  * \brief            The PKCS#12 derivation function uses a password and a salt


### PR DESCRIPTION
### Motivation
Using standard `mbedtls_pkcs12_pbe()` function there is no way to define how many actual bytes was written to the output buffer. Actual written bytes length differs from the input bytes length due to padding.

### Solution
Add new function `mbedtls_pkcs12_pbe_ext()` which returns actual length of the written bytes.