### PR TITLE
Remove unused var warnings in windows tests

### DIFF
--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -261,7 +261,9 @@ int main(int argc, const char *argv[])
     char buf[5000];
     char *params[50];
     void *pointer;
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     int stdout_fd = -1;
+#endif /* __unix__ || __APPLE__ __MACH__ */
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)


### PR DESCRIPTION
This PR removes unused variable warnings when compiling the test_suite_* programs by conditionally compiling the definition of a variable `stdout_fd` that is used in the output redirection. The original changes were introduced in https://github.com/ARMmbed/mbedtls/commit/2573136fa8147abeddcdc8c49b7a3d3a284f7170.