### PR TITLE
Backport 1.3: Enhance support for signature-hash-algorithm extension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+mbed TLS 1.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix insufficient support for signature-hash-algorithm extension,
+     resulting in compatibility problems with Chrome. Found by hfloyrd. #823
+
 = mbed TLS 1.3.19 branch released 2017-03-08
 
 Security

--- a/include/polarssl/ssl_ciphersuites.h
+++ b/include/polarssl/ssl_ciphersuites.h
@@ -290,6 +290,7 @@ const ssl_ciphersuite_t *ssl_ciphersuite_from_id( int ciphersuite_id );
 
 #if defined(POLARSSL_PK_C)
 pk_type_t ssl_get_ciphersuite_sig_pk_alg( const ssl_ciphersuite_t *info );
+pk_type_t ssl_get_ciphersuite_sig_alg( const ssl_ciphersuite_t *info );
 #endif
 
 int ssl_ciphersuite_uses_ec( const ssl_ciphersuite_t *info );

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -1803,6 +1803,24 @@ pk_type_t ssl_get_ciphersuite_sig_pk_alg( const ssl_ciphersuite_t *info )
             return( POLARSSL_PK_NONE );
     }
 }
+
+pk_type_t ssl_get_ciphersuite_sig_alg( const ssl_ciphersuite_t *info )
+{
+    switch( info->key_exchange )
+    {
+        case POLARSSL_KEY_EXCHANGE_RSA:
+        case POLARSSL_KEY_EXCHANGE_DHE_RSA:
+        case POLARSSL_KEY_EXCHANGE_ECDHE_RSA:
+            return( POLARSSL_PK_RSA );
+
+        case POLARSSL_KEY_EXCHANGE_ECDHE_ECDSA:
+            return( POLARSSL_PK_ECDSA );
+
+        default:
+            return( POLARSSL_PK_NONE );
+    }
+}
+
 #endif /* POLARSSL_PK_C */
 
 #if defined(POLARSSL_ECDH_C) || defined(POLARSSL_ECDSA_C)


### PR DESCRIPTION
This is the backport of https://github.com/ARMmbed/mbedtls/pull/888 to mbed TLS 1.3.

Please review. Though it's functionally a subset of https://github.com/ARMmbed/mbedtls/pull/888, rebasing was done manually and needed adaption at some places. In particular, the lack of an `ssl_internal.h` makes this structurally different from the original PR.