### PR TITLE
Clarified documentation of mbedtls_ssl_setup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.x.x branch released 2017-xx-xx
+
+Changes
+   * Clarify the documentation of mbedtls_ssl_setup.
+
 = mbed TLS 2.4.2 branch released 2017-03-08
 
 Security

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -960,8 +960,13 @@ void mbedtls_ssl_init( mbedtls_ssl_context *ssl );
  * \note           No copy of the configuration context is made, it can be
  *                 shared by many mbedtls_ssl_context structures.
  *
- * \warning        Modifying the conf structure after it has been used in this
- *                 function is unsupported!
+ * \warning        The conf structure will be accessed during the session.
+ *                 It must not be modified or freed as long as the session
+ *                 is active.
+ *
+ * \warning        This function must be called exactly once per context.
+ *                 Calling mbedtls_ssl_setup again is not supported, even
+ *                 if no session is active.
  *
  * \param ssl      SSL context
  * \param conf     SSL configuration to use


### PR DESCRIPTION
Note that the configuration structure must remain accessible. The
previous wording could have been taken as implying that it's ok to
change the structure but changes wouldn't be taken into account.

Also note that calling this function twice is not supported (it would
at least be a memory leak).

Internal ref: IOTSSL-1416