### PR TITLE
Workaround for 32 bit linux platform failure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -582,6 +582,8 @@ Bugfix
      digits. Found and fixed by Guido Vranken.
    * Fix unlisted DES configuration dependency in some pkparse test cases. Found
      by inestlerode. #555
+   * Disable i386 Big Number multiplication assembly code,
+     as it causes segmentatoin faults.
 
 = mbed TLS 2.4.1 branch released 2016-12-13
 

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -49,7 +49,11 @@
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
     ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
-#if defined(__i386__)
+/*
+ * The i386 assembly is reported to be broken.
+ * Disable it for now, until we're able to fix it.
+ */
+#if 0 &&  defined(__i386__)
 
 #define MULADDC_INIT                        \
     asm(                                    \

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -48,12 +48,12 @@
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
-    ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
+    ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 ) && \
+    !defined(__i386__) && !defined (__x86_64__)
 /*
  * The i386 assembly is reported to be broken.
  * Disable it for now, until we're able to fix it.
  */
-#if 0 &&  defined(__i386__)
 
 #define MULADDC_INIT                        \
     asm(                                    \
@@ -161,7 +161,6 @@
         : "eax", "ecx", "edx", "esi", "edi"             \
     );
 #endif /* SSE2 */
-#endif /* i386 */
 
 #if defined(__amd64__) || defined (__x86_64__)
 


### PR DESCRIPTION
Disable the i386 assembly on bn_mul. Otherwise, a segmentation fault will happen