### PR TITLE
Backport 1.3: Wrong preproccessor condition fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Replace preproccessor condition from #if defined(MBEDTLS_THREADING_PTHREAD)
+     to #if defined(MBEDTLS_THREADING_C) as the library cannot assume they will
+     always be implemented by pthread support. Fix for #696
+
 = mbed TLS 1.3.18 branch 2016-10-17
 
 Security

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1034,10 +1034,10 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
     if( dir == NULL )
         return( POLARSSL_ERR_X509_FILE_IO_ERROR );
 
-#if defined(POLARSSL_THREADING_PTHREAD)
+#if defined(POLARSSL_THREADING_C)
     if( ( ret = polarssl_mutex_lock( &readdir_mutex ) ) != 0 )
         return( ret );
-#endif
+#endif /* POLARSSL_THREADING_C */
 
     while( ( entry = readdir( dir ) ) != NULL )
     {
@@ -1064,10 +1064,10 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
     closedir( dir );
 
 cleanup:
-#if defined(POLARSSL_THREADING_PTHREAD)
+#if defined(POLARSSL_THREADING_C)
     if( polarssl_mutex_unlock( &readdir_mutex ) != 0 )
         ret = POLARSSL_ERR_THREADING_MUTEX_ERROR;
-#endif
+#endif /* POLARSSL_THREADING_C */
 
 #endif /* _WIN32 */
 


### PR DESCRIPTION
Fix for issue #696
Change #if defined(MBEDTLS_THREADING_PTHREAD)
to #if defined(MBEDTLS_THREADING_C)