### PR TITLE
Include order of Curve25519 base point in curve data

### DIFF
--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -142,7 +142,7 @@ typedef struct
     mbedtls_mpi A;              /*!<  1. A in the equation, or 2. (A + 2) / 4       */
     mbedtls_mpi B;              /*!<  1. B in the equation, or 2. unused            */
     mbedtls_ecp_point G;        /*!<  generator of the (sub)group used              */
-    mbedtls_mpi N;              /*!<  1. the order of G, or 2. unused               */
+    mbedtls_mpi N;              /*!<  the order of G                                */
     size_t pbits;       /*!<  number of bits in P                           */
     size_t nbits;       /*!<  number of bits in 1. P, or 2. private keys    */
     unsigned int h;     /*!<  internal: 1 if the constants are static       */

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -670,6 +670,11 @@ static int ecp_use_curve25519( mbedtls_ecp_group *grp )
     MBEDTLS_MPI_CHK( mbedtls_mpi_sub_int( &grp->P, &grp->P, 19 ) );
     grp->pbits = mbedtls_mpi_bitlen( &grp->P );
 
+    /* N = 2^252 + 27742317777372353535851937790883648493 */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &grp->N, 16,
+                                              "14DEF9DEA2F79CD65812631A5CF5D3ED" ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_set_bit( &grp->N, 252, 1 ) );
+
     /* Y intentionaly not set, since we use x/z coordinates.
      * This is used as a marker to identify Montgomery curves! */
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &grp->G.X, 9 ) );


### PR DESCRIPTION
I needed this in some EC work I was doing recently, it seems odd that the basepoint order isn't included in the standard curve data.

I've double-checked the constant is correct by printing the value of N with mbedtls_mpi_write_string and googling the number: it's the same value in the source code for Nettle and BoringSSL.
