### PR TITLE
FIx Unresolved symbols for VS 14 2015 ARM

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -91,7 +91,7 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(WIN32)
-    set(libs ${libs} ws2_32)
+    set(libs ${libs} ws2_32 advapi32)
 endif(WIN32)
 
 if(USE_PKCS11_HELPER_LIBRARY)


### PR DESCRIPTION
Reported and fix suggested by gatkinso in https://github.com/ARMmbed/mbedtls/issues/735
Add advapi32 to be linked in the CMakelists.txt rule for windows