### PR TITLE
Added cmac.o to libary/Makefile

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -48,9 +48,9 @@ OBJS_CRYPTO=	aes.o		aesni.o		arc4.o		\
 		asn1parse.o	asn1write.o	base64.o	\
 		bignum.o	blowfish.o	camellia.o	\
 		ccm.o		cipher.o	cipher_wrap.o	\
-		ctr_drbg.o	des.o		dhm.o		\
-		ecdh.o		ecdsa.o		ecjpake.o	\
-		ecp.o						\
+		cmac.o		ctr_drbg.o	des.o		\
+		dhm.o		ecdh.o		ecdsa.o		\
+		ecjpake.o	ecp.o				\
 		ecp_curves.o	entropy.o	entropy_poll.o	\
 		error.o		gcm.o		havege.o	\
 		hmac_drbg.o	md.o		md2.o		\


### PR DESCRIPTION
Support for CMAC was added to the Cmake build system, but not to the Make build system.