### PR TITLE
Fix footprint.sh call to makefile

### DIFF
--- a/scripts/footprint.sh
+++ b/scripts/footprint.sh
@@ -69,8 +69,9 @@ doit()
         scripts/config.pl --force set MBEDTLS_NO_PLATFORM_ENTROPY || true
     } >/dev/null 2>&1
 
+    make clean >/dev/null
     CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld \
-        CFLAGS="$ARMGCC_FLAGS" make clean lib >/dev/null
+        CFLAGS="$ARMGCC_FLAGS" make lib >/dev/null
 
     OUT="size-${NAME}.txt"
     arm-none-eabi-size -t library/libmbed*.a > "$OUT"


### PR DESCRIPTION
Ideally, Makefile targets should be called irrespectively of their
execution order. In this sense, `clean` and `lib` should not be
passed both as target command line arguments in the same make
invocation. This is because out-of-order execution could cause a
failure. This change ensures that `clean` and `lib` are called in
separate executions of make in scripts/footprint.sh.