### PR TITLE
Fix all.sh check_tools function to handle paths

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -116,7 +116,7 @@ err_msg()
 check_tools()
 {
     for TOOL in "$@"; do
-        if ! `hash "$TOOL" >/dev/null 2>&1`; then
+        if ! `type "$TOOL" >/dev/null 2>&1`; then
             err_msg "$TOOL not found!"
             exit 1
         fi


### PR DESCRIPTION
Fix the all.sh testing script so that it fails when full executable paths of tools are not valid.