### PR TITLE
Enable 64-bit compilation with ARM Compiler 6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x released xxxx-xx-xx
+
+Bugfix
+   * Fix conditional preprocessor directives in bignum.h to enable 64-bit
+     compilation when using ARM Compiler 6.
+
 = mbed TLS 2.5.1 released 2017-06-21
 
 Security

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,13 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS x.x.x released xxxx-xx-xx
 
+Changes
+   * Added config.h option MBEDTLS_NO_UDBL_DIVISION, to prevent the use of
+     64-bit division.
+   * Added config.h option MBEDTLS_TYPE_UDBL to allow configuring the
+     double-width integer type used in the bignum module when the compiler is
+     unknown.
+
 Bugfix
    * Fix conditional preprocessor directives in bignum.h to enable 64-bit
      compilation when using ARM Compiler 6.

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,9 +5,6 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Changes
    * Added config.h option MBEDTLS_NO_UDBL_DIVISION, to prevent the use of
      64-bit division.
-   * Added config.h option MBEDTLS_TYPE_UDBL to allow configuring the
-     double-width integer type used in the bignum module when the compiler is
-     unknown.
 
 Bugfix
    * Fix conditional preprocessor directives in bignum.h to enable 64-bit

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -103,13 +103,28 @@
 /*
  * Define the base integer type, architecture-wise.
  *
- * 32-bit integers can be forced on 64-bit arches (eg. for testing purposes)
- * by defining MBEDTLS_HAVE_INT32 and undefining MBEDTLS_HAVE_ASM
+ * 32 or 64-bit integer types can be forced regardless of the underlying
+ * architecture by defining MBEDTLS_HAVE_INT32 or MBEDTLS_HAVE_INT64
+ * respectively and undefining MBEDTLS_HAVE_ASM.
+ *
+ * Double length integers (e.g. 128-bit in 64-bit architectures) can be
+ * disabled by defining MBEDTLS_NO_UDBL_DIVISION.
+ *
+ * The double length integer types can be configured by defining
+ * MBEDTLS_TYPE_UDBL when the type cannot be automatically deduced by the
+ * library (e.g. the compiler is unknown). The definition of MBEDTLS_TYPE_UDBL
+ * must be a complete statement of the form:
+ *      typedef <UDBL_TYPE> mbedtls_t_udbl <OTHER_DIRECTIVES>
+ * for example:
+ *      #define MBEDTLS_TYPE_UDBL       \
+ *          typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)))
  */
 #if !defined(MBEDTLS_HAVE_INT32)
     #if defined(_MSC_VER) && defined(_M_AMD64)
         /* Always choose 64-bit when using MSC */
-        #define MBEDTLS_HAVE_INT64
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
     #elif defined(__GNUC__) && (                         \
@@ -118,22 +133,39 @@
         defined(__ia64__)  || defined(__alpha__)      || \
         ( defined(__sparc__) && defined(__arch64__) ) || \
         defined(__s390x__) || defined(__mips64) )
-        #define MBEDTLS_HAVE_INT64
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        /* mbedtls_t_udbl defined as 128-bit unsigned int */
-        typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
-        #define MBEDTLS_HAVE_UDBL
+        #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+            /* mbedtls_t_udbl defined as 128-bit unsigned int */
+            typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
+            #define MBEDTLS_HAVE_UDBL
+        #endif /* !MBEDTLS_NO_UDBL_DIVISION */
     #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
-        /* __ARMCC_VERSION is defined for both armcc and armclang and
+        /*
+         * __ARMCC_VERSION is defined for both armcc and armclang and
          * __aarch64__ is only defined by armclang when compiling 64-bit code
          */
-        #define MBEDTLS_HAVE_INT64
+        #if !defined(MBEDTLS_HAVE_INT64)
+            #define MBEDTLS_HAVE_INT64
+        #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        /* mbedtls_t_udbl defined as 128-bit unsigned int */
-        typedef __uint128_t mbedtls_t_udbl;
-        #define MBEDTLS_HAVE_UDBL
+        #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+            /* mbedtls_t_udbl defined as 128-bit unsigned int */
+            typedef __uint128_t mbedtls_t_udbl;
+            #define MBEDTLS_HAVE_UDBL
+        #endif /* !MBEDTLS_NO_UDBL_DIVISION */
+    #elif defined(MBEDTLS_HAVE_INT64)
+        /* Force 64-bit integers with unknown compiler */
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_NO_UDBL_DIVISION) && defined(MBEDTLS_TYPE_UDBL)
+            MBEDTLS_TYPE_UDBL;
+            #define MBEDTLS_HAVE_UDBL
+        #endif /* !MBEDTLS_NO_UDBL_DIVISION && MBEDTLS_TYPE_UDBL */
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -144,8 +176,9 @@
     #endif /* !MBEDTLS_HAVE_INT32 */
     typedef  int32_t mbedtls_mpi_sint;
     typedef uint32_t mbedtls_mpi_uint;
-    typedef uint64_t mbedtls_t_udbl;
-    #define MBEDTLS_HAVE_UDBL
+    #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+        typedef uint64_t mbedtls_t_udbl;
+    #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
 
 #ifdef __cplusplus

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -106,33 +106,47 @@
  * 32-bit integers can be forced on 64-bit arches (eg. for testing purposes)
  * by defining MBEDTLS_HAVE_INT32 and undefining MBEDTLS_HAVE_ASM
  */
-#if ( ! defined(MBEDTLS_HAVE_INT32) && \
-        defined(_MSC_VER) && defined(_M_AMD64) )
-  #define MBEDTLS_HAVE_INT64
-  typedef  int64_t mbedtls_mpi_sint;
-  typedef uint64_t mbedtls_mpi_uint;
-#else
-  #if ( ! defined(MBEDTLS_HAVE_INT32) &&               \
-        defined(__GNUC__) && (                          \
-        defined(__amd64__) || defined(__x86_64__)    || \
-        defined(__ppc64__) || defined(__powerpc64__) || \
-        defined(__ia64__)  || defined(__alpha__)     || \
-        (defined(__sparc__) && defined(__arch64__))  || \
-        defined(__s390x__) || defined(__mips64) ) )
-     #define MBEDTLS_HAVE_INT64
-     typedef  int64_t mbedtls_mpi_sint;
-     typedef uint64_t mbedtls_mpi_uint;
-     /* mbedtls_t_udbl defined as 128-bit unsigned int */
-     typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
-     #define MBEDTLS_HAVE_UDBL
-  #else
-     #define MBEDTLS_HAVE_INT32
-     typedef  int32_t mbedtls_mpi_sint;
-     typedef uint32_t mbedtls_mpi_uint;
-     typedef uint64_t mbedtls_t_udbl;
-     #define MBEDTLS_HAVE_UDBL
-  #endif /* !MBEDTLS_HAVE_INT32 && __GNUC__ && 64-bit platform */
-#endif /* !MBEDTLS_HAVE_INT32 && _MSC_VER && _M_AMD64 */
+#if !defined(MBEDTLS_HAVE_INT32)
+    #if defined(_MSC_VER) && defined(_M_AMD64)
+        /* Always choose 64-bit when using MSC */
+        #define MBEDTLS_HAVE_INT64
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+    #elif defined(__GNUC__) && (                         \
+        defined(__amd64__) || defined(__x86_64__)     || \
+        defined(__ppc64__) || defined(__powerpc64__)  || \
+        defined(__ia64__)  || defined(__alpha__)      || \
+        ( defined(__sparc__) && defined(__arch64__) ) || \
+        defined(__s390x__) || defined(__mips64) )
+        #define MBEDTLS_HAVE_INT64
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+        /* mbedtls_t_udbl defined as 128-bit unsigned int */
+        typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
+        #define MBEDTLS_HAVE_UDBL
+    #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
+        /* __ARMCC_VERSION is defined for both armcc and armclang and
+         * __aarch64__ is only defined by armclang when compiling 64-bit code
+         */
+        #define MBEDTLS_HAVE_INT64
+        typedef  int64_t mbedtls_mpi_sint;
+        typedef uint64_t mbedtls_mpi_uint;
+        /* mbedtls_t_udbl defined as 128-bit unsigned int */
+        typedef __uint128_t mbedtls_t_udbl;
+        #define MBEDTLS_HAVE_UDBL
+    #endif
+#endif /* !MBEDTLS_HAVE_INT32 */
+
+#if !defined(MBEDTLS_HAVE_INT64)
+    /* Default to 32-bit compilation */
+    #if !defined(MBEDTLS_HAVE_INT32)
+        #define MBEDTLS_HAVE_INT32
+    #endif /* !MBEDTLS_HAVE_INT32 */
+    typedef  int32_t mbedtls_mpi_sint;
+    typedef uint32_t mbedtls_mpi_uint;
+    typedef uint64_t mbedtls_t_udbl;
+    #define MBEDTLS_HAVE_UDBL
+#endif /* !MBEDTLS_HAVE_INT64 */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -109,15 +109,6 @@
  *
  * Double-width integers (e.g. 128-bit in 64-bit architectures) can be
  * disabled by defining MBEDTLS_NO_UDBL_DIVISION.
- *
- * The double-width integer types can be configured by defining
- * MBEDTLS_TYPE_UDBL when the type cannot be automatically deduced by the
- * library (e.g. the compiler is unknown). The definition of MBEDTLS_TYPE_UDBL
- * must be a complete statement of the form:
- *      typedef <UDBL_TYPE> mbedtls_t_udbl <OTHER_DIRECTIVES>
- * for example:
- *      #define MBEDTLS_TYPE_UDBL       \
- *          typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)))
  */
 #if !defined(MBEDTLS_HAVE_INT32)
     #if defined(_MSC_VER) && defined(_M_AMD64)
@@ -162,10 +153,6 @@
         /* Force 64-bit integers with unknown compiler */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        #if !defined(MBEDTLS_NO_UDBL_DIVISION) && defined(MBEDTLS_TYPE_UDBL)
-            MBEDTLS_TYPE_UDBL;
-            #define MBEDTLS_HAVE_UDBL
-        #endif /* !MBEDTLS_NO_UDBL_DIVISION && MBEDTLS_TYPE_UDBL */
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -178,6 +165,7 @@
     typedef uint32_t mbedtls_mpi_uint;
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
         typedef uint64_t mbedtls_t_udbl;
+        #define MBEDTLS_HAVE_UDBL
     #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
 

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -107,10 +107,10 @@
  * architecture by defining MBEDTLS_HAVE_INT32 or MBEDTLS_HAVE_INT64
  * respectively and undefining MBEDTLS_HAVE_ASM.
  *
- * Double length integers (e.g. 128-bit in 64-bit architectures) can be
+ * Double-width integers (e.g. 128-bit in 64-bit architectures) can be
  * disabled by defining MBEDTLS_NO_UDBL_DIVISION.
  *
- * The double length integer types can be configured by defining
+ * The double-width integer types can be configured by defining
  * MBEDTLS_TYPE_UDBL when the type cannot be automatically deduced by the
  * library (e.g. the compiler is unknown). The definition of MBEDTLS_TYPE_UDBL
  * must be a complete statement of the form:

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -654,8 +654,8 @@
 #error "MBEDTLS_HAVE_INT32 and MBEDTLS_HAVE_INT64 cannot be defined simultaneously"
 #endif /* MBEDTLS_HAVE_INT32 && MBEDTLS_HAVE_INT64 */
 
-#if (defined(MBEDTLS_HAVE_INT32) || define(MBEDTLS_HAVE_INT64)) && \
-    defined(MBEDTLS_HAVE_ASM
+#if ( defined(MBEDTLS_HAVE_INT32) || defined(MBEDTLS_HAVE_INT64) ) && \
+    defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_INT64 cannot be"
     "defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -656,8 +656,7 @@
 
 #if ( defined(MBEDTLS_HAVE_INT32) || defined(MBEDTLS_HAVE_INT64) ) && \
     defined(MBEDTLS_HAVE_ASM)
-#error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_INT64 cannot be"
-    "defined simultaneously"
+#error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
 
 /*

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -650,6 +650,16 @@
 #error "MBEDTLS_X509_CSR_WRITE_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_HAVE_INT32) && defined(MBEDTLS_HAVE_INT64)
+#error "MBEDTLS_HAVE_INT32 and MBEDTLS_HAVE_INT64 cannot be defined simultaneously"
+#endif /* MBEDTLS_HAVE_INT32 && MBEDTLS_HAVE_INT64 */
+
+#if (defined(MBEDTLS_HAVE_INT32) || define(MBEDTLS_HAVE_INT64)) && \
+    defined(MBEDTLS_HAVE_ASM
+#error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_INT64 cannot be"
+    "defined simultaneously"
+#endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
+
 /*
  * Avoid warning from -pedantic. This is a convenient place for this
  * workaround since this is included by every single file before the

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -76,7 +76,10 @@
  *
  * Note that division for the native integer type is always required.
  * Furthermore, a 64-bit type is always required even on a 32-bit
- * platform, but it need not support multiplication or division.
+ * platform, but it need not support multiplication or division. In some
+ * cases it is also desirable to disable some double-width operations. For
+ * example, if double-width division is implemented in software, disabling
+ * it can reduce code size in some embedded targets.
  */
 //#define MBEDTLS_NO_UDBL_DIVISION
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -56,6 +56,31 @@
 #define MBEDTLS_HAVE_ASM
 
 /**
+ * \def MBEDTLS_NO_UDBL_DIVISION
+ *
+ * The platform lacks support for double-width integer division (64-bit
+ * division on a 32-bit platform, 128-bit division on a 64-bit platform).
+ *
+ * Used in:
+ *      include/mbedtls/bignum.h
+ *      library/bignum.c
+ *
+ * The bignum code uses double-width division to speed up some operations.
+ * Double-width division is often implemented in software that needs to
+ * be linked with the program. The presence of a double-width integer
+ * type is usually detected automatically through preprocessor macros,
+ * but the automatic detection cannot know whether the code needs to
+ * and can be linked with an implementation of division for that type.
+ * By default division is assumed to be usable if the type is present.
+ * Uncomment this option to prevent the use of double-width division.
+ *
+ * Note that division for the native integer type is always required.
+ * Furthermore, a 64-bit type is always required even on a 32-bit
+ * platform, but it need not support multiplication or division.
+ */
+//#define MBEDTLS_NO_UDBL_DIVISION
+
+/**
  * \def MBEDTLS_HAVE_SSE2
  *
  * CPU supports SSE2 instruction set.

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -36,6 +36,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_HAVE_ASM)
     "MBEDTLS_HAVE_ASM",
 #endif /* MBEDTLS_HAVE_ASM */
+#if defined(MBEDTLS_NO_UDBL_DIVISION)
+    "MBEDTLS_NO_UDBL_DIVISION",
+#endif /* MBEDTLS_NO_UDBL_DIVISION */
 #if defined(MBEDTLS_HAVE_SSE2)
     "MBEDTLS_HAVE_SSE2",
 #endif /* MBEDTLS_HAVE_SSE2 */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -468,6 +468,13 @@ scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
 
+msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+cleanup
+scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
+CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
+echo "Checking that software 64-bit division is not required"
+! grep __aeabi_uldiv library/*.o
+
 msg "build: ARM Compiler 5, make"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -447,9 +447,30 @@ scripts/config.pl unset MBEDTLS_AESNI_C
 scripts/config.pl unset MBEDTLS_PADLOCK_C
 CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32' make
 
-msg "test: gcc, force 32-bit compilation"
+msg "build: gcc, force 64-bit compilation"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
+
+msg "test: gcc, force 64-bit compilation"
 make test
+
+msg "build: gcc, force 64-bit compilation, attempt to set MBEDTLS_TYPE_UDBL"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64 -DMBEDTLS_TYPE_UDBL="typedef XXXXXX"' make
 fi # x86_64
+
+msg "build: gcc, attempt to set MBEDTLS_TYPE_UDBL for known compiler"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_TYPE_UDBL="typedef XXXXXX"' make
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -438,6 +438,17 @@ if uname -a | grep -F x86_64 >/dev/null; then
 msg "build: i386, make, gcc" # ~ 30s
 cleanup
 CC=gcc CFLAGS='-Werror -Wall -Wextra -m32' make
+
+msg "build: gcc, force 32-bit compilation"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32' make
+
+msg "test: gcc, force 32-bit compilation"
+make test
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -458,19 +458,14 @@ CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
 msg "test: gcc, force 64-bit compilation"
 make test
 
-msg "build: gcc, force 64-bit compilation, attempt to set MBEDTLS_TYPE_UDBL"
+msg "build: gcc, force 64-bit compilation"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_HAVE_ASM
 scripts/config.pl unset MBEDTLS_AESNI_C
 scripts/config.pl unset MBEDTLS_PADLOCK_C
-CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64 -DMBEDTLS_TYPE_UDBL="typedef XXXXXX"' make
+CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
 fi # x86_64
-
-msg "build: gcc, attempt to set MBEDTLS_TYPE_UDBL for known compiler"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_TYPE_UDBL="typedef XXXXXX"' make
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -491,6 +491,18 @@ CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wa
 
 msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
 cleanup
+scripts/config.pl full
+scripts/config.pl unset MBEDTLS_NET_C
+scripts/config.pl unset MBEDTLS_TIMING_C
+scripts/config.pl unset MBEDTLS_FS_IO
+scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+# following things are not in the default config
+scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+scripts/config.pl unset MBEDTLS_THREADING_C
+scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
 echo "Checking that software 64-bit division is not required"


### PR DESCRIPTION
This patch fixes the conditional preprocessor directives in
include/mbedtls/bignum.h to enable 64-bit compilation with ARM
Compiler 6.

Also:
* Import @gilles-peskine-arm from https://github.com/ARMmbed/mbedtls/pull/949
* Allow configuring double-width int types when the compiler is unknown.
* Add tests to all.sh
* Allow users to force 32 or 64 bit compilation.
* Add sanity checks to check_config.h

Backports to mbed TLS 2.1 or 1.3 are not needed as this is an interface change equivalent to a new feature.