### PR TITLE
Adds dl link library to OpenSSL example builds

### DIFF
--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -31,7 +31,7 @@ install(TARGETS selftest benchmark ssl_test ssl_cert_test
 if(OPENSSL_FOUND)
     add_executable(o_p_test o_p_test.c)
     include_directories(${OPENSSL_INCLUDE_DIR})
-    target_link_libraries(o_p_test ${libs} ${OPENSSL_LIBRARIES})
+    target_link_libraries(o_p_test ${libs} ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
 
     install(TARGETS o_p_test
         DESTINATION "bin"


### PR DESCRIPTION
The example `o_p_test` uses OpenSSL. On some platforms that fails to build
unless the dl library is included as a static link library.

Note this fix is only required on the mbedtls 1.3 branch as the `o_p_test` example was removed in later versions of mbed TLS.