### PR TITLE
Fix bug in threading sample implementation #667

### DIFF
--- a/library/threading.c
+++ b/library/threading.c
@@ -32,7 +32,7 @@
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || mutex->is_valid )
+    if( mutex == NULL )
         return;
 
     mutex->is_valid = pthread_mutex_init( &mutex->mutex, NULL ) == 0;


### PR DESCRIPTION
`threading_mutex_init_pthread` fails whenever `mutex->is_valid` is not 0.

It is the right behaviour if it is nonzero because it has been initialised (in the sense of calling this init function) before.

Unfortunately `mutex->is_valid` can be nonzero too if the `mbedtls_threading_mutex_t` structure hasn't been initialised (in the sense of initialising variables in the C language) yet.

In this latter case the current implementation of the init function will return without doing anything and every operation involving these mutexes will fail.
