### PR TITLE
Microsoft Visual C Compiler Warning Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,9 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(MSVC)
-    set(CMAKE_C_FLAGS_CHECK       "/WX")
+    # Strictest warnings, and treat as errors
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
 endif(MSVC)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -105,7 +105,7 @@ static int cmac_multiply_by_u( unsigned char *output,
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
     }
 
-    for( i = blocksize - 1; i >= 0; i-- )
+    for( i = (int)blocksize - 1; i >= 0; i-- )
     {
         output[i] = input[i] << 1 | overflow;
         overflow = input[i] >> 7;
@@ -209,7 +209,7 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
     if( ctx == NULL || ctx->cipher_info == NULL || key == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    if( ( retval = mbedtls_cipher_setkey( ctx, key, keybits,
+    if( ( retval = mbedtls_cipher_setkey( ctx, key, (int)keybits,
                                           MBEDTLS_ENCRYPT ) ) != 0 )
         return( retval );
 
@@ -244,8 +244,8 @@ int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
 {
     mbedtls_cmac_context_t* cmac_ctx;
     unsigned char *state;
-    int n, j, ret = 0;
-    size_t olen, block_size;
+    int ret = 0;
+    size_t n, j, olen, block_size;
 
     if( ctx == NULL || ctx->cipher_info == NULL || input == NULL ||
         ctx->cmac_ctx == NULL )
@@ -280,8 +280,9 @@ int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
     /* n is the number of blocks including any final partial block */
     n = ( ilen + block_size - 1 ) / block_size;
 
-   /* Iterate across the input data in block sized chunks */
-    for( j = 0; j < n - 1; j++ )
+    /* Iterate across the input data in block sized chunks, excluding any
+     * final partial or complete block */
+    for( j = 1; j < n; j++ )
     {
         cmac_xor_block( state, input, state, block_size );
 

--- a/library/platform.c
+++ b/library/platform.c
@@ -237,7 +237,7 @@ int mbedtls_platform_std_nv_seed_read( unsigned char *buf, size_t buf_len )
     }
 
     fclose( file );
-    return( n );
+    return( (int)n );
 }
 
 int mbedtls_platform_std_nv_seed_write( unsigned char *buf, size_t buf_len )
@@ -255,7 +255,7 @@ int mbedtls_platform_std_nv_seed_write( unsigned char *buf, size_t buf_len )
     }
 
     fclose( file );
-    return( n );
+    return( (int)n );
 }
 #endif /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1122,7 +1122,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     p = filename + len;
     filename[len++] = '*';
 
-    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, len, szDir,
+    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, (int)len, szDir,
                                  MAX_PATH - 3 );
     if( w_ret == 0 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,9 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /w") # no warnings here
+    # If a warning level has been defined, suppress all warnings for test code
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W0")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX-")
 endif(MSVC)
 
 add_test_suite(aes aes.ecb)


### PR DESCRIPTION
This PR fixes various compiler warnings found with Microsoft Visual Studio 2015 (and earlier versions), and also fixes a problem where the switch for compiler warnings was being configured twice on the test suites with Microsoft Visual Studio.