### PR TITLE
Backport 1.3: Correctly handle leap year in x509_date_is_valid()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Bugfix
    * Fixed the templates used to generate project and solution files for Visual
      Studio 2015 as well as the files themselves, to remove a build warning
      generated in Visual Studio 2015. Reported by Steve Valliere. #742
+   * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
+     dates on leap years with 100 and 400 intervals are handled correctly. Found
+     by Nicholas Wilson. #694
 
 = mbed TLS 1.3.18 branch 2016-10-17
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -493,6 +493,7 @@ static int x509_parse_int(unsigned char **p, unsigned n, int *res){
 static int x509_date_is_valid(const x509_time *time)
 {
     int ret = POLARSSL_ERR_X509_INVALID_DATE;
+    int month_len;
 
     CHECK_RANGE( 0, 9999, time->year );
     CHECK_RANGE( 0, 23,   time->hour );
@@ -502,17 +503,22 @@ static int x509_date_is_valid(const x509_time *time)
     switch( time->mon )
     {
         case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-            CHECK_RANGE( 1, 31, time->day );
+            month_len = 31;
             break;
         case 4: case 6: case 9: case 11:
-            CHECK_RANGE( 1, 30, time->day );
+            month_len = 30;
             break;
         case 2:
-            CHECK_RANGE( 1, 28 + (time->year % 4 == 0), time->day );
+            if( ( !( time->year % 4 ) && time->year % 100 ) ||
+                !( time->year % 400 ) )
+                month_len = 29;
+            else
+                month_len = 28;
             break;
         default:
             return( ret );
     }
+    CHECK_RANGE( 1, month_len, time->day );
 
     return( 0 );
 }

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1499,3 +1499,19 @@ x509_get_time:ASN1_UTC_TIME:"001130236012Z":POLARSSL_ERR_X509_INVALID_DATE:0:0:0
 X509 Get time (UTC invalid sec)
 depends_on:POLARSSL_X509_USE_C
 x509_get_time:ASN1_UTC_TIME:"001130235960Z":POLARSSL_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (Generalized Time invalid leap year multiple of 4 and 100)
+depends_on:POLARSSL_X509_USE_C
+x509_get_time:ASN1_GENERALIZED_TIME:"19000229000000Z":POLARSSL_ERR_X509_INVALID_DATE:0:0:0:0:0:0
+
+X509 Get time (Generalized Time year multiple of 4 and not multiple of 100)
+depends_on:POLARSSL_X509_USE_C
+x509_get_time:ASN1_GENERALIZED_TIME:"19920229000000Z":0:1992:2:29:0:0:0
+
+X509 Get time (Generalized Time year multiple of 400)
+depends_on:POLARSSL_X509_USE_C
+x509_get_time:ASN1_GENERALIZED_TIME:"20000229000000Z":0:2000:2:29:0:0:0
+
+X509 Get time (Generalized Time invalid leap year not multiple of 4, 100 or 400)
+depends_on:POLARSSL_X509_USE_C
+x509_get_time:ASN1_GENERALIZED_TIME:"19910229000000Z":POLARSSL_ERR_X509_INVALID_DATE:0:0:0:0:0:0


### PR DESCRIPTION
This patch ensures that invalid dates on leap years with 100 or 400
years intervals are handled correctly.

**NOTES:**
* This is a backport for PR https://github.com/ARMmbed/mbedtls/pull/702