### PR TITLE
Fix to test output in test suites

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -8,16 +8,13 @@
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
-#define mbedtls_printf     printf
 #define mbedtls_fprintf    fprintf
-#define mbedtls_calloc    calloc
+#define mbedtls_snprintf   snprintf
+#define mbedtls_calloc     calloc
 #define mbedtls_free       free
 #define mbedtls_exit       exit
 #define mbedtls_time       time
 #define mbedtls_time_t     time_t
-#define mbedtls_fprintf    fprintf
-#define mbedtls_printf     printf
-#define mbedtls_snprintf   snprintf
 #define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
 #define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
@@ -355,7 +352,8 @@ static void test_fail( const char *test, int line_no, const char* filename )
 {
     test_errors++;
     if( test_errors == 1 )
-        mbedtls_printf( "FAILED\n" );
-    mbedtls_printf( "  %s\n  at line %d, %s\n", test, line_no, filename );
+        mbedtls_fprintf( stdout, "FAILED\n" );
+    mbedtls_fprintf( stdout, "  %s\n  at line %d, %s\n", test, line_no,
+                        filename );
 }
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -7,7 +7,8 @@ int verify_string( char **str )
     if( (*str)[0] != '"' ||
         (*str)[strlen( *str ) - 1] != '"' )
     {
-        mbedtls_printf( "Expected string (with \"\") for parameter and got: %s\n", *str );
+        mbedtls_fprintf( stderr,
+            "Expected string (with \"\") for parameter and got: %s\n", *str );
         return( -1 );
     }
 
@@ -60,7 +61,8 @@ int verify_int( char *str, int *value )
 
 MAPPING_CODE
 
-    mbedtls_printf( "Expected integer for parameter and got: %s\n", str );
+    mbedtls_fprintf( stderr,
+                    "Expected integer for parameter and got: %s\n", str );
     return( KEY_VALUE_MAPPING_NOT_FOUND );
 }
 
@@ -76,6 +78,12 @@ SUITE_POST_DEP
 
 /*----------------------------------------------------------------------------*/
 /* Test dispatch code */
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#endif
+#include <stdio.h>
+
 
 int dep_check( char *str )
 {
@@ -249,6 +257,7 @@ int main(int argc, const char *argv[])
     const char **test_files = NULL;
     int testfile_count = 0;
     int option_verbose = 0;
+    int tests_stdout;
 
     /* Other Local variables */
     int arg_index = 1;
@@ -343,7 +352,8 @@ int main(int argc, const char *argv[])
         {
             if( unmet_dep_count > 0 )
             {
-                mbedtls_printf("FATAL: Dep count larger than zero at start of loop\n");
+                mbedtls_fprintf( stderr,
+                    "FATAL: Dep count larger than zero at start of loop\n");
                 mbedtls_exit( MBEDTLS_EXIT_FAILURE );
             }
             unmet_dep_count = 0;
@@ -379,7 +389,7 @@ int main(int argc, const char *argv[])
                         unmet_dependencies[ unmet_dep_count ] = strdup(params[i]);
                         if(  unmet_dependencies[ unmet_dep_count ] == NULL )
                         {
-                            mbedtls_printf("FATAL: Out of memory\n");
+                            mbedtls_fprintf( stderr, "FATAL: Out of memory\n");
                             mbedtls_exit( MBEDTLS_EXIT_FAILURE );
                         }
                         unmet_dep_count++;
@@ -395,7 +405,50 @@ int main(int argc, const char *argv[])
             if( unmet_dep_count == 0 )
             {
                 test_errors = 0;
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+                /* Suppress all output from the library unless we're verbose
+                 * mode
+                 */
+                if( !option_verbose )
+                {
+                    /* Redirect all stdout output to /dev/null */
+                    tests_stdout = dup( fileno(stdout) );
+                    if( tests_stdout == -1 )
+                    {
+                        /* Redirection has failed with no stdout so exit */
+                        exit(1);
+                    }
+
+                    fflush( stdout );
+                    fclose( stdout );
+                    stdout = fopen("/dev/null", "w" );
+                    if( stdout == NULL )
+                    {
+                        /* Redirection has failed with no stdout so exit */
+                        exit(1);
+                    }
+                }
+#endif /* __unix__ || __APPLE__ __MACH__ */
+
                 ret = dispatch_test( cnt, params );
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+                if( !option_verbose )
+                {
+                    /* Restore stdout */
+                    fflush( stdout );
+                    fclose( stdout );
+
+                    stdout = fdopen ( tests_stdout, "w");
+                    if( stdout == NULL )
+                    {
+                        /* Redirection has failed with no stdout so exit */
+                        exit(1);
+                    }
+                }
+#endif /* __unix__ || __APPLE__ __MACH__ */
+
             }
 
             if( unmet_dep_count > 0 || ret == DISPATCH_UNSUPPORTED_SUITE )


### PR DESCRIPTION
Fixes the test suites to consistently use mbedtls_fprintf to output to stdout or stderr.

Also redirects output from the tests to /dev/null to avoid confusing output if the test suite code or library outputs anything to stdout.