### PR TITLE
Fix IE incompatibility bug (#513)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,9 @@ Bugfix
      a contribution from Tobias Tangemann. #541
    * Fixed cert_app sample program for debug output and for use when no root
      certificates are provided.
+   * Fix compatibility issue with Internet Explorer client authentication,
+     where the limited hash choices prevented the client from sending its
+     certificate. Found by teumas. #513
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -107,7 +107,7 @@
 #define MBEDTLS_ERR_SSL_TIMEOUT                           -0x6800  /**< The operation timed out. */
 #define MBEDTLS_ERR_SSL_CLIENT_RECONNECT                  -0x6780  /**< The client initiated a reconnect from the same port. */
 #define MBEDTLS_ERR_SSL_UNEXPECTED_RECORD                 -0x6700  /**< Record header looks valid but is not expected. */
-#define MBEDTLS_ERR_SSL_IGNORE_NON_FATAL                  -0x6680  /**< The message is a non-fatal error. */
+#define MBEDTLS_ERR_SSL_NON_FATAL                         -0x6680  /**< The message is a non-fatal error. */
 
 /*
  * Various constants

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -108,6 +108,7 @@
 #define MBEDTLS_ERR_SSL_CLIENT_RECONNECT                  -0x6780  /**< The client initiated a reconnect from the same port. */
 #define MBEDTLS_ERR_SSL_UNEXPECTED_RECORD                 -0x6700  /**< Record header looks valid but is not expected. */
 #define MBEDTLS_ERR_SSL_NON_FATAL                         -0x6680  /**< The message is a non-fatal error. */
+#define MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH               -0x6600  /**< Couldn't set the hash for verifying CertificateVerify */
 
 /*
  * Various constants

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -107,6 +107,7 @@
 #define MBEDTLS_ERR_SSL_TIMEOUT                           -0x6800  /**< The operation timed out. */
 #define MBEDTLS_ERR_SSL_CLIENT_RECONNECT                  -0x6780  /**< The client initiated a reconnect from the same port. */
 #define MBEDTLS_ERR_SSL_UNEXPECTED_RECORD                 -0x6700  /**< Record header looks valid but is not expected. */
+#define MBEDTLS_ERR_SSL_IGNORE_NON_FATAL                  -0x6680  /**< The message is a non-fatal error. */
 
 /*
  * Various constants

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -107,7 +107,7 @@
 #define MBEDTLS_ERR_SSL_TIMEOUT                           -0x6800  /**< The operation timed out. */
 #define MBEDTLS_ERR_SSL_CLIENT_RECONNECT                  -0x6780  /**< The client initiated a reconnect from the same port. */
 #define MBEDTLS_ERR_SSL_UNEXPECTED_RECORD                 -0x6700  /**< Record header looks valid but is not expected. */
-#define MBEDTLS_ERR_SSL_NON_FATAL                         -0x6680  /**< The message is a non-fatal error. */
+#define MBEDTLS_ERR_SSL_NON_FATAL                         -0x6680  /**< The alert message received indicates a non-fatal error. */
 #define MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH               -0x6600  /**< Couldn't set the hash for verifying CertificateVerify */
 
 /*

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -355,6 +355,8 @@ int mbedtls_ssl_send_fatal_handshake_failure( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl );
 
+int mbedtls_ssl_read_record_layer( mbedtls_ssl_context *ssl );
+
 int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want );
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -356,6 +356,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_read_record_layer( mbedtls_ssl_context *ssl );
+int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -384,6 +384,7 @@ mbedtls_pk_type_t mbedtls_ssl_pk_alg_from_sig( unsigned char sig );
 
 mbedtls_md_type_t mbedtls_ssl_md_alg_from_hash( unsigned char hash );
 unsigned char mbedtls_ssl_hash_from_md_alg( int md );
+int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md );
 
 #if defined(MBEDTLS_ECP_C)
 int mbedtls_ssl_check_curve( const mbedtls_ssl_context *ssl, mbedtls_ecp_group_id grp_id );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -356,6 +356,8 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_read_record_layer( mbedtls_ssl_context *ssl );
+int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl );
+void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want );

--- a/library/error.c
+++ b/library/error.c
@@ -436,7 +436,9 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) )
             mbedtls_snprintf( buf, buflen, "SSL - Record header looks valid but is not expected" );
         if( use_ret == -(MBEDTLS_ERR_SSL_NON_FATAL) )
-            mbedtls_snprintf( buf, buflen, "SSL - The message is a non-fatal error" );
+            mbedtls_snprintf( buf, buflen, "SSL - The alert message received indicates a non-fatal error" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH) )
+            mbedtls_snprintf( buf, buflen, "SSL - Couldn't set the hash for verifying CertificateVerify" );
 #endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)

--- a/library/error.c
+++ b/library/error.c
@@ -435,6 +435,8 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
             mbedtls_snprintf( buf, buflen, "SSL - The client initiated a reconnect from the same port" );
         if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) )
             mbedtls_snprintf( buf, buflen, "SSL - Record header looks valid but is not expected" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_IGNORE_NON_FATAL) )
+            mbedtls_snprintf( buf, buflen, "SSL - The message is a non-fatal error" );
 #endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)

--- a/library/error.c
+++ b/library/error.c
@@ -435,7 +435,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
             mbedtls_snprintf( buf, buflen, "SSL - The client initiated a reconnect from the same port" );
         if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) )
             mbedtls_snprintf( buf, buflen, "SSL - Record header looks valid but is not expected" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_IGNORE_NON_FATAL) )
+        if( use_ret == -(MBEDTLS_ERR_SSL_NON_FATAL) )
             mbedtls_snprintf( buf, buflen, "SSL - The message is a non-fatal error" );
 #endif /* MBEDTLS_SSL_TLS_C */
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2630,6 +2630,15 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
     {
         size_t sig_alg_len = ( ( buf[mbedtls_ssl_hs_hdr_len( ssl ) + 1 + n] <<  8 )
                              | ( buf[mbedtls_ssl_hs_hdr_len( ssl ) + 2 + n]       ) );
+#if defined(MBEDTLS_DEBUG_C)
+        unsigned char* sig_alg = buf + mbedtls_ssl_hs_hdr_len( ssl ) + 3 + n;
+        size_t i;
+
+        for( i = 0; i < sig_alg_len; i+=2 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Signature Algorithm found: %d,%d", sig_alg[i], sig_alg[i+1]  ) );
+        }
+#endif
 
         n += 2 + sig_alg_len;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2634,9 +2634,9 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
         unsigned char* sig_alg = buf + mbedtls_ssl_hs_hdr_len( ssl ) + 3 + n;
         size_t i;
 
-        for( i = 0; i < sig_alg_len; i+=2 )
+        for( i = 0; i < sig_alg_len; i += 2 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Signature Algorithm found: %d,%d", sig_alg[i], sig_alg[i+1]  ) );
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Supported Signature Algorithm found: %d,%d", sig_alg[i], sig_alg[i + 1]  ) );
         }
 #endif
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3588,7 +3588,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
 
         ret = mbedtls_ssl_handle_message_type( ssl );
 
-    } while( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret );
+    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret );
 
     if( 0 != ret )
     {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2481,7 +2481,6 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
     const unsigned char * const end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     const mbedtls_x509_crt *crt;
     int authmode;
-    const int *cur;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate request" ) );
 
@@ -2555,6 +2554,7 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
      */
     if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
     {
+        const int *cur;
         /*
          * Only use current running hash algorithm that is already required
          * for requested ciphersuite.

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3654,8 +3654,10 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY );
         }
 
+#if !defined(MBEDTLS_MD_SHA1)
         if( MBEDTLS_MD_SHA1 == md_alg )
             hash_start += 16;
+#endif
 
         /* Info from md_alg will be used instead */
         hashlen = 0;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2555,17 +2555,6 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
     if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
     {
         const int *cur;
-        /*
-         * Only use current running hash algorithm that is already required
-         * for requested ciphersuite.
-         */
-        ssl->handshake->verify_sig_alg = MBEDTLS_SSL_HASH_SHA256;
-
-        if( ssl->transform_negotiate->ciphersuite_info->mac ==
-            MBEDTLS_MD_SHA384 )
-        {
-            ssl->handshake->verify_sig_alg = MBEDTLS_SSL_HASH_SHA384;
-        }
 
         /*
          * Supported signature algorithms

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3750,7 +3750,7 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
 
         ret = mbedtls_ssl_handle_message_type( ssl );
 
-    } while( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret );
+    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret );
 
     if( 0 != ret )
     {
@@ -4013,7 +4013,7 @@ int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_PROTO_SSL3 && MBEDTLS_SSL_SRV_C */
 
         /* Silently ignore: fetch new message */
-        return MBEDTLS_ERR_SSL_IGNORE_NON_FATAL;
+        return MBEDTLS_ERR_SSL_NON_FATAL;
     }
 
     return( 0 );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3743,17 +3743,25 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
     do {
 
         if( ( ret = mbedtls_ssl_read_record_layer( ssl ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, ( "mbedtls_ssl_read_record_layer" ), ret );
             return( ret );
+        }
 
         ret = mbedtls_ssl_handle_message_type( ssl );
 
     } while( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret );
 
     if( 0 != ret )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, ( "mbedtls_ssl_handle_message_type" ), ret );
         return( ret );
+    }
 
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
+    {
         mbedtls_ssl_update_handshake_status( ssl );
+    }
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= read record" ) );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3793,7 +3793,10 @@ int mbedtls_ssl_read_record_layer( mbedtls_ssl_context *ssl )
     /*
      * Read the record header and parse it
      */
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
 read_record_header:
+#endif
+
     if( ( ret = mbedtls_ssl_fetch_input( ssl, mbedtls_ssl_hdr_len( ssl ) ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_fetch_input", ret );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7650,7 +7650,7 @@ int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md )
 {
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( ssl->minor_ver != MBEDTLS_SSL_MINOR_VERSION_3 )
-        return -1;
+        return MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH;
 
     switch( md )
     {
@@ -7677,7 +7677,7 @@ int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md )
             break;
 #endif
         default:
-            return -1;
+            return MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH;
     }
 
     return 0;
@@ -7685,7 +7685,7 @@ int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md )
     (void) ssl;
     (void) md;
 
-    return -1;
+    return MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3742,15 +3742,14 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> read record" ) );
 
-read_new_record:
+    do {
 
-    if( ( ret = mbedtls_ssl_read_record_layer( ssl ) ) != 0 )
-        return( ret );
+        if( ( ret = mbedtls_ssl_read_record_layer( ssl ) ) != 0 )
+            return( ret );
 
-    ret = ssl_handle_message_type( ssl );
+        ret = ssl_handle_message_type( ssl );
 
-    if( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret )
-        goto read_new_record;
+    } while( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret );
 
     if( 0 != ret )
         return( ret );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7603,4 +7603,47 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
     }
 }
 
+int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md )
+{
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if( ssl->minor_ver != MBEDTLS_SSL_MINOR_VERSION_3 )
+        return -1;
+
+    switch( md )
+    {
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
+#if defined(MBEDTLS_MD5_C)
+        case MBEDTLS_SSL_HASH_MD5:
+            ssl->handshake->calc_verify = ssl_calc_verify_tls;
+            break;
+#endif
+#if defined(MBEDTLS_SHA1_C)
+        case MBEDTLS_SSL_HASH_SHA1:
+            ssl->handshake->calc_verify = ssl_calc_verify_tls;
+            break;
+#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 */
+#if defined(MBEDTLS_SHA512_C)
+        case MBEDTLS_SSL_HASH_SHA384:
+            ssl->handshake->calc_verify = ssl_calc_verify_tls_sha384;
+            break;
+#endif
+#if defined(MBEDTLS_SHA256_C)
+        case MBEDTLS_SSL_HASH_SHA256:
+            ssl->handshake->calc_verify = ssl_calc_verify_tls_sha256;
+            break;
+#endif
+        default:
+            return -1;
+    }
+
+    return 0;
+#else /* !MBEDTLS_SSL_PROTO_TLS1_2 */
+    (void) ssl;
+    (void) md;
+
+    return -1;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+}
+
 #endif /* MBEDTLS_SSL_TLS_C */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3165,6 +3165,12 @@ static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
     }
 
+    return( 0 );
+}
+
+static void ssl_update_handshake_status( mbedtls_ssl_context *ssl )
+{
+
     if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER &&
         ssl->handshake != NULL )
     {
@@ -3179,8 +3185,6 @@ static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
         ssl->handshake->in_msg_seq++;
     }
 #endif
-
-    return( 0 );
 }
 
 /*
@@ -3948,7 +3952,11 @@ static int ssl_handle_message_type( mbedtls_ssl_context *ssl )
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
     {
         if( ( ret = ssl_prepare_handshake_record( ssl ) ) != 0 )
+        {
             return( ret );
+        }
+
+        ssl_update_handshake_status( ssl );
     }
 
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_ALERT )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3727,8 +3727,6 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl )
 
 static void ssl_handshake_wrapup_free_hs_transform( mbedtls_ssl_context *ssl );
 
-static int ssl_handle_message_type( mbedtls_ssl_context *ssl );
-
 /*
  * Read a record.
  *
@@ -3747,12 +3745,15 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
         if( ( ret = mbedtls_ssl_read_record_layer( ssl ) ) != 0 )
             return( ret );
 
-        ret = ssl_handle_message_type( ssl );
+        ret = mbedtls_ssl_handle_message_type( ssl );
 
     } while( MBEDTLS_ERR_SSL_IGNORE_NON_FATAL == ret );
 
     if( 0 != ret )
         return( ret );
+
+    if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
+        mbedtls_ssl_update_handshake_status( ssl );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= read record" ) );
 
@@ -3941,7 +3942,7 @@ read_record_header:
     return( 0 );
 }
 
-static int ssl_handle_message_type( mbedtls_ssl_context *ssl )
+int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl )
 {
     int ret;
 
@@ -3954,8 +3955,6 @@ static int ssl_handle_message_type( mbedtls_ssl_context *ssl )
         {
             return( ret );
         }
-
-        mbedtls_ssl_update_handshake_status( ssl );
     }
 
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_ALERT )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3083,7 +3083,7 @@ static int ssl_reassemble_dtls_handshake( mbedtls_ssl_context *ssl )
 }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
-static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
+int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
 {
     if( ssl->in_msglen < mbedtls_ssl_hs_hdr_len( ssl ) )
     {
@@ -3168,7 +3168,7 @@ static int ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
     return( 0 );
 }
 
-static void ssl_update_handshake_status( mbedtls_ssl_context *ssl )
+void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl )
 {
 
     if( ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER &&
@@ -3951,12 +3951,12 @@ static int ssl_handle_message_type( mbedtls_ssl_context *ssl )
      */
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
     {
-        if( ( ret = ssl_prepare_handshake_record( ssl ) ) != 0 )
+        if( ( ret = mbedtls_ssl_prepare_handshake_record( ssl ) ) != 0 )
         {
             return( ret );
         }
 
-        ssl_update_handshake_status( ssl );
+        mbedtls_ssl_update_handshake_status( ssl );
     }
 
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_ALERT )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1721,6 +1721,24 @@ run_test    "Authentication: server badcert, client none" \
             -C "! mbedtls_ssl_handshake returned" \
             -C "X509 - Certificate verification failed"
 
+run_test    "Authentication: client SHA256, server required" \
+            "$P_SRV auth_mode=required" \
+            "$P_CLI debug_level=3 crt_file=data_files/server6.crt \
+             key_file=data_files/server6.key \
+             force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384" \
+            0 \
+            -c "Supported Signature Algorithm found: 4," \
+            -c "Supported Signature Algorithm found: 5,"
+
+run_test    "Authentication: client SHA384, server required" \
+            "$P_SRV auth_mode=required" \
+            "$P_CLI debug_level=3 crt_file=data_files/server6.crt \
+             key_file=data_files/server6.key \
+             force_ciphersuite=TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256" \
+            0 \
+            -c "Supported Signature Algorithm found: 4," \
+            -c "Supported Signature Algorithm found: 5,"
+
 run_test    "Authentication: client badcert, server required" \
             "$P_SRV debug_level=3 auth_mode=required" \
             "$P_CLI debug_level=3 crt_file=data_files/server5-badsign.crt \


### PR DESCRIPTION
This PR
- adds extra hash algorithms in the outgoing CertificateRequest 
- adds the necessary capability to handle CertificateVerify
- refactors the parts of the TLS module wherever it is necessary 

Adding extra  hash algorithms in the outgoing CertificateRequest is necessary, because without them Internet Explorer choses not to send the client certificate in some cases. 
