### PR TITLE
Add extra compilation conditions to X.509 samples

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,9 +31,9 @@ Bugfix
      a contribution from Tobias Tangemann. #541
    * Fixed cert_app sample program for debug output and for use when no root
      certificates are provided.
-   * Fixed sample application 'programs/pkey/gen_key.c' for builds where the
-     configuration MBEDTLS_PEM_WRITE_C is not defined. Found by inestlerode.
-     #559.
+   * Fixed the sample applications gen_key.c, cert_req.c and cert_write.c for
+     builds where the configuration MBEDTLS_PEM_WRITE_C is not defined. Found
+     by inestlerode. #559.
 
 Changes
    * Extended test coverage of special cases, and added new timing test suite.

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -34,7 +34,8 @@
 
 #if !defined(MBEDTLS_X509_CSR_WRITE_C) || !defined(MBEDTLS_FS_IO) ||  \
     !defined(MBEDTLS_PK_PARSE_C) || !defined(MBEDTLS_SHA256_C) || \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C)
+    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
+    !defined(MBEDTLS_PEM_WRITE_C)
 int main( void )
 {
     mbedtls_printf( "MBEDTLS_X509_CSR_WRITE_C and/or MBEDTLS_FS_IO and/or "
@@ -341,4 +342,4 @@ exit:
     return( ret );
 }
 #endif /* MBEDTLS_X509_CSR_WRITE_C && MBEDTLS_PK_PARSE_C && MBEDTLS_FS_IO &&
-          MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C */
+          MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C && MBEDTLS_PEM_WRITE_C */

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -32,10 +32,11 @@
 #define mbedtls_printf     printf
 #endif
 
-#if !defined(MBEDTLS_X509_CRT_WRITE_C) ||                                  \
-    !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) ||      \
-    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||        \
-    !defined(MBEDTLS_ERROR_C) || !defined(MBEDTLS_SHA256_C)
+#if !defined(MBEDTLS_X509_CRT_WRITE_C) || \
+    !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) || \
+    !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
+    !defined(MBEDTLS_ERROR_C) || !defined(MBEDTLS_SHA256_C) || \
+    !defined(MBEDTLS_PEM_WRITE_C)
 int main( void )
 {
     mbedtls_printf( "MBEDTLS_X509_CRT_WRITE_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "
@@ -664,4 +665,4 @@ exit:
 }
 #endif /* MBEDTLS_X509_CRT_WRITE_C && MBEDTLS_X509_CRT_PARSE_C &&
           MBEDTLS_FS_IO && MBEDTLS_ENTROPY_C && MBEDTLS_CTR_DRBG_C &&
-          MBEDTLS_ERROR_C */
+          MBEDTLS_ERROR_C && MBEDTLS_PEM_WRITE_C */


### PR DESCRIPTION
The sample applications programs/pkey/cert_req.c and programs/pkey/cert_write.c use the library functions mbedtls_pk_write_csr_pem() and mbedtls_pk_write_crt_pem() respectively which are dependent on the configuration option MBEDTLS_PEM_WRITE_C. If the option isn't defined the build breaks.
    
This change adds the compilation condition MBEDTLS_PEM_WRITE_C to these sample application.

This issue is a variant of #559 but on other sample applications.