### PR TITLE
Add safety check to sample mutex implementation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ Bugfix
      enabled unless others were also present. Found by David Fernandez. #428
    * Fixed cert_app sample program for debug output and for use when no root
      certificates are provided.
+   * Fixed default threading implementation to avoid accidental double
+     initialisations and double frees.
 
 = mbed TLS 2.1.5 branch released 2016-06-28
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -32,7 +32,7 @@
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL )
+    if( mutex == NULL || mutex->is_valid )
         return;
 
     mutex->is_valid = pthread_mutex_init( &mutex->mutex, NULL ) == 0;
@@ -40,10 +40,11 @@ static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
 
 static void threading_mutex_free_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL )
+    if( mutex == NULL || !mutex->is_valid )
         return;
 
     (void) pthread_mutex_destroy( &mutex->mutex );
+    mutex->is_valid = 0;
 }
 
 static int threading_mutex_lock_pthread( mbedtls_threading_mutex_t *mutex )


### PR DESCRIPTION
Due to inconsistent freeing strategy in pkparse.c the sample mutex
implementation in threading.c could lead to undefined behaviour by
destroying the same mutex several times.

This fix prevents mutexes from being destroyed several times in the
sample threading implementation.