### PR TITLE
Fix invalid conversion

### DIFF
--- a/library/sha1.c
+++ b/library/sha1.c
@@ -49,7 +49,7 @@
 
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+    volatile unsigned char *p = (unsigned char*) v; while( n-- ) *p++ = 0;
 }
 
 /*


### PR DESCRIPTION
Added this cast since without it the compiler for Particle.io will throw the following error: invalid conversion from 'void*' to 'volatile unsigned char*'. I hope this helps :)