### PR TITLE
Backport 1.3: Check rc of mbedtls_mpi_fill_random

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+   * Add MPI_CHK to check for error value of mpi_fill_random.
+     Backported from a report and fix suggestion by guidovranken in #740
+
 = mbed TLS 1.3.18 branch 2016-10-17
 
 Security

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -163,7 +163,7 @@ int dhm_make_params( dhm_context *ctx, int x_size,
      */
     do
     {
-        mpi_fill_random( &ctx->X, x_size, f_rng, p_rng );
+        MPI_CHK( mpi_fill_random( &ctx->X, x_size, f_rng, p_rng ) );
 
         while( mpi_cmp_mpi( &ctx->X, &ctx->P ) >= 0 )
             MPI_CHK( mpi_shift_r( &ctx->X, 1 ) );
@@ -249,7 +249,7 @@ int dhm_make_public( dhm_context *ctx, int x_size,
      */
     do
     {
-        mpi_fill_random( &ctx->X, x_size, f_rng, p_rng );
+        MPI_CHK( mpi_fill_random( &ctx->X, x_size, f_rng, p_rng ) );
 
         while( mpi_cmp_mpi( &ctx->X, &ctx->P ) >= 0 )
             MPI_CHK( mpi_shift_r( &ctx->X, 1 ) );
@@ -322,7 +322,7 @@ static int dhm_update_blinding( dhm_context *ctx,
     count = 0;
     do
     {
-        mpi_fill_random( &ctx->Vi, mpi_size( &ctx->P ), f_rng, p_rng );
+        MPI_CHK( mpi_fill_random( &ctx->Vi, mpi_size( &ctx->P ), f_rng, p_rng ) );
 
         while( mpi_cmp_mpi( &ctx->Vi, &ctx->P ) >= 0 )
             MPI_CHK( mpi_shift_r( &ctx->Vi, 1 ) );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1151,7 +1151,7 @@ static int ecp_randomize_jac( const ecp_group *grp, ecp_point *pt,
     /* Generate l such that 1 < l < p */
     do
     {
-        mpi_fill_random( &l, p_size, f_rng, p_rng );
+        MPI_CHK( mpi_fill_random( &l, p_size, f_rng, p_rng ) );
 
         while( mpi_cmp_mpi( &l, &grp->P ) >= 0 )
             MPI_CHK( mpi_shift_r( &l, 1 ) );
@@ -1536,7 +1536,7 @@ static int ecp_randomize_mxz( const ecp_group *grp, ecp_point *P,
     /* Generate l such that 1 < l < p */
     do
     {
-        mpi_fill_random( &l, p_size, f_rng, p_rng );
+        MPI_CHK( mpi_fill_random( &l, p_size, f_rng, p_rng ) );
 
         while( mpi_cmp_mpi( &l, &grp->P ) >= 0 )
             MPI_CHK( mpi_shift_r( &l, 1 ) );


### PR DESCRIPTION
Add MPI_CHK to check for error value of mpi_fill_random.
Backport from Report and fix suggestion by guidovranken in #740