### PR TITLE
Added support for different address families to mbedtls_net_bind()

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1478,6 +1478,18 @@
  */
 #define MBEDTLS_AES_C
 
+
+/**
+ * \def MBEDTLS_AF6_ALLOW_AF4
+ *
+ * Disables IPV6_V6ONLY before binding to an IPv6 socket,
+ * allowing IPv4 connections.
+ *
+ * Module:  library/net_sockets.c
+ *
+ */
+#define MBEDTLS_AF6_ALLOW_AF4
+
 /**
  * \def MBEDTLS_ARC4_C
  *

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -45,11 +45,16 @@
 #define MBEDTLS_ERR_NET_UNKNOWN_HOST                      -0x0052  /**< Failed to get an IP address for the given hostname. */
 #define MBEDTLS_ERR_NET_BUFFER_TOO_SMALL                  -0x0043  /**< Buffer is too small to hold the data. */
 #define MBEDTLS_ERR_NET_INVALID_CONTEXT                   -0x0045  /**< The context is invalid, eg because it was free()ed. */
+#define MBEDTLS_ERR_NET_UNKNOWN_ADDR_FAMILY               -0x0047  /**< The address family is invalid */
 
-#define MBEDTLS_NET_LISTEN_BACKLOG         10 /**< The backlog that listen() should use. */
+#define MBEDTLS_NET_LISTEN_BACKLOG  10 /**< The backlog that listen() should use. */
 
-#define MBEDTLS_NET_PROTO_TCP 0 /**< The TCP transport protocol */
-#define MBEDTLS_NET_PROTO_UDP 1 /**< The UDP transport protocol */
+#define MBEDTLS_NET_PROTO_TCP       0  /**< The TCP transport protocol */
+#define MBEDTLS_NET_PROTO_UDP       1  /**< The UDP transport protocol */
+
+#define MBEDTLS_NET_ADDR_FAMILY_4   0  /**< The address family to use, IPv4 */
+#define MBEDTLS_NET_ADDR_FAMILY_6   1  /**< The address family to use, IPv6 */
+#define MBEDTLS_NET_ADDR_FAMILY_ANY 2 /**< The address family to use, either IPv4 or IPv6 */
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,7 +115,7 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  * \note           Regardless of the protocol, opens the sockets and binds it.
  *                 In addition, make the socket listening if protocol is TCP.
  */
-int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto );
+int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto , int addr_family);
 
 /**
  * \brief           Accept a connection from a remote client

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -172,7 +172,7 @@ int main( void )
     mbedtls_printf( "\n  . Waiting for a remote connection" );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, SERVER_PORT, MBEDTLS_NET_PROTO_TCP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, SERVER_PORT, MBEDTLS_NET_PROTO_TCP, MBEDTLS_NET_ADDR_FAMILY_ANY) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -170,7 +170,7 @@ int main( void )
     printf( "  . Bind on udp/*/4433 ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_UDP, MBEDTLS_NET_ADDR_FAMILY_ANY ) ) != 0 )
     {
         printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -204,7 +204,7 @@ int main( void )
     mbedtls_printf( "  . Bind on https://localhost:4433/ ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_TCP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_TCP, MBEDTLS_NET_ADDR_FAMILY_ANY ) ) != 0 )
     {
         mbedtls_printf( " failed!  mbedtls_net_bind returned %d\n\n", ret );
         goto exit;

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -166,7 +166,7 @@ int main( void )
     mbedtls_printf( "  . Bind on https://localhost:4433/ ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_TCP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_TCP, MBEDTLS_NET_ADDR_FAMILY_ANY ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1608,7 +1608,8 @@ int main( int argc, char *argv[] )
 
     if( ( ret = mbedtls_net_bind( &listen_fd, opt.server_addr, opt.server_port,
                           opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
-                          MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+                          MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP,
+                          MBEDTLS_NET_ADDR_FAMILY_ANY ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_bind returned -0x%x\n\n", -ret );
         goto exit;

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -521,7 +521,7 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     if( ( ret = mbedtls_net_bind( &listen_fd, opt.listen_addr, opt.listen_port,
-                          MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+                          MBEDTLS_NET_PROTO_UDP, MBEDTLS_NET_ADDR_FAMILY_ANY ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;


### PR DESCRIPTION
And for optionally allowing IPv4 connections on IPv6 sockets.

This makes it possible to specify which address family you want to use, so things like servers don't bind to an IPv6 interface when you're expecting connections on IPv4, or vice versa. It also allows, if enabled, servers bound to IPv6 interfaces to accept connections from both IPv4 and IPv6.