### PR TITLE
Fix main Makefile to allow parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ PREFIX=mbedtls_
 
 .PHONY: all no_test programs lib tests install uninstall clean test check covtest lcov apidoc apidoc_clean
 
-all: programs tests post_build
+all: programs tests
+	$(MAKE) post_build
 
 no_test: programs
 


### PR DESCRIPTION
Modify the main Makefile so that post_build target is not started in
parallel with tests and programs recipe.