### PR TITLE
Fix curves.pl script to build

### DIFF
--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -34,7 +34,7 @@ for my $curve (@curves) {
     system( "scripts/config.pl unset $curve" )
         and abort "Failed to disable $curve\n";
 
-    system( "make polarssl" ) and abort "Failed to build lib: $curve\n";
+    system( "make lib" ) and abort "Failed to build lib: $curve\n";
     system( "cd tests && make" ) and abort "Failed to build tests: $curve\n";
     system( "make $test" ) and abort "Failed test suite: $curve\n";
 


### PR DESCRIPTION
The script, `tests/scripts/curves.pl` was broken, and did not build due to the make command not having been updated with the change from polarssl to mbed TLS.

This pull request changes the build command to `make lib` from `make polarssl`.