### PR TITLE
Add new api functions to peek at network data.

### DIFF
--- a/include/mbedtls/net.h
+++ b/include/mbedtls/net.h
@@ -174,6 +174,21 @@ void mbedtls_net_usleep( unsigned long usec );
 int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len );
 
 /**
+ * \brief          Read at most 'len' characters. If no error occurs,
+ *                 the actual amount read is returned.
+ *
+ * \param ctx      Socket
+ * \param buf      The buffer to write to
+ * \param len      Maximum length of the buffer
+ * \param flags    Bitwise or collection of MBEDTLS_NET_MSG_* flags or 0
+ *
+ * \return         the number of bytes received,
+ *                 or a non-zero error code; with a non-blocking socket,
+ *                 MBEDTLS_ERR_SSL_WANT_READ indicates read() would block.
+ */
+int mbedtls_net_recv4( void *ctx, unsigned char *buf, size_t len, int flags );
+
+/**
  * \brief          Write at most 'len' characters. If no error occurs,
  *                 the actual amount read is returned.
  *

--- a/library/net.c
+++ b/library/net.c
@@ -457,13 +457,24 @@ void mbedtls_net_usleep( unsigned long usec )
  */
 int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
 {
-    int ret;
+    return mbedtls_net_recv4( ctx, buf, len, 0 );
+}
+
+/*
+ * Read at most 'len' characters
+ */
+int mbedtls_net_recv4( void *ctx, unsigned char *buf, size_t len, int flags )
+{
+    int ret, pflags = 0;
     int fd = ((mbedtls_net_context *) ctx)->fd;
 
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
-    ret = (int) read( fd, buf, len );
+    if( flags & MBEDTLS_NET_MSG_PEEK )
+        pflags |= MSG_PEEK;
+
+    ret = (int) recv( fd, buf, len, pflags );
 
     if( ret < 0 )
     {


### PR DESCRIPTION
New functions:
mbedtls_net_recv4 (mbedtls_net_recv + flags argument)
mbedtls_ssl_read4 (mbedtls_ssl_read + flags argument)

The functions accept a flag argument that optionally specifies extended behavior.
Supported flag arguments:
MBEDTLS_NET_MSG_PEEK - Read data from a (net/ssl context) without removing the data from the socket buffer (MSG_PEEK functionality)

This resolves #551