### PR TITLE
Adds check for valgrind to ssl-opt.sh

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -551,6 +551,12 @@ if [ ! -x "$P_PXY" ]; then
     echo "Command '$P_PXY' is not an executable file"
     exit 1
 fi
+if [ "$MEMCHECK" -gt 0 ]; then
+    if which valgrind >/dev/null 2>&1; then :; else
+        echo "Memcheck not possible. Valgrind not found"
+        exit 1
+    fi
+fi
 if which $OPENSSL_CMD >/dev/null 2>&1; then :; else
     echo "Command '$OPENSSL_CMD' not found"
     exit 1


### PR DESCRIPTION
Provides graceful exit rather than fail silently if valgrind isn't installed.