### PR TITLE
Fix checks for TLS_FALLBACK_SCSV

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,9 @@ Bugfix
      in RFC 6347 Section 4.3.1. This could cause the execution of the
      renegotiation routines at unexpected times when the protocol is DTLS. Found
      by wariua. #687
+   * Fix TLS server checks for MBEDTLS_SSL_FALLBACK_SCSV_VALUE to ensure that it
+     is the last cipher suite in the list sent in the ClientHello as recommended
+     (SHOULD) in RFC7507 Section 4. Found by Hugo Leisink. #810
 
 = mbed TLS 2.4.1 branch released 2016-12-13
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -982,7 +982,12 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
-            if( ssl->minor_ver < ssl->conf->max_minor_ver )
+            /*
+             * Check if the server supports a higher protocol version than the
+             * one indicated in the ClientHello. Also, check that FALLBACK_SCSV
+             * is after all cipher suites.
+             */
+            if( ssl->minor_ver < ssl->conf->max_minor_ver || i + 3 != ciph_len )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "inapropriate fallback" ) );
 
@@ -1700,14 +1705,20 @@ read_record_header:
 #endif
 
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
-    for( i = 0, p = buf + 41 + sess_len; i < ciph_len; i += 2, p += 2 )
+    for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
         if( p[0] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
             p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 
-            if( ssl->minor_ver < ssl->conf->max_minor_ver )
+            /*
+             * Check if the server supports a higher protocol version than the
+             * one indicated in the ClientHello. Also, check that
+             * TLS_FALLBACK_SCSV is after all cipher suites. Refer to RFC7507
+             * Sections 3 and 4.
+             */
+            if( ssl->minor_ver < ssl->conf->max_minor_ver || i + 2 != ciph_len )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "inapropriate fallback" ) );
 
@@ -1740,7 +1751,7 @@ read_record_header:
 
                 return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
             }
-#endif
+#endif /* MBEDTLS_SSL_RENEGOTIATION */
             ssl->secure_renegotiation = MBEDTLS_SSL_SECURE_RENEGOTIATION;
             break;
         }


### PR DESCRIPTION
The code in library/ssl_srv.c looks for the cipher suite value
TLS_FALLBACK_SCSV in the list of supported cipher suites of the
ClientHello as decribed in RFC7507. However, Section 4 says that the
client SHOULD place the TLS_FALLBACK_SCSV at the end of the list of
cipher suites, a condition that was not checked. This patch introduces
the additional check.

**NOTES:**
* The PR needs to be backported to mbed TLS versions 1.3 and 2.1.
* This change addresses https://github.com/ARMmbed/mbedtls/issues/810
* The PR does not include automated tests because to enforce the path through the code we need to craft a special ClientHello that does not have the TLS_FALLBACK_SCSV at the end of the cipher suites list. However, the change was tested manually.