### PR TITLE
Microsoft Visual C Compiler Warning Fixes - backport to 1.3

### DIFF
--- a/library/ccm.c
+++ b/library/ccm.c
@@ -140,7 +140,7 @@ static int ccm_auth_crypt( ccm_context *ctx, int mode, size_t length,
 {
     int ret;
     unsigned char i;
-    unsigned char q = 16 - 1 - iv_len;
+    unsigned char q;
     size_t len_left, olen;
     unsigned char b[16];
     unsigned char y[16];
@@ -162,6 +162,8 @@ static int ccm_auth_crypt( ccm_context *ctx, int mode, size_t length,
 
     if( add_len > 0xFF00 )
         return( POLARSSL_ERR_CCM_BAD_INPUT );
+
+    q = 16 - 1 - (unsigned char) iv_len;
 
     /*
      * First block B_0:
@@ -254,7 +256,7 @@ static int ccm_auth_crypt( ccm_context *ctx, int mode, size_t length,
 
     while( len_left > 0 )
     {
-        unsigned char use_len = len_left > 16 ? 16 : len_left;
+        size_t use_len = len_left > 16 ? 16 : len_left;
 
         if( mode == CCM_ENCRYPT )
         {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2981,7 +2981,17 @@ static int ssl_parse_encrypted_pms( ssl_context *ssl,
     ssl->handshake->pmslen = 48;
 
     /* mask = diff ? 0xff : 0x00 */
+    /* MSVC has a warning about unary minus on unsigned, but this is
+     * well-defined and precisely what we want to do here */
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4146 )
+#endif
     mask = - ( diff | - diff ) >> ( sizeof( unsigned int ) * 8 - 1 );
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+
     for( i = 0; i < ssl->handshake->pmslen; i++ )
         pms[i] = ( mask & fake_pms[i] ) | ( (~mask) & peer_pms[i] );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1484,7 +1484,7 @@ static int ssl_decrypt_buf( ssl_context *ssl )
         unsigned char add_data[13];
         unsigned char taglen = ssl->transform_in->ciphersuite_info->flags &
                                POLARSSL_CIPHERSUITE_SHORT_TAG ? 8 : 16;
-        unsigned char explicit_iv_len =  ssl->transform_in->ivlen -
+        size_t explicit_iv_len =  ssl->transform_in->ivlen -
                                          ssl->transform_in->fixed_ivlen;
 
         if( ssl->in_msglen < (size_t) explicit_iv_len + taglen )

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -988,7 +988,7 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
     p = filename + len;
     filename[len++] = '*';
 
-    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, len, szDir,
+    w_ret = MultiByteToWideChar( CP_ACP, 0, filename, (int)len, szDir,
                                  MAX_PATH - 3 );
     if( w_ret == 0 )
         return( POLARSSL_ERR_X509_BAD_INPUT_DATA );


### PR DESCRIPTION
This PR fixes various compiler warnings found with Microsoft Visual Studio 2015 (and earlier versions).

Note, it does not fix *all* compiler warnings in the 1.3 branch - just some, and those in #670 which were broken in 1.3.