### PR TITLE
Iotssl 1293 add ca suppress feature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.x.x branch released xxxx-xx-xx
+
+Feature
+   * Add a new configuration option to 'mbedtls_ssl_config' to enable
+     suppressing the CA list in Certificate Request messages. The default
+     behaviour has not changed, namely every configured CAs name is included.
+
 = mbed TLS 2.4.2 branch released 2017-03-08
 
 Security

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -185,6 +185,9 @@
 #define MBEDTLS_SSL_PRESET_DEFAULT              0
 #define MBEDTLS_SSL_PRESET_SUITEB               2
 
+#define MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED       1
+#define MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED      0
+
 /*
  * Default range for DTLS retransmission timer value, in milliseconds.
  * RFC 6347 4.2.4.1 says from 1 second to 60 seconds.
@@ -748,6 +751,10 @@ struct mbedtls_ssl_config
 #endif
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV) && defined(MBEDTLS_SSL_CLI_C)
     unsigned int fallback : 1;      /*!< is this a fallback?                */
+#endif
+#if defined(MBEDTLS_SSL_SRV_C)
+    unsigned int cert_req_ca_list : 1;  /*!< enable sending CA list in
+                                          Certificate Request messages?     */
 #endif
 };
 
@@ -2030,6 +2037,20 @@ void mbedtls_ssl_conf_extended_master_secret( mbedtls_ssl_config *conf, char ems
  */
 void mbedtls_ssl_conf_arc4_support( mbedtls_ssl_config *conf, char arc4 );
 #endif /* MBEDTLS_ARC4_C */
+
+#if defined(MBEDTLS_SSL_SRV_C)
+/**
+ * \brief          Whether to send a list of acceptable CAs in
+ *                 CertificateRequest messages.
+ *                 (Default: do send)
+ *
+ * \param conf     SSL configuration
+ * \param cert_req_ca_list   MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED or
+ *                          MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED
+ */
+void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
+                                          char cert_req_ca_list );
+#endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6050,6 +6050,14 @@ void mbedtls_ssl_conf_fallback( mbedtls_ssl_config *conf, char fallback )
 }
 #endif
 
+#if defined(MBEDTLS_SSL_SRV_C)
+void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
+                                          char cert_req_ca_list )
+{
+    conf->cert_req_ca_list = cert_req_ca_list;
+}
+#endif
+
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
 void mbedtls_ssl_conf_encrypt_then_mac( mbedtls_ssl_config *conf, char etm )
 {
@@ -7230,6 +7238,10 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
     conf->anti_replay = MBEDTLS_SSL_ANTI_REPLAY_ENABLED;
+#endif
+
+#if defined(MBEDTLS_SSL_SRV_C)
+    conf->cert_req_ca_list = MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1804,6 +1804,23 @@ run_test    "Authentication: client badcert, server required" \
             -c "! mbedtls_ssl_handshake returned" \
             -s "X509 - Certificate verification failed"
 
+run_test    "Authentication: client cert not trusted, server required" \
+            "$P_SRV debug_level=3 auth_mode=required" \
+            "$P_CLI debug_level=3 crt_file=data_files/server5-selfsigned.crt \
+             key_file=data_files/server5.key" \
+            1 \
+            -S "skip write certificate request" \
+            -C "skip parse certificate request" \
+            -c "got a certificate request" \
+            -C "skip write certificate" \
+            -C "skip write certificate verify" \
+            -S "skip parse certificate verify" \
+            -s "x509_verify_cert() returned" \
+            -s "! The certificate is not correctly signed by the trusted CA" \
+            -s "! mbedtls_ssl_handshake returned" \
+            -c "! mbedtls_ssl_handshake returned" \
+            -s "X509 - Certificate verification failed"
+
 run_test    "Authentication: client badcert, server optional" \
             "$P_SRV debug_level=3 auth_mode=optional" \
             "$P_CLI debug_level=3 crt_file=data_files/server5-badsign.crt \
@@ -1892,6 +1909,34 @@ run_test    "Authentication: client no cert, ssl3" \
             -S "! mbedtls_ssl_handshake returned" \
             -C "! mbedtls_ssl_handshake returned" \
             -S "X509 - Certificate verification failed"
+
+# Tests for CA list in CertificateRequest messages
+
+run_test    "Authentication: send CA list in CertificateRequest  (default)" \
+            "$P_SRV debug_level=3 auth_mode=required" \
+            "$P_CLI crt_file=data_files/server6.crt \
+             key_file=data_files/server6.key" \
+            0 \
+            -s "requested DN"
+
+run_test    "Authentication: do not send CA list in CertificateRequest" \
+            "$P_SRV debug_level=3 auth_mode=required cert_req_ca_list=0" \
+            "$P_CLI crt_file=data_files/server6.crt \
+             key_file=data_files/server6.key" \
+            0 \
+            -S "requested DN"
+
+run_test    "Authentication: send CA list in CertificateRequest, client self signed" \
+            "$P_SRV debug_level=3 auth_mode=required cert_req_ca_list=0" \
+            "$P_CLI debug_level=3 crt_file=data_files/server5-selfsigned.crt \
+             key_file=data_files/server5.key" \
+            1 \
+            -S "requested DN" \
+            -s "x509_verify_cert() returned" \
+            -s "! The certificate is not correctly signed by the trusted CA" \
+            -s "! mbedtls_ssl_handshake returned" \
+            -c "! mbedtls_ssl_handshake returned" \
+            -s "X509 - Certificate verification failed"
 
 # Tests for certificate selection based on SHA verson
 


### PR DESCRIPTION
    According to RFC5246 the server can indicate the known Certificate
    Authorities or can constrain the aurhorisation space by sending a
    certificate list. This part of the message is optional and if omitted,
    the client may send any certificate in the response.
    
    The previous behaviour of mbed TLS was to always send the name of all the
    CAs that are configured as root CAs. In certain cases this might cause
    usability and privacy issues for example:
    - If the list of the CA names is longer than the peers input buffer then
      the handshake will fail
    - If the configured CAs belong to third parties, this message gives away
      information on the relations to these third parties
    
    Therefore we introduce an option to suppress the CA list in the
    Certificate Request message.
    
    Providing this feature as a runtime option comes with a little cost in
    code size and advantages in maintenance and flexibility.