### PR TITLE
Tighten compiler warning configurations in the release script

### DIFF
--- a/library/debug.c
+++ b/library/debug.c
@@ -71,7 +71,7 @@ static inline void debug_send_line( const mbedtls_ssl_context *ssl, int level,
      */
 #if defined(MBEDTLS_THREADING_C)
     char idstr[20 + DEBUG_BUF_SIZE]; /* 0x + 16 nibbles + ': ' */
-    mbedtls_snprintf( idstr, sizeof( idstr ), "%p: %s", ssl, str );
+    mbedtls_snprintf( idstr, sizeof( idstr ), "%p: %s", (void*)ssl, str );
     ssl->conf->f_dbg( ssl->conf->p_dbg, level, file, line, idstr );
 #else
     ssl->conf->f_dbg( ssl->conf->p_dbg, level, file, line, str );

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -133,7 +133,8 @@ void mbedtls_net_init( mbedtls_net_context *ctx )
 /*
  * Initiate a TCP connection with host:port and the given protocol
  */
-int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto )
+int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,
+                         const char *port, int proto )
 {
     int ret;
     struct addrinfo hints, *addr_list, *cur;
@@ -322,7 +323,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
     {
         /* TCP: actual accept() */
         ret = client_ctx->fd = (int) accept( bind_ctx->fd,
-                                         (struct sockaddr *) &client_addr, &n );
+                                             (struct sockaddr *) &client_addr, &n );
     }
     else
     {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -209,7 +209,7 @@ export GNUTLS_SERV="$GNUTLS_SERV"
 # Make sure the tools we need are available.
 check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
     "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-    "arm-none-eabi-gcc" "armcc"
+    "arm-none-eabi-gcc" "armcc" "i686-w64-mingw32-gcc"
 
 #
 # Test Suites to be executed
@@ -435,20 +435,18 @@ scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
 CC=armcc AR=armar WARNING_CFLAGS='--strict --c99' make lib
 
-if which i686-w64-mingw32-gcc >/dev/null; then
-    msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
-    cleanup
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 make lib programs
+msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+cleanup
+CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 make lib programs
 
-    # note Make tests only builds the tests, but doesn't run them
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 make tests
-    WINDOWS_BUILD=1 make clean
+# note Make tests only builds the tests, but doesn't run them
+CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 make tests
+WINDOWS_BUILD=1 make clean
 
-    msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make lib programs
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make tests
-    WINDOWS_BUILD=1 make clean
-fi
+msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
+CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make lib programs
+CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make tests
+WINDOWS_BUILD=1 make clean
 
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -439,12 +439,14 @@ if which i686-w64-mingw32-gcc >/dev/null; then
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
     cleanup
     CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 make lib programs
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 make test
+
+    # note Make tests only builds the tests, but doesn't run them
+    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 make tests
     WINDOWS_BUILD=1 make clean
 
     msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS'=-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make lib programs
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS'=-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make test
+    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make lib programs
+    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 make tests
     WINDOWS_BUILD=1 make clean
 fi
 

--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -49,7 +49,8 @@ for my $curve (@curves) {
     system( "scripts/config.pl unset $curve" )
         and abort "Failed to disable $curve\n";
 
-    system( "make lib" ) and abort "Failed to build lib: $curve\n";
+    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
+        and abort "Failed to build lib: $curve\n";
     system( "cd tests && make" ) and abort "Failed to build tests: $curve\n";
     system( "make test" ) and abort "Failed test suite: $curve\n";
 

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -1,9 +1,15 @@
 #!/usr/bin/perl
 
-# test standard configurations:
-# - build
-# - run test suite
-# - run compat.sh
+# test-ref-configs.pl
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# For each reference configuration file in the configs directory, build the
+# configuration, run the test suites and compat.sh
 #
 # Usage: tests/scripts/test-ref-configs.pl [config-name [...]]
 
@@ -63,7 +69,7 @@ while( my ($conf, $data) = each %configs ) {
     system( "cp configs/$conf $config_h" )
         and abort "Failed to activate $conf\n";
 
-    system( "make CFLAGS='-Os -Werror'" ) and abort "Failed to build: $conf\n";
+    system( "CFLAGS='-Os -Werror -Wall -Wextra' make" ) and abort "Failed to build: $conf\n";
     system( "make test" ) and abort "Failed test suite: $conf\n";
 
     my $compat = $data->{'compat'};


### PR DESCRIPTION
This pull request changes the configuration of compiler warnings in the `all.sh` test script, and for some test builds enforces compilation against the C99 standard. In addition, it also makes the mingw test build a mandatory step in the test script and no longer optional, and fixes some minor bugs that were throwing up warnings.

As an improvement on test quality, this does not need back porting.
