### PR TITLE
Fix check-doxy-blocks.pl errors (cmac.c ecjpake.h)

### DIFF
--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -116,7 +116,7 @@ int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
                            const unsigned char *secret,
                            size_t len );
 
-/*
+/**
  * \brief           Check if a context is ready for use
  *
  * \param ctx       Context to check

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -1,4 +1,4 @@
-/*
+/**
  * \file cmac.c
  *
  * \brief NIST SP800-38B compliant CMAC implementation for AES and 3DES


### PR DESCRIPTION
This PR fixes two errors generated by the script `./tests/scripts/check-doxy-blocks.pl` in the files `library/cmac.c` and `include/mbedtls/ecjpake.h`.

Notes:
* This change does not require tests.
* No backports to mbed TLS 1.3 and 2.1 are required.
