### PR TITLE
Fix sig->tag update in mbedtls_x509_get_sig()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,9 @@ Bugfix
      enabled unless others were also present. Found by David Fernandez. #428
    * Fix for out-of-tree builds using CMake. Found by jwurzer, and fix based on
      a contribution from Tobias Tangemann. #541
+   * Fix mbedtls_x509_get_sig() to update the ASN1 type in the mbedtls_x509_buf
+     data structure until after error checks are successful. Found by
+     subramanyam-c.
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/library/x509.c
+++ b/library/x509.c
@@ -559,16 +559,18 @@ int mbedtls_x509_get_sig( unsigned char **p, const unsigned char *end, mbedtls_x
 {
     int ret;
     size_t len;
+    int tag_type;
 
     if( ( end - *p ) < 1 )
         return( MBEDTLS_ERR_X509_INVALID_SIGNATURE +
                 MBEDTLS_ERR_ASN1_OUT_OF_DATA );
 
-    sig->tag = **p;
+    tag_type = **p;
 
     if( ( ret = mbedtls_asn1_get_bitstring_null( p, end, &len ) ) != 0 )
         return( MBEDTLS_ERR_X509_INVALID_SIGNATURE + ret );
 
+    sig->tag = tag_type;
     sig->len = len;
     sig->p = *p;
 


### PR DESCRIPTION
This PR fixes mbedtls_x509_get_sig() so that it only updates the output parameter `sig` until after the checks by `mbedtls_asn1_get_bitstring_null()` succeed.

This fixes the issue [#622](https://github.com/ARMmbed/mbedtls/issues/622).