### PR TITLE
Check that server name extension contains a valid DNS

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -495,12 +495,12 @@ static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t
  */
 typedef enum
 {
-    DNS_PARSER_STATE_START,
-    DNS_PARSER_STATE_ACCEPT_SPACE,
-    DNS_PARSER_STATE_ACCEPT_NOSPACE,
-    DNS_PARSER_STATE_REJECT,
-    DNS_PARSER_STATE_DASH,
-    DNS_PARSER_STATE_DOT,
+    MBEDTLS_DNS_PARSER_STATE_START,
+    MBEDTLS_DNS_PARSER_STATE_ACCEPT_SPACE,
+    MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE,
+    MBEDTLS_DNS_PARSER_STATE_REJECT,
+    MBEDTLS_DNS_PARSER_STATE_DASH,
+    MBEDTLS_DNS_PARSER_STATE_DOT,
 } dns_parser_states;
 
 /*
@@ -523,64 +523,64 @@ static int mbedtls_ssl_parse_dns( const unsigned char *buf, size_t len )
         return( 1 );
     }
 
-    state = DNS_PARSER_STATE_START;
+    state = MBEDTLS_DNS_PARSER_STATE_START;
     i = 0;
     while( i < len )
     {
         switch( state )
         {
-        case DNS_PARSER_STATE_START:
+        case MBEDTLS_DNS_PARSER_STATE_START:
             if( buf[i] == ' ' )
             {
-                state = DNS_PARSER_STATE_ACCEPT_SPACE;
+                state = MBEDTLS_DNS_PARSER_STATE_ACCEPT_SPACE;
                 i++;
             }
             else if( isalpha( buf[i] ) )
             {
-                state = DNS_PARSER_STATE_ACCEPT_NOSPACE;
+                state = MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE;
                 i++;
             }
             else
-                state = DNS_PARSER_STATE_REJECT;
+                state = MBEDTLS_DNS_PARSER_STATE_REJECT;
             break;
-        case DNS_PARSER_STATE_ACCEPT_SPACE:
-            state = DNS_PARSER_STATE_REJECT;
+        case MBEDTLS_DNS_PARSER_STATE_ACCEPT_SPACE:
+            state = MBEDTLS_DNS_PARSER_STATE_REJECT;
             break;
-        case DNS_PARSER_STATE_ACCEPT_NOSPACE:
+        case MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE:
             if( isalpha( buf[i] ) || isdigit( buf[i] ) )
                 i++;
             else if( buf[i] == '-' )
             {
-                state = DNS_PARSER_STATE_DASH;
+                state = MBEDTLS_DNS_PARSER_STATE_DASH;
                 i++;
             }
             else if( buf[i] == '.' )
             {
-                state = DNS_PARSER_STATE_DOT;
+                state = MBEDTLS_DNS_PARSER_STATE_DOT;
                 i++;
             }
             else
-                state = DNS_PARSER_STATE_REJECT;
+                state = MBEDTLS_DNS_PARSER_STATE_REJECT;
             break;
-        case DNS_PARSER_STATE_DOT:
+        case MBEDTLS_DNS_PARSER_STATE_DOT:
             if( isalpha( buf[i] ) )
             {
-                state = DNS_PARSER_STATE_ACCEPT_NOSPACE;
+                state = MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE;
                 i++;
             }
             else
-                state = DNS_PARSER_STATE_REJECT;
+                state = MBEDTLS_DNS_PARSER_STATE_REJECT;
             break;
-        case DNS_PARSER_STATE_DASH:
+        case MBEDTLS_DNS_PARSER_STATE_DASH:
             if( isalpha( buf[i] ) || isdigit( buf[i] ) )
             {
-                state = DNS_PARSER_STATE_ACCEPT_NOSPACE;
+                state = MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE;
                 i++;
             }
             else
-                state = DNS_PARSER_STATE_REJECT;
+                state = MBEDTLS_DNS_PARSER_STATE_REJECT;
             break;
-        case DNS_PARSER_STATE_REJECT:
+        case MBEDTLS_DNS_PARSER_STATE_REJECT:
             goto exit;
         }
     }
@@ -588,9 +588,9 @@ static int mbedtls_ssl_parse_dns( const unsigned char *buf, size_t len )
 exit:
     switch( state )
     {
-    case DNS_PARSER_STATE_ACCEPT_SPACE:
+    case MBEDTLS_DNS_PARSER_STATE_ACCEPT_SPACE:
         return( 0 );
-    case DNS_PARSER_STATE_ACCEPT_NOSPACE:
+    case MBEDTLS_DNS_PARSER_STATE_ACCEPT_NOSPACE:
         return( 0 );
     default:
         return( 1 );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -535,7 +535,7 @@ static int mbedtls_ssl_parse_dns( const unsigned char *buf, size_t len )
                 state = DNS_PARSER_STATE_ACCEPT_SPACE;
                 i++;
             }
-            else if( isalpha( buf[i] ) || isdigit( buf[i] ) )
+            else if( isalpha( buf[i] ) )
             {
                 state = DNS_PARSER_STATE_ACCEPT_NOSPACE;
                 i++;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -73,7 +73,14 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
 
     hostname_len = strlen( ssl->hostname );
 
-    if( end < p || (size_t)( end - p ) < hostname_len + 9 )
+    if( mbedtls_ssl_parse_dns( (const unsigned char *) ssl->hostname,
+        hostname_len )  != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "client hello, hostname is not a valid DNS"
+            ". Omitting server name extension" ) );
+        return;
+    }
+    else if( end < p || (size_t)( end - p ) < hostname_len + 9 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small" ) );
         return;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -87,7 +87,6 @@ void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
-
 static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
                                      const unsigned char *buf,
                                      size_t len )
@@ -131,7 +130,6 @@ static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
                         MBEDTLS_SSL_ALERT_MSG_UNRECOGNIZED_NAME );
                 return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
             }
-
             return( 0 );
         }
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -87,6 +87,7 @@ void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+
 static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
                                      const unsigned char *buf,
                                      size_t len )
@@ -116,6 +117,11 @@ static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
 
         if( p[0] == MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME )
         {
+            if( mbedtls_ssl_parse_dns( p + 3, hostname_len ) != 0 )
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ("ServerName is not a valid DNS" ) );
+            }
+
             ret = ssl->conf->f_sni( ssl->conf->p_sni,
                                     ssl, p + 3, hostname_len );
             if( ret != 0 )
@@ -125,6 +131,7 @@ static int ssl_parse_servername_ext( mbedtls_ssl_context *ssl,
                         MBEDTLS_SSL_ALERT_MSG_UNRECOGNIZED_NAME );
                 return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
             }
+
             return( 0 );
         }
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2008,6 +2008,17 @@ run_test    "SNI: CA override with CRL" \
             -S "! The certificate is not correctly signed by the trusted CA" \
             -s "The certificate has been revoked (is on a CRL)"
 
+run_test    "SNI: server name extension is not a valid DNS" \
+            "$P_SRV debug_level=3 \
+             crt_file=data_files/server5.crt key_file=data_files/server5.key \
+             sni=127.0.0.1,data_files/server2.crt,data_files/server2.key,-,-,optional \
+             server_addr=127.0.0.1" \
+            "$P_CLI debug_level=3 server_name=127.0.0.1 \
+             server_addr=127.0.0.1 auth_mode=optional" \
+            0 \
+            -c "client hello, hostname is not a valid DNS. Omitting server name extension" \
+            -S "ServerName is not a valid DNS"
+
 # Tests for non-blocking I/O: exercise a variety of handshake flows
 
 run_test    "Non-blocking I/O: basic handshake" \


### PR DESCRIPTION
This pull request addresses an issue related to https://github.com/ARMmbed/mbedtls/issues/466.

The main problem is that RFC-6066 says that the ServerName in the SNI TLS extension should be a valid DNS. Nevertheless, mbedTLS gets the server name from the mbedtls_ssl_context hostname field which can be set to other values such as IP addresses. This patch introduces some checks to ensure that when the hostname is set to an invalid DNS the server name extension is not included in client hello.
