### PR TITLE
Modify mbedtls_rsa_gen_key to guarantee that P > Q

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Bugfix
      enabled unless others were also present. Found by David Fernandez. #428
    * Fix for out-of-tree builds using CMake. Found by jwurzer, and fix based on
      a contribution from Tobias Tangemann. #541
+   * Fix mbedtls_rsa_gen_key() to ensure that P > Q. Even though this is not
+     required by the PKCS, it is a common pattern. Found by inestlerode.
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -127,6 +127,13 @@ int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
                                 f_rng, p_rng ) );
         }
 
+        /*
+         * This code seems redundant since it only guarantees that P > Q. This
+         * is not required by the PKCS, but is a convention.
+         */
+        if( mbedtls_mpi_cmp_mpi( &ctx->P, &ctx->Q ) < 0 )
+            mbedtls_mpi_swap( &ctx->P, &ctx->Q );
+
         if( mbedtls_mpi_cmp_mpi( &ctx->P, &ctx->Q ) == 0 )
             continue;
 


### PR DESCRIPTION
This change puts back the code in library/rsa.c that guarantees that P > Q when `mbedtls_rsa_gen_key()` is called. Even though this is not required by the PKCS, it is a common pattern.  `mbedtls_rsa_gen_key()`  used to guarantee this, but the functionality was removed in commit https://github.com/ARMmbed/mbedtls/commit/10c575be3ee5d332923a888cf261b650e590eb32.

This patch addresses the issue https://github.com/ARMmbed/mbedtls/issues/558.