### PR TITLE
Automate generation of mbed 5.0 tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ function(add_test_suite suite_name)
 
     add_custom_command(
         OUTPUT test_suite_${data_name}.c
-        COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_code.pl ${CMAKE_CURRENT_SOURCE_DIR}/suites test_suite_${suite_name} test_suite_${data_name}
+        COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_code.pl --suitedir ${CMAKE_CURRENT_SOURCE_DIR}/suites --suitename test_suite_${suite_name} --dataname test_suite_${data_name}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_code.pl mbedtls suites/helpers.function suites/main_test.function suites/test_suite_${suite_name}.function suites/test_suite_${data_name}.data
     )
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -98,103 +98,103 @@ $(DEP):
 
 test_suite_aes.ecb.c : suites/test_suite_aes.function suites/test_suite_aes.ecb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.ecb
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.ecb
 
 test_suite_aes.cbc.c : suites/test_suite_aes.function suites/test_suite_aes.cbc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.cbc
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cbc
 
 test_suite_aes.cfb.c : suites/test_suite_aes.function suites/test_suite_aes.cfb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.cfb
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cfb
 
 test_suite_aes.rest.c : suites/test_suite_aes.function suites/test_suite_aes.rest.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.rest
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.rest
 
 test_suite_cipher.aes.c : suites/test_suite_cipher.function suites/test_suite_cipher.aes.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.aes
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.aes
 
 test_suite_cipher.arc4.c : suites/test_suite_cipher.function suites/test_suite_cipher.arc4.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.arc4
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.arc4
 
 test_suite_cipher.ccm.c : suites/test_suite_cipher.function suites/test_suite_cipher.ccm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.ccm
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.ccm
 
 test_suite_cipher.gcm.c : suites/test_suite_cipher.function suites/test_suite_cipher.gcm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.gcm
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.gcm
 
 test_suite_cipher.blowfish.c : suites/test_suite_cipher.function suites/test_suite_cipher.blowfish.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.blowfish
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.blowfish
 
 test_suite_cipher.camellia.c : suites/test_suite_cipher.function suites/test_suite_cipher.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.camellia
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.camellia
 
 test_suite_cipher.des.c : suites/test_suite_cipher.function suites/test_suite_cipher.des.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.des
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.des
 
 test_suite_cipher.null.c : suites/test_suite_cipher.function suites/test_suite_cipher.null.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.null
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.null
 
 test_suite_cipher.padding.c : suites/test_suite_cipher.function suites/test_suite_cipher.padding.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.padding
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.padding
 
 test_suite_gcm.aes128_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes128_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_de
 
 test_suite_gcm.aes192_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes192_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_de
 
 test_suite_gcm.aes256_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes256_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_de
 
 test_suite_gcm.aes128_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes128_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_en
 
 test_suite_gcm.aes192_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes192_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_en
 
 test_suite_gcm.aes256_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes256_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_en
 
 test_suite_gcm.camellia.c : suites/test_suite_gcm.function suites/test_suite_gcm.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.camellia
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.camellia
 
 test_suite_hmac_drbg.misc.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.misc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.misc
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.misc
 
 test_suite_hmac_drbg.no_reseed.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.no_reseed.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.no_reseed
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.no_reseed
 
 test_suite_hmac_drbg.nopr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.nopr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.nopr
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.nopr
 
 test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.pr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.pr
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.pr
 
 %.c : suites/%.function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites $* $*
+	perl scripts/generate_code.pl --suitedir suites --suitename $* --dataname $*
 
 test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
 	echo "  CC    $<"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ LOCAL_LDFLAGS = -L../library 			\
 		-lmbedcrypto$(SHARED_SUFFIX)
 
 ifdef MBED_TEST
-    GEN_CODE_OPTS=--mbed
+    GEN_CODE_OPTS=--mbed --mainfile suites/main_test_mbed.function
     SRCEXT=.cpp
 else
     GEN_CODE_OPTS=

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -75,7 +75,7 @@ TEST_SUITES = test_suite_aes.ecb \
 	test_suite_ctr_drbg \
 	test_suite_debug \
 	test_suite_des \
-    test_suite_dhm \
+	test_suite_dhm \
 	test_suite_ecdh \
 	test_suite_ecdsa \
 	test_suite_ecjpake \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,14 @@ LOCAL_LDFLAGS = -L../library 			\
 		-lmbedx509$(SHARED_SUFFIX)	\
 		-lmbedcrypto$(SHARED_SUFFIX)
 
+ifdef MBED_TEST
+    GEN_CODE_OPTS=--mbed
+    SRCEXT=.cpp
+else
+    GEN_CODE_OPTS=
+    SRCEXT=.c
+endif
+
 ifndef SHARED
 DEP=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
 else
@@ -85,6 +93,46 @@ APPS =	test_suite_aes.ecb$(EXEXT)	test_suite_aes.cbc$(EXEXT)	\
 	test_suite_x509parse$(EXEXT)	test_suite_x509write$(EXEXT)	\
 	test_suite_xtea$(EXEXT)		test_suite_version$(EXEXT)
 
+APPS_SRC =	test_suite_aes.ecb$(SRCEXT)	test_suite_aes.cbc$(SRCEXT)	\
+	test_suite_aes.cfb$(SRCEXT)	test_suite_aes.rest$(SRCEXT)	    \
+	test_suite_arc4$(SRCEXT)		test_suite_asn1write$(SRCEXT)	\
+	test_suite_base64$(SRCEXT)	test_suite_blowfish$(SRCEXT)	    \
+	test_suite_camellia$(SRCEXT)	test_suite_ccm$(SRCEXT)		    \
+	test_suite_cipher.aes$(SRCEXT)					                \
+	test_suite_cipher.arc4$(SRCEXT)	test_suite_cipher.ccm$(SRCEXT)	\
+	test_suite_cipher.gcm$(SRCEXT)					                \
+	test_suite_cipher.blowfish$(SRCEXT)				                \
+	test_suite_cipher.camellia$(SRCEXT)				                \
+	test_suite_cipher.des$(SRCEXT)	test_suite_cipher.null$(SRCEXT)	\
+	test_suite_cipher.padding$(SRCEXT)				                \
+	test_suite_ctr_drbg$(SRCEXT)	test_suite_debug$(SRCEXT)	    \
+	test_suite_des$(SRCEXT)		test_suite_dhm$(SRCEXT)		        \
+	test_suite_ecdh$(SRCEXT)		test_suite_ecdsa$(SRCEXT)	    \
+	test_suite_ecjpake$(SRCEXT)	test_suite_ecp$(SRCEXT)		        \
+	test_suite_error$(SRCEXT)	test_suite_entropy$(SRCEXT)	        \
+	test_suite_gcm.aes128_de$(SRCEXT)				                \
+	test_suite_gcm.aes192_de$(SRCEXT)				                \
+	test_suite_gcm.aes256_de$(SRCEXT)				                \
+	test_suite_gcm.aes128_en$(SRCEXT)				                \
+	test_suite_gcm.aes192_en$(SRCEXT)				                \
+	test_suite_gcm.aes256_en$(SRCEXT)				                \
+	test_suite_gcm.camellia$(SRCEXT)					            \
+	test_suite_hmac_drbg.misc$(SRCEXT)				                \
+	test_suite_hmac_drbg.no_reseed$(SRCEXT)				            \
+	test_suite_hmac_drbg.nopr$(SRCEXT)				                \
+	test_suite_hmac_drbg.pr$(SRCEXT)					            \
+	test_suite_md$(SRCEXT)		test_suite_mdx$(SRCEXT)		        \
+	test_suite_memory_buffer_alloc$(SRCEXT)				            \
+	test_suite_mpi$(SRCEXT)						                    \
+	test_suite_pem$(SRCEXT)			test_suite_pkcs1_v15$(SRCEXT)	\
+	test_suite_pkcs1_v21$(SRCEXT)	test_suite_pkcs5$(SRCEXT)	    \
+	test_suite_pkparse$(SRCEXT)	test_suite_pkwrite$(SRCEXT)	        \
+	test_suite_pk$(SRCEXT)						                    \
+	test_suite_rsa$(SRCEXT)		test_suite_shax$(SRCEXT)		    \
+	test_suite_ssl$(SRCEXT)						                    \
+	test_suite_x509parse$(SRCEXT)	test_suite_x509write$(SRCEXT)	\
+	test_suite_xtea$(SRCEXT)		test_suite_version$(SRCEXT)
+
 .SILENT:
 
 .PHONY: all check test clean
@@ -96,105 +144,105 @@ $(DEP):
 
 # invoke perl explicitly for the sake of mingw32-make
 
-test_suite_aes.ecb.c : suites/test_suite_aes.function suites/test_suite_aes.ecb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_aes.ecb$(SRCEXT) : suites/test_suite_aes.function suites/test_suite_aes.ecb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.ecb
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.ecb $(GEN_CODE_OPTS)
 
-test_suite_aes.cbc.c : suites/test_suite_aes.function suites/test_suite_aes.cbc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_aes.cbc$(SRCEXT) : suites/test_suite_aes.function suites/test_suite_aes.cbc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cbc
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cbc $(GEN_CODE_OPTS)
 
-test_suite_aes.cfb.c : suites/test_suite_aes.function suites/test_suite_aes.cfb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_aes.cfb$(SRCEXT) : suites/test_suite_aes.function suites/test_suite_aes.cfb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cfb
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.cfb $(GEN_CODE_OPTS)
 
-test_suite_aes.rest.c : suites/test_suite_aes.function suites/test_suite_aes.rest.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_aes.rest$(SRCEXT) : suites/test_suite_aes.function suites/test_suite_aes.rest.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.rest
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_aes --dataname test_suite_aes.rest $(GEN_CODE_OPTS)
 
-test_suite_cipher.aes.c : suites/test_suite_cipher.function suites/test_suite_cipher.aes.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.aes$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.aes.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.aes
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.aes $(GEN_CODE_OPTS)
 
-test_suite_cipher.arc4.c : suites/test_suite_cipher.function suites/test_suite_cipher.arc4.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.arc4$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.arc4.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.arc4
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.arc4 $(GEN_CODE_OPTS)
 
-test_suite_cipher.ccm.c : suites/test_suite_cipher.function suites/test_suite_cipher.ccm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.ccm$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.ccm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.ccm
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.ccm $(GEN_CODE_OPTS)
 
-test_suite_cipher.gcm.c : suites/test_suite_cipher.function suites/test_suite_cipher.gcm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.gcm$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.gcm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.gcm
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.gcm $(GEN_CODE_OPTS)
 
-test_suite_cipher.blowfish.c : suites/test_suite_cipher.function suites/test_suite_cipher.blowfish.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.blowfish$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.blowfish.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.blowfish
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.blowfish $(GEN_CODE_OPTS)
 
-test_suite_cipher.camellia.c : suites/test_suite_cipher.function suites/test_suite_cipher.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.camellia$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.camellia
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.camellia $(GEN_CODE_OPTS)
 
-test_suite_cipher.des.c : suites/test_suite_cipher.function suites/test_suite_cipher.des.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.des$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.des.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.des
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.des $(GEN_CODE_OPTS)
 
-test_suite_cipher.null.c : suites/test_suite_cipher.function suites/test_suite_cipher.null.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.null$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.null.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.null
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.null $(GEN_CODE_OPTS)
 
-test_suite_cipher.padding.c : suites/test_suite_cipher.function suites/test_suite_cipher.padding.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_cipher.padding$(SRCEXT) : suites/test_suite_cipher.function suites/test_suite_cipher.padding.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.padding
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_cipher --dataname test_suite_cipher.padding $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes128_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes128_de$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_de $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes192_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes192_de$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_de $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes256_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes256_de$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_de
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_de $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes128_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes128_en$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes128_en $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes192_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes192_en$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes192_en $(GEN_CODE_OPTS)
 
-test_suite_gcm.aes256_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.aes256_en$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_en
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.aes256_en $(GEN_CODE_OPTS)
 
-test_suite_gcm.camellia.c : suites/test_suite_gcm.function suites/test_suite_gcm.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_gcm.camellia$(SRCEXT) : suites/test_suite_gcm.function suites/test_suite_gcm.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.camellia
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_gcm --dataname test_suite_gcm.camellia $(GEN_CODE_OPTS)
 
-test_suite_hmac_drbg.misc.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.misc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_hmac_drbg.misc$(SRCEXT) : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.misc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.misc
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.misc $(GEN_CODE_OPTS)
 
-test_suite_hmac_drbg.no_reseed.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.no_reseed.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_hmac_drbg.no_reseed$(SRCEXT) : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.no_reseed.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.no_reseed
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.no_reseed $(GEN_CODE_OPTS)
 
-test_suite_hmac_drbg.nopr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.nopr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_hmac_drbg.nopr$(SRCEXT) : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.nopr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.nopr
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.nopr $(GEN_CODE_OPTS)
 
-test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.pr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+test_suite_hmac_drbg.pr$(SRCEXT) : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.pr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.pr
+	perl scripts/generate_code.pl --suitedir suites --suitename test_suite_hmac_drbg --dataname test_suite_hmac_drbg.pr $(GEN_CODE_OPTS)
 
-%.c : suites/%.function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+%$(SRCEXT) : suites/%.function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl --suitedir suites --suitename $* --dataname $*
+	perl scripts/generate_code.pl --suitedir suites --suitename $* --dataname $* $(GEN_CODE_OPTS)
 
 test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
 	echo "  CC    $<"
@@ -434,7 +482,7 @@ test_suite_version$(EXEXT): test_suite_version.c $(DEP)
 
 clean:
 ifndef WINDOWS
-	rm -f $(APPS) *.c
+	rm -f $(APPS) *.c *.cpp
 else
 	del /Q /F *.c *.exe
 endif
@@ -443,3 +491,5 @@ check: $(APPS)
 	perl scripts/run-test-suites.pl
 
 test: check
+
+gen_test_code: $(APPS_SRC)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,85 +53,68 @@ ifdef ZLIB
 LOCAL_LDFLAGS += -lz
 endif
 
-APPS =	test_suite_aes.ecb$(EXEXT)	test_suite_aes.cbc$(EXEXT)	\
-	test_suite_aes.cfb$(EXEXT)	test_suite_aes.rest$(EXEXT)	\
-	test_suite_arc4$(EXEXT)		test_suite_asn1write$(EXEXT)	\
-	test_suite_base64$(EXEXT)	test_suite_blowfish$(EXEXT)	\
-	test_suite_camellia$(EXEXT)	test_suite_ccm$(EXEXT)		\
-	test_suite_cipher.aes$(EXEXT)					\
-	test_suite_cipher.arc4$(EXEXT)	test_suite_cipher.ccm$(EXEXT)	\
-	test_suite_cipher.gcm$(EXEXT)					\
-	test_suite_cipher.blowfish$(EXEXT)				\
-	test_suite_cipher.camellia$(EXEXT)				\
-	test_suite_cipher.des$(EXEXT)	test_suite_cipher.null$(EXEXT)	\
-	test_suite_cipher.padding$(EXEXT)				\
-	test_suite_ctr_drbg$(EXEXT)	test_suite_debug$(EXEXT)	\
-	test_suite_des$(EXEXT)		test_suite_dhm$(EXEXT)		\
-	test_suite_ecdh$(EXEXT)		test_suite_ecdsa$(EXEXT)	\
-	test_suite_ecjpake$(EXEXT)	test_suite_ecp$(EXEXT)		\
-	test_suite_error$(EXEXT)	test_suite_entropy$(EXEXT)	\
-	test_suite_gcm.aes128_de$(EXEXT)				\
-	test_suite_gcm.aes192_de$(EXEXT)				\
-	test_suite_gcm.aes256_de$(EXEXT)				\
-	test_suite_gcm.aes128_en$(EXEXT)				\
-	test_suite_gcm.aes192_en$(EXEXT)				\
-	test_suite_gcm.aes256_en$(EXEXT)				\
-	test_suite_gcm.camellia$(EXEXT)					\
-	test_suite_hmac_drbg.misc$(EXEXT)				\
-	test_suite_hmac_drbg.no_reseed$(EXEXT)				\
-	test_suite_hmac_drbg.nopr$(EXEXT)				\
-	test_suite_hmac_drbg.pr$(EXEXT)					\
-	test_suite_md$(EXEXT)		test_suite_mdx$(EXEXT)		\
-	test_suite_memory_buffer_alloc$(EXEXT)				\
-	test_suite_mpi$(EXEXT)						\
-	test_suite_pem$(EXEXT)			test_suite_pkcs1_v15$(EXEXT)	\
-	test_suite_pkcs1_v21$(EXEXT)	test_suite_pkcs5$(EXEXT)	\
-	test_suite_pkparse$(EXEXT)	test_suite_pkwrite$(EXEXT)	\
-	test_suite_pk$(EXEXT)						\
-	test_suite_rsa$(EXEXT)		test_suite_shax$(EXEXT)		\
-	test_suite_ssl$(EXEXT)						\
-	test_suite_x509parse$(EXEXT)	test_suite_x509write$(EXEXT)	\
-	test_suite_xtea$(EXEXT)		test_suite_version$(EXEXT)
+TEST_SUITES = test_suite_aes.ecb \
+	test_suite_aes.cbc\
+	test_suite_aes.cfb \
+	test_suite_aes.rest \
+	test_suite_arc4 \
+	test_suite_asn1write \
+	test_suite_base64 \
+	test_suite_blowfish \
+	test_suite_camellia \
+	test_suite_ccm \
+	test_suite_cipher.aes \
+	test_suite_cipher.arc4 \
+	test_suite_cipher.ccm \
+	test_suite_cipher.gcm \
+	test_suite_cipher.blowfish \
+	test_suite_cipher.camellia \
+	test_suite_cipher.des \
+	test_suite_cipher.null \
+	test_suite_cipher.padding \
+	test_suite_ctr_drbg \
+	test_suite_debug \
+	test_suite_des \
+    test_suite_dhm \
+	test_suite_ecdh \
+	test_suite_ecdsa \
+	test_suite_ecjpake \
+	test_suite_ecp \
+	test_suite_error \
+	test_suite_entropy \
+	test_suite_gcm.aes128_de \
+	test_suite_gcm.aes192_de \
+	test_suite_gcm.aes256_de \
+	test_suite_gcm.aes128_en \
+	test_suite_gcm.aes192_en \
+	test_suite_gcm.aes256_en \
+	test_suite_gcm.camellia \
+	test_suite_hmac_drbg.misc \
+	test_suite_hmac_drbg.no_reseed \
+	test_suite_hmac_drbg.nopr \
+	test_suite_hmac_drbg.pr \
+	test_suite_md \
+	test_suite_mdx \
+	test_suite_memory_buffer_alloc \
+	test_suite_mpi  \
+	test_suite_pem \
+	test_suite_pkcs1_v15 \
+	test_suite_pkcs1_v21 \
+	test_suite_pkcs5 \
+	test_suite_pkparse \
+	test_suite_pkwrite \
+	test_suite_pk \
+	test_suite_rsa \
+	test_suite_shax \
+	test_suite_ssl \
+	test_suite_x509parse \
+	test_suite_x509write \
+	test_suite_xtea \
+	test_suite_version
 
-APPS_SRC =	test_suite_aes.ecb$(SRCEXT)	test_suite_aes.cbc$(SRCEXT)	\
-	test_suite_aes.cfb$(SRCEXT)	test_suite_aes.rest$(SRCEXT)	    \
-	test_suite_arc4$(SRCEXT)		test_suite_asn1write$(SRCEXT)	\
-	test_suite_base64$(SRCEXT)	test_suite_blowfish$(SRCEXT)	    \
-	test_suite_camellia$(SRCEXT)	test_suite_ccm$(SRCEXT)		    \
-	test_suite_cipher.aes$(SRCEXT)					                \
-	test_suite_cipher.arc4$(SRCEXT)	test_suite_cipher.ccm$(SRCEXT)	\
-	test_suite_cipher.gcm$(SRCEXT)					                \
-	test_suite_cipher.blowfish$(SRCEXT)				                \
-	test_suite_cipher.camellia$(SRCEXT)				                \
-	test_suite_cipher.des$(SRCEXT)	test_suite_cipher.null$(SRCEXT)	\
-	test_suite_cipher.padding$(SRCEXT)				                \
-	test_suite_ctr_drbg$(SRCEXT)	test_suite_debug$(SRCEXT)	    \
-	test_suite_des$(SRCEXT)		test_suite_dhm$(SRCEXT)		        \
-	test_suite_ecdh$(SRCEXT)		test_suite_ecdsa$(SRCEXT)	    \
-	test_suite_ecjpake$(SRCEXT)	test_suite_ecp$(SRCEXT)		        \
-	test_suite_error$(SRCEXT)	test_suite_entropy$(SRCEXT)	        \
-	test_suite_gcm.aes128_de$(SRCEXT)				                \
-	test_suite_gcm.aes192_de$(SRCEXT)				                \
-	test_suite_gcm.aes256_de$(SRCEXT)				                \
-	test_suite_gcm.aes128_en$(SRCEXT)				                \
-	test_suite_gcm.aes192_en$(SRCEXT)				                \
-	test_suite_gcm.aes256_en$(SRCEXT)				                \
-	test_suite_gcm.camellia$(SRCEXT)					            \
-	test_suite_hmac_drbg.misc$(SRCEXT)				                \
-	test_suite_hmac_drbg.no_reseed$(SRCEXT)				            \
-	test_suite_hmac_drbg.nopr$(SRCEXT)				                \
-	test_suite_hmac_drbg.pr$(SRCEXT)					            \
-	test_suite_md$(SRCEXT)		test_suite_mdx$(SRCEXT)		        \
-	test_suite_memory_buffer_alloc$(SRCEXT)				            \
-	test_suite_mpi$(SRCEXT)						                    \
-	test_suite_pem$(SRCEXT)			test_suite_pkcs1_v15$(SRCEXT)	\
-	test_suite_pkcs1_v21$(SRCEXT)	test_suite_pkcs5$(SRCEXT)	    \
-	test_suite_pkparse$(SRCEXT)	test_suite_pkwrite$(SRCEXT)	        \
-	test_suite_pk$(SRCEXT)						                    \
-	test_suite_rsa$(SRCEXT)		test_suite_shax$(SRCEXT)		    \
-	test_suite_ssl$(SRCEXT)						                    \
-	test_suite_x509parse$(SRCEXT)	test_suite_x509write$(SRCEXT)	\
-	test_suite_xtea$(SRCEXT)		test_suite_version$(SRCEXT)
+APPS = $(addsuffix $(EXEXT),$(TEST_SUITES))
+
+APPS_SRC = $(addsuffix $(SRCEXT),$(TEST_SUITES))
 
 .SILENT:
 

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -31,6 +31,7 @@
 #           DISPATCH_FUNCTION
 #           !LINE_NO!
 #           TEST_DATA_CODE
+#           TEST_ASSERT
 #
 #   - common helper code file - 'helpers.function'
 #       Common helper functions
@@ -99,6 +100,10 @@ undef $/;
 open(TEST_HELPERS, "$test_common_helper_file") or die "Opening test helpers
 '$test_common_helper_file': $!";
 my $test_common_helpers = <TEST_HELPERS>;
+if ($is_mbed)
+{
+    $test_common_helpers =~ s/TEST_ASSERT/MBEDTLS_TEST_ASSERT/;
+}
 close(TEST_HELPERS);
 
 open(TEST_MAIN, "$test_main_file") or die "Opening test main '$test_main_file': $!";
@@ -131,6 +136,10 @@ for my $line (@test_cases_lines) {
 
     $test_cases = $test_cases.$line;
     $index++;
+}
+if ($is_mbed)
+{
+    $test_cases =~ s/TEST_ASSERT/MBEDTLS_TEST_ASSERT/g;
 }
 
 close(TEST_CASES);
@@ -195,7 +204,19 @@ while (@var_req_arr)
 $/ = $line_separator;
 
 # Add mbed header if necessary
-my $mbed_headers = $is_mbed ? "#include \"mbed.h\"" : "";
+my $mbed_headers = "";
+if ($is_mbed)
+{
+    $mbed_headers = << "END";
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "rtos.h"
+
+using namespace utest::v1;
+END
+}
 
 open(TEST_FILE, ">$test_file") or die "Opening destination file '$test_file': $!";
 print TEST_FILE << "END";

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -83,7 +83,8 @@ $suite_name ne "" or die "Missing suite name";
 $data_name ne "" or die "Missing data name";
 $test_main_file = $suite_dir."/main_test.function" if ($test_main_file eq "");
 
-my $test_file = $data_name.".c";
+# mbed files can only be c++
+my $test_file = $is_mbed ? $data_name.".cpp" : $data_name.".c";
 my $test_common_helper_file = $suite_dir."/helpers.function";
 my $test_case_file = $suite_dir."/".$suite_name.".function";
 my $test_case_data = $suite_dir."/".$data_name.".data";

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -152,6 +152,8 @@ if ($is_mbed)
     my $test_data_code = "";
     for my $line (@test_data_lines) {
         chop($line);
+        # Escape any \ in the input data
+        $line =~ s/\\/\\\\/g;
         # Escape " character
         $line =~ s/"/\\"/g;
         # Add " and spaces at beginning and \n" at the end

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -12,7 +12,30 @@
 # contain the test suites, and the test suite file names for the test code and
 # test data.
 #
-# Usage: generate_code.pl <suite dir> <code file> <data file> [main code file]
+# It is also possible to generate test code for on target testing in mbed 5.0
+# by passing the --mbed flag as a command line argument to this script. In this
+# case, C++ files will be generated (instead of C files). To use the generated
+# source code, clone the repository at git@github.com:ARMmbed/mbed-os.git.
+# Then copy all the .cpp files into appropriate directories under
+# mbed-os/TESTS. This can be easily achieved using bash commands such as:
+#     mkdir <MBED_OS_ROOT>/TESTS/mbedtls
+#     for suite in test_suite_*.cpp; do
+#         mkdir <MBED_OS_ROOT>/TESTS/mbedtls/${suite%.cpp}
+#         cp $suite <MBED_OS_ROOT>/TESTS/mbedtls/${suite%.cpp}/.
+#     done
+# Then compile the tests using mbed-cli and ensure that there are no errors:
+#     cd <MBED_OS_ROOT>
+#     mbed test --compile -m K64F -t GCC_ARM --test-spec test_spec.json
+# Finally, run the tests using mbedgt:
+#     mbedgt -VS --test-spec test_spec.json
+# Notes:
+#   - To successfully run the mbed 5.0 tests, make sure that you have the
+#     necessary hardware e.g. K64F.
+#   - Ensure that the necessary software tools are available in your
+#     environment: mbed-cli, mbed greeentea (mbedgt), htrun, mbed-ls.
+#   - On Linux systems, you may need to add your user to the dialout Unix
+#     group; otherwise, mbedgt may not be able to connect to the hardware
+#     target using the serial interface. Alternatively, run mbedgt using sudo.
 #
 # Structure of files
 #

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -171,10 +171,10 @@ static void hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
  */
 static unsigned char *zero_alloc( size_t len )
 {
-    void *p;
+    unsigned char *p;
     size_t actual_len = ( len != 0 ) ? len : 1;
 
-    p = mbedtls_calloc( 1, actual_len );
+    p = (unsigned char *) mbedtls_calloc( 1, actual_len );
     assert( p != NULL );
 
     memset( p, 0x00, actual_len );
@@ -201,7 +201,7 @@ static unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
     if( *olen == 0 )
         return( zero_alloc( *olen ) );
 
-    obuf = mbedtls_calloc( 1, *olen );
+    obuf = (unsigned char *) mbedtls_calloc( 1, *olen );
     assert( obuf != NULL );
 
     (void) unhexify( obuf, ibuf );

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -2,6 +2,12 @@
 /*----------------------------------------------------------------------------*/
 /* Headers */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include <mbedtls/config.h>
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #include <stdlib.h>
 
 #if defined(MBEDTLS_PLATFORM_C)

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -67,7 +67,7 @@ typedef UINT32 uint32_t;
 
 #define assert(a) if( !( a ) )                                      \
 {                                                                   \
-    mbedtls_fprintf( stderr, "Assertion Failed at %s:%d - %s\n",   \
+    mbedtls_fprintf( stderr, "Assertion Failed at %s:%d - %s\r\n",   \
                              __FILE__, __LINE__, #a );              \
     mbedtls_exit( 1 );                                             \
 }
@@ -100,7 +100,6 @@ typedef UINT32 uint32_t;
 /* Global variables */
 
 static int test_errors = 0;
-
 
 /*----------------------------------------------------------------------------*/
 /* Helper Functions */
@@ -355,7 +354,7 @@ static void test_fail( const char *test, int line_no, const char* filename )
 {
     test_errors++;
     if( test_errors == 1 )
-        mbedtls_printf( "FAILED\n" );
-    mbedtls_printf( "  %s\n  at line %d, %s\n", test, line_no, filename );
+        mbedtls_printf( "FAILED\r\n" );
+    mbedtls_printf( "  %s\r\n  at line %d, %s\r\n", test, line_no, filename );
 }
 

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -417,7 +417,7 @@ Case cases[] = {
 };
 
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(40, "default_auto");
+    GREENTEA_SETUP(60, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -1,4 +1,4 @@
-#line 1 "main_test.function"
+#line 1 "main_test_mbed.function"
 SUITE_PRE_DEP
 #define TEST_SUITE_ACTIVE
 
@@ -71,7 +71,7 @@ MAPPING_CODE
 FUNCTION_CODE
 SUITE_POST_DEP
 
-#line !LINE_NO! "main_test.function"
+#line !LINE_NO! "main_test_mbed.function"
 
 
 /*----------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ int dep_check( char *str )
         return( 1 );
 
 DEP_CHECK_CODE
-#line !LINE_NO! "main_test.function"
+#line !LINE_NO! "main_test_mbed.function"
 
     return( DEPENDENCY_NOT_SUPPORTED );
 }
@@ -102,7 +102,7 @@ int dispatch_test(int cnt, char *params[50])
 
 DISPATCH_FUNCTION
     {
-#line !LINE_NO! "main_test.function"
+#line !LINE_NO! "main_test_mbed.function"
         mbedtls_fprintf( stdout,
                          "FAILED\r\nSkipping unknown test function '%s'\r\n",
                          params[0] );
@@ -119,7 +119,7 @@ DISPATCH_FUNCTION
 /*----------------------------------------------------------------------------*/
 /* Main Test code */
 
-#line !LINE_NO! "main_test.function"
+#line !LINE_NO! "main_test_mbed.function"
 
 int get_line( char** test_data, char *buf, size_t len )
 {
@@ -248,6 +248,8 @@ int main()
 {
     /* Test suite data */
     char *test_suite_data = TEST_DATA_CODE;
+
+#line !LINE_NO! "main_test_mbed.function"
 
     /* Other Local variables */
     int ret, i, cnt;

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -121,34 +121,37 @@ DISPATCH_FUNCTION
 
 #line !LINE_NO! "main_test.function"
 
-#define USAGE \
-    "Usage: %s [OPTIONS] files...\r\n\r\n" \
-    "   Command line arguments:\r\n" \
-    "     files...          One or more test data file. If no file is specified\r\n" \
-    "                       the followimg default test case is used:\r\n" \
-    "                           %s\r\n\r\n" \
-    "   Options:\r\n" \
-    "     -v | --verbose    Display full information about each test\r\n" \
-    "     -h | --help       Display this information\r\n\r\n", \
-    argv[0], \
-    "TESTCASE_FILENAME"
-
-
-int get_line( FILE *f, char *buf, size_t len )
+int get_line( char** test_data, char *buf, size_t len )
 {
-    char *ret;
+    // this function currently does not handle \r\r\n line terminators, but we
+    // are hard-coding the test data inside the c file, so this should not
+    // cause problems.
 
-    ret = fgets( buf, len, f );
-    if( ret == NULL )
-        return( -1 );
+    size_t i;
 
-    if( strlen( buf ) && buf[strlen(buf) - 1] == '\n' )
-        buf[strlen(buf) - 1] = '\0';
-    if( strlen( buf ) && buf[strlen(buf) - 1] == '\r' )
-        buf[strlen(buf) - 1] = '\0';
+    // if the string is empty fail and the destination remains unchanged
+    if ( **test_data == '\0' )
+         return( -1 );
 
-    return( 0 );
+    // copy character by character until capacity or eof is reached
+    for( i = 0; i < len; i++ )
+    {
+        if( **test_data == '\n' ) {
+            buf[i] = '\0';
+            *test_data += 1;
+            break;
+        } else if( **test_data == '\0' ) {
+            buf[i] = '\0';
+            break;
+        } else {
+            buf[i] = **test_data;
+            *test_data += 1;
+        }
+    }
+
+     return( 0 );
 }
+
 
 int parse_arguments( char *buf, size_t len, char *params[50] )
 {
@@ -241,24 +244,19 @@ static int run_test_snprintf( void )
             test_snprintf( 5, "123",         3 ) != 0 );
 }
 
-int main(int argc, const char *argv[])
+int main()
 {
-    /* Local Configurations and options */
-    const char *default_filename = "TESTCASE_FILENAME";
-    const char *test_filename = NULL;
-    const char **test_files = NULL;
-    int testfile_count = 0;
-    int option_verbose = 0;
+    /* Test suite data */
+    char *test_suite_data = TEST_DATA_CODE;
 
     /* Other Local variables */
-    int arg_index = 1;
-    const char *next_arg;
-    int testfile_index, ret, i, cnt;
+    int ret, i, cnt;
     int total_errors = 0, total_tests = 0, total_skipped = 0;
-    FILE *file;
     char buf[5000];
     char *params[50];
     void *pointer;
+    int unmet_dep_count = 0;
+    char *unmet_dependencies[20];
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
@@ -287,171 +285,117 @@ int main(int argc, const char *argv[])
         return( 0 );
     }
 
-    while( arg_index < argc)
+    /* Now begin to execute the tests */
+    while( *test_suite_data != '\0' )
     {
-        next_arg = argv[ arg_index ];
-
-        if( strcmp(next_arg, "--verbose" ) == 0 ||
-                 strcmp(next_arg, "-v" ) == 0 )
+        if( unmet_dep_count > 0 )
         {
-            option_verbose = 1;
+            mbedtls_printf("FATAL: Dep count larger than zero at start of loop\r\n");
+            mbedtls_exit( MBEDTLS_EXIT_FAILURE );
         }
-        else if( strcmp(next_arg, "--help" ) == 0 ||
-                 strcmp(next_arg, "-h" ) == 0 )
+        unmet_dep_count = 0;
+
+        if( ( ret = get_line( &test_suite_data, buf, sizeof(buf) ) ) != 0 )
+            break;
+        mbedtls_fprintf( stdout, "%s%.66s", test_errors ? "\r\n" : "", buf );
+        mbedtls_fprintf( stdout, " " );
+        for( i = strlen( buf ) + 1; i < 67; i++ )
+            mbedtls_fprintf( stdout, "." );
+        mbedtls_fprintf( stdout, " " );
+        fflush( stdout );
+
+        total_tests++;
+
+        if( ( ret = get_line( &test_suite_data, buf, sizeof(buf) ) ) != 0 )
+            break;
+        cnt = parse_arguments( buf, strlen(buf), params );
+
+        if( strcmp( params[0], "depends_on" ) == 0 )
         {
-            mbedtls_fprintf( stdout, USAGE );
-            mbedtls_exit( EXIT_SUCCESS );
-        }
-        else
-        {
-            /* Not an option, therefore treat all further arguments as the file
-             * list.
-             */
-            test_files = &argv[ arg_index ];
-            testfile_count = argc - arg_index;
-        }
-
-        arg_index++;
-    }
-
-    /* If no files were specified, assume a default */
-    if ( test_files == NULL || testfile_count == 0 )
-    {
-        test_files = &default_filename;
-        testfile_count = 1;
-    }
-
-    /* Now begin to execute the tests in the testfiles */
-    for ( testfile_index = 0;
-          testfile_index < testfile_count;
-          testfile_index++ )
-    {
-        int unmet_dep_count = 0;
-        char *unmet_dependencies[20];
-
-        test_filename = test_files[ testfile_index ];
-
-        file = fopen( test_filename, "r" );
-        if( file == NULL )
-        {
-            mbedtls_fprintf( stderr, "Failed to open test file: %s\r\n",
-                             test_filename );
-            return( 1 );
-        }
-
-        while( !feof( file ) )
-        {
-            if( unmet_dep_count > 0 )
+            for( i = 1; i < cnt; i++ )
             {
-                mbedtls_printf("FATAL: Dep count larger than zero at start of loop\r\n");
-                mbedtls_exit( MBEDTLS_EXIT_FAILURE );
+                if( dep_check( params[i] ) != DEPENDENCY_SUPPORTED )
+                {
+                    if( 0 == option_verbose )
+                    {
+                        /* Only one count is needed if not verbose */
+                        unmet_dep_count++;
+                        break;
+                    }
+
+                    unmet_dependencies[ unmet_dep_count ] = strdup(params[i]);
+                    if(  unmet_dependencies[ unmet_dep_count ] == NULL )
+                    {
+                        mbedtls_printf("FATAL: Out of memory\r\n");
+                        mbedtls_exit( MBEDTLS_EXIT_FAILURE );
+                    }
+                    unmet_dep_count++;
+                }
             }
-            unmet_dep_count = 0;
 
-            if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
-                break;
-            mbedtls_fprintf( stdout, "%s%.66s", test_errors ? "\r\n" : "", buf );
-            mbedtls_fprintf( stdout, " " );
-            for( i = strlen( buf ) + 1; i < 67; i++ )
-                mbedtls_fprintf( stdout, "." );
-            mbedtls_fprintf( stdout, " " );
-            fflush( stdout );
-
-            total_tests++;
-
-            if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
+            if( ( ret = get_line( &test_suite_data, buf, sizeof(buf) ) ) != 0 )
                 break;
             cnt = parse_arguments( buf, strlen(buf), params );
-
-            if( strcmp( params[0], "depends_on" ) == 0 )
-            {
-                for( i = 1; i < cnt; i++ )
-                {
-                    if( dep_check( params[i] ) != DEPENDENCY_SUPPORTED )
-                    {
-                        if( 0 == option_verbose )
-                        {
-                            /* Only one count is needed if not verbose */
-                            unmet_dep_count++;
-                            break;
-                        }
-
-                        unmet_dependencies[ unmet_dep_count ] = strdup(params[i]);
-                        if(  unmet_dependencies[ unmet_dep_count ] == NULL )
-                        {
-                            mbedtls_printf("FATAL: Out of memory\r\n");
-                            mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-                        }
-                        unmet_dep_count++;
-                    }
-                }
-
-                if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
-                    break;
-                cnt = parse_arguments( buf, strlen(buf), params );
-            }
- 
-            // If there are no unmet dependencies execute the test
-            if( unmet_dep_count == 0 )
-            {
-                test_errors = 0;
-                ret = dispatch_test( cnt, params );
-            }
-
-            if( unmet_dep_count > 0 || ret == DISPATCH_UNSUPPORTED_SUITE )
-            {
-                total_skipped++;
-                mbedtls_fprintf( stdout, "----\r\n" );
-
-                if( 1 == option_verbose && ret == DISPATCH_UNSUPPORTED_SUITE )
-                {
-                    mbedtls_fprintf( stdout, "   Test Suite not enabled" );
-                }
-
-                if( 1 == option_verbose && unmet_dep_count > 0 )
-                {
-                    mbedtls_fprintf( stdout, "   Unmet dependencies: " );
-                    for( i = 0; i < unmet_dep_count; i++ )
-                    {
-                        mbedtls_fprintf(stdout, "%s  ",
-                                        unmet_dependencies[i]);
-                        free(unmet_dependencies[i]);
-                    }
-                    mbedtls_fprintf( stdout, "\r\n" );
-                }
-                fflush( stdout );
-
-                unmet_dep_count = 0;
-            }
-            else if( ret == DISPATCH_TEST_SUCCESS && test_errors == 0 )
-            {
-                mbedtls_fprintf( stdout, "PASS\r\n" );
-                fflush( stdout );
-            }
-            else if( ret == DISPATCH_INVALID_TEST_DATA )
-            {
-                mbedtls_fprintf( stderr, "FAILED: FATAL PARSE ERROR\r\n" );
-                fclose(file);
-                mbedtls_exit( 2 );
-            }
-            else
-                total_errors++;
-
-            if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
-                break;
-            if( strlen(buf) != 0 )
-            {
-                mbedtls_fprintf( stderr, "Should be empty %d\r\n",
-                                 (int) strlen(buf) );
-                return( 1 );
-            }
         }
-        fclose(file);
 
-        /* In case we encounter early end of file */
-        for( i = 0; i < unmet_dep_count; i++ )
-            free( unmet_dependencies[i] );
+        // If there are no unmet dependencies execute the test
+        if( unmet_dep_count == 0 )
+        {
+            test_errors = 0;
+            ret = dispatch_test( cnt, params );
+        }
+
+        if( unmet_dep_count > 0 || ret == DISPATCH_UNSUPPORTED_SUITE )
+        {
+            total_skipped++;
+            mbedtls_fprintf( stdout, "----\r\n" );
+
+            if( 1 == option_verbose && ret == DISPATCH_UNSUPPORTED_SUITE )
+            {
+                mbedtls_fprintf( stdout, "   Test Suite not enabled" );
+            }
+
+            if( 1 == option_verbose && unmet_dep_count > 0 )
+            {
+                mbedtls_fprintf( stdout, "   Unmet dependencies: " );
+                for( i = 0; i < unmet_dep_count; i++ )
+                {
+                    mbedtls_fprintf(stdout, "%s  ",
+                                    unmet_dependencies[i]);
+                    free(unmet_dependencies[i]);
+                }
+                mbedtls_fprintf( stdout, "\r\n" );
+            }
+            fflush( stdout );
+
+            unmet_dep_count = 0;
+        }
+        else if( ret == DISPATCH_TEST_SUCCESS && test_errors == 0 )
+        {
+            mbedtls_fprintf( stdout, "PASS\r\n" );
+            fflush( stdout );
+        }
+        else if( ret == DISPATCH_INVALID_TEST_DATA )
+        {
+            mbedtls_fprintf( stderr, "FAILED: FATAL PARSE ERROR\r\n" );
+            mbedtls_exit( 2 );
+        }
+        else
+            total_errors++;
+
+        if( ( ret = get_line( &test_suite_data, buf, sizeof(buf) ) ) != 0 )
+            break;
+        if( strlen(buf) != 0 )
+        {
+            mbedtls_fprintf( stderr, "Should be empty %d\r\n",
+                             (int) strlen(buf) );
+            return( 1 );
+        }
     }
+
+    /* In case we encounter early end of file */
+    for( i = 0; i < unmet_dep_count; i++ )
+        free( unmet_dependencies[i] );
 
     mbedtls_fprintf( stdout, "\r\n----------------------------------------------------------------------------\r\n\r\n");
     if( total_errors == 0 )

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -244,7 +244,7 @@ static int run_test_snprintf( void )
             test_snprintf( 5, "123",         3 ) != 0 );
 }
 
-int main()
+void test_case()
 {
     /* Test suite data */
     char *test_suite_data = TEST_DATA_CODE;
@@ -275,7 +275,7 @@ int main()
     if( pointer != NULL )
     {
         mbedtls_fprintf( stderr, "all-bits-zero is not a NULL pointer\r\n" );
-        return( 1 );
+        TEST_ASSERT( 1 );
     }
 
     /*
@@ -284,7 +284,7 @@ int main()
     if( run_test_snprintf() != 0 )
     {
         mbedtls_fprintf( stderr, "the snprintf implementation is broken\r\n" );
-        return( 0 );
+        TEST_ASSERT( 0 );
     }
 
     /* Now begin to execute the tests */
@@ -384,7 +384,7 @@ int main()
         {
             mbedtls_fprintf( stderr, "Should be empty %d\r\n",
                              (int) strlen(buf) );
-            return( 1 );
+            TEST_ASSERT( 1 );
         }
     }
 
@@ -409,6 +409,20 @@ int main()
     mbedtls_memory_buffer_alloc_free();
 #endif
 
-    return( total_errors != 0 );
+    TEST_ASSERT( total_errors == 0 );
 }
 
+Case cases[] = {
+    Case("Machine generated testcase for TESTCASE_FILENAME", test_case)
+};
+
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(40, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -121,7 +121,7 @@ DISPATCH_FUNCTION
 
 #line !LINE_NO! "main_test_mbed.function"
 
-int get_line( char **test_data, char *buf, size_t len )
+int get_line( const char **test_data, char *buf, size_t len )
 {
     // this function currently does not handle \r\r\n line terminators, but we
     // are hard-coding the test data inside the c file, so this should not
@@ -247,7 +247,7 @@ static int run_test_snprintf( void )
 void test_case()
 {
     /* Test suite data */
-    char *test_suite_data = TEST_DATA_CODE;
+    const char *test_suite_data = TEST_DATA_CODE;
 
 #line !LINE_NO! "main_test_mbed.function"
 
@@ -259,12 +259,6 @@ void test_case()
     void *pointer;
     int unmet_dep_count = 0;
     char *unmet_dependencies[20];
-
-#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
-    !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
-    unsigned char alloc_buf[1000000];
-    mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
-#endif
 
     /*
      * The C standard doesn't guarantee that all-bits-0 is the representation
@@ -400,14 +394,6 @@ void test_case()
 
     mbedtls_fprintf( stdout, " (%d / %d tests (%d skipped))\r\n",
              total_tests - total_errors, total_tests, total_skipped );
-
-#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
-    !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
-#if defined(MBEDTLS_MEMORY_DEBUG)
-    mbedtls_memory_buffer_alloc_status();
-#endif
-    mbedtls_memory_buffer_alloc_free();
-#endif
 
     TEST_ASSERT( total_errors == 0 );
 }

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -121,7 +121,7 @@ DISPATCH_FUNCTION
 
 #line !LINE_NO! "main_test_mbed.function"
 
-int get_line( char** test_data, char *buf, size_t len )
+int get_line( char **test_data, char *buf, size_t len )
 {
     // this function currently does not handle \r\r\n line terminators, but we
     // are hard-coding the test data inside the c file, so this should not

--- a/tests/suites/main_test_mbed.function
+++ b/tests/suites/main_test_mbed.function
@@ -316,13 +316,6 @@ int main()
             {
                 if( dep_check( params[i] ) != DEPENDENCY_SUPPORTED )
                 {
-                    if( 0 == option_verbose )
-                    {
-                        /* Only one count is needed if not verbose */
-                        unmet_dep_count++;
-                        break;
-                    }
-
                     unmet_dependencies[ unmet_dep_count ] = strdup(params[i]);
                     if(  unmet_dependencies[ unmet_dep_count ] == NULL )
                     {
@@ -350,12 +343,12 @@ int main()
             total_skipped++;
             mbedtls_fprintf( stdout, "----\r\n" );
 
-            if( 1 == option_verbose && ret == DISPATCH_UNSUPPORTED_SUITE )
+            if( ret == DISPATCH_UNSUPPORTED_SUITE )
             {
                 mbedtls_fprintf( stdout, "   Test Suite not enabled" );
             }
 
-            if( 1 == option_verbose && unmet_dep_count > 0 )
+            if( unmet_dep_count > 0 )
             {
                 mbedtls_fprintf( stdout, "   Unmet dependencies: " );
                 for( i = 0; i < unmet_dep_count; i++ )

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -26,7 +26,7 @@ void mbedtls_ccm_setkey( int cipher_id, int key_size, int result )
     memset( key, 0x2A, sizeof( key ) );
     TEST_ASSERT( (unsigned) key_size <= 8 * sizeof( key ) );
 
-    ret = mbedtls_ccm_setkey( &ctx, cipher_id, key, key_size );
+    ret = mbedtls_ccm_setkey( &ctx, (mbedtls_cipher_id_t) cipher_id, key, key_size );
     TEST_ASSERT( ret == result );
 
 exit:
@@ -103,7 +103,7 @@ void mbedtls_ccm_encrypt_and_tag( int cipher_id,
     result_len = unhexify( result, result_hex );
     tag_len = result_len - msg_len;
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, (mbedtls_cipher_id_t) cipher_id, key, key_len * 8 ) == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_ccm_encrypt_and_tag( &ctx, msg_len, iv, iv_len, add, add_len,
@@ -162,7 +162,7 @@ void mbedtls_ccm_auth_decrypt( int cipher_id,
         result_len = unhexify( result, result_hex );
     }
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, (mbedtls_cipher_id_t) cipher_id, key, key_len * 8 ) == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_ccm_auth_decrypt( &ctx, msg_len, iv, iv_len, add, add_len,

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -17,7 +17,7 @@ void mbedtls_cipher_list( )
     const int *cipher_type;
 
     for( cipher_type = mbedtls_cipher_list(); *cipher_type != 0; cipher_type++ )
-        TEST_ASSERT( mbedtls_cipher_info_from_type( *cipher_type ) != NULL );
+        TEST_ASSERT( mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) *cipher_type ) != NULL );
 }
 /* END_CASE */
 
@@ -25,7 +25,7 @@ void mbedtls_cipher_list( )
 void cipher_null_args( )
 {
     mbedtls_cipher_context_t ctx;
-    const mbedtls_cipher_info_t *info = mbedtls_cipher_info_from_type( *( mbedtls_cipher_list() ) );
+    const mbedtls_cipher_info_t *info = mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) *( mbedtls_cipher_list() ) );
     unsigned char buf[1] = { 0 };
     size_t olen;
 
@@ -117,7 +117,7 @@ void enc_dec_buf( int cipher_id, char *cipher_string, int key_len,
     memset( key, 0x2a, sizeof( key ) );
 
     /* Check and get info structures */
-    cipher_info = mbedtls_cipher_info_from_type( cipher_id );
+    cipher_info = mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id );
     TEST_ASSERT( NULL != cipher_info );
     TEST_ASSERT( mbedtls_cipher_info_from_string( cipher_string ) == cipher_info );
 
@@ -131,8 +131,8 @@ void enc_dec_buf( int cipher_id, char *cipher_string, int key_len,
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
     if( -1 != pad_mode )
     {
-        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_dec, pad_mode ) );
-        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_enc, pad_mode ) );
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_dec, (mbedtls_cipher_padding_t) pad_mode ) );
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_enc, (mbedtls_cipher_padding_t) pad_mode ) );
     }
 #else
     (void) pad_mode;
@@ -241,14 +241,14 @@ void enc_fail( int cipher_id, int pad_mode, int key_len,
     memset( encbuf, 0, 64 );
 
     /* Check and get info structures */
-    cipher_info = mbedtls_cipher_info_from_type( cipher_id );
+    cipher_info = mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id );
     TEST_ASSERT( NULL != cipher_info );
 
     /* Initialise context */
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx, cipher_info ) );
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, key_len, MBEDTLS_ENCRYPT ) );
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
-    TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, pad_mode ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, (mbedtls_cipher_padding_t) pad_mode ) );
 #else
     (void) pad_mode;
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
@@ -351,7 +351,7 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
     memset( decbuf, 0, 64 );
 
     /* Initialise enc and dec contexts */
-    cipher_info = mbedtls_cipher_info_from_type( cipher_id );
+    cipher_info = mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id );
     TEST_ASSERT( NULL != cipher_info);
 
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx_dec, cipher_info ) );
@@ -458,11 +458,11 @@ void decrypt_test_vec( int cipher_id, int pad_mode,
 
     /* Prepare context */
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
-                                       mbedtls_cipher_info_from_type( cipher_id ) ) );
+                                       mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id ) ) );
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, MBEDTLS_DECRYPT ) );
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
     if( pad_mode != -1 )
-        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, pad_mode ) );
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, (mbedtls_cipher_padding_t) pad_mode ) );
 #else
     (void) pad_mode;
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
@@ -532,7 +532,7 @@ void auth_crypt_tv( int cipher_id, char *hex_key, char *hex_iv,
 
     /* Prepare context */
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
-                                       mbedtls_cipher_info_from_type( cipher_id ) ) );
+                                       mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id ) ) );
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, MBEDTLS_DECRYPT ) );
 
     /* decode buffer and check tag */
@@ -605,7 +605,7 @@ void test_vec_ecb( int cipher_id, int operation, char *hex_key,
 
     /* Prepare context */
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
-                                       mbedtls_cipher_info_from_type( cipher_id ) ) );
+                                       mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id ) ) );
 
     key_len = unhexify( key, hex_key );
     TEST_ASSERT( unhexify( input, hex_input ) ==
@@ -613,7 +613,7 @@ void test_vec_ecb( int cipher_id, int operation, char *hex_key,
     TEST_ASSERT( unhexify( result, hex_result ) ==
                  (int) mbedtls_cipher_get_block_size( &ctx ) );
 
-    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, operation ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, (mbedtls_operation_t) operation ) );
 
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx, input,
                                      mbedtls_cipher_get_block_size( &ctx ),
@@ -641,11 +641,11 @@ void set_padding( int cipher_id, int pad_mode, int ret )
 
     mbedtls_cipher_init( &ctx );
 
-    cipher_info = mbedtls_cipher_info_from_type( cipher_id );
+    cipher_info = mbedtls_cipher_info_from_type( (mbedtls_cipher_type_t) cipher_id );
     TEST_ASSERT( NULL != cipher_info );
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx, cipher_info ) );
 
-    TEST_ASSERT( ret == mbedtls_cipher_set_padding_mode( &ctx, pad_mode ) );
+    TEST_ASSERT( ret == mbedtls_cipher_set_padding_mode( &ctx, (mbedtls_cipher_padding_t) pad_mode ) );
 
 exit:
     mbedtls_cipher_free( &ctx );
@@ -665,7 +665,7 @@ void check_padding( int pad_mode, char *input_str, int ret, int dlen_check )
     cipher_info.mode = MBEDTLS_MODE_CBC;
     ctx.cipher_info = &cipher_info;
 
-    TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, pad_mode ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, (mbedtls_cipher_padding_t) pad_mode ) );
 
     ilen = unhexify( input, input_str );
 

--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -21,7 +21,7 @@ void ecdh_primitive_random( int id )
     mbedtls_mpi_init( &zA ); mbedtls_mpi_init( &zB );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_ecdh_gen_public( &grp, &dA, &qA, &rnd_pseudo_rand, &rnd_info )
                  == 0 );
@@ -59,7 +59,7 @@ void ecdh_primitive_testvec( int id, char *dA_str, char *xA_str, char *yA_str,
     mbedtls_mpi_init( &dA ); mbedtls_mpi_init( &dB );
     mbedtls_mpi_init( &zA ); mbedtls_mpi_init( &zB ); mbedtls_mpi_init( &check );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     rnd_info_A.buf = rnd_buf_A;
     rnd_info_A.length = unhexify( rnd_buf_A, dA_str );
@@ -136,7 +136,7 @@ void ecdh_exchange( int id )
     mbedtls_ecdh_init( &cli );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &srv.grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &srv.grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     memset( buf, 0x00, sizeof( buf ) ); vbuf = buf;
     TEST_ASSERT( mbedtls_ecdh_make_params( &srv, &len, buf, 1000,

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -24,7 +24,7 @@ void ecdsa_prim_random( int id )
 
     /* prepare material for signature */
     TEST_ASSERT( rnd_pseudo_rand( &rnd_info, buf, sizeof( buf ) ) == 0 );
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_gen_keypair( &grp, &d, &Q, &rnd_pseudo_rand, &rnd_info )
                  == 0 );
 
@@ -58,7 +58,7 @@ void ecdsa_prim_test_vectors( int id, char *d_str, char *xQ_str, char *yQ_str,
     memset( hash, 0, sizeof( hash ) );
     memset( rnd_buf, 0, sizeof( rnd_buf ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &Q, 16, xQ_str, yQ_str ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &d, 16, d_str ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &r_check, 16, r_str ) == 0 );
@@ -110,17 +110,17 @@ void ecdsa_det_test_vectors( int id, char *d_str, int md_alg,
     mbedtls_mpi_init( &r_check ); mbedtls_mpi_init( &s_check );
     memset( hash, 0, sizeof( hash ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &d, 16, d_str ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &r_check, 16, r_str ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &s_check, 16, s_str ) == 0 );
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
     hlen = mbedtls_md_get_size( md_info );
     mbedtls_md( md_info, (const unsigned char *) msg, strlen( msg ), hash );
 
-    TEST_ASSERT( mbedtls_ecdsa_sign_det( &grp, &r, &s, &d, hash, hlen, md_alg ) == 0 );
+    TEST_ASSERT( mbedtls_ecdsa_sign_det( &grp, &r, &s, &d, hash, hlen, (mbedtls_md_type_t) md_alg ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_cmp_mpi( &r, &r_check ) == 0 );
     TEST_ASSERT( mbedtls_mpi_cmp_mpi( &s, &s_check ) == 0 );
@@ -150,7 +150,7 @@ void ecdsa_write_read_random( int id )
     TEST_ASSERT( rnd_pseudo_rand( &rnd_info, hash, sizeof( hash ) ) == 0 );
 
     /* generate signing key */
-    TEST_ASSERT( mbedtls_ecdsa_genkey( &ctx, id, &rnd_pseudo_rand, &rnd_info ) == 0 );
+    TEST_ASSERT( mbedtls_ecdsa_genkey( &ctx, (mbedtls_ecp_group_id) id, &rnd_pseudo_rand, &rnd_info ) == 0 );
 
     /* generate and write signature, then read and verify it */
     TEST_ASSERT( mbedtls_ecdsa_write_signature( &ctx, MBEDTLS_MD_SHA256,

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -14,7 +14,7 @@ void mbedtls_ecp_curve_info( int id, int tls_id, int size, char *name )
 {
     const mbedtls_ecp_curve_info *by_id, *by_tls, *by_name;
 
-    by_id   = mbedtls_ecp_curve_info_from_grp_id( id     );
+    by_id   = mbedtls_ecp_curve_info_from_grp_id( (mbedtls_ecp_group_id) id );
     by_tls  = mbedtls_ecp_curve_info_from_tls_id( tls_id );
     by_name = mbedtls_ecp_curve_info_from_name(   name   );
     TEST_ASSERT( by_id   != NULL );
@@ -37,7 +37,7 @@ void ecp_check_pub_mx( int grp_id, char *key_hex, int ret )
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &P );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, grp_id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) grp_id ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &P.X, 16, key_hex ) == 0 );
     TEST_ASSERT( mbedtls_mpi_lset( &P.Z, 1 ) == 0 );
@@ -65,7 +65,7 @@ void ecp_test_vect( int id, char *dA_str, char *xA_str, char *yA_str,
     mbedtls_mpi_init( &xB ); mbedtls_mpi_init( &yB ); mbedtls_mpi_init( &xZ ); mbedtls_mpi_init( &yZ );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_check_pubkey( &grp, &grp.G ) == 0 );
 
@@ -120,7 +120,7 @@ void ecp_test_vec_x( int id, char *dA_hex, char *xA_hex,
     mbedtls_mpi_init( &xS );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_check_pubkey( &grp, &grp.G ) == 0 );
 
@@ -166,7 +166,7 @@ void ecp_fast_mod( int id, char *N_str )
     mbedtls_ecp_group_init( &grp );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, 16, N_str ) == 0 );
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( grp.modp != NULL );
 
     /*
@@ -203,7 +203,7 @@ void ecp_write_binary( int id, char *x, char *y, char *z, int format,
 
     mbedtls_ecp_group_init( &grp ); mbedtls_ecp_point_init( &P );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &P.X, 16, x ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &P.Y, 16, y ) == 0 );
@@ -238,7 +238,7 @@ void ecp_read_binary( int id, char *input, char *x, char *y, char *z,
     mbedtls_ecp_group_init( &grp ); mbedtls_ecp_point_init( &P );
     mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &Z );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &X, 16, x ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, 16, y ) == 0 );
@@ -277,7 +277,7 @@ void mbedtls_ecp_tls_read_point( int id, char *input, char *x, char *y, char *z,
     mbedtls_ecp_group_init( &grp ); mbedtls_ecp_point_init( &P );
     mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &Z );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &X, 16, x ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, 16, y ) == 0 );
@@ -313,7 +313,7 @@ void ecp_tls_write_read_point( int id )
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &pt );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     memset( buf, 0x00, sizeof( buf ) ); vbuf = buf;
     TEST_ASSERT( mbedtls_ecp_tls_write_point( &grp, &grp.G,
@@ -393,7 +393,7 @@ void ecp_tls_write_read_group( int id )
     mbedtls_ecp_group_init( &grp2 );
     memset( buf, 0x00, sizeof( buf ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp1, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp1, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_tls_write_group( &grp1, &len, buf, 10 ) == 0 );
     ret = mbedtls_ecp_tls_read_group( &grp2, &vbuf, len );
@@ -420,7 +420,7 @@ void mbedtls_ecp_check_privkey( int id, char *key_hex, int ret )
     mbedtls_ecp_group_init( &grp );
     mbedtls_mpi_init( &d );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &d, 16, key_hex ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_check_privkey( &grp, &d ) == ret );
@@ -441,11 +441,11 @@ void mbedtls_ecp_check_pub_priv( int id_pub, char *Qx_pub, char *Qy_pub,
     mbedtls_ecp_keypair_init( &prv );
 
     if( id_pub != MBEDTLS_ECP_DP_NONE )
-        TEST_ASSERT( mbedtls_ecp_group_load( &pub.grp, id_pub ) == 0 );
+        TEST_ASSERT( mbedtls_ecp_group_load( &pub.grp, (mbedtls_ecp_group_id) id_pub ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &pub.Q, 16, Qx_pub, Qy_pub ) == 0 );
 
     if( id != MBEDTLS_ECP_DP_NONE )
-        TEST_ASSERT( mbedtls_ecp_group_load( &prv.grp, id ) == 0 );
+        TEST_ASSERT( mbedtls_ecp_group_load( &prv.grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &prv.Q, 16, Qx, Qy ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &prv.d, 16, d ) == 0 );
 
@@ -470,7 +470,7 @@ void mbedtls_ecp_gen_keypair( int id )
     mbedtls_mpi_init( &d );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &grp, (mbedtls_ecp_group_id) id ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_gen_keypair( &grp, &d, &Q, &rnd_pseudo_rand, &rnd_info )
                  == 0 );
@@ -494,7 +494,7 @@ void mbedtls_ecp_gen_key( int id )
     mbedtls_ecp_keypair_init( &key );
     memset( &rnd_info, 0x00, sizeof( rnd_pseudo_info ) );
 
-    TEST_ASSERT( mbedtls_ecp_gen_key( id, &key, &rnd_pseudo_rand, &rnd_info ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_gen_key( (mbedtls_ecp_group_id) id, &key, &rnd_pseudo_rand, &rnd_info ) == 0 );
 
     TEST_ASSERT( mbedtls_ecp_check_pubkey( &key.grp, &key.Q ) == 0 );
     TEST_ASSERT( mbedtls_ecp_check_privkey( &key.grp, &key.d ) == 0 );

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -42,7 +42,7 @@ void gcm_encrypt_and_tag( int cipher_id,
     iv_len = unhexify( iv_str, hex_iv_string );
     add_len = unhexify( add_str, hex_add_string );
 
-    TEST_ASSERT( mbedtls_gcm_setkey( &ctx, cipher_id, key_str, key_len * 8 ) == init_result );
+    TEST_ASSERT( mbedtls_gcm_setkey( &ctx, (mbedtls_cipher_id_t) cipher_id, key_str, key_len * 8 ) == init_result );
     if( init_result == 0 )
     {
         TEST_ASSERT( mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_ENCRYPT, pt_len, iv_str, iv_len, add_str, add_len, src_str, output, tag_len, tag_output ) == 0 );
@@ -93,7 +93,7 @@ void gcm_decrypt_and_verify( int cipher_id,
     add_len = unhexify( add_str, hex_add_string );
     unhexify( tag_str, hex_tag_string );
 
-    TEST_ASSERT( mbedtls_gcm_setkey( &ctx, cipher_id, key_str, key_len * 8 ) == init_result );
+    TEST_ASSERT( mbedtls_gcm_setkey( &ctx, (mbedtls_cipher_id_t) cipher_id, key_str, key_len * 8 ) == init_result );
     if( init_result == 0 )
     {
         ret = mbedtls_gcm_auth_decrypt( &ctx, pt_len, iv_str, iv_len, add_str, add_len, tag_str, tag_len, src_str, output );

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -45,7 +45,7 @@ void hmac_drbg_entropy_usage( int md_alg )
     entropy.len = sizeof( buf );
     entropy.p = buf;
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
 
     /* Init must use entropy */
@@ -143,7 +143,7 @@ void hmac_drbg_buf( int md_alg )
     memset( buf, 0, sizeof( buf ) );
     memset( out, 0, sizeof( out ) );
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
     TEST_ASSERT( mbedtls_hmac_drbg_seed_buf( &ctx, md_info, buf, sizeof( buf ) ) == 0 );
 
@@ -187,7 +187,7 @@ void hmac_drbg_no_reseed( int md_alg,
     p_entropy.len = unhexify( entropy, entropy_hex );
     p_entropy.p = entropy;
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
 
     /* Test the simplified buffer-based variant */
@@ -248,7 +248,7 @@ void hmac_drbg_nopr( int md_alg,
     p_entropy.len = unhexify( entropy, entropy_hex );
     p_entropy.p = entropy;
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
 
     TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &p_entropy,
@@ -293,7 +293,7 @@ void hmac_drbg_pr( int md_alg,
     p_entropy.len = unhexify( entropy, entropy_hex );
     p_entropy.p = entropy;
 
-    md_info = mbedtls_md_info_from_type( md_alg );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_alg );
     TEST_ASSERT( md_info != NULL );
 
     TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &p_entropy,

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -27,7 +27,7 @@ void mbedtls_md_process( )
      */
     for( md_type_ptr = mbedtls_md_list(); *md_type_ptr != 0; md_type_ptr++ )
     {
-        info = mbedtls_md_info_from_type( *md_type_ptr );
+        info = mbedtls_md_info_from_type( (mbedtls_md_type_t) *md_type_ptr );
         TEST_ASSERT( info != NULL );
         TEST_ASSERT( mbedtls_md_setup( &ctx, info, 0 ) == 0 );
         TEST_ASSERT( mbedtls_md_process( &ctx, buf ) == 0 );
@@ -43,7 +43,7 @@ exit:
 void md_null_args( )
 {
     mbedtls_md_context_t ctx;
-    const mbedtls_md_info_t *info = mbedtls_md_info_from_type( *( mbedtls_md_list() ) );
+    const mbedtls_md_info_t *info = mbedtls_md_info_from_type( (mbedtls_md_type_t) *( mbedtls_md_list() ) );
     unsigned char buf[1] = { 0 };
 
     mbedtls_md_init( &ctx );
@@ -109,7 +109,7 @@ void md_info( int md_type, char *md_name, int md_size )
     const int *md_type_ptr;
     int found;
 
-    md_info = mbedtls_md_info_from_type( md_type );
+    md_info = mbedtls_md_info_from_type( (mbedtls_md_type_t) md_type );
     TEST_ASSERT( md_info != NULL );
     TEST_ASSERT( md_info == mbedtls_md_info_from_string( md_name ) );
 

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -155,16 +155,19 @@ void md_text( char *text_md_name, char *text_src_string, char *hex_hash_string )
 void md_hex( char *text_md_name, char *hex_src_string, char *hex_hash_string )
 {
     char md_name[100];
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
+    unsigned char *src_str;
+    unsigned char hash_str[100 * 2 + 1];
     unsigned char output[100];
     int src_len;
     const mbedtls_md_info_t *md_info = NULL;
 
-    memset(md_name, 0x00, 100);
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 100);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(md_name, 0x00, sizeof( md_name ) );
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     strncpy( (char *) md_name, text_md_name, sizeof(md_name) - 1 );
     md_info = mbedtls_md_info_from_string(md_name);
@@ -176,6 +179,8 @@ void md_hex( char *text_md_name, char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, mbedtls_md_get_size(md_info) );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
@@ -223,8 +228,8 @@ void md_hex_multi( char *text_md_name, char *hex_src_string,
                    char *hex_hash_string )
 {
     char md_name[100];
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
+    unsigned char *src_str;
+    unsigned char hash_str[100 * 2 + 1];
     unsigned char output[100];
     int src_len;
     const mbedtls_md_info_t *md_info = NULL;
@@ -232,10 +237,13 @@ void md_hex_multi( char *text_md_name, char *hex_src_string,
 
     mbedtls_md_init( &ctx );
 
-    memset(md_name, 0x00, 100);
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 100);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(md_name, 0x00, sizeof( md_name ) );
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     strncpy( (char *) md_name, text_md_name, sizeof(md_name) - 1 );
     md_info = mbedtls_md_info_from_string(md_name);
@@ -253,6 +261,8 @@ void md_hex_multi( char *text_md_name, char *hex_src_string,
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
 
+    mbedtls_free( src_str );
+
 exit:
     mbedtls_md_free( &ctx );
 }
@@ -263,18 +273,26 @@ void mbedtls_md_hmac( char *text_md_name, int trunc_size, char *hex_key_string,
               char *hex_src_string, char *hex_hash_string )
 {
     char md_name[100];
-    unsigned char src_str[10000];
-    unsigned char key_str[10000];
-    unsigned char hash_str[10000];
+    unsigned char *src_str;
+    unsigned char *key_str;
+    unsigned char hash_str[100 * 2 + 1];
     unsigned char output[100];
     int key_len, src_len;
     const mbedtls_md_info_t *md_info = NULL;
 
-    memset(md_name, 0x00, 100);
-    memset(src_str, 0x00, 10000);
-    memset(key_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 100);
+    key_str = (unsigned char *) mbedtls_calloc( strlen( hex_key_string ) / 2, sizeof( unsigned char ) );
+    if( key_str == NULL )
+        TEST_ASSERT( 0 );
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+    {
+        mbedtls_free( key_str );
+        TEST_ASSERT( 0 );
+    }
+
+    memset(md_name, 0x00, sizeof( md_name ) );
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     strncpy( (char *) md_name, text_md_name, sizeof(md_name) - 1 );
     md_info = mbedtls_md_info_from_string( md_name );
@@ -287,6 +305,9 @@ void mbedtls_md_hmac( char *text_md_name, int trunc_size, char *hex_key_string,
     hexify( hash_str, output, mbedtls_md_get_size(md_info) );
 
     TEST_ASSERT( strncmp( (char *) hash_str, hex_hash_string, trunc_size * 2 ) == 0 );
+
+    mbedtls_free( key_str );
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
@@ -295,9 +316,9 @@ void md_hmac_multi( char *text_md_name, int trunc_size, char *hex_key_string,
                     char *hex_src_string, char *hex_hash_string )
 {
     char md_name[100];
-    unsigned char src_str[10000];
-    unsigned char key_str[10000];
-    unsigned char hash_str[10000];
+    unsigned char *src_str;
+    unsigned char *key_str;
+    unsigned char hash_str[100 * 2 + 1];
     unsigned char output[100];
     int key_len, src_len;
     const mbedtls_md_info_t *md_info = NULL;
@@ -305,11 +326,19 @@ void md_hmac_multi( char *text_md_name, int trunc_size, char *hex_key_string,
 
     mbedtls_md_init( &ctx );
 
-    memset(md_name, 0x00, 100);
-    memset(src_str, 0x00, 10000);
-    memset(key_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 100);
+    key_str = (unsigned char *) mbedtls_calloc( strlen( hex_key_string ) / 2, sizeof( unsigned char ) );
+    if( key_str == NULL )
+        TEST_ASSERT( 0 );
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+    {
+        mbedtls_free( key_str );
+        TEST_ASSERT( 0 );
+    }
+
+    memset(md_name, 0x00, sizeof( md_name ) );
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     strncpy( (char *) md_name, text_md_name, sizeof(md_name) - 1 );
     md_info = mbedtls_md_info_from_string( md_name );
@@ -328,8 +357,8 @@ void md_hmac_multi( char *text_md_name, int trunc_size, char *hex_key_string,
     TEST_ASSERT( strncmp( (char *) hash_str, hex_hash_string, trunc_size * 2 ) == 0 );
 
     /* Test again, for reset() */
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 100);
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     TEST_ASSERT ( 0 == mbedtls_md_hmac_reset( &ctx ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str, src_len ) );
@@ -337,6 +366,9 @@ void md_hmac_multi( char *text_md_name, int trunc_size, char *hex_key_string,
 
     hexify( hash_str, output, mbedtls_md_get_size(md_info) );
     TEST_ASSERT( strncmp( (char *) hash_str, hex_hash_string, trunc_size * 2 ) == 0 );
+
+    mbedtls_free( key_str );
+    mbedtls_free( src_str );
 
 exit:
     mbedtls_md_free( &ctx );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -70,11 +70,11 @@ void pk_utils( int type, int size, int len, char *name )
 
     mbedtls_pk_init( &pk );
 
-    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
+    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( (mbedtls_pk_type_t) type ) ) == 0 );
     TEST_ASSERT( pk_genkey( &pk ) == 0 );
 
     TEST_ASSERT( (int) mbedtls_pk_get_type( &pk ) == type );
-    TEST_ASSERT( mbedtls_pk_can_do( &pk, type ) );
+    TEST_ASSERT( mbedtls_pk_can_do( &pk, (mbedtls_pk_type_t) type ) );
     TEST_ASSERT( mbedtls_pk_get_bitlen( &pk ) == (unsigned) size );
     TEST_ASSERT( mbedtls_pk_get_len( &pk ) == (unsigned) len );
     TEST_ASSERT( strcmp( mbedtls_pk_get_name( &pk), name ) == 0 );
@@ -141,10 +141,10 @@ void pk_rsa_verify_test_vec( char *message_hex_string, int digest,
     msg_len = unhexify( message_str, message_hex_string );
     unhexify( result_str, result_hex_str );
 
-    if( mbedtls_md_info_from_type( digest ) != NULL )
-        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( digest ), message_str, msg_len, hash_result ) == 0 );
+    if( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ) != NULL )
+        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ), message_str, msg_len, hash_result ) == 0 );
 
-    TEST_ASSERT( mbedtls_pk_verify( &pk, digest, hash_result, 0,
+    TEST_ASSERT( mbedtls_pk_verify( &pk, (mbedtls_md_type_t) digest, hash_result, 0,
                             result_str, mbedtls_pk_get_len( &pk ) ) == result );
 
 exit:
@@ -187,7 +187,7 @@ void pk_rsa_verify_ext_test_vec( char *message_hex_string, int digest,
 
     if( digest != MBEDTLS_MD_NONE )
     {
-        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( digest ),
+        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ),
                      message_str, msg_len, hash_result ) == 0 );
         hash_len = 0;
     }
@@ -205,12 +205,12 @@ void pk_rsa_verify_ext_test_vec( char *message_hex_string, int digest,
     {
         options = &pss_opts;
 
-        pss_opts.mgf1_hash_id = mgf1_hash_id;
+        pss_opts.mgf1_hash_id = (mbedtls_md_type_t) mgf1_hash_id;
         pss_opts.expected_salt_len = salt_len;
     }
 
-    TEST_ASSERT( mbedtls_pk_verify_ext( pk_type, options, &pk,
-                                digest, hash_result, hash_len,
+    TEST_ASSERT( mbedtls_pk_verify_ext( (mbedtls_pk_type_t) pk_type, options, &pk,
+                                (mbedtls_md_type_t) digest, hash_result, hash_len,
                                 result_str, mbedtls_pk_get_len( &pk ) ) == result );
 
 exit:
@@ -233,12 +233,12 @@ void pk_ec_test_vec( int type, int id, char *key_str,
     memset( sig, 0, sizeof( sig ) );    sig_len = unhexify(sig, sig_str);
     memset( key, 0, sizeof( key ) );    key_len = unhexify(key, key_str);
 
-    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
+    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( (mbedtls_pk_type_t) type ) ) == 0 );
 
     TEST_ASSERT( mbedtls_pk_can_do( &pk, MBEDTLS_PK_ECDSA ) );
     eckey = mbedtls_pk_ec( pk );
 
-    TEST_ASSERT( mbedtls_ecp_group_load( &eckey->grp, id ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_group_load( &eckey->grp, (mbedtls_ecp_group_id) id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_binary( &eckey->grp, &eckey->Q,
                                         key, key_len ) == 0 );
 
@@ -262,7 +262,7 @@ void pk_sign_verify( int type, int sign_ret, int verify_ret )
     memset( hash, 0x2a, sizeof hash );
     memset( sig, 0, sizeof sig );
 
-    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
+    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( (mbedtls_pk_type_t) type ) ) == 0 );
     TEST_ASSERT( pk_genkey( &pk ) == 0 );
 
     TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_SHA256, hash, sizeof hash,
@@ -399,7 +399,7 @@ void pk_ec_nocrypt( int type )
     memset( output,     0, sizeof( output ) );
     memset( input,      0, sizeof( input ) );
 
-    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
+    TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( (mbedtls_pk_type_t) type ) ) == 0 );
 
     TEST_ASSERT( mbedtls_pk_encrypt( &pk, input, sizeof( input ),
                              output, &olen, sizeof( output ),

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -58,10 +58,10 @@ void mbedtls_rsa_pkcs1_sign( char *message_hex_string, int padding_mode, int dig
 
     msg_len = unhexify( message_str, message_hex_string );
 
-    if( mbedtls_md_info_from_type( digest ) != NULL )
-        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( digest ), message_str, msg_len, hash_result ) == 0 );
+    if( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ) != NULL )
+        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ), message_str, msg_len, hash_result ) == 0 );
 
-    TEST_ASSERT( mbedtls_rsa_pkcs1_sign( &ctx, &rnd_pseudo_rand, &rnd_info, MBEDTLS_RSA_PRIVATE, digest, 0, hash_result, output ) == result );
+    TEST_ASSERT( mbedtls_rsa_pkcs1_sign( &ctx, &rnd_pseudo_rand, &rnd_info, MBEDTLS_RSA_PRIVATE, (mbedtls_md_type_t) digest, 0, hash_result, output ) == result );
     if( result == 0 )
     {
         hexify( output_str, output, ctx.len );
@@ -100,10 +100,10 @@ void mbedtls_rsa_pkcs1_verify( char *message_hex_string, int padding_mode, int d
     msg_len = unhexify( message_str, message_hex_string );
     unhexify( result_str, result_hex_str );
 
-    if( mbedtls_md_info_from_type( digest ) != NULL )
-        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( digest ), message_str, msg_len, hash_result ) == 0 );
+    if( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ) != NULL )
+        TEST_ASSERT( mbedtls_md( mbedtls_md_info_from_type( (mbedtls_md_type_t) digest ), message_str, msg_len, hash_result ) == 0 );
 
-    TEST_ASSERT( mbedtls_rsa_pkcs1_verify( &ctx, NULL, NULL, MBEDTLS_RSA_PUBLIC, digest, 0, hash_result, result_str ) == result );
+    TEST_ASSERT( mbedtls_rsa_pkcs1_verify( &ctx, NULL, NULL, MBEDTLS_RSA_PUBLIC, (mbedtls_md_type_t) digest, 0, hash_result, result_str ) == result );
 
 exit:
     mbedtls_rsa_free( &ctx );

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -7,14 +7,17 @@
 /* BEGIN_CASE depends_on:MBEDTLS_SHA1_C */
 void mbedtls_sha1( char *hex_src_string, char *hex_hash_string )
 {
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
-    unsigned char output[41];
+    unsigned char *src_str;
+    unsigned char hash_str[20 * 2 + 1];
+    unsigned char output[20];
     int src_len;
 
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 41);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     src_len = unhexify( src_str, hex_src_string );
 
@@ -22,20 +25,25 @@ void mbedtls_sha1( char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, 20 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
 void sha224(char *hex_src_string, char *hex_hash_string )
 {
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
-    unsigned char output[57];
+    unsigned char *src_str;
+    unsigned char hash_str[28 * 2 + 1];
+    unsigned char output[28];
     int src_len;
 
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 57);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     src_len = unhexify( src_str, hex_src_string );
 
@@ -43,20 +51,25 @@ void sha224(char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, 28 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
 void mbedtls_sha256(char *hex_src_string, char *hex_hash_string )
 {
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
-    unsigned char output[65];
+    unsigned char *src_str;
+    unsigned char hash_str[32 * 2 + 1];
+    unsigned char output[32];
     int src_len;
 
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 65);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     src_len = unhexify( src_str, hex_src_string );
 
@@ -64,20 +77,25 @@ void mbedtls_sha256(char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, 32 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA512_C */
 void sha384(char *hex_src_string, char *hex_hash_string )
 {
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
-    unsigned char output[97];
+    unsigned char *src_str;
+    unsigned char hash_str[48 * 2 + 1];
+    unsigned char output[48];
     int src_len;
 
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 97);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     src_len = unhexify( src_str, hex_src_string );
 
@@ -85,20 +103,25 @@ void sha384(char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, 48 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA512_C */
 void mbedtls_sha512(char *hex_src_string, char *hex_hash_string )
 {
-    unsigned char src_str[10000];
-    unsigned char hash_str[10000];
-    unsigned char output[129];
+    unsigned char *src_str;
+    unsigned char hash_str[64 * 2 + 1];
+    unsigned char output[64];
     int src_len;
 
-    memset(src_str, 0x00, 10000);
-    memset(hash_str, 0x00, 10000);
-    memset(output, 0x00, 129);
+    src_str = (unsigned char *) mbedtls_calloc( strlen( hex_src_string ) / 2, sizeof( unsigned char ) );
+    if( src_str == NULL )
+        TEST_ASSERT( 0 );
+
+    memset(hash_str, 0x00, sizeof( hash_str ) );
+    memset(output, 0x00, sizeof( output ) );
 
     src_len = unhexify( src_str, hex_src_string );
 
@@ -106,6 +129,8 @@ void mbedtls_sha512(char *hex_src_string, char *hex_hash_string )
     hexify( hash_str, output, 64 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
+
+    mbedtls_free( src_str );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -9,7 +9,7 @@
  */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_DTLS_ANTI_REPLAY */
-void ssl_dtls_replay( char *prevs, char *new, int ret )
+void ssl_dtls_replay( char *prevs, char *new_num, int ret )
 {
     mbedtls_ssl_context ssl;
     mbedtls_ssl_config conf;
@@ -33,7 +33,7 @@ void ssl_dtls_replay( char *prevs, char *new, int ret )
     }
 
     /* Check new number */
-    unhexify( ssl.in_ctr + 2, new );
+    unhexify( ssl.in_ctr + 2, new_num );
     TEST_ASSERT( mbedtls_ssl_dtls_replay_check( &ssl ) == ret );
 
     mbedtls_ssl_free( &ssl );


### PR DESCRIPTION
This change modifies the mbedTLS test infrastructure to automate the generation of C++ test code that can be used for on target testing on the mbed 5.0 platform with mbed-cli and mbed greentea. The changes include:
1. Modify the tests/scripts/generate_code.pl script to accept a --mbed command line flag that enables the generation of tests for mbed 5.0.
2. Create/modify existing .function code to create compatible tests for all platforms when required.
3. Modify tests/Makefile to properly use the generate_code.pl script's new command line interface and add a target to generate all .cpp files.
4. Modify the test suite code in .function files to fix the compiler errors thrown by C++. Recall that the original mbedTLS tests are written in C.

Detailed documentation on how to use the generated C++ code can be found at the head comment of the tests/scripts/generate_code.pl script.
