### PR TITLE
Add check for validity of date in x509_get_time()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,8 @@ Bugfix
      a contribution from Tobias Tangemann. #541
    * Fixed cert_app sample program for debug output and for use when no root
      certificates are provided.
+   * Fix check for validity of date when parsing in mbedtls_x509_get_time().
+     Found by subramanyam-c.
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/library/x509.c
+++ b/library/x509.c
@@ -80,6 +80,7 @@
 #endif
 
 #define CHECK(code) if( ( ret = code ) != 0 ){ return( ret ); }
+#define CHECK_RANGE(min, max, val) if( val < min || val > max ){ return( ret ); }
 
 /*
  *  CertificateSerialNumber  ::=  INTEGER
@@ -489,6 +490,33 @@ static int x509_parse_int(unsigned char **p, unsigned n, int *res){
     return 0;
 }
 
+static int x509_date_is_valid(const mbedtls_x509_time *time)
+{
+    int ret = MBEDTLS_ERR_X509_INVALID_DATE;
+
+    CHECK_RANGE( 0, 9999, time->year );
+    CHECK_RANGE( 0, 23,   time->hour );
+    CHECK_RANGE( 0, 59,   time->min  );
+    CHECK_RANGE( 0, 59,   time->sec  );
+
+    switch( time->mon )
+    {
+        case 1: case 3: case 5: case 7: case 8: case 10: case 12:
+            CHECK_RANGE( 1, 31, time->day );
+            break;
+        case 4: case 6: case 9: case 11:
+            CHECK_RANGE( 1, 30, time->day );
+            break;
+        case 2:
+            CHECK_RANGE( 1, 28 + (time->year % 4 == 0), time->day );
+            break;
+        default:
+            return( ret );
+    }
+
+    return( 0 );
+}
+
 /*
  *  Time ::= CHOICE {
  *       utcTime        UTCTime,
@@ -528,6 +556,8 @@ int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
         time->year +=  100 * ( time->year < 50 );
         time->year += 1900;
 
+        CHECK( x509_date_is_valid( time ) );
+
         return( 0 );
     }
     else if( tag == MBEDTLS_ASN1_GENERALIZED_TIME )
@@ -547,6 +577,8 @@ int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
             CHECK( x509_parse_int( p, 2, &time->sec ) );
         if( len > 14 && *(*p)++ != 'Z' )
             return( MBEDTLS_ERR_X509_INVALID_DATE );
+
+        CHECK( x509_date_is_valid( time ) );
 
         return( 0 );
     }

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1526,3 +1526,39 @@ x509parse_crt_file:"data_files/server7_all_space.crt":MBEDTLS_ERR_PEM_INVALID_DA
 X509 File parse (trailing spaces, OK)
 depends_on:MBEDTLS_ECP_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED:MBEDTLS_SHA256_C
 x509parse_crt_file:"data_files/server7_trailing_space.crt":0
+
+X509 Get time (UTC no issues)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"500101000000Z":0:1950:1:1:0:0:0
+
+X509 Get time (Generalized Time no issues)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_GENERALIZED_TIME:"99991231235959Z":0:9999:12:31:23:59:59
+
+X509 Get time (UTC year without leap day)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"490229121212Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (UTC year with leap day)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"000229121212Z":0:2000:2:29:12:12:12
+
+X509 Get time (UTC invalid day of month #1)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"000132121212Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (UTC invalid day of month #2)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001131121212Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (UTC invalid hour)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001130241212Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (UTC invalid min)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001130236012Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (UTC invalid sec)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001130235960Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -1,4 +1,5 @@
 /* BEGIN_HEADER */
+#include "mbedtls/x509.h"
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/x509_crl.h"
 #include "mbedtls/x509_csr.h"
@@ -587,6 +588,39 @@ void x509_check_extended_key_usage( char *crt_file, char *usage_hex, int ret )
 
 exit:
     mbedtls_x509_crt_free( &crt );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C */
+void x509_get_time( int tag,  char *time_str, int ret,
+                    int year, int mon, int day,
+                    int hour, int min, int sec )
+{
+    mbedtls_x509_time time;
+    unsigned char buf[17];
+    unsigned char* start = buf;
+    unsigned char* end = buf;
+
+    memset( &time, 0x00, sizeof( time ) );
+    *end = (unsigned char)tag; end++;
+    if( tag == MBEDTLS_ASN1_UTC_TIME )
+        *end = 13;
+    else
+        *end = 15;
+    end++;
+    memcpy( end, time_str, (size_t)*(end - 1) );
+    end += *(end - 1);
+
+    TEST_ASSERT( mbedtls_x509_get_time( &start, end, &time ) == ret );
+    if( ret == 0 )
+    {
+        TEST_ASSERT( year == time.year );
+        TEST_ASSERT( mon  == time.mon  );
+        TEST_ASSERT( day  == time.day  );
+        TEST_ASSERT( hour == time.hour );
+        TEST_ASSERT( min  == time.min  );
+        TEST_ASSERT( sec  == time.sec  );
+    }
 }
 /* END_CASE */
 


### PR DESCRIPTION
Add a check to mbedtls_x509_get_time() to ensure that the parsed date is valid.

This fix is related to https://github.com/ARMmbed/mbedtls/issues/604.