### PR TITLE
Workaround for GCC Bug

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -765,7 +765,7 @@ static int cmac_test_subkeys( int verbose,
                               int block_size,
                               int num_tests )
 {
-    int i, ret;
+    int i, ret = 0;
     mbedtls_cipher_context_t ctx;
     const mbedtls_cipher_info_t *cipher_info;
     unsigned char K1[MBEDTLS_CIPHER_BLKSIZE_MAX];
@@ -847,7 +847,7 @@ static int cmac_test_wth_cipher( int verbose,
                                  int num_tests )
 {
     const mbedtls_cipher_info_t *cipher_info;
-    int i, ret;
+    int i, ret = 0;
     unsigned char output[MBEDTLS_CIPHER_BLKSIZE_MAX];
 
     cipher_info = mbedtls_cipher_info_from_type( cipher_type );


### PR DESCRIPTION
In certain circumstances, some versions of GCC 4.* produce spurious compiler warnings related to uninitialized variables in conditional statements.  For details, see the [GCC bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145).

This pull request initializes two variables in `cmac.c` as a work around to the GCC issue.