### PR TITLE
Fixed unchecked calls to mbedtls_md_setup in rsa.c

### DIFF
--- a/library/rsa.c
+++ b/library/rsa.c
@@ -558,7 +558,11 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     memcpy( p, input, ilen );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
+    {
+        mbedtls_md_free(&md_ctx);
+        return( ret );
+    }
 
     // maskedDB: Apply dbMask to DB
     //
@@ -728,7 +732,12 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     hlen = mbedtls_md_get_size( md_info );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
+    {
+        mbedtls_md_free(&md_ctx);
+        return( ret );
+    }
+
 
     /* Generate lHash */
     mbedtls_md( md_info, label, label_len, lhash );
@@ -972,7 +981,11 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     p += slen;
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
+    {
+        mbedtls_md_free(&md_ctx);
+        return( ret );
+    }
 
     // Generate H = Hash( M' )
     //
@@ -1245,7 +1258,11 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
     mbedtls_md_init( &md_ctx );
-    mbedtls_md_setup( &md_ctx, md_info, 0 );
+    if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
+    {
+        mbedtls_md_free(&md_ctx);
+        return( ret );
+    }
 
     mgf_mask( p, siglen - hlen - 1, p + siglen - hlen - 1, hlen, &md_ctx );
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -560,7 +560,7 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
     {
-        mbedtls_md_free(&md_ctx);
+        mbedtls_md_free( &md_ctx );
         return( ret );
     }
 
@@ -734,7 +734,7 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
     {
-        mbedtls_md_free(&md_ctx);
+        mbedtls_md_free( &md_ctx );
         return( ret );
     }
 
@@ -983,7 +983,7 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
     {
-        mbedtls_md_free(&md_ctx);
+        mbedtls_md_free( &md_ctx );
         return( ret );
     }
 
@@ -1260,7 +1260,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
     {
-        mbedtls_md_free(&md_ctx);
+        mbedtls_md_free( &md_ctx );
         return( ret );
     }
 


### PR DESCRIPTION
In `rsa.c`, there are several unchecked calls to `mbedtls_md_setup()`.  If the call fails, the MGF routine is passed an invalid `&md_ctx`.  

We found this bug while attempting to generate a RSA OAEP cryptogram on an embedded system with limited heap.  The existing code returns success but generates an invalid cryptogram.

Thanks to @sergbuslovsky for helping to find and diagnose this bug. 