### PR TITLE
Backport 1.3: Fix unused variable/function compilation warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch xxxx-xx-xx
+
+Bugfix
+   * Fix unused variable/function compilation warnings in pem.c and x509_csr.c
+     that are reported when building mbed TLS with a config.h that does not
+     define POLARSSL_PEM_PARSE_C. #562
+
 = mbed TLS 1.3.18 branch 2016-10-17
 
 Security

--- a/library/pem.c
+++ b/library/pem.c
@@ -45,12 +45,12 @@
 #define polarssl_free       free
 #endif
 
+#if defined(POLARSSL_PEM_PARSE_C)
 /* Implementation that should never be optimized out by the compiler */
 static void polarssl_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
 
-#if defined(POLARSSL_PEM_PARSE_C)
 void pem_init( pem_context *ctx )
 {
     memset( ctx, 0, sizeof( pem_context ) );

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -260,8 +260,8 @@ int x509_csr_parse_der( x509_csr *csr,
  */
 int x509_csr_parse( x509_csr *csr, const unsigned char *buf, size_t buflen )
 {
-    int ret;
 #if defined(POLARSSL_PEM_PARSE_C)
+    int ret;
     size_t use_len;
     pem_context pem;
 #endif


### PR DESCRIPTION
This PR fixes a number of unused variable/function compilation warnings
that arise when using a config.h that does not define the macro
POLARSSL_PEM_PARSE_C.