### PR TITLE
Fix documentation for mbedtls_gcm_finish()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,8 @@ Bugfix
      a contribution from Tobias Tangemann. #541
    * Fixed cert_app sample program for debug output and for use when no root
      certificates are provided.
+   * Fix documentation and implementation missmatch for function arguments of
+     mbedtls_gcm_finish(). Found by cmiatpaar.
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -190,8 +190,8 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
  *                  16 bytes.
  *
  * \param ctx       GCM context
- * \param tag       buffer for holding the tag (may be NULL if tag_len is 0)
- * \param tag_len   length of the tag to generate
+ * \param tag       buffer for holding the tag
+ * \param tag_len   length of the tag to generate (must be at least 4)
  *
  * \return          0 if successful or MBEDTLS_ERR_GCM_BAD_INPUT
  */

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -415,8 +415,7 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     if( tag_len > 16 || tag_len < 4 )
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
 
-    if( tag_len != 0 )
-        memcpy( tag, ctx->base_ectr, tag_len );
+    memcpy( tag, ctx->base_ectr, tag_len );
 
     if( orig_len || orig_add_len )
     {


### PR DESCRIPTION
Fix implementation and documentation missmatch for the function
arguments to mbedtls_gcm_finish(). Also, removed redundant if condition
that always evaluates to true.

This PR fixes issue https://github.com/ARMmbed/mbedtls/issues/602.