### PR TITLE
Add support for ASN.1 tags on multiple bytes

### DIFF
--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -55,6 +55,14 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
 /**
  * \brief           Write an ASN.1 tag in ASN.1 format.
  *
+ * \note            See \c mbedtls_asn1_write_long_tag for description
+ */
+int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
+                            unsigned char tag );
+
+/**
+ * \brief           Write an ASN.1 tag in ASN.1 format.
+ *
  * \note            This function works backwards in data buffer.
  *
  * \param p         The reference to the current position pointer.
@@ -64,8 +72,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
-                            unsigned char tag );
+int mbedtls_asn1_write_long_tag( unsigned char **p, unsigned char *start,
+                            int tag );
 
 /**
  * \brief           Write raw buffer data.

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -109,13 +109,24 @@ int mbedtls_asn1_get_tag( unsigned char **p,
                   const unsigned char *end,
                   size_t *len, int tag )
 {
-    if( ( end - *p ) < 1 )
-        return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+    unsigned char tag_byte;
+    size_t i = sizeof( int );
 
-    if( **p != tag )
-        return( MBEDTLS_ERR_ASN1_UNEXPECTED_TAG );
+    while ( i > 0 ) {
+        i--;
+        tag_byte = ( tag >> ( i * 8 ) ) & 0xFF;
 
-    (*p)++;
+        if ( tag_byte == 0x00 && i != 0 )
+            continue;
+
+        if( ( end - *p ) < 1 )
+            return( MBEDTLS_ERR_ASN1_OUT_OF_DATA );
+
+        if( **p != tag_byte )
+            return( MBEDTLS_ERR_ASN1_UNEXPECTED_TAG );
+
+        (*p)++;
+    }
 
     return( mbedtls_asn1_get_len( p, end, len ) );
 }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -105,12 +105,23 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
 
 int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start, unsigned char tag )
 {
-    if( *p - start < 1 )
-        return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+    return mbedtls_asn1_write_long_tag( p, start, tag );
+}
 
-    *--(*p) = tag;
+int mbedtls_asn1_write_long_tag( unsigned char **p, unsigned char *start, int tag )
+{
+    size_t len = 0;
 
-    return( 1 );
+    while ( tag != 0 ) {
+        if( *p - start < 1 )
+            return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+
+        *--(*p) = tag & 0xFF;
+        tag >>= 8;
+        len++;
+    }
+
+    return( (int) len );
 }
 
 int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,


### PR DESCRIPTION
I am using the ASN.1 parser to read card verifiable certificates used in ICAO, for example. They use tags on more than one byte, like `0x7F4E` for the certificate body. This PR adds support for parsing and writing tags with more than one byte.

I am actively using the parser code. The writer code should work, but is untested so far. All internal tests are passing (`make test`).