### PR TITLE
Correct memory leak in `mbedtls_ssl_set_hostname`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ Security
      team. #569 CVE-2017-2784
 
 Bugfix
+   * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.
+     Found by jethrogb, #836.
    * Fix output certificate verification flags set by x509_crt_verify_top() when
      traversing a chain of trusted CA. The issue would cause both flags,
      MBEDTLS_X509_BADCERT_NOT_TRUSTED and MBEDTLS_X509_BADCERT_EXPIRED, to be

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1794,13 +1794,12 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
  * \note           Maximum hostname length MBEDTLS_SSL_MAX_HOST_NAME_LEN.
  *
  * \return         0 if successful, MBEDTLS_ERR_SSL_ALLOC_FAILED on 
- *                 allocation failure, MBEDTLS_ERR_BAD_INPUT_DATA on 
+ *                 allocation failure, MBEDTLS_ERR_SSL_BAD_INPUT_DATA on 
  *                 too long input hostname.
  *
- * \post           Hostname set to the one provided on success (cleared
+ *                 Hostname set to the one provided on success (cleared
  *                 when NULL). On allocation failure hostname is cleared. 
  *                 On too long input failure, old hostname is unchanged.
- *
  */
 int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1784,15 +1784,23 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**
- * \brief          Set the hostname to check against the received server
- *                 certificate. It sets the ServerName TLS extension too,
- *                 if the extension is enabled.
- *                 (client-side only)
+ * \brief          Set or reset the hostname to check against the received 
+ *                 server certificate. It sets the ServerName TLS extension, 
+ *                 too, if that extension is enabled. (client-side only)
  *
  * \param ssl      SSL context
- * \param hostname the server hostname
+ * \param hostname the server hostname, may be NULL to clear hostname
+ 
+ * \note           Maximum hostname length MBEDTLS_SSL_MAX_HOST_NAME_LEN.
  *
- * \return         0 if successful or MBEDTLS_ERR_SSL_ALLOC_FAILED
+ * \return         0 if successful, MBEDTLS_ERR_SSL_ALLOC_FAILED on 
+ *                 allocation failure, MBEDTLS_ERR_BAD_INPUT_DATA on 
+ *                 too long input hostname.
+ *
+ * \post           Hostname set to the one provided on success (cleared
+ *                 when NULL). On allocation failure hostname is cleared. 
+ *                 On too long input failure, old hostname is unchanged.
+ *
  */
 int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -80,6 +80,13 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
     }
 
     /*
+     * Sect. 3, RFC 6066 (TLS Extensions Definitions)
+     *
+     * In order to provide any of the server names, clients MAY include an
+     * extension of type "server_name" in the (extended) client hello. The
+     * "extension_data" field of this extension SHALL contain
+     * "ServerNameList" where:
+     *
      * struct {
      *     NameType name_type;
      *     select (name_type) {
@@ -96,6 +103,7 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * struct {
      *     ServerName server_name_list<1..2^16-1>
      * } ServerNameList;
+     *
      */
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME >> 8 ) & 0xFF );
     *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME      ) & 0xFF );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6005,7 +6005,7 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
 
     return( 0 );
 }
-#endif
+#endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5946,7 +5946,7 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
 {
     conf->sig_hashes = hashes;
 }
-#endif
+#endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
 #if defined(MBEDTLS_ECP_C)
 /*
@@ -5957,32 +5957,51 @@ void mbedtls_ssl_conf_curves( mbedtls_ssl_config *conf,
 {
     conf->curve_list = curve_list;
 }
-#endif
+#endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
 {
-    size_t hostname_len;
+    /* Initialize to suppress unnecessary compiler warning */
+    size_t hostname_len = 0;
+
+    /* Check if new hostname is valid before
+     * making any change to current one */
+
+    if( hostname != NULL )
+    {
+        hostname_len = strlen( hostname );
+
+        if( hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN )
+            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+    }
+
+    /* Now it's clear that we will overwrite the old hostname,
+     * so we can free it safely */
+
+    if( ssl->hostname != NULL )
+    {
+        mbedtls_zeroize( ssl->hostname, strlen( ssl->hostname ) );
+        mbedtls_free( ssl->hostname );
+    }
+
+    /* Passing NULL as hostname shall clear the old one */
 
     if( hostname == NULL )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+    {
+        ssl->hostname = NULL;
+    }
+    else
+    {
+        ssl->hostname = mbedtls_calloc( 1, hostname_len + 1 );
 
-    hostname_len = strlen( hostname );
+        if( ssl->hostname == NULL )
+            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-    if( hostname_len + 1 == 0 )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+        memcpy( ssl->hostname, hostname, hostname_len );
 
-    if( hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN )
-        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
-
-    ssl->hostname = mbedtls_calloc( 1, hostname_len + 1 );
-
-    if( ssl->hostname == NULL )
-        return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
-
-    memcpy( ssl->hostname, hostname, hostname_len );
-
-    ssl->hostname[hostname_len] = '\0';
+        ssl->hostname[hostname_len] = '\0';
+    }
 
     return( 0 );
 }

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -54,3 +54,6 @@ ssl_dtls_replay:"abcd12340000,abcd12340100":"abcd12340101":0
 
 SSL DTLS replay: big jump then just delayed
 ssl_dtls_replay:"abcd12340000,abcd12340100":"abcd123400ff":0
+
+SSL SET_HOSTNAME memory leak: call ssl_set_hostname twice
+ssl_set_hostname_twice:"server0":"server1"

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -40,3 +40,16 @@ void ssl_dtls_replay( char *prevs, char *new, int ret )
     mbedtls_ssl_config_free( &conf );
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C */
+void ssl_set_hostname_twice( char *hostname0, char *hostname1 )
+{
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_init( &ssl );
+
+    TEST_ASSERT( mbedtls_ssl_set_hostname( &ssl, hostname0 ) == 0 );
+    TEST_ASSERT( mbedtls_ssl_set_hostname( &ssl, hostname1 ) == 0 );
+
+    mbedtls_ssl_free( &ssl );
+}
+/* END_CASE */


### PR DESCRIPTION
__Context:__ This pull request addresses [issue 836](https://github.com/ARMmbed/mbedtls/issues/836) on a memory leak in `mbedtls_ssl_set_hostname`.

__Changes:__ `mbedtls_ssl_set_hostname` is now safe to be called multiple times, in which case the previously set hostname is zeroized and freed. Also, the function can be called with `NULL` parameter to clear a previously set hostname. The documentation is enhanced to include all failure conditions and to describe the state of the hostname in each case.

__Backport:__ Needs backport to mbedTLS 1.3 and mbedTLS 2.1.