### PR TITLE
Add missing mbedtls_time_t definitions

### DIFF
--- a/library/error.c
+++ b/library/error.c
@@ -34,6 +34,7 @@
 #include "mbedtls/platform.h"
 #else
 #define mbedtls_snprintf snprintf
+#define mbedtls_time_t   time_t
 #endif
 
 #if defined(MBEDTLS_ERROR_C)

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -30,6 +30,7 @@
 #else
 #include <stdio.h>
 #define mbedtls_printf     printf
+#define mbedtls_time_t     time_t
 #endif
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -30,6 +30,7 @@
 #else
 #include <stdio.h>
 #define mbedtls_printf     printf
+#define mbedtls_time_t     time_t
 #endif
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_ENTROPY_C) ||   \

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -30,6 +30,7 @@
 #else
 #include <stdio.h>
 #define mbedtls_printf     printf
+#define mbedtls_time_t     time_t
 #endif
 
 #if defined(MBEDTLS_AES_C) && defined(MBEDTLS_DHM_C) && \

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #define mbedtls_printf     printf
 #define mbedtls_fprintf    fprintf
+#define mbedtls_time_t     time_t
 #endif
 
 #if !defined(MBEDTLS_SSL_CLI_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #define mbedtls_printf     printf
 #define mbedtls_fprintf    fprintf
+#define mbedtls_time_t     time_t
 #endif
 
 #if !defined(MBEDTLS_SSL_SRV_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #define mbedtls_fprintf    fprintf
 #define mbedtls_printf     printf
+#define mbedtls_time_t     time_t
 #endif
 
 #if !defined(MBEDTLS_BIGNUM_C) || !defined(MBEDTLS_CERTS_C) ||    \

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -34,6 +34,7 @@
 #include "mbedtls/platform.h"
 #else
 #define mbedtls_snprintf snprintf
+#define mbedtls_time_t   time_t
 #endif
 
 #if defined(MBEDTLS_ERROR_C)


### PR DESCRIPTION
Add missing mbedtls_time_t definitions to sample applications and the error.c generation script.

Fixes #490.