### PR TITLE
Add extra compilation conditions to gen_key.c

### DIFF
--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -120,12 +120,14 @@ int dev_random_entropy_poll( void *data, unsigned char *output,
     USAGE_DEV_RANDOM                                    \
     "\n"
 
-#if !defined(MBEDTLS_PK_WRITE_C) || !defined(MBEDTLS_FS_IO) ||    \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C)
+#if !defined(MBEDTLS_PK_WRITE_C) || !defined(MBEDTLS_PEM_WRITE_C) || \
+    !defined(MBEDTLS_FS_IO) || !defined(MBEDTLS_ENTROPY_C) || \
+    !defined(MBEDTLS_CTR_DRBG_C)
 int main( void )
 {
     mbedtls_printf( "MBEDTLS_PK_WRITE_C and/or MBEDTLS_FS_IO and/or "
-            "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C "
+            "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
+            "MBEDTLS_PEM_WRITE_C"
             "not defined.\n" );
     return( 0 );
 }
@@ -418,4 +420,6 @@ exit:
 
     return( ret );
 }
-#endif /* MBEDTLS_PK_WRITE_C && MBEDTLS_FS_IO */
+#endif /* MBEDTLS_PK_WRITE_C && MBEDTLS_PEM_WRITE_C && MBEDTLS_FS_IO &&
+        * MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C */
+


### PR DESCRIPTION
The sample application programs/pkey/gen_key.c uses the library function
mbedtls_pk_write_key_pem() which is dependent on the configuration option
MBEDTLS_PEM_WRITE_C. If the option isn't defined the build breaks.

This change adds the compilation condition MBEDTLS_PEM_WRITE_C to the gen_key.c
sample application.