### PR TITLE
Fix issue with reuse of custom yotta configs for target_config.h

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2567,7 +2567,11 @@
 /* \} name SECTION: Customisation configuration options */
 
 /* Target and application specific configurations */
-//#define YOTTA_CFG_MBEDTLS_USER_CONFIG_FILE "target_config.h"
+//#define YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE "mbedtls/target_config.h"
+
+#if defined(TARGET_LIKE_MBED) && defined(YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE)
+#include YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE
+#endif
 
 /*
  * Allow user to override any previous default.

--- a/yotta/data/adjust-config.sh
+++ b/yotta/data/adjust-config.sh
@@ -16,7 +16,7 @@ conf() {
 
 
 # Set the target specific header
-conf set YOTTA_CFG_MBEDTLS_USER_CONFIG_FILE \"target_config.h\"
+conf set YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE \"mbedtls/target_config.h\"
 
 # not supported on mbed OS, nor used by mbed Client
 conf unset MBEDTLS_NET_C


### PR DESCRIPTION
This pull request changes back the use of `YOTTA_CFG_MBEDTLS_USER_CONFIG_FILE` to allow user or third party configurations, and provides a new, yotta specific way of specifying the target header `target_config.h`.