### PR TITLE
Backup errno in net_would_block

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix net_would_block to avoid modification by errno through fcntl call.
+     Found by nkolban. Fixes #845.
+
 = mbed TLS 2.4.2 branch released 2017-03-08
 
 Security

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -270,13 +270,18 @@ static int net_would_block( const mbedtls_net_context *ctx )
  */
 static int net_would_block( const mbedtls_net_context *ctx )
 {
+    int err = errno;
+    
     /*
      * Never return 'WOULD BLOCK' on a non-blocking socket
      */
     if( ( fcntl( ctx->fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
+    {
+        errno = err;
         return( 0 );
+    }
 
-    switch( errno )
+    switch( errno = err )
     {
 #if defined EAGAIN
         case EAGAIN:


### PR DESCRIPTION
__Context:__ This PR corrects a bug in `net_would_block` from `net_sockets.c` raised in #845. 

__Changes:__ Safe and restore the current value of `errno` in `net_would_block` to ensure it's not affected by the guarding call to `fcntl`. 

__Backports:__ Needs backport to mbed TLS 1.3 and 2.1.