### PR TITLE
Backport 1.3: Resource leak fix on windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix resource leak on windows platform, in mbedtls_x509_crt_parse_path.
+     In case of failure, when an error occures, goto cleanup.
+     Found by redplait #590
+
 = mbed TLS 1.3.18 branch 2016-10-17
 
 Security

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1010,7 +1010,10 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
                                      p, (int) len - 1,
                                      NULL, NULL );
         if( w_ret == 0 )
-            return( POLARSSL_ERR_X509_FILE_IO_ERROR );
+        {
+            ret = POLARSSL_ERR_X509_FILE_IO_ERROR;
+            goto cleanup;
+        }
 
         w_ret = x509_crt_parse_file( chain, filename );
         if( w_ret < 0 )
@@ -1023,6 +1026,7 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
     if( GetLastError() != ERROR_NO_MORE_FILES )
         ret = POLARSSL_ERR_X509_FILE_IO_ERROR;
 
+cleanup:
     FindClose( hFind );
 #else /* _WIN32 */
     int t_ret;


### PR DESCRIPTION
Fix a resource leak on windows platform, in mbedtls_x509_crt_parse_path,
in case a failure. when an error occurs, goto cleanup, and free the
resource, instead of returning error code immediately.