### PR TITLE
Rename misleading timing-safe comparison function

### DIFF
--- a/include/mbedtls/compat-1.3.h
+++ b/include/mbedtls/compat-1.3.h
@@ -2307,7 +2307,7 @@
 #define rsa_self_test mbedtls_rsa_self_test
 #define rsa_set_padding mbedtls_rsa_set_padding
 #define rsa_sign_func mbedtls_rsa_sign_func
-#define safer_memcmp mbedtls_ssl_safer_memcmp
+#define safer_memcmp mbedtls_ssl_safe_byte_cmp
 #define set_alarm mbedtls_set_alarm
 #define sha1 mbedtls_sha1
 #define sha1_context mbedtls_sha1_context

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -480,7 +480,7 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 #endif
 
 /* constant-time buffer comparison */
-static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
+static inline int mbedtls_ssl_safe_byte_cmp( const void *a, const void *b, size_t n )
 {
     size_t i;
     const unsigned char *A = (const unsigned char *) a;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1063,9 +1063,9 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len * 2 ||
             buf[0] !=     ssl->verify_data_len * 2 ||
-            mbedtls_ssl_safer_memcmp( buf + 1,
+            mbedtls_ssl_safe_byte_cmp( buf + 1,
                           ssl->own_verify_data, ssl->verify_data_len ) != 0 ||
-            mbedtls_ssl_safer_memcmp( buf + 1 + ssl->verify_data_len,
+            mbedtls_ssl_safe_byte_cmp( buf + 1 + ssl->verify_data_len,
                           ssl->peer_verify_data, ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -238,7 +238,7 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     if( ret != 0 )
         return( ret );
 
-    if( mbedtls_ssl_safer_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
+    if( mbedtls_ssl_safe_byte_cmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
         return( -1 );
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -154,7 +154,7 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len ||
             buf[0] !=     ssl->verify_data_len ||
-            mbedtls_ssl_safer_memcmp( buf + 1, ssl->peer_verify_data,
+            mbedtls_ssl_safe_byte_cmp( buf + 1, ssl->peer_verify_data,
                           ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );
@@ -3248,7 +3248,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
         /* Identity is not a big secret since clients send it in the clear,
          * but treat it carefully anyway, just in case */
         if( n != ssl->conf->psk_identity_len ||
-            mbedtls_ssl_safer_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
+            mbedtls_ssl_safe_byte_cmp( ssl->conf->psk_identity, *p, n ) != 0 )
         {
             ret = MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY;
         }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1757,7 +1757,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
             MBEDTLS_SSL_DEBUG_BUF( 4, "computed mac", computed_mac,
                                               ssl->transform_in->maclen );
 
-            if( mbedtls_ssl_safer_memcmp( ssl->in_iv + ssl->in_msglen, computed_mac,
+            if( mbedtls_ssl_safe_byte_cmp( ssl->in_iv + ssl->in_msglen, computed_mac,
                               ssl->transform_in->maclen ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "message mac does not match" ) );
@@ -1985,7 +1985,7 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         MBEDTLS_SSL_DEBUG_BUF( 4, "computed mac", ssl->in_msg + ssl->in_msglen,
                        ssl->transform_in->maclen );
 
-        if( mbedtls_ssl_safer_memcmp( tmp, ssl->in_msg + ssl->in_msglen,
+        if( mbedtls_ssl_safe_byte_cmp( tmp, ssl->in_msg + ssl->in_msglen,
                          ssl->transform_in->maclen ) != 0 )
         {
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
@@ -5185,7 +5185,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_HS_FINISHED );
     }
 
-    if( mbedtls_ssl_safer_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
+    if( mbedtls_ssl_safe_byte_cmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
                       buf, hash_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );

--- a/scripts/data_files/rename-1.3-2.0.txt
+++ b/scripts/data_files/rename-1.3-2.0.txt
@@ -1850,7 +1850,7 @@ rsa_rsassa_pss_verify_ext mbedtls_rsa_rsassa_pss_verify_ext
 rsa_self_test mbedtls_rsa_self_test
 rsa_set_padding mbedtls_rsa_set_padding
 rsa_sign_func mbedtls_rsa_sign_func
-safer_memcmp mbedtls_ssl_safer_memcmp
+safer_memcmp mbedtls_ssl_safe_byte_cmp
 set_alarm mbedtls_set_alarm
 sha1 mbedtls_sha1
 sha1_context mbedtls_sha1_context


### PR DESCRIPTION
The name `mbedtls_ssl_safer_memcmp` is misleading as it can make the
reader think the returned values follow the convention of `memcmp`. In
reality, that function only returns 0 if the two compared memory regions
are equal, any other value if not.

It has been renamed to `mbedtls_ssl_safe_byte_cmp` so that readers won't
wrongly assume it works the same way as `memcmp`.