### PR TITLE
Fix undefined variable in scripts/config.pl

### DIFF
--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -5,6 +5,7 @@
 use warnings;
 use strict;
 
+my $config_file = "include/mbedtls/config.h";
 my $usage = <<EOU;
 $0 [-f <file>] [set <symbol> <value> | unset <symbol> | full | realfull]
 
@@ -57,8 +58,6 @@ _ALT\s*$
 my @non_excluded = qw(
 PLATFORM_[A-Z0-9]+_ALT
 );
-
-my $config_file = "include/mbedtls/config.h";
 
 # get -f option
 if (@ARGV >= 2 && $ARGV[0] eq "-f") {


### PR DESCRIPTION
The variable `$config_file` was being referenced without being defined in the script `config.pl`.

* This issue does not apply to `development`, `mbedtls-2.4` nor `mbedtls-1.3` branches.