### PR TITLE
Bare metal compilation with IAR compiler

### DIFF
--- a/scripts/config_baremetal.sh
+++ b/scripts/config_baremetal.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# config_baremetal.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2017, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# To generate config for bare metal build.
+#
+# Warning: the test is destructive. It modifies config via config.h.
+# Original config.h is backed up as config.h.bak. Revert to it if
+# modified config.h is not wanted.
+#
+set -eu
+
+CONFIG_H='include/mbedtls/config.h'
+CONFIG_BAK="$CONFIG_H.bak"
+
+echo "Backing up $CONFIG_H => $CONFIG_BAK"
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl full
+scripts/config.pl unset MBEDTLS_NET_C
+scripts/config.pl unset MBEDTLS_TIMING_C
+scripts/config.pl unset MBEDTLS_FS_IO
+scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+scripts/config.pl unset MBEDTLS_HAVE_TIME
+scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
+scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+# following things are not in the default config
+scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
+scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+scripts/config.pl unset MBEDTLS_THREADING_C
+scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
+scripts/config.pl unset MBEDTLS_PLATFORM_FPRINTF_ALT # depends on MBEDTLS_FS_IO
+echo "Updated $CONFIG_H"
+


### PR DESCRIPTION
At this stage only compilation of mbedtls library with IAR is enabled. 
Hence only ```make lib``` with ```CC=iccarm``` and ```AR=iarchive```.

### Changes:
- Makefile assumes gcc based compiler and uses 
-- Warning options specific to gcc
-- Object archive command line options specific to ```ar```.
- Changes made to set ```CFLAGS``` and ```AR``` based on selected compiler. At this stage IAR or else.
- Since bare metal needs some config. Created a script to do the config and build with given compiler.

```iarchive``` does not have options similar to ```ar```. It does not allow "modify existing archive" ```-r``` and "create if not exist" ```-c``` options together. Hence when building with IAR ```make clean``` is required before  ```make lib```.