### PR TITLE
DRAFT: Tighten up compile options for warnings in all.sh

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -198,7 +198,7 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
 CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check .
-make
+CFLAGS='-Werror -std=c99 -pedantic' make
 
 msg "test: main suites (full config)" # ~ 5s
 make test
@@ -221,7 +221,7 @@ tests/scripts/key-exchanges.pl
 
 msg "build: Unix make, -Os (gcc)" # ~ 30s
 cleanup
-CC=gcc CFLAGS='-Werror -Os' make
+CC=gcc CFLAGS='-Werror -std=c99 -pedantic -Os' make
 
 # this is meant to cath missing #define mbedtls_printf etc
 # disable fsio to catch some more missing #include <stdio.h>


### PR DESCRIPTION
This pull request adds checks for C99 compliance and adds the pedantic and warnings as errors options to the Clang and Unix builds in all.sh
