### PR TITLE
Unchecked calls to mbedtls_md_setup() and associated Memory Leaks.

### DIFF
--- a/library/md.c
+++ b/library/md.c
@@ -423,7 +423,10 @@ int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key,
     mbedtls_md_init( &ctx );
 
     if( ( ret = mbedtls_md_setup( &ctx, md_info, 1 ) ) != 0 )
+    {
+        mbedtls_md_free( &ctx );
         return( ret );
+    }
 
     mbedtls_md_hmac_starts( &ctx, key, keylen );
     mbedtls_md_hmac_update( &ctx, input, ilen );

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -275,7 +275,10 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
     mbedtls_md_init( &md_ctx );
 
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
+    {
+        mbedtls_md_free( &md_ctx );
         return( ret );
+    }
     hlen = mbedtls_md_get_size( md_info );
 
     if( hlen <= 32 )

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -558,7 +558,11 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     memcpy( p, input, ilen );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) != 0 ) )
+    {
+        mbedtls_md_free( &md_ctx );
+        return( ret );
+    }
 
     // maskedDB: Apply dbMask to DB
     //
@@ -728,7 +732,11 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     hlen = mbedtls_md_get_size( md_info );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) != 0 ) )
+    {
+        mbedtls_md_free( &md_ctx );
+        return( ret );
+    }
 
     /* Generate lHash */
     mbedtls_md( md_info, label, label_len, lhash );
@@ -972,7 +980,11 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     p += slen;
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) != 0 ) )
+    {
+        mbedtls_md_free( &md_ctx );
+        return( ret );
+    }
 
     // Generate H = Hash( M' )
     //
@@ -1245,7 +1257,11 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) != 0 ) )
+    {
+        mbedtls_md_free( &md_ctx );
+        return( ret );
+    }
 
     mgf_mask( p, siglen - hlen - 1, p + siglen - hlen - 1, hlen, &md_ctx );
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2457,6 +2457,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
                                      mbedtls_md_info_from_type( md_alg ), 0 ) ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_setup", ret );
+                mbedtls_md_free( &ctx );
                 return( ret );
             }
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -118,9 +118,7 @@ int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
 
     ret = mbedtls_md_setup( &ctx->hmac_ctx, mbedtls_md_info_from_type( COOKIE_MD ), 1 );
     if( ret != 0 )
-    {
-       return( ret );
-    }
+        return( ret );
 
     ret = mbedtls_md_hmac_starts( &ctx->hmac_ctx, key, sizeof( key ) );
     if( ret != 0 )

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -118,7 +118,9 @@ int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
 
     ret = mbedtls_md_setup( &ctx->hmac_ctx, mbedtls_md_info_from_type( COOKIE_MD ), 1 );
     if( ret != 0 )
-        return( ret );
+    {
+       return( ret );
+    }
 
     ret = mbedtls_md_hmac_starts( &ctx->hmac_ctx, key, sizeof( key ) );
     if( ret != 0 )

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2960,6 +2960,7 @@ curve_matching_done:
             if( ( ret = mbedtls_md_setup( &ctx, md_info, 0 ) ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_setup", ret );
+                mbedtls_md_free( &ctx );
                 return( ret );
             }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -303,8 +303,10 @@ static int tls1_prf( const unsigned char *secret, size_t slen,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 1 ) ) != 0 )
+    {
+        mbedtls_md_free( &md_ctx );
         return( ret );
-
+    }
     mbedtls_md_hmac_starts( &md_ctx, S1, hs );
     mbedtls_md_hmac_update( &md_ctx, tmp + 20, nb );
     mbedtls_md_hmac_finish( &md_ctx, 4 + tmp );
@@ -334,7 +336,10 @@ static int tls1_prf( const unsigned char *secret, size_t slen,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
 
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 1 ) ) != 0 )
+    {
+        mbedtls_md_free( &md_ctx );
         return( ret );
+    }
 
     mbedtls_md_hmac_starts( &md_ctx, S2, hs );
     mbedtls_md_hmac_update( &md_ctx, tmp + 20, nb );
@@ -399,8 +404,10 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
      * Compute P_<hash>(secret, label + random)[0..dlen]
      */
     if ( ( ret = mbedtls_md_setup( &md_ctx, md_info, 1 ) ) != 0 )
+    {
+        mbedtls_md_free( &md_ctx );
         return( ret );
-
+    }
     mbedtls_md_hmac_starts( &md_ctx, secret, slen );
     mbedtls_md_hmac_update( &md_ctx, tmp + md_len, nb );
     mbedtls_md_hmac_finish( &md_ctx, tmp );


### PR DESCRIPTION
In `rsa.c`, there are several unchecked call to `mbedtls_md_setup()`.  If the call fails, the MGF routine is passed an invalid `&md_ctx`.  

Thanks to @sergbuslovsky for diagnosing this bug.  Our fix to this issue resulted in us finding and fixing a related potential memory leak

We found this bug when running mbedTLS on an embedded system with limited RAM.  When available heap space was limited, calls to `mbedtls_md_setup()` were failing due to `calloc` failures. 

We found that other calls to `mbedtls_md_setup()` used the same idiom as our fix, but did not always call ` mbedtls_md_free( &ctx )` . If  mbedtls_md_setup is called with `hmac = 1`, then `mbedtls_md_setup()` makes 2 separate calls to `mbedtls_calloc`.  If the second call fails and `mbedtls_md_free()` is not called, then the first heap allocated variable (`mbedtls_md_context_t->md_ctx`) is not freed, resulting in a memory leak.  Such  a memory leak is particularly pernicious since it is most likely to occur when available heap is already severely constrained.

To fix this memory leak, we ensured that, in all functions that used  `mbedtls_md_setup()`, the function  `mbedtls_md_free()`  would  always be called whenever both:
-  `mbedtls_md_setup()`  returned an error value, and
-  `mbedtls_md_free()` would have been called before a normal function exit.