### PR TITLE
Backport 2.1: Fix unused variable/function compilation warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix unused variable/function compilation warnings in pem.c and x509_csr.c
+     that are reported when building mbed TLS with a config.h that does not
+     define MBEDTLS_PEM_PARSE_C. #562
+
 = mbed TLS 2.1.6 branch released 2016-10-17
 
 Security

--- a/library/pem.c
+++ b/library/pem.c
@@ -44,12 +44,12 @@
 #define mbedtls_free       free
 #endif
 
+#if defined(MBEDTLS_PEM_PARSE_C)
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
 
-#if defined(MBEDTLS_PEM_PARSE_C)
 void mbedtls_pem_init( mbedtls_pem_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_pem_context ) );

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -259,8 +259,8 @@ int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
  */
 int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, size_t buflen )
 {
-    int ret;
 #if defined(MBEDTLS_PEM_PARSE_C)
+    int ret;
     size_t use_len;
     mbedtls_pem_context pem;
 #endif


### PR DESCRIPTION
This PR fixes a number of unused variable/function compilation warnings
that arise when using a config.h that does not define the macro
MBEDTLS_PEM_PARSE_C.