### PR TITLE
Add missing dependency to check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ifndef WINDOWS
 	find . \( -name \*.gcno -o -name \*.gcda -o -name \*.info \) -exec rm {} +
 endif
 
-check: lib
+check: lib tests
 	$(MAKE) -C tests check
 
 test: check


### PR DESCRIPTION
The main makefile check target does not depend on tests. When running
make with the -j option it could happen that the tests are build twice
and concurrently, which causes errors.