### PR TITLE
tests Makefile optimizations

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -152,27 +152,25 @@ func.test_suite_version.c := test_suite_version
 
 .PHONY: all check test clean
 
+BINARIES := $(addsuffix $(EXEXT),$(APPS))
+
+all: $(BINARIES)
+
 $(DEP):
 	$(MAKE) -C ../library
 
 # invoke perl explicitly for the sake of mingw32-make
 
-C_FILES := $(addsuffix .c,$(APPS))
-
 .SECONDEXPANSION:
-$(C_FILES): %.c: suites/$$(func.$$*.c).function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+%.c: suites/$$(func.$$*.c).function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
 	perl scripts/generate_code.pl suites $(func.$@) $*
 
 
-BINARIES := $(addsuffix $(EXEXT),$(APPS))
-
-$(BINARIES): %$(EXEXT): %.c $(DEP)
+%$(EXEXT): %.c $(DEP)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-
-all: $(BINARIES)
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,24 +45,24 @@ ifdef ZLIB
 LOCAL_LDFLAGS += -lz
 endif
 
-APPS =	test_suite_aes.ecb	test_suite_aes.cbc	\
-	test_suite_aes.cfb	test_suite_aes.rest	\
-	test_suite_arc4		test_suite_asn1write	\
-	test_suite_base64	test_suite_blowfish	\
-	test_suite_camellia	test_suite_ccm		\
+APPS =	test_suite_aes.ecb	test_suite_aes.cbc		\
+	test_suite_aes.cfb	test_suite_aes.rest		\
+	test_suite_arc4		test_suite_asn1write		\
+	test_suite_base64	test_suite_blowfish		\
+	test_suite_camellia	test_suite_ccm			\
 	test_suite_cmac						\
 	test_suite_cipher.aes					\
-	test_suite_cipher.arc4	test_suite_cipher.ccm	\
+	test_suite_cipher.arc4	test_suite_cipher.ccm		\
 	test_suite_cipher.gcm					\
 	test_suite_cipher.blowfish				\
 	test_suite_cipher.camellia				\
-	test_suite_cipher.des	test_suite_cipher.null	\
+	test_suite_cipher.des	test_suite_cipher.null		\
 	test_suite_cipher.padding				\
-	test_suite_ctr_drbg	test_suite_debug	\
-	test_suite_des		test_suite_dhm		\
-	test_suite_ecdh		test_suite_ecdsa	\
-	test_suite_ecjpake	test_suite_ecp		\
-	test_suite_error	test_suite_entropy	\
+	test_suite_ctr_drbg	test_suite_debug		\
+	test_suite_des		test_suite_dhm			\
+	test_suite_ecdh		test_suite_ecdsa		\
+	test_suite_ecjpake	test_suite_ecp			\
+	test_suite_error	test_suite_entropy		\
 	test_suite_gcm.aes128_de				\
 	test_suite_gcm.aes192_de				\
 	test_suite_gcm.aes256_de				\
@@ -74,16 +74,16 @@ APPS =	test_suite_aes.ecb	test_suite_aes.cbc	\
 	test_suite_hmac_drbg.no_reseed				\
 	test_suite_hmac_drbg.nopr				\
 	test_suite_hmac_drbg.pr					\
-	test_suite_md		test_suite_mdx		\
+	test_suite_md		test_suite_mdx			\
 	test_suite_memory_buffer_alloc				\
 	test_suite_mpi						\
 	test_suite_pem			test_suite_pkcs1_v15	\
-	test_suite_pkcs1_v21	test_suite_pkcs5	\
-	test_suite_pkparse	test_suite_pkwrite	\
+	test_suite_pkcs1_v21	test_suite_pkcs5		\
+	test_suite_pkparse	test_suite_pkwrite		\
 	test_suite_pk						\
-	test_suite_rsa		test_suite_shax		\
-	test_suite_ssl		test_suite_timing			\
-	test_suite_x509parse	test_suite_x509write	\
+	test_suite_rsa		test_suite_shax			\
+	test_suite_ssl		test_suite_timing		\
+	test_suite_x509parse	test_suite_x509write		\
 	test_suite_xtea		test_suite_version
 
 # Look up for associated function files

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -86,6 +86,68 @@ APPS =	test_suite_aes.ecb	test_suite_aes.cbc	\
 	test_suite_x509parse	test_suite_x509write	\
 	test_suite_xtea		test_suite_version
 
+# Look up for associated function files
+func.test_suite_aes.ecb.c := test_suite_aes
+func.test_suite_aes.cbc.c := test_suite_aes
+func.test_suite_aes.cfb.c := test_suite_aes
+func.test_suite_aes.rest.c := test_suite_aes
+func.test_suite_arc4.c := test_suite_arc4
+func.test_suite_asn1write.c := test_suite_asn1write
+func.test_suite_base64.c := test_suite_base64
+func.test_suite_blowfish.c := test_suite_blowfish
+func.test_suite_camellia.c := test_suite_camellia
+func.test_suite_ccm.c := test_suite_ccm
+func.test_suite_cmac.c := test_suite_cmac
+func.test_suite_cipher.aes.c := test_suite_cipher
+func.test_suite_cipher.arc4.c := test_suite_cipher
+func.test_suite_cipher.ccm.c := test_suite_cipher
+func.test_suite_cipher.gcm.c := test_suite_cipher
+func.test_suite_cipher.blowfish.c := test_suite_cipher
+func.test_suite_cipher.camellia.c := test_suite_cipher
+func.test_suite_cipher.des.c := test_suite_cipher
+func.test_suite_cipher.null.c := test_suite_cipher
+func.test_suite_cipher.padding.c := test_suite_cipher
+func.test_suite_ctr_drbg.c := test_suite_ctr_drbg
+func.test_suite_debug.c := test_suite_debug
+func.test_suite_des.c := test_suite_des
+func.test_suite_dhm.c := test_suite_dhm
+func.test_suite_ecdh.c := test_suite_ecdh
+func.test_suite_ecdsa.c := test_suite_ecdsa
+func.test_suite_ecjpake.c := test_suite_ecjpake
+func.test_suite_ecp.c := test_suite_ecp
+func.test_suite_error.c := test_suite_error
+func.test_suite_entropy.c := test_suite_entropy
+func.test_suite_gcm.aes128_de.c := test_suite_gcm
+func.test_suite_gcm.aes192_de.c := test_suite_gcm
+func.test_suite_gcm.aes256_de.c := test_suite_gcm
+func.test_suite_gcm.aes128_en.c := test_suite_gcm
+func.test_suite_gcm.aes192_en.c := test_suite_gcm
+func.test_suite_gcm.aes256_en.c := test_suite_gcm
+func.test_suite_gcm.camellia.c := test_suite_gcm
+func.test_suite_hmac_drbg.misc.c := test_suite_hmac_drbg
+func.test_suite_hmac_drbg.no_reseed.c := test_suite_hmac_drbg
+func.test_suite_hmac_drbg.nopr.c := test_suite_hmac_drbg
+func.test_suite_hmac_drbg.pr.c := test_suite_hmac_drbg
+func.test_suite_md.c := test_suite_md
+func.test_suite_mdx.c := test_suite_mdx
+func.test_suite_memory_buffer_alloc.c := test_suite_memory_buffer_alloc
+func.test_suite_mpi.c := test_suite_mpi
+func.test_suite_pem.c := test_suite_pem
+func.test_suite_pkcs1_v15.c := test_suite_pkcs1_v15
+func.test_suite_pkcs1_v21.c := test_suite_pkcs1_v21
+func.test_suite_pkcs5.c := test_suite_pkcs5
+func.test_suite_pkparse.c := test_suite_pkparse
+func.test_suite_pkwrite.c := test_suite_pkwrite
+func.test_suite_pk.c := test_suite_pk
+func.test_suite_rsa.c := test_suite_rsa
+func.test_suite_shax.c := test_suite_shax
+func.test_suite_ssl.c := test_suite_ssl
+func.test_suite_timing.c := test_suite_timing
+func.test_suite_x509parse.c := test_suite_x509parse
+func.test_suite_x509write.c := test_suite_x509write
+func.test_suite_xtea.c := test_suite_xtea
+func.test_suite_version.c := test_suite_version
+
 .SILENT:
 
 .PHONY: all check test clean
@@ -97,9 +159,10 @@ $(DEP):
 
 C_FILES := $(addsuffix .c,$(APPS))
 
-$(C_FILES): %.c: 
+.SECONDEXPANSION:
+$(C_FILES): %.c: suites/$$(func.$$*.c).function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites $(shell perl -e "(my $$out=\"$@\")=~s/\..*//;print $$out") $*
+	perl scripts/generate_code.pl suites $(func.$@) $*
 
 
 BINARIES := $(addsuffix $(EXEXT),$(APPS))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,397 +45,75 @@ ifdef ZLIB
 LOCAL_LDFLAGS += -lz
 endif
 
-APPS =	test_suite_aes.ecb$(EXEXT)	test_suite_aes.cbc$(EXEXT)	\
-	test_suite_aes.cfb$(EXEXT)	test_suite_aes.rest$(EXEXT)	\
-	test_suite_arc4$(EXEXT)		test_suite_asn1write$(EXEXT)	\
-	test_suite_base64$(EXEXT)	test_suite_blowfish$(EXEXT)	\
-	test_suite_camellia$(EXEXT)	test_suite_ccm$(EXEXT)		\
-	test_suite_cmac$(EXEXT)						\
-	test_suite_cipher.aes$(EXEXT)					\
-	test_suite_cipher.arc4$(EXEXT)	test_suite_cipher.ccm$(EXEXT)	\
-	test_suite_cipher.gcm$(EXEXT)					\
-	test_suite_cipher.blowfish$(EXEXT)				\
-	test_suite_cipher.camellia$(EXEXT)				\
-	test_suite_cipher.des$(EXEXT)	test_suite_cipher.null$(EXEXT)	\
-	test_suite_cipher.padding$(EXEXT)				\
-	test_suite_ctr_drbg$(EXEXT)	test_suite_debug$(EXEXT)	\
-	test_suite_des$(EXEXT)		test_suite_dhm$(EXEXT)		\
-	test_suite_ecdh$(EXEXT)		test_suite_ecdsa$(EXEXT)	\
-	test_suite_ecjpake$(EXEXT)	test_suite_ecp$(EXEXT)		\
-	test_suite_error$(EXEXT)	test_suite_entropy$(EXEXT)	\
-	test_suite_gcm.aes128_de$(EXEXT)				\
-	test_suite_gcm.aes192_de$(EXEXT)				\
-	test_suite_gcm.aes256_de$(EXEXT)				\
-	test_suite_gcm.aes128_en$(EXEXT)				\
-	test_suite_gcm.aes192_en$(EXEXT)				\
-	test_suite_gcm.aes256_en$(EXEXT)				\
-	test_suite_gcm.camellia$(EXEXT)					\
-	test_suite_hmac_drbg.misc$(EXEXT)				\
-	test_suite_hmac_drbg.no_reseed$(EXEXT)				\
-	test_suite_hmac_drbg.nopr$(EXEXT)				\
-	test_suite_hmac_drbg.pr$(EXEXT)					\
-	test_suite_md$(EXEXT)		test_suite_mdx$(EXEXT)		\
-	test_suite_memory_buffer_alloc$(EXEXT)				\
-	test_suite_mpi$(EXEXT)						\
-	test_suite_pem$(EXEXT)			test_suite_pkcs1_v15$(EXEXT)	\
-	test_suite_pkcs1_v21$(EXEXT)	test_suite_pkcs5$(EXEXT)	\
-	test_suite_pkparse$(EXEXT)	test_suite_pkwrite$(EXEXT)	\
-	test_suite_pk$(EXEXT)						\
-	test_suite_rsa$(EXEXT)		test_suite_shax$(EXEXT)		\
-	test_suite_ssl$(EXEXT)		test_suite_timing$(EXEXT)			\
-	test_suite_x509parse$(EXEXT)	test_suite_x509write$(EXEXT)	\
-	test_suite_xtea$(EXEXT)		test_suite_version$(EXEXT)
+APPS =	test_suite_aes.ecb	test_suite_aes.cbc	\
+	test_suite_aes.cfb	test_suite_aes.rest	\
+	test_suite_arc4		test_suite_asn1write	\
+	test_suite_base64	test_suite_blowfish	\
+	test_suite_camellia	test_suite_ccm		\
+	test_suite_cmac						\
+	test_suite_cipher.aes					\
+	test_suite_cipher.arc4	test_suite_cipher.ccm	\
+	test_suite_cipher.gcm					\
+	test_suite_cipher.blowfish				\
+	test_suite_cipher.camellia				\
+	test_suite_cipher.des	test_suite_cipher.null	\
+	test_suite_cipher.padding				\
+	test_suite_ctr_drbg	test_suite_debug	\
+	test_suite_des		test_suite_dhm		\
+	test_suite_ecdh		test_suite_ecdsa	\
+	test_suite_ecjpake	test_suite_ecp		\
+	test_suite_error	test_suite_entropy	\
+	test_suite_gcm.aes128_de				\
+	test_suite_gcm.aes192_de				\
+	test_suite_gcm.aes256_de				\
+	test_suite_gcm.aes128_en				\
+	test_suite_gcm.aes192_en				\
+	test_suite_gcm.aes256_en				\
+	test_suite_gcm.camellia					\
+	test_suite_hmac_drbg.misc				\
+	test_suite_hmac_drbg.no_reseed				\
+	test_suite_hmac_drbg.nopr				\
+	test_suite_hmac_drbg.pr					\
+	test_suite_md		test_suite_mdx		\
+	test_suite_memory_buffer_alloc				\
+	test_suite_mpi						\
+	test_suite_pem			test_suite_pkcs1_v15	\
+	test_suite_pkcs1_v21	test_suite_pkcs5	\
+	test_suite_pkparse	test_suite_pkwrite	\
+	test_suite_pk						\
+	test_suite_rsa		test_suite_shax		\
+	test_suite_ssl		test_suite_timing			\
+	test_suite_x509parse	test_suite_x509write	\
+	test_suite_xtea		test_suite_version
 
 .SILENT:
 
 .PHONY: all check test clean
-
-all: $(APPS)
 
 $(DEP):
 	$(MAKE) -C ../library
 
 # invoke perl explicitly for the sake of mingw32-make
 
-test_suite_aes.ecb.c : suites/test_suite_aes.function suites/test_suite_aes.ecb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.ecb
+C_FILES := $(addsuffix .c,$(APPS))
 
-test_suite_aes.cbc.c : suites/test_suite_aes.function suites/test_suite_aes.cbc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.cbc
+$(C_FILES): %.c: 
+	@suite=`echo $*|cut -d. -f1`; \
+	if [ -z $$suite ]; then \
+		suite=$*; \
+	fi; \
+	echo "  Gen   $@"; \
+	perl scripts/generate_code.pl suites $$suite $*
 
-test_suite_aes.cfb.c : suites/test_suite_aes.function suites/test_suite_aes.cfb.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.cfb
 
-test_suite_aes.rest.c : suites/test_suite_aes.function suites/test_suite_aes.rest.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_aes test_suite_aes.rest
+BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
-test_suite_cipher.aes.c : suites/test_suite_cipher.function suites/test_suite_cipher.aes.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.aes
-
-test_suite_cipher.arc4.c : suites/test_suite_cipher.function suites/test_suite_cipher.arc4.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.arc4
-
-test_suite_cipher.ccm.c : suites/test_suite_cipher.function suites/test_suite_cipher.ccm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.ccm
-
-test_suite_cipher.gcm.c : suites/test_suite_cipher.function suites/test_suite_cipher.gcm.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.gcm
-
-test_suite_cipher.blowfish.c : suites/test_suite_cipher.function suites/test_suite_cipher.blowfish.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.blowfish
-
-test_suite_cipher.camellia.c : suites/test_suite_cipher.function suites/test_suite_cipher.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.camellia
-
-test_suite_cipher.des.c : suites/test_suite_cipher.function suites/test_suite_cipher.des.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.des
-
-test_suite_cipher.null.c : suites/test_suite_cipher.function suites/test_suite_cipher.null.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.null
-
-test_suite_cipher.padding.c : suites/test_suite_cipher.function suites/test_suite_cipher.padding.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_cipher test_suite_cipher.padding
-
-test_suite_gcm.aes128_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes128_de
-
-test_suite_gcm.aes192_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes192_de
-
-test_suite_gcm.aes256_de.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_de.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes256_de
-
-test_suite_gcm.aes128_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes128_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes128_en
-
-test_suite_gcm.aes192_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes192_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes192_en
-
-test_suite_gcm.aes256_en.c : suites/test_suite_gcm.function suites/test_suite_gcm.aes256_en.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.aes256_en
-
-test_suite_gcm.camellia.c : suites/test_suite_gcm.function suites/test_suite_gcm.camellia.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_gcm test_suite_gcm.camellia
-
-test_suite_hmac_drbg.misc.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.misc.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.misc
-
-test_suite_hmac_drbg.no_reseed.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.no_reseed.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.no_reseed
-
-test_suite_hmac_drbg.nopr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.nopr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.nopr
-
-test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_suite_hmac_drbg.pr.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites test_suite_hmac_drbg test_suite_hmac_drbg.pr
-
-%.c : suites/%.function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
-	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites $* $*
-
-test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
+$(BINARIES): %$(EXEXT): %.c $(DEP)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test_suite_aes.cbc$(EXEXT): test_suite_aes.cbc.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-test_suite_aes.cfb$(EXEXT): test_suite_aes.cfb.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_aes.rest$(EXEXT): test_suite_aes.rest.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_arc4$(EXEXT): test_suite_arc4.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_asn1write$(EXEXT): test_suite_asn1write.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_base64$(EXEXT): test_suite_base64.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_blowfish$(EXEXT): test_suite_blowfish.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_camellia$(EXEXT): test_suite_camellia.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ccm$(EXEXT): test_suite_ccm.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cmac$(EXEXT): test_suite_cmac.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.aes$(EXEXT): test_suite_cipher.aes.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.arc4$(EXEXT): test_suite_cipher.arc4.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.ccm$(EXEXT): test_suite_cipher.ccm.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.gcm$(EXEXT): test_suite_cipher.gcm.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.blowfish$(EXEXT): test_suite_cipher.blowfish.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.camellia$(EXEXT): test_suite_cipher.camellia.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.des$(EXEXT): test_suite_cipher.des.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.null$(EXEXT): test_suite_cipher.null.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_cipher.padding$(EXEXT): test_suite_cipher.padding.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ctr_drbg$(EXEXT): test_suite_ctr_drbg.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_des$(EXEXT): test_suite_des.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_dhm$(EXEXT): test_suite_dhm.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ecdh$(EXEXT): test_suite_ecdh.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ecdsa$(EXEXT): test_suite_ecdsa.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ecjpake$(EXEXT): test_suite_ecjpake.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ecp$(EXEXT): test_suite_ecp.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_entropy$(EXEXT): test_suite_entropy.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_error$(EXEXT): test_suite_error.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes128_de$(EXEXT): test_suite_gcm.aes128_de.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes192_de$(EXEXT): test_suite_gcm.aes192_de.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes256_de$(EXEXT): test_suite_gcm.aes256_de.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes128_en$(EXEXT): test_suite_gcm.aes128_en.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes192_en$(EXEXT): test_suite_gcm.aes192_en.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.aes256_en$(EXEXT): test_suite_gcm.aes256_en.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_gcm.camellia$(EXEXT): test_suite_gcm.camellia.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_hmac_drbg.misc$(EXEXT): test_suite_hmac_drbg.misc.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_hmac_drbg.no_reseed$(EXEXT): test_suite_hmac_drbg.no_reseed.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_hmac_drbg.nopr$(EXEXT): test_suite_hmac_drbg.nopr.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_hmac_drbg.pr$(EXEXT): test_suite_hmac_drbg.pr.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_md$(EXEXT): test_suite_md.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_mdx$(EXEXT): test_suite_mdx.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_memory_buffer_alloc$(EXEXT): test_suite_memory_buffer_alloc.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_mpi$(EXEXT): test_suite_mpi.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pem$(EXEXT): test_suite_pem.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pkcs1_v15$(EXEXT): test_suite_pkcs1_v15.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pkcs1_v21$(EXEXT): test_suite_pkcs1_v21.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pkcs5$(EXEXT): test_suite_pkcs5.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pkparse$(EXEXT): test_suite_pkparse.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pkwrite$(EXEXT): test_suite_pkwrite.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_pk$(EXEXT): test_suite_pk.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_rsa$(EXEXT): test_suite_rsa.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_shax$(EXEXT): test_suite_shax.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_ssl$(EXEXT): test_suite_ssl.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_timing$(EXEXT): test_suite_timing.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_x509parse$(EXEXT): test_suite_x509parse.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_x509write$(EXEXT): test_suite_x509write.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_xtea$(EXEXT): test_suite_xtea.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_debug$(EXEXT): test_suite_debug.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
-
-test_suite_version$(EXEXT): test_suite_version.c $(DEP)
-	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+all: $(BINARIES)
 
 clean:
 ifndef WINDOWS
@@ -444,7 +122,7 @@ else
 	del /Q /F *.c *.exe
 endif
 
-check: $(APPS)
+check: $(BINARIES)
 	perl scripts/run-test-suites.pl
 
 test: check

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,113 +45,16 @@ ifdef ZLIB
 LOCAL_LDFLAGS += -lz
 endif
 
-APPS =	test_suite_aes.ecb	test_suite_aes.cbc		\
-	test_suite_aes.cfb	test_suite_aes.rest		\
-	test_suite_arc4		test_suite_asn1write		\
-	test_suite_base64	test_suite_blowfish		\
-	test_suite_camellia	test_suite_ccm			\
-	test_suite_cmac						\
-	test_suite_cipher.aes					\
-	test_suite_cipher.arc4	test_suite_cipher.ccm		\
-	test_suite_cipher.gcm					\
-	test_suite_cipher.blowfish				\
-	test_suite_cipher.camellia				\
-	test_suite_cipher.des	test_suite_cipher.null		\
-	test_suite_cipher.padding				\
-	test_suite_ctr_drbg	test_suite_debug		\
-	test_suite_des		test_suite_dhm			\
-	test_suite_ecdh		test_suite_ecdsa		\
-	test_suite_ecjpake	test_suite_ecp			\
-	test_suite_error	test_suite_entropy		\
-	test_suite_gcm.aes128_de				\
-	test_suite_gcm.aes192_de				\
-	test_suite_gcm.aes256_de				\
-	test_suite_gcm.aes128_en				\
-	test_suite_gcm.aes192_en				\
-	test_suite_gcm.aes256_en				\
-	test_suite_gcm.camellia					\
-	test_suite_hmac_drbg.misc				\
-	test_suite_hmac_drbg.no_reseed				\
-	test_suite_hmac_drbg.nopr				\
-	test_suite_hmac_drbg.pr					\
-	test_suite_md		test_suite_mdx			\
-	test_suite_memory_buffer_alloc				\
-	test_suite_mpi						\
-	test_suite_pem			test_suite_pkcs1_v15	\
-	test_suite_pkcs1_v21	test_suite_pkcs5		\
-	test_suite_pkparse	test_suite_pkwrite		\
-	test_suite_pk						\
-	test_suite_rsa		test_suite_shax			\
-	test_suite_ssl		test_suite_timing		\
-	test_suite_x509parse	test_suite_x509write		\
-	test_suite_xtea		test_suite_version
-
-# Look up for associated function files
-func.test_suite_aes.ecb.c := test_suite_aes
-func.test_suite_aes.cbc.c := test_suite_aes
-func.test_suite_aes.cfb.c := test_suite_aes
-func.test_suite_aes.rest.c := test_suite_aes
-func.test_suite_arc4.c := test_suite_arc4
-func.test_suite_asn1write.c := test_suite_asn1write
-func.test_suite_base64.c := test_suite_base64
-func.test_suite_blowfish.c := test_suite_blowfish
-func.test_suite_camellia.c := test_suite_camellia
-func.test_suite_ccm.c := test_suite_ccm
-func.test_suite_cmac.c := test_suite_cmac
-func.test_suite_cipher.aes.c := test_suite_cipher
-func.test_suite_cipher.arc4.c := test_suite_cipher
-func.test_suite_cipher.ccm.c := test_suite_cipher
-func.test_suite_cipher.gcm.c := test_suite_cipher
-func.test_suite_cipher.blowfish.c := test_suite_cipher
-func.test_suite_cipher.camellia.c := test_suite_cipher
-func.test_suite_cipher.des.c := test_suite_cipher
-func.test_suite_cipher.null.c := test_suite_cipher
-func.test_suite_cipher.padding.c := test_suite_cipher
-func.test_suite_ctr_drbg.c := test_suite_ctr_drbg
-func.test_suite_debug.c := test_suite_debug
-func.test_suite_des.c := test_suite_des
-func.test_suite_dhm.c := test_suite_dhm
-func.test_suite_ecdh.c := test_suite_ecdh
-func.test_suite_ecdsa.c := test_suite_ecdsa
-func.test_suite_ecjpake.c := test_suite_ecjpake
-func.test_suite_ecp.c := test_suite_ecp
-func.test_suite_error.c := test_suite_error
-func.test_suite_entropy.c := test_suite_entropy
-func.test_suite_gcm.aes128_de.c := test_suite_gcm
-func.test_suite_gcm.aes192_de.c := test_suite_gcm
-func.test_suite_gcm.aes256_de.c := test_suite_gcm
-func.test_suite_gcm.aes128_en.c := test_suite_gcm
-func.test_suite_gcm.aes192_en.c := test_suite_gcm
-func.test_suite_gcm.aes256_en.c := test_suite_gcm
-func.test_suite_gcm.camellia.c := test_suite_gcm
-func.test_suite_hmac_drbg.misc.c := test_suite_hmac_drbg
-func.test_suite_hmac_drbg.no_reseed.c := test_suite_hmac_drbg
-func.test_suite_hmac_drbg.nopr.c := test_suite_hmac_drbg
-func.test_suite_hmac_drbg.pr.c := test_suite_hmac_drbg
-func.test_suite_md.c := test_suite_md
-func.test_suite_mdx.c := test_suite_mdx
-func.test_suite_memory_buffer_alloc.c := test_suite_memory_buffer_alloc
-func.test_suite_mpi.c := test_suite_mpi
-func.test_suite_pem.c := test_suite_pem
-func.test_suite_pkcs1_v15.c := test_suite_pkcs1_v15
-func.test_suite_pkcs1_v21.c := test_suite_pkcs1_v21
-func.test_suite_pkcs5.c := test_suite_pkcs5
-func.test_suite_pkparse.c := test_suite_pkparse
-func.test_suite_pkwrite.c := test_suite_pkwrite
-func.test_suite_pk.c := test_suite_pk
-func.test_suite_rsa.c := test_suite_rsa
-func.test_suite_shax.c := test_suite_shax
-func.test_suite_ssl.c := test_suite_ssl
-func.test_suite_timing.c := test_suite_timing
-func.test_suite_x509parse.c := test_suite_x509parse
-func.test_suite_x509write.c := test_suite_x509write
-func.test_suite_xtea.c := test_suite_xtea
-func.test_suite_version.c := test_suite_version
+# A test application is built for each suites/test_suite_*.data file.
+# Application name is same as .data file's base name and can be
+# constructed by stripping path 'suites/' and extension .data.
+APPS = $(basename $(subst suites/,,$(wildcard suites/test_suite_*.data)))
 
 .SILENT:
 
 .PHONY: all check test clean
 
+# Construct executable name by adding OS specific suffix $(EXEXT).
 BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
 all: $(BINARIES)
@@ -159,12 +62,25 @@ all: $(BINARIES)
 $(DEP):
 	$(MAKE) -C ../library
 
-# invoke perl explicitly for the sake of mingw32-make
-
+# Wildcard target for test code generation:
+# A .c file is generated for each .data file in the suites/ directory. Each .c
+# file depends on a .data and .function file from suites/ directory. Following
+# nameing convention is followed:
+#
+#     C file        |        Depends on
+#-----------------------------------------------------------------------------
+#  foo.c            | suites/foo.function suites/foo.data
+#  foo.bar.c        | suites/foo.function suites/foo.bar.data
+#
+# Note above that .c and .data files have same base name.
+# However, corresponding .function file's base name is the word before first
+# dot in .c file's base name.
+#
+# Perl: invoke perl explicitly for the sake of mingw32-make
 .SECONDEXPANSION:
-%.c: suites/$$(func.$$*.c).function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
+%.c: suites/$$(firstword $$(subst ., ,$$*)).function suites/%.data scripts/generate_code.pl suites/helpers.function suites/main_test.function
 	echo "  Gen   $@"
-	perl scripts/generate_code.pl suites $(func.$@) $*
+	perl scripts/generate_code.pl suites $(firstword $(subst ., ,$*)) $*
 
 
 %$(EXEXT): %.c $(DEP)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -98,9 +98,8 @@ $(DEP):
 C_FILES := $(addsuffix .c,$(APPS))
 
 $(C_FILES): %.c: 
-	@suite=`echo $*|cut -d. -f1`; \
-	echo "  Gen   $@"; \
-	perl scripts/generate_code.pl suites $$suite $*
+	echo "  Gen   $@"
+	perl scripts/generate_code.pl suites $(shell perl -e "(my $$out=\"$@\")=~s/\..*//;print $$out") $*
 
 
 BINARIES := $(addsuffix $(EXEXT),$(APPS))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -99,9 +99,6 @@ C_FILES := $(addsuffix .c,$(APPS))
 
 $(C_FILES): %.c: 
 	@suite=`echo $*|cut -d. -f1`; \
-	if [ -z $$suite ]; then \
-		suite=$*; \
-	fi; \
 	echo "  Gen   $@"; \
 	perl scripts/generate_code.pl suites $$suite $*
 


### PR DESCRIPTION
This PR tidies up the tests Makefile. It replaces individual targets with group targets. 
It will help in adding on target test related changes.

@andresag01 @yanesca @sbutcher-arm please review.