### PR TITLE
Set selftest verbose flag to boost line coverage

### DIFF
--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -292,6 +292,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void aes_selftest()
 {
-    TEST_ASSERT( mbedtls_aes_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_aes_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_arc4.function
+++ b/tests/suites/test_suite_arc4.function
@@ -41,6 +41,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void arc4_selftest()
 {
-    TEST_ASSERT( mbedtls_arc4_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_arc4_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_base64.function
+++ b/tests/suites/test_suite_base64.function
@@ -119,6 +119,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void base64_selftest()
 {
-    TEST_ASSERT( mbedtls_base64_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_base64_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -224,6 +224,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void camellia_selftest()
 {
-    TEST_ASSERT( mbedtls_camellia_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_camellia_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -10,7 +10,7 @@
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST:MBEDTLS_AES_C */
 void mbedtls_ccm_self_test( )
 {
-    TEST_ASSERT( mbedtls_ccm_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -216,6 +216,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ctr_drbg_selftest( )
 {
-    TEST_ASSERT( mbedtls_ctr_drbg_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_des.function
+++ b/tests/suites/test_suite_des.function
@@ -362,6 +362,6 @@ void des_key_parity_run()
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void des_selftest()
 {
-    TEST_ASSERT( mbedtls_des_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_des_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_dhm.function
+++ b/tests/suites/test_suite_dhm.function
@@ -123,6 +123,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void dhm_selftest()
 {
-    TEST_ASSERT( mbedtls_dhm_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_dhm_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -101,7 +101,7 @@ cleanup:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ecjpake_selftest()
 {
-    TEST_ASSERT( mbedtls_ecjpake_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ecjpake_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -507,6 +507,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void ecp_selftest()
 {
-    TEST_ASSERT( mbedtls_ecp_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -380,6 +380,6 @@ void entropy_nv_seed( char *read_seed_str )
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void entropy_selftest( int result )
 {
-    TEST_ASSERT( mbedtls_entropy_self_test( 0 ) == result );
+    TEST_ASSERT( mbedtls_entropy_self_test( 1 ) == result );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -119,6 +119,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void gcm_selftest()
 {
-    TEST_ASSERT( mbedtls_gcm_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_gcm_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -314,6 +314,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void hmac_drbg_selftest( )
 {
-    TEST_ASSERT( mbedtls_hmac_drbg_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_hmac_drbg_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -88,27 +88,27 @@ void ripemd160_text( char *text_src_string, char *hex_hash_string )
 /* BEGIN_CASE depends_on:MBEDTLS_MD2_C:MBEDTLS_SELF_TEST */
 void md2_selftest()
 {
-    TEST_ASSERT( mbedtls_md2_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_md2_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_MD4_C:MBEDTLS_SELF_TEST */
 void md4_selftest()
 {
-    TEST_ASSERT( mbedtls_md4_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_md4_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_MD5_C:MBEDTLS_SELF_TEST */
 void md5_selftest()
 {
-    TEST_ASSERT( mbedtls_md5_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_md5_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_RIPEMD160_C:MBEDTLS_SELF_TEST */
 void ripemd160_selftest()
 {
-    TEST_ASSERT( mbedtls_ripemd160_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ripemd160_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_memory_buffer_alloc.function
+++ b/tests/suites/test_suite_memory_buffer_alloc.function
@@ -25,7 +25,7 @@ static int check_pointer( void *p )
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void mbedtls_memory_buffer_alloc_self_test( )
 {
-    TEST_ASSERT( mbedtls_memory_buffer_alloc_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_memory_buffer_alloc_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -877,6 +877,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void mpi_selftest()
 {
-    TEST_ASSERT( mbedtls_mpi_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_pkcs5.function
+++ b/tests/suites/test_suite_pkcs5.function
@@ -82,6 +82,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void pkcs5_selftest( )
 {
-    TEST_ASSERT( mbedtls_pkcs5_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_pkcs5_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -690,6 +690,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void rsa_selftest()
 {
-    TEST_ASSERT( mbedtls_rsa_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_rsa_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -112,20 +112,20 @@ void mbedtls_sha512(char *hex_src_string, char *hex_hash_string )
 /* BEGIN_CASE depends_on:MBEDTLS_SHA1_C:MBEDTLS_SELF_TEST */
 void sha1_selftest()
 {
-    TEST_ASSERT( mbedtls_sha1_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_sha1_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA256_C:MBEDTLS_SELF_TEST */
 void sha256_selftest()
 {
-    TEST_ASSERT( mbedtls_sha256_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_sha256_self_test( 1 ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA512_C:MBEDTLS_SELF_TEST */
 void sha512_selftest()
 {
-    TEST_ASSERT( mbedtls_sha512_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_sha512_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_timing.function
+++ b/tests/suites/test_suite_timing.function
@@ -10,6 +10,6 @@
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void timing_selftest()
 {
-    TEST_ASSERT( mbedtls_timing_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_timing_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -623,6 +623,6 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_SELF_TEST */
 void x509_selftest()
 {
-    TEST_ASSERT( mbedtls_x509_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_x509_self_test( 1 ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_xtea.function
+++ b/tests/suites/test_suite_xtea.function
@@ -124,6 +124,6 @@ void xtea_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
 void xtea_selftest()
 {
-    TEST_ASSERT( mbedtls_xtea_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_xtea_self_test( 1 ) == 0 );
 }
 /* END_CASE */


### PR DESCRIPTION
This change increases the mbedtls line coverage by ensuring that all `test_suite_*` binaries execute their corresponding `mbedtls_*_self_test()` with the verbose flag set, which enables execution of additional print statements in the library code.