### PR TITLE
Backport 2.1: Correctly handle leap year in x509_date_is_valid()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,9 @@ Bugfix
      generated in Visual Studio 2015. Reported by Steve Valliere. #742
    * Fix a resource leak in ssl_cookie, when using MBEDTLS_THREADING_C.
      Raised and fix suggested by Alan Gillingham in the mbed TLS forum. #771
+   * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
+     dates on leap years with 100 and 400 intervals are handled correctly. Found
+     by Nicholas Wilson. #694
 
 = mbed TLS 2.1.6 branch released 2016-10-17
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -488,6 +488,7 @@ static int x509_parse_int(unsigned char **p, unsigned n, int *res){
 static int x509_date_is_valid(const mbedtls_x509_time *time)
 {
     int ret = MBEDTLS_ERR_X509_INVALID_DATE;
+    int month_len;
 
     CHECK_RANGE( 0, 9999, time->year );
     CHECK_RANGE( 0, 23,   time->hour );
@@ -497,17 +498,22 @@ static int x509_date_is_valid(const mbedtls_x509_time *time)
     switch( time->mon )
     {
         case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-            CHECK_RANGE( 1, 31, time->day );
+            month_len = 31;
             break;
         case 4: case 6: case 9: case 11:
-            CHECK_RANGE( 1, 30, time->day );
+            month_len = 30;
             break;
         case 2:
-            CHECK_RANGE( 1, 28 + (time->year % 4 == 0), time->day );
+            if( ( !( time->year % 4 ) && time->year % 100 ) ||
+                !( time->year % 400 ) )
+                month_len = 29;
+            else
+                month_len = 28;
             break;
         default:
             return( ret );
     }
+    CHECK_RANGE( 1, month_len, time->day );
 
     return( 0 );
 }

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1512,3 +1512,19 @@ x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001130236012Z":MBEDTLS_ERR_X509_INVALID_DAT
 X509 Get time (UTC invalid sec)
 depends_on:MBEDTLS_X509_USE_C
 x509_get_time:MBEDTLS_ASN1_UTC_TIME:"001130235960Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (Generalized Time invalid leap year multiple of 4 and 100)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_GENERALIZED_TIME:"19000229000000Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (Generalized Time year multiple of 4 and not multiple of 100)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_GENERALIZED_TIME:"19920229000000Z":0:1992:2:29:0:0:0
+
+X509 Get time (Generalized Time year multiple of 400)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_GENERALIZED_TIME:"20000229000000Z":0:2000:2:29:0:0:0
+
+X509 Get time (Generalized Time invalid leap year not multiple of 4, 100 or 400)
+depends_on:MBEDTLS_X509_USE_C
+x509_get_time:MBEDTLS_ASN1_GENERALIZED_TIME:"19910229000000Z":MBEDTLS_ERR_X509_INVALID_DATE:0:0:0:0:0:0


### PR DESCRIPTION
This patch ensures that invalid dates on leap years with 100 or 400
years intervals are handled correctly.

**NOTES:**
* This is a backport for PR https://github.com/ARMmbed/mbedtls/pull/702