### PR TITLE
Documentation and entropy self test changes

### DIFF
--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -255,6 +255,9 @@ int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *
 /**
  * \brief          Checkup routine
  *
+ *                 This module self-test also calls the entropy self-test,
+ *                 mbedtls_entropy_source_self_test();
+ *
  * \return         0 if successful, or 1 if a test failed
  */
 int mbedtls_entropy_self_test( int verbose );
@@ -262,6 +265,14 @@ int mbedtls_entropy_self_test( int verbose );
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 /**
  * \brief          Checkup routine
+ *
+ *                 Verifies the integrity of the hardware entropy source
+ *                 provided by the function 'mbedtls_hardware_poll()'.
+ *
+ *                 Note this is the only hardware entropy source that is known
+ *                 at link time, and other entropy sources configured
+ *                 dynamically at runtime by the function
+ *                 mbedtls_entropy_add_source() will not be tested.
  *
  * \return         0 if successful, or 1 if a test failed
  */

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -575,7 +575,7 @@ cleanup:
  */
 int mbedtls_entropy_self_test( int verbose )
 {
-    int ret = 0;
+    int ret = 1;
     mbedtls_entropy_context ctx;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE] = { 0 };
     unsigned char acc[MBEDTLS_ENTROPY_BLOCK_SIZE] = { 0 };
@@ -584,6 +584,7 @@ int mbedtls_entropy_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "  ENTROPY test: " );
 
+#if !defined(MBEDTLS_TEST_NULL_ENTROPY)
     mbedtls_entropy_init( &ctx );
 
     /* First do a gather to make sure we have default sources */
@@ -631,6 +632,7 @@ int mbedtls_entropy_self_test( int verbose )
 
 cleanup:
     mbedtls_entropy_free( &ctx );
+#endif /* !MBEDTLS_TEST_NULL_ENTROPY */
 
     if( verbose != 0 )
     {


### PR DESCRIPTION
Ensure that the entropy self test always fails whenever
MBEDTLS_TEST_NULL_ENTROPY is defined. This is because the option is
meant to be for testing and development purposes rather than production
quality software. Also, this patch enhances the documentation for
mbedtls_entropy_source_self_test() and mbedtls_entropy_self_test().

Documentation improvements by @sbutcher-arm 