### PR TITLE
Backport: Modify mbedtls_rsa_gen_key to guarantee that P > Q

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Bugfix
      when GCM is used. #441
    * Fix for key exchanges based on ECDH-RSA or ECDH-ECDSA which weren't
      enabled unless others were also present. Found by David Fernandez. #428
+   * Fix mbedtls_rsa_gen_key() to ensure that P > Q. Even though this is not
+     required by the PKCS, it is a common pattern. Found by inestlerode.
 
 = mbed TLS 2.1.5 branch released 2016-06-28
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -121,6 +121,13 @@ int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
                                 f_rng, p_rng ) );
         }
 
+        /*
+         * This code seems redundant since it only guarantees that P > Q. This
+         * is not required by the PKCS, but is a convention.
+         */
+        if( mbedtls_mpi_cmp_mpi( &ctx->P, &ctx->Q ) < 0 )
+            mbedtls_mpi_swap( &ctx->P, &ctx->Q );
+
         if( mbedtls_mpi_cmp_mpi( &ctx->P, &ctx->Q ) == 0 )
             continue;
 


### PR DESCRIPTION
This PR is a backport of fix https://github.com/ARMmbed/mbedtls/pull/598 for issue https://github.com/ARMmbed/mbedtls/issues/558.