### PR TITLE
Clang analyze fixes

### DIFF
--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -93,7 +93,7 @@ static int pkcs12_pbe_derive_key_iv( mbedtls_asn1_buf *pbe_params, mbedtls_md_ty
                                      unsigned char *key, size_t keylen,
                                      unsigned char *iv,  size_t ivlen )
 {
-    int ret, iterations;
+    int ret, iterations = 0;
     mbedtls_asn1_buf salt;
     size_t i;
     unsigned char unipwd[PKCS12_MAX_PWDLEN * 2 + 2];

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -797,7 +797,12 @@ int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
     int ret;
     size_t ilen, pad_count = 0, i;
     unsigned char *p, bad, pad_done = 0;
+#ifdef __clang_analyzer__
+    /* Shut up Clang, mbedtls_rsa_public/private writes to this */
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = { };
+#else
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+#endif
 
     if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -1175,13 +1180,18 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     int ret;
     size_t siglen;
     unsigned char *p;
-    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
     unsigned char result[MBEDTLS_MD_MAX_SIZE];
     unsigned char zeros[8];
     unsigned int hlen;
     size_t slen, msb;
     const mbedtls_md_info_t *md_info;
     mbedtls_md_context_t md_ctx;
+#ifdef __clang_analyzer__
+    /* Shut up Clang, mbedtls_rsa_public/private writes to this */
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = { };
+#else
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+#endif
 
     if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V21 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
@@ -1320,10 +1330,15 @@ int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
     int ret;
     size_t len, siglen, asn1_len;
     unsigned char *p, *end;
-    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
     mbedtls_md_type_t msg_md_alg;
     const mbedtls_md_info_t *md_info;
     mbedtls_asn1_buf oid;
+#ifdef __clang_analyzer__
+    /* Shut up Clang, mbedtls_rsa_public/private writes to this */
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE] = { };
+#else
+    unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+#endif
 
     if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -265,7 +265,6 @@ static void ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_ECP_C)
     for( grp_id = ssl->conf->curve_list; *grp_id != MBEDTLS_ECP_DP_NONE; grp_id++ )
     {
-        info = mbedtls_ecp_curve_info_from_grp_id( *grp_id );
 #else
     for( info = mbedtls_ecp_curve_list(); info->grp_id != MBEDTLS_ECP_DP_NONE; info++ )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2708,7 +2708,7 @@ void mbedtls_ssl_send_flight_completed( mbedtls_ssl_context *ssl )
  */
 int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl )
 {
-    int ret, done = 0;
+    int ret, done = 0, out_msg_type;
     size_t len = ssl->out_msglen;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write record" ) );
@@ -2724,7 +2724,9 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl )
 #endif
     if( ssl->out_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
     {
-        if( ssl->out_msg[0] != MBEDTLS_SSL_HS_HELLO_REQUEST &&
+        out_msg_type = ssl->out_msg[0];
+
+        if( out_msg_type != MBEDTLS_SSL_HS_HELLO_REQUEST &&
             ssl->handshake == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
@@ -2751,7 +2753,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl )
             len += 8;
 
             /* Write message_seq and update it, except for HelloRequest */
-            if( ssl->out_msg[0] != MBEDTLS_SSL_HS_HELLO_REQUEST )
+            if( out_msg_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
                 ssl->out_msg[4] = ( ssl->handshake->out_msg_seq >> 8 ) & 0xFF;
                 ssl->out_msg[5] = ( ssl->handshake->out_msg_seq      ) & 0xFF;
@@ -2769,7 +2771,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl )
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-        if( ssl->out_msg[0] != MBEDTLS_SSL_HS_HELLO_REQUEST )
+        if( out_msg_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             ssl->handshake->update_checksum( ssl, ssl->out_msg, len );
     }
 

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -104,7 +104,7 @@ int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
     /*
      * Check for valid input
      */
-    if( csr == NULL || buf == NULL )
+    if( csr == NULL || buf == NULL || buflen == 0 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
 
     mbedtls_x509_csr_init( csr );
@@ -274,14 +274,14 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
     /*
      * Check for valid input
      */
-    if( csr == NULL || buf == NULL )
+    if( csr == NULL || buf == NULL || buflen == 0 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_PEM_PARSE_C)
     mbedtls_pem_init( &pem );
 
     /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
-    if( buflen == 0 || buf[buflen - 1] != '\0' )
+    if( buf[buflen - 1] != '\0' )
         ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
     else
         ret = mbedtls_pem_read_buffer( &pem,

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -83,7 +83,7 @@ static int generic_check( const mbedtls_md_info_t *md_info, char *filename )
     int nb_err1, nb_err2;
     int nb_tot1, nb_tot2;
     unsigned char sum[MBEDTLS_MD_MAX_SIZE];
-    char buf[MBEDTLS_MD_MAX_SIZE * 2 + 1], line[1024];
+    char buf[MBEDTLS_MD_MAX_SIZE * 2 + 1] = { }, line[1024];
     char diff;
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )


### PR DESCRIPTION
Some fixes to shut up clang-analyze warnings.

While running it, I found two actual bugs, a double-free in ssl_tls.c and a memory leak in rsa.c, but thankfully it looks like both of those have been fixed since the release I was testing.