### PR TITLE
Fix warning on implicit casting in aescrypt.c

### DIFF
--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -73,7 +73,7 @@ int main( int argc, char *argv[] )
 {
     int ret = 1;
 
-    int i, n;
+    unsigned int i, n;
     int mode, lastn;
     size_t keylen;
     FILE *fkey, *fin = NULL, *fout = NULL;


### PR DESCRIPTION
Warning was being generated by call to `sscanf()`at line 170 by implicit cast of unsigned int to signed int.