### PR TITLE
Documentation error in `mbedtls_ssl_get_session`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
      Philippe Antoine. Fixes #1623.
+   * Remove wrong documentation for `mbedtls_ssl_get_session`.
+     This API has deep copy of the session, and the peer
+     certificate is not lost. #926
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,9 +18,9 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
      Philippe Antoine. Fixes #1623.
-   * Remove wrong documentation for `mbedtls_ssl_get_session`.
+   * Correct the documentation for `mbedtls_ssl_get_session()`.
      This API has deep copy of the session, and the peer
-     certificate is not lost. #926
+     certificate is not lost. Fixes #926.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2737,7 +2737,6 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  * \brief          Save session in order to resume it later (client-side only)
  *                 Session data is copied to presented session structure.
  *
- * \warning        Currently, peer certificate is lost in the operation.
  *
  * \param ssl      SSL context
  * \param session  session context
@@ -2746,6 +2745,11 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 MBEDTLS_ERR_SSL_ALLOC_FAILED if memory allocation failed,
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
  *                 arguments are otherwise invalid
+ *
+ * \note           Only the server certificate is copied, and not the chain
+ *                 but this is not a problem because the result of the chain
+ *                 verification is stored in `verify_result` and can be checked
+ *                 with \c mbedtls_ssl_get_verify_result()
  *
  * \sa             mbedtls_ssl_set_session()
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2744,12 +2744,12 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  * \return         0 if successful,
  *                 MBEDTLS_ERR_SSL_ALLOC_FAILED if memory allocation failed,
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
- *                 arguments are otherwise invalid
+ *                 arguments are otherwise invalid.
  *
  * \note           Only the server certificate is copied, and not the chain
  *                 but this is not a problem because the result of the chain
  *                 verification is stored in `verify_result` and can be checked
- *                 with \c mbedtls_ssl_get_verify_result()
+ *                 with \c mbedtls_ssl_get_verify_result().
  *
  * \sa             mbedtls_ssl_set_session()
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2746,10 +2746,16 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
  *                 arguments are otherwise invalid.
  *
- * \note           Only the server certificate is copied, and not the chain
- *                 but this is not a problem because the result of the chain
- *                 verification is stored in `verify_result` and can be checked
- *                 with \c mbedtls_ssl_get_verify_result().
+ * \note           Only the server certificate is copied, and not the full chain,
+ *                 so you should not attempt to validate the certificate again
+ *                 by calling \c mbedtls_x509_crt_verify() on it.
+ *                 Instead, you should use the results from the verification
+ *                 in the original handshake by calling \c mbedtls_ssl_get_verify_result()
+ *                 after loading the session again into a new SSL context
+ *                 using \c mbedtls_ssl_set_session().
+ *
+ * \note           Once the session object is not needed anymore, you should
+ *                 free it by calling \c mbedtls_ssl_session_free().
  *
  * \sa             mbedtls_ssl_set_session()
  */
@@ -3026,6 +3032,9 @@ void mbedtls_ssl_session_init( mbedtls_ssl_session *session );
 /**
  * \brief          Free referenced items in an SSL session including the
  *                 peer certificate and clear memory
+ *
+ * \note           A session object can be freed even if the SSL context
+ *                 that was used to retrieve the session is still in use.
  *
  * \param session  SSL session
  */


### PR DESCRIPTION
Fix Documentation error in `mbedtls_ssl_get_session`.
This function supports deep copying of the session,
and the peer certificate is not lost anymore, Resolves #926