### PR TITLE
fixed old-style functions definition warning (C99 compliant)

### DIFF
--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -113,7 +113,7 @@ static void debug_header( memory_header *hdr )
 #endif
 }
 
-static void debug_chain()
+static void debug_chain(void)
 {
     memory_header *cur = heap.first;
 
@@ -180,7 +180,7 @@ static int verify_header( memory_header *hdr )
     return( 0 );
 }
 
-static int verify_chain()
+static int verify_chain(void)
 {
     memory_header *prv = heap.first, *cur = heap.first->next;
 
@@ -500,13 +500,13 @@ void mbedtls_memory_buffer_set_verify( int verify )
     heap.verify = verify;
 }
 
-int mbedtls_memory_buffer_alloc_verify()
+int mbedtls_memory_buffer_alloc_verify(void)
 {
     return verify_chain();
 }
 
 #if defined(MBEDTLS_MEMORY_DEBUG)
-void mbedtls_memory_buffer_alloc_status()
+void mbedtls_memory_buffer_alloc_status(void)
 {
     mbedtls_fprintf( stderr,
                       "Current use: %zu blocks / %zu bytes, max: %zu blocks / "
@@ -600,7 +600,7 @@ void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len )
     heap.first_free = heap.first;
 }
 
-void mbedtls_memory_buffer_alloc_free()
+void mbedtls_memory_buffer_alloc_free(void)
 {
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &heap.mutex );

--- a/library/version.c
+++ b/library/version.c
@@ -30,7 +30,7 @@
 #include "mbedtls/version.h"
 #include <string.h>
 
-unsigned int mbedtls_version_get_number()
+unsigned int mbedtls_version_get_number(void)
 {
     return( MBEDTLS_VERSION_NUMBER );
 }


### PR DESCRIPTION
Hello.

I'm porting mbedts to RIOT (http://www.riot-os.org). 
I added these new style definitions for making them C99 compliant. 

Best regards
