### PR TITLE
Fix for entropy self-test in MBEDTLS_TEST_NULL_ENTROPY builds

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -456,6 +456,7 @@ int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)
+#if !defined(MBEDTLS_TEST_NULL_ENTROPY)
 /*
  * Dummy source function
  */
@@ -469,6 +470,7 @@ static int entropy_dummy_source( void *data, unsigned char *output,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_TEST_NULL_ENTROPY */
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
@@ -576,10 +578,12 @@ cleanup:
 int mbedtls_entropy_self_test( int verbose )
 {
     int ret = 1;
+#if !defined(MBEDTLS_TEST_NULL_ENTROPY)
     mbedtls_entropy_context ctx;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE] = { 0 };
     unsigned char acc[MBEDTLS_ENTROPY_BLOCK_SIZE] = { 0 };
     size_t i, j;
+#endif /* !MBEDTLS_TEST_NULL_ENTROPY */
 
     if( verbose != 0 )
         mbedtls_printf( "  ENTROPY test: " );

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -166,9 +166,8 @@ cleanup
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: main suites and selftest (ASan build)" # ~ 50s
+msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
-programs/test/selftest
 
 msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
 tests/ssl-opt.sh
@@ -196,9 +195,8 @@ scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: SSLv3 - main suites and selftest (ASan build)" # ~ 50s
+msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
-programs/test/selftest
 
 msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
 tests/compat.sh -m 'ssl3 tls1 tls1_1 tls1_2 dtls1 dtls1_2'
@@ -298,9 +296,8 @@ scripts/config.pl unset MBEDTLS_HAVEGE_C
 CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
 make
 
-msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites and selftest (ASan build)"
+msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
 make test
-programs/test/selftest
 
 if uname -a | grep -F Linux >/dev/null; then
 msg "build/test: make shared" # ~ 40s

--- a/tests/suites/test_suite_entropy.data
+++ b/tests/suites/test_suite_entropy.data
@@ -53,4 +53,9 @@ Check NV seed manually #3
 entropy_nv_seed:"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 
 Entropy self test
-entropy_selftest:
+depends_on:!MBEDTLS_TEST_NULL_ENTROPY
+entropy_selftest:0
+
+Entropy self test (MBEDTLS_TEST_NULL_ENTROPY)
+depends_on:MBEDTLS_TEST_NULL_ENTROPY
+entropy_selftest:1

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -123,7 +123,7 @@ static int read_nv_seed( unsigned char *buf, size_t buf_len )
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_NV_SEED:MBEDTLS_FS_IO */
 void entropy_seed_file( char *path, int ret )
 {
     mbedtls_entropy_context ctx;
@@ -210,7 +210,7 @@ void entropy_source_fail( char *path )
                  == MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     TEST_ASSERT( mbedtls_entropy_gather( &ctx )
                  == MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
-#if defined(MBEDTLS_FS_IO)
+#if defined(MBEDTLS_FS_IO) && defined(MBEDTLS_ENTROPY_NV_SEED)
     TEST_ASSERT( mbedtls_entropy_write_seed_file( &ctx, path )
                  == MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     TEST_ASSERT( mbedtls_entropy_update_seed_file( &ctx, path )
@@ -378,8 +378,8 @@ void entropy_nv_seed( char *read_seed_str )
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
-void entropy_selftest( )
+void entropy_selftest( int result )
 {
-    TEST_ASSERT( mbedtls_entropy_self_test( 0 ) == 0 );
+    TEST_ASSERT( mbedtls_entropy_self_test( 0 ) == result );
 }
 /* END_CASE */


### PR DESCRIPTION
This pull request:

 * fixes the test suite test for the entropy module self-test for MBEDTLS_TEST_NULL_ENTROPY builds. The test must always fail in such builds and the test suite should check as much
 * removes redundant self-tests in tests/scripts/all.sh
 * fixes compiler warnings for unused variables in MBEDTLS_TEST_NULL_ENTROPY builds