### PR TITLE
Fix indentation inconsistency

### DIFF
--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -502,14 +502,14 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
     {
         mbedtls_pem_init( &pem );
 
-    /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
-    if( buflen == 0 || buf[buflen - 1] != '\0' )
-        ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
-    else
-        ret = mbedtls_pem_read_buffer( &pem,
-                               "-----BEGIN X509 CRL-----",
-                               "-----END X509 CRL-----",
-                               buf, NULL, 0, &use_len );
+        /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
+        if( buflen == 0 || buf[buflen - 1] != '\0' )
+            ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
+        else
+            ret = mbedtls_pem_read_buffer( &pem,
+                                   "-----BEGIN X509 CRL-----",
+                                   "-----END X509 CRL-----",
+                                   buf, NULL, 0, &use_len );
 
         if( ret == 0 )
         {


### PR DESCRIPTION
GCC version 6.1 outputs a warning for the mismatched indentation of
if-else clauses.

Here we fix that warning by correcting the indentation of block inside
the do-while loop.