### PR TITLE
mbedtls_net_accept: client_ip can be NULL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Changes
-   * Improve the documentation of mbedtls_net_accept(). Contributed by aitap.
+   * Improve the documentation of mbedtls_net_accept(). Contributed by Ivan Krylov.
 
 = mbed TLS 2.4.1 branch released 2016-12-13
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Changes
+   * Improve the documentation of mbedtls_net_accept(). Contributed by aitap.
+
 = mbed TLS 2.4.1 branch released 2016-12-13
 
 Changes

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -120,7 +120,7 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  * \param client_ip Will contain the client IP address, can be NULL
  * \param buf_size  Size of the client_ip buffer
  * \param ip_len    Will receive the size of the client IP written,
- *                  can be NULL if client_ip == NULL
+ *                  can be NULL if client_ip is null
  *
  * \return          0 if successful, or
  *                  MBEDTLS_ERR_NET_ACCEPT_FAILED, or

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -117,9 +117,10 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *
  * \param bind_ctx  Relevant socket
  * \param client_ctx Will contain the connected client socket
- * \param client_ip Will contain the client IP address
+ * \param client_ip Will contain the client IP address, can be NULL
  * \param buf_size  Size of the client_ip buffer
- * \param ip_len    Will receive the size of the client IP written
+ * \param ip_len    Will receive the size of the client IP written,
+ *                  can be NULL if client_ip == NULL
  *
  * \return          0 if successful, or
  *                  MBEDTLS_ERR_NET_ACCEPT_FAILED, or


### PR DESCRIPTION
This currently works and is used in example programs, but not explicitly documented (unlike mbedtls_net_bind).

Since only the official documentation and headers are the contract that developers are expected to adhere to and digging the source to gather information about library behavior might be relying on implementation details, I would like to clarify if mbedtls_net_accept is supposed to accept a NULL client_ip argument.

If passing client_ip=NULL is supported, would you please accept this PR?