### PR TITLE
mbedtls_ssl_set_hostname: Free any pre-allocated hostname before allo…

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1787,7 +1787,8 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
  *                 (client-side only)
  *
  * \param ssl      SSL context
- * \param hostname the server hostname
+ * \param hostname the server hostname. Does not need to remain valid
+ *                 after the function returns.
  *
  * \return         0 if successful or MBEDTLS_ERR_SSL_ALLOC_FAILED
  */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5946,6 +5946,12 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
     if( hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
+    if( ssl->hostname != NULL )
+    {
+        mbedtls_zeroize( ssl->hostname, strlen( ssl->hostname ) );
+        mbedtls_free( ssl->hostname );
+    }
+
     ssl->hostname = mbedtls_calloc( 1, hostname_len + 1 );
 
     if( ssl->hostname == NULL )


### PR DESCRIPTION
…cating a new one

Prevents a memory leak if user calls mbedtls_ssl_session_reset() to
reuse session, but then calls mbedtls_ssl_set_hostname() again.

Also add a note in the documentation that the hostname will be copied,
so the argument pointer can be freed.

---

Minor fix I found useful, got tripped up by a memory leak when reusing sessions. I guess this is a minor fix so won't need copyright assignment, but I'm happy to sign a CLA if that's necessary.

Thanks for mbedTLS! It's so good having a solid modern free software TLS library. :)
