### PR TITLE
Backport 2.1:Resource leak in ssl_cookie and mutex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+    * Fix a resource leak in ssl_cookie, when using MBEDTLS_THREADING_C.
+      Raised and fix suggested by Alan Gillingham in the mbed TLS forum. #771
+
 = mbed TLS 2.1.6 branch released 2016-10-17
 
 Security

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -98,7 +98,7 @@ void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx )
     mbedtls_md_free( &ctx->hmac_ctx );
 
 #if defined(MBEDTLS_THREADING_C)
-    mbedtls_mutex_init( &ctx->mutex );
+    mbedtls_mutex_free( &ctx->mutex );
 #endif
 
     mbedtls_zeroize( ctx, sizeof( mbedtls_ssl_cookie_ctx ) );


### PR DESCRIPTION
When using ssl_cookie with MBEDTLS_THREADING_C, fix a resource leak caused by
initiating a mutex in mbedtls_ssl_cookie_free instead of freeing it.
Raised and fix suggested by lan Gillingham in the mbed TLS forum
Tracked in #771