### PR TITLE
Remove need for elevated command line in Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
         if (CMAKE_HOST_UNIX)
             set(command ln -s ${target} ${link})
         else()
-            set(command cmd.exe /c mklink /d ${link} ${target})
+            set(command cmd.exe /c mklink /j ${link} ${target})
         endif()
 
         execute_process(COMMAND ${command}


### PR DESCRIPTION
Changes use of `mklink` in Windows test builds, to create junctions instead of directory symbolic links. This removes the need for an elevated command prompt when running `cmake` to create the Visual Studio project files.

Fixes #686.