### PR TITLE
Compilation warning fixes on 32 bit platfrom with IAR

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Bugfix
      Found by redplait #590
    * Add MBEDTLS_MPI_CHK to check for error value of mbedtls_mpi_fill_random.
      Reported and fix suggested by guidovranken in #740
+   * Fix compilation warnings with IAR toolchain, on 32 bit platform.
+     Reported by rahmanih in #683
 
 Features
    * Add the functions mbedtls_platform_setup() and mbedtls_platform_teardown()

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -28,6 +28,7 @@
 #if defined(MBEDTLS_ASN1_WRITE_C)
 
 #include "mbedtls/asn1write.h"
+#include "mbedtls/bignum.h"
 
 #include <string.h>
 
@@ -82,8 +83,13 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         *--(*p) = 0x83;
         return( 4 );
     }
-
+/*
+ * Relevant only for 64 bit platforms.
+ * On 32 bit platforms, size_t should always be 32 bits
+ */
+#if defined(MBEDTLS_HAVE_INT64)
     if( len <= 0xFFFFFFFF )
+#endif
     {
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
@@ -95,8 +101,13 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         *--(*p) = 0x84;
         return( 5 );
     }
-
+/*
+ * Relevant only for 64 bit platforms.
+ * On 32 bit platforms, this return statement will not be reached
+ */
+#if defined(MBEDTLS_HAVE_INT64)
     return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
+#endif
 }
 
 int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start, unsigned char tag )

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -41,6 +41,7 @@
 #include "mbedtls/asn1.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/oid.h"
+#include "mbedtls/bignum.h"
 
 #include <string.h>
 
@@ -230,9 +231,14 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
 
     memset( counter, 0, 4 );
     counter[3] = 1;
-
+/*
+ * Relevant only for 64 bit platforms.
+ * On 32 bit platforms, unsigned int cannot exceed 32 bits
+ */
+#if defined(MBEDTLS_HAVE_INT64)
     if( iteration_count > 0xFFFFFFFF )
         return( MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA );
+#endif
 
     while( key_length )
     {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2838,7 +2838,7 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME_PFS__ENABLED)
     unsigned char *p = ssl->out_msg + 4;
-    size_t len;
+    size_t len = 0;
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
     unsigned char *dig_signed = p;
     size_t dig_signed_len = 0;


### PR DESCRIPTION
Fix compilation warnings with IAR toolchain, on 32 bit platform.
Reported by rahmanih in #683