### PR TITLE
Backport 1.3: Backup errno in net_would_block

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix net_would_block to avoid modification by errno through fcntl call.
+     Found by nkolban. Fixes #845.
+
 = mbed TLS 1.3.19 branch released 2017-03-08
 
 Security

--- a/library/net.c
+++ b/library/net.c
@@ -396,13 +396,18 @@ static int net_would_block( int fd )
  */
 static int net_would_block( int fd )
 {
+    int err = errno;
+
     /*
      * Never return 'WOULD BLOCK' on a non-blocking socket
      */
     if( ( fcntl( fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
+    {
+        errno = err;
         return( 0 );
+    }
 
-    switch( errno )
+    switch( errno = err )
     {
 #if defined EAGAIN
         case EAGAIN:


### PR DESCRIPTION
This is the backport of #895 to mbed TLS 1.3.