### PR TITLE
Update ssl-opt.sh capabilities to help with debugging

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -33,6 +33,7 @@ MEMCHECK=0
 FILTER='.*'
 EXCLUDE='^$'
 
+SHOW_TEST_NUMBER=0
 RUN_TEST_NUMBER=''
 
 print_usage() {
@@ -42,6 +43,7 @@ print_usage() {
     printf "  -f|--filter\tOnly matching tests are executed (default: '$FILTER')\n"
     printf "  -e|--exclude\tMatching tests are excluded (default: '$EXCLUDE')\n"
     printf "  -n|--number\tExecute only numbered test (comma-separated, e.g. '245,256')\n"
+    printf "  -s|--show-numbers\tShow test numbers in front of test names\n"
 }
 
 get_options() {
@@ -58,6 +60,9 @@ get_options() {
                 ;;
             -n|--number)
                 shift; RUN_TEST_NUMBER=$1
+                ;;
+            -s|--show-numbers)
+                SHOW_TEST_NUMBER=1
                 ;;
             -h|--help)
                 print_usage
@@ -143,12 +148,19 @@ needs_more_time() {
 
 # print_name <name>
 print_name() {
-    printf "$1 "
-    LEN=$(( 72 - `echo "$1" | wc -c` ))
+    TESTS=$(( $TESTS + 1 ))
+    LINE=""
+
+    if [ "$SHOW_TEST_NUMBER" -gt 0 ]; then
+        LINE="$TESTS "
+    fi
+
+    LINE="$LINE$1"
+    printf "$LINE "
+    LEN=$(( 72 - `echo "$LINE" | wc -c` ))
     for i in `seq 1 $LEN`; do printf '.'; done
     printf ' '
 
-    TESTS=$(( $TESTS + 1 ))
 }
 
 # fail <message>

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -33,12 +33,15 @@ MEMCHECK=0
 FILTER='.*'
 EXCLUDE='^$'
 
+RUN_TEST_NUMBER=''
+
 print_usage() {
     echo "Usage: $0 [options]"
     printf "  -h|--help\tPrint this help.\n"
     printf "  -m|--memcheck\tCheck memory leaks and errors.\n"
     printf "  -f|--filter\tOnly matching tests are executed (default: '$FILTER')\n"
     printf "  -e|--exclude\tMatching tests are excluded (default: '$EXCLUDE')\n"
+    printf "  -n|--number\tExecute only numbered test (comma-separated, e.g. '245,256')\n"
 }
 
 get_options() {
@@ -52,6 +55,9 @@ get_options() {
                 ;;
             -m|--memcheck)
                 MEMCHECK=1
+                ;;
+            -n|--number)
+                shift; RUN_TEST_NUMBER=$1
                 ;;
             -h|--help)
                 print_usage
@@ -292,6 +298,13 @@ run_test() {
     fi
 
     print_name "$NAME"
+
+    # Do we only run numbered tests?
+    if [ "X$RUN_TEST_NUMBER" = "X" ]; then :
+    elif echo ",$RUN_TEST_NUMBER," | grep ",$TESTS," >/dev/null; then :
+    else
+        SKIP_NEXT="YES"
+    fi
 
     # should we skip?
     if [ "X$SKIP_NEXT" = "XYES" ]; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -36,6 +36,8 @@ EXCLUDE='^$'
 SHOW_TEST_NUMBER=0
 RUN_TEST_NUMBER=''
 
+PRESERVE_LOGS=0
+
 print_usage() {
     echo "Usage: $0 [options]"
     printf "  -h|--help\tPrint this help.\n"
@@ -44,6 +46,7 @@ print_usage() {
     printf "  -e|--exclude\tMatching tests are excluded (default: '$EXCLUDE')\n"
     printf "  -n|--number\tExecute only numbered test (comma-separated, e.g. '245,256')\n"
     printf "  -s|--show-numbers\tShow test numbers in front of test names\n"
+    printf "  -p|--preserve-logs\tPreserve logs of successful tests as well\n"
 }
 
 get_options() {
@@ -63,6 +66,9 @@ get_options() {
                 ;;
             -s|--show-numbers)
                 SHOW_TEST_NUMBER=1
+                ;;
+            -p|--preserve-logs)
+                PRESERVE_LOGS=1
                 ;;
             -h|--help)
                 print_usage
@@ -485,6 +491,11 @@ run_test() {
 
     # if we're here, everything is ok
     echo "PASS"
+    if [ "$PRESERVE_LOGS" -gt 0 ]; then
+        mv $SRV_OUT o-srv-${TESTS}.log
+        mv $CLI_OUT o-cli-${TESTS}.log
+    fi
+
     rm -f $SRV_OUT $CLI_OUT $PXY_OUT
 }
 


### PR DESCRIPTION
In order to reduce debugging time, allows you to only run interesting
tests (by number) from the commandline.

e.g. the command 'tests/ssl-opt.sh -n 246,258' will only run test 246
and 258 (as per the number in the log file names)