### PR TITLE
Rename time and index parameter to avoid name conflict.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Changes
+   * Avoid shadowing of time and index functions through mbed TLS function
+     arguments. Found by inestlerode. Fixes #557.
+
 = mbed TLS 2.4.2 branch released 2017-03-08
 
 Security

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -452,7 +452,7 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp, const mbedtls_ecp
  * \brief           Set a group using well-known domain parameters
  *
  * \param grp       Destination group
- * \param index     Index in the list of well-known domain parameters
+ * \param id        Index in the list of well-known domain parameters
  *
  * \return          0 if successful,
  *                  MBEDTLS_ERR_MPI_XXX if initialization failed
@@ -461,7 +461,7 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp, const mbedtls_ecp
  * \note            Index should be a value of RFC 4492's enum NamedCurve,
  *                  usually in the form of a MBEDTLS_ECP_DP_XXX macro.
  */
-int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id index );
+int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id );
 
 /**
  * \brief           Set a group from a TLS ECParameters record

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -246,12 +246,12 @@ int mbedtls_x509_serial_gets( char *buf, size_t size, const mbedtls_x509_buf *se
  * \note           Intended usage is "if( is_past( valid_to ) ) ERROR".
  *                 Hence the return value of 1 if on internal errors.
  *
- * \param time     mbedtls_x509_time to check
+ * \param to       mbedtls_x509_time to check
  *
  * \return         1 if the given time is in the past or an error occured,
  *                 0 otherwise.
  */
-int mbedtls_x509_time_is_past( const mbedtls_x509_time *time );
+int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
 
 /**
  * \brief          Check a given mbedtls_x509_time against the system time
@@ -260,12 +260,12 @@ int mbedtls_x509_time_is_past( const mbedtls_x509_time *time );
  * \note           Intended usage is "if( is_future( valid_from ) ) ERROR".
  *                 Hence the return value of 1 if on internal errors.
  *
- * \param time     mbedtls_x509_time to check
+ * \param from     mbedtls_x509_time to check
  *
  * \return         1 if the given time is in the future or an error occured,
  *                 0 otherwise.
  */
-int mbedtls_x509_time_is_future( const mbedtls_x509_time *time );
+int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
 
 /**
  * \brief          Checkup routine
@@ -294,7 +294,7 @@ int mbedtls_x509_get_sig_alg( const mbedtls_x509_buf *sig_oid, const mbedtls_x50
                       mbedtls_md_type_t *md_alg, mbedtls_pk_type_t *pk_alg,
                       void **sig_opts );
 int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
-                   mbedtls_x509_time *time );
+                   mbedtls_x509_time *t );
 int mbedtls_x509_get_serial( unsigned char **p, const unsigned char *end,
                      mbedtls_x509_buf *serial );
 int mbedtls_x509_get_ext( unsigned char **p, const unsigned char *end,

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -169,10 +169,10 @@ static void cmac_xor_block( unsigned char *output, const unsigned char *input1,
                             const unsigned char *input2,
                             const size_t block_size )
 {
-    size_t index;
+    size_t idx;
 
-    for( index = 0; index < block_size; index++ )
-        output[ index ] = input1[ index ] ^ input2[ index ];
+    for( idx = 0; idx < block_size; idx++ )
+        output[ idx ] = input1[ idx ] ^ input2[ idx ];
 }
 
 /*

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -132,24 +132,24 @@ int mbedtls_entropy_add_source( mbedtls_entropy_context *ctx,
                         mbedtls_entropy_f_source_ptr f_source, void *p_source,
                         size_t threshold, int strong )
 {
-    int index, ret = 0;
+    int idx, ret = 0;
 
 #if defined(MBEDTLS_THREADING_C)
     if( ( ret = mbedtls_mutex_lock( &ctx->mutex ) ) != 0 )
         return( ret );
 #endif
 
-    index = ctx->source_count;
-    if( index >= MBEDTLS_ENTROPY_MAX_SOURCES )
+    idx = ctx->source_count;
+    if( idx >= MBEDTLS_ENTROPY_MAX_SOURCES )
     {
         ret = MBEDTLS_ERR_ENTROPY_MAX_SOURCES;
         goto exit;
     }
 
-    ctx->source[index].f_source  = f_source;
-    ctx->source[index].p_source  = p_source;
-    ctx->source[index].threshold = threshold;
-    ctx->source[index].strong    = strong;
+    ctx->source[idx].f_source  = f_source;
+    ctx->source[idx].p_source  = p_source;
+    ctx->source[idx].threshold = threshold;
+    ctx->source[idx].strong    = strong;
 
     ctx->source_count++;
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -496,25 +496,25 @@ static int x509_parse_int( unsigned char **p, size_t n, int *res )
     return( 0 );
 }
 
-static int x509_date_is_valid(const mbedtls_x509_time *time)
+static int x509_date_is_valid(const mbedtls_x509_time *t)
 {
     int ret = MBEDTLS_ERR_X509_INVALID_DATE;
 
-    CHECK_RANGE( 0, 9999, time->year );
-    CHECK_RANGE( 0, 23,   time->hour );
-    CHECK_RANGE( 0, 59,   time->min  );
-    CHECK_RANGE( 0, 59,   time->sec  );
+    CHECK_RANGE( 0, 9999, t->year );
+    CHECK_RANGE( 0, 23,   t->hour );
+    CHECK_RANGE( 0, 59,   t->min  );
+    CHECK_RANGE( 0, 59,   t->sec  );
 
-    switch( time->mon )
+    switch( t->mon )
     {
         case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-            CHECK_RANGE( 1, 31, time->day );
+            CHECK_RANGE( 1, 31, t->day );
             break;
         case 4: case 6: case 9: case 11:
-            CHECK_RANGE( 1, 30, time->day );
+            CHECK_RANGE( 1, 30, t->day );
             break;
         case 2:
-            CHECK_RANGE( 1, 28 + (time->year % 4 == 0), time->day );
+            CHECK_RANGE( 1, 28 + (t->year % 4 == 0), t->day );
             break;
         default:
             return( ret );
@@ -528,7 +528,7 @@ static int x509_date_is_valid(const mbedtls_x509_time *time)
  * field.
  */
 static int x509_parse_time( unsigned char **p, size_t len, size_t yearlen,
-        mbedtls_x509_time *time )
+                            mbedtls_x509_time *tm )
 {
     int ret;
 
@@ -542,26 +542,26 @@ static int x509_parse_time( unsigned char **p, size_t len, size_t yearlen,
     /*
      * Parse year, month, day, hour, minute
      */
-    CHECK( x509_parse_int( p, yearlen, &time->year ) );
+    CHECK( x509_parse_int( p, yearlen, &tm->year ) );
     if ( 2 == yearlen )
     {
-        if ( time->year < 50 )
-            time->year += 100;
+        if ( tm->year < 50 )
+            tm->year += 100;
 
-        time->year += 1900;
+        tm->year += 1900;
     }
 
-    CHECK( x509_parse_int( p, 2, &time->mon ) );
-    CHECK( x509_parse_int( p, 2, &time->day ) );
-    CHECK( x509_parse_int( p, 2, &time->hour ) );
-    CHECK( x509_parse_int( p, 2, &time->min ) );
+    CHECK( x509_parse_int( p, 2, &tm->mon ) );
+    CHECK( x509_parse_int( p, 2, &tm->day ) );
+    CHECK( x509_parse_int( p, 2, &tm->hour ) );
+    CHECK( x509_parse_int( p, 2, &tm->min ) );
 
     /*
      * Parse seconds if present
      */
     if ( len >= 2 )
     {
-        CHECK( x509_parse_int( p, 2, &time->sec ) );
+        CHECK( x509_parse_int( p, 2, &tm->sec ) );
         len -= 2;
     }
     else
@@ -582,7 +582,7 @@ static int x509_parse_time( unsigned char **p, size_t len, size_t yearlen,
     if ( 0 != len )
         return ( MBEDTLS_ERR_X509_INVALID_DATE );
 
-    CHECK( x509_date_is_valid( time ) );
+    CHECK( x509_date_is_valid( tm ) );
 
     return ( 0 );
 }
@@ -593,7 +593,7 @@ static int x509_parse_time( unsigned char **p, size_t len, size_t yearlen,
  *       generalTime    GeneralizedTime }
  */
 int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
-                   mbedtls_x509_time *time )
+                           mbedtls_x509_time *tm )
 {
     int ret;
     size_t len, year_len;
@@ -619,7 +619,7 @@ int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
     if( ret != 0 )
         return( MBEDTLS_ERR_X509_INVALID_DATE + ret );
 
-    return x509_parse_time( p, len, year_len, time );
+    return x509_parse_time( p, len, year_len, tm );
 }
 
 int mbedtls_x509_get_sig( unsigned char **p, const unsigned char *end, mbedtls_x509_buf *sig )

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -264,7 +264,7 @@ int mbedtls_x509write_crt_set_ns_cert_type( mbedtls_x509write_cert *ctx,
 }
 
 static int x509_write_time( unsigned char **p, unsigned char *start,
-                            const char *time, size_t size )
+                            const char *t, size_t size )
 {
     int ret;
     size_t len = 0;
@@ -272,10 +272,10 @@ static int x509_write_time( unsigned char **p, unsigned char *start,
     /*
      * write MBEDTLS_ASN1_UTC_TIME if year < 2050 (2 bytes shorter)
      */
-    if( time[0] == '2' && time[1] == '0' && time [2] < '5' )
+    if( t[0] == '2' && t[1] == '0' && t[2] < '5' )
     {
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_raw_buffer( p, start,
-                                             (const unsigned char *) time + 2,
+                                             (const unsigned char *) t + 2,
                                              size - 2 ) );
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( p, start, MBEDTLS_ASN1_UTC_TIME ) );
@@ -283,7 +283,7 @@ static int x509_write_time( unsigned char **p, unsigned char *start,
     else
     {
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_raw_buffer( p, start,
-                                                  (const unsigned char *) time,
+                                                  (const unsigned char *) t,
                                                   size ) );
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( p, start, MBEDTLS_ASN1_GENERALIZED_TIME ) );


### PR DESCRIPTION
As noted in #557, the functions `mbedtls_ecp_group_load`,
`mbedtls_x509_time_is_past` and `mbedtls_x509_time_is_future` use
'index' resp. 'time' as parameter names in their declarations, which
might cause conflict with the functions in the C standard library of
the same name. This commit renames the arguments accordingly.

__Internal reference:__ IOTSSL-957

__Backports:__ https://github.com/ARMmbed/mbedtls/pull/1032 and https://github.com/ARMmbed/mbedtls/pull/1031