### PR TITLE
Backport 1.3: Fix errors for 64-bit ILP32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,9 @@ Bugfix
      when dealing with negative MPI. Found by Guido Vranken.
    * Fix potential stack underflow in mpi_read_file.
      Found by Guido Vranken.
+   * Fix assembly sequences in bn_mul.h and aesni.c to avoid segmentation
+     faults and errors when building for the 64-bit ILP32 ABI. Found and fixed
+     by James Cowgill.
 
 Changes
    * Clarify ECDSA documentation and improve the sample code to avoid

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ clean:
 check: tests
 	$(MAKE) -C tests check
 
+test: check
+
 test-ref-configs:
 	tests/scripts/test-ref-configs.pl
 

--- a/include/polarssl/bn_mul.h
+++ b/include/polarssl/bn_mul.h
@@ -159,10 +159,6 @@
 
 #define MULADDC_INIT                        \
     asm(                                    \
-        "movq   %3, %%rsi           \n\t"   \
-        "movq   %4, %%rdi           \n\t"   \
-        "movq   %5, %%rcx           \n\t"   \
-        "movq   %6, %%rbx           \n\t"   \
         "xorq   %%r8, %%r8          \n\t"
 
 #define MULADDC_CORE                        \
@@ -178,12 +174,9 @@
         "addq   $8,      %%rdi      \n\t"
 
 #define MULADDC_STOP                        \
-        "movq   %%rcx, %0           \n\t"   \
-        "movq   %%rdi, %1           \n\t"   \
-        "movq   %%rsi, %2           \n\t"   \
-        : "=m" (c), "=m" (d), "=m" (s)                      \
-        : "m" (s), "m" (d), "m" (c), "m" (b)                \
-        : "rax", "rcx", "rdx", "rbx", "rsi", "rdi", "r8"    \
+        : "+c" (c), "+D" (d), "+S" (s)      \
+        : "b" (b)                           \
+        : "rax", "rdx", "r8"                \
     );
 
 #endif /* AMD64 */

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -97,7 +97,7 @@ int aesni_crypt_ecb( aes_context *ctx,
     asm( "movdqu    (%3), %%xmm0    \n\t" // load input
          "movdqu    (%1), %%xmm1    \n\t" // load round key 0
          "pxor      %%xmm1, %%xmm0  \n\t" // round 0
-         "addq      $16, %1         \n\t" // point to next round key
+         "add       $16, %1         \n\t" // point to next round key
          "subl      $1, %0          \n\t" // normal rounds = nr - 1
          "test      %2, %2          \n\t" // mode?
          "jz        2f              \n\t" // 0 = decrypt
@@ -105,7 +105,7 @@ int aesni_crypt_ecb( aes_context *ctx,
          "1:                        \n\t" // encryption loop
          "movdqu    (%1), %%xmm1    \n\t" // load round key
          AESENC     xmm1_xmm0      "\n\t" // do round
-         "addq      $16, %1         \n\t" // point to next round key
+         "add       $16, %1         \n\t" // point to next round key
          "subl      $1, %0          \n\t" // loop
          "jnz       1b              \n\t"
          "movdqu    (%1), %%xmm1    \n\t" // load round key
@@ -115,7 +115,7 @@ int aesni_crypt_ecb( aes_context *ctx,
          "2:                        \n\t" // decryption loop
          "movdqu    (%1), %%xmm1    \n\t"
          AESDEC     xmm1_xmm0      "\n\t" // do round
-         "addq      $16, %1         \n\t"
+         "add       $16, %1         \n\t"
          "subl      $1, %0          \n\t"
          "jnz       2b              \n\t"
          "movdqu    (%1), %%xmm1    \n\t" // load round key

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -344,7 +344,17 @@ fi
 if uname -a | grep -F x86_64 >/dev/null; then
 msg "build: i386, make, gcc" # ~ 30s
 cleanup
-CC=gcc CFLAGS='-Werror -m32' make
+CC=gcc CFLAGS='-Werror -Wall -Wextra -m32' make
+
+msg "test: i386, make, gcc"
+make test
+
+msg "build: 64-bit ILP32, make, gcc" # ~ 30s
+cleanup
+CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32' make
+
+msg "test: 64-bit ILP32, make, gcc"
+make test
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -5,8 +5,8 @@
 #include "polarssl/ecp.h"
 #include "polarssl/rsa.h"
 
-/* For detecting 64-bit compilation */
-#include "polarssl/bignum.h"
+#include <limits.h>
+#include <stdint.h>
 
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );
 
@@ -417,13 +417,13 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:POLARSSL_RSA_C:POLARSSL_HAVE_INT64 */
+/* BEGIN_CASE depends_on:POLARSSL_RSA_C */
 void pk_rsa_overflow( )
 {
     pk_context pk;
-    size_t hash_len = (size_t)-1;
+    size_t hash_len = SIZE_MAX;
 
-    if( sizeof( size_t ) <= sizeof( unsigned int ) )
+    if( SIZE_MAX <= UINT_MAX )
         return;
 
     pk_init( &pk );
@@ -492,16 +492,13 @@ void pk_rsa_alt( )
     TEST_ASSERT( strcmp( pk_get_name( &alt ), "RSA-alt" ) == 0 );
 
     /* Test signature */
+#if SIZE_MAX > UINT_MAX
+    TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, (size_t)-1,
+                          sig, &sig_len, rnd_std_rand, NULL ) ==
+                 POLARSSL_ERR_PK_BAD_INPUT_DATA );
+#endif /* SIZE_MAX > UINT_MAX */
     TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, sizeof hash,
                           sig, &sig_len, rnd_std_rand, NULL ) == 0 );
-#if defined(POLARSSL_HAVE_INT64)
-    if( sizeof( size_t ) > sizeof( unsigned int ) )
-    {
-        TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, (size_t)-1,
-                              NULL, NULL, rnd_std_rand, NULL ) ==
-                     POLARSSL_ERR_PK_BAD_INPUT_DATA );
-    }
-#endif /* POLARSSL_HAVE_INT64 */
 
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( pk_verify( &rsa, POLARSSL_MD_NONE,

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -423,6 +423,9 @@ void pk_rsa_overflow( )
     pk_context pk;
     size_t hash_len = (size_t)-1;
 
+    if( sizeof( size_t ) <= sizeof( unsigned int ) )
+        return;
+
     pk_init( &pk );
 
     TEST_ASSERT( pk_init_ctx( &pk, pk_info_from_type( POLARSSL_PK_RSA ) ) == 0 );
@@ -492,10 +495,14 @@ void pk_rsa_alt( )
     TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, sizeof hash,
                           sig, &sig_len, rnd_std_rand, NULL ) == 0 );
 #if defined(POLARSSL_HAVE_INT64)
-    TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, (size_t)-1,
-                          NULL, NULL, rnd_std_rand, NULL ) ==
-                 POLARSSL_ERR_PK_BAD_INPUT_DATA );
+    if( sizeof( size_t ) > sizeof( unsigned int ) )
+    {
+        TEST_ASSERT( pk_sign( &alt, POLARSSL_MD_NONE, hash, (size_t)-1,
+                              NULL, NULL, rnd_std_rand, NULL ) ==
+                     POLARSSL_ERR_PK_BAD_INPUT_DATA );
+    }
 #endif /* POLARSSL_HAVE_INT64 */
+
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( pk_verify( &rsa, POLARSSL_MD_NONE,
                             hash, sizeof hash, sig, sig_len ) == 0 );


### PR DESCRIPTION
This PR does the following things:
* Backports the changes in https://github.com/ARMmbed/mbedtls/pull/376
* Fixes the tests `pk_rsa_overflow()` and `pk_rsa_alt()` in `test_suite_pk.function` that previously caused segfaults when building with `-mx32`.
* Adds a build and tests to `all.sh` to compile and run mbed TLS with the flags `-m32` and `mx32` (backport of #900).

These changes fixes the library problems when building with the 64-bit ILP32 ABI and addresses the issue at https://github.com/ARMmbed/mbedtls/issues/849