### PR TITLE
Backport 2.1: Set correct minimal versions in default conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.1.x branch released xxxx-xx-xx
+
+Bugs
+   * Fix setting version TLSv1 as minimal version, even if TLS 1
+     is not enabled. Set `MBEDTLS_SSL_MIN_MAJOR_VERSION`
+     and `MBEDTLS_SSL_MIN_MINOR_VERSION` instead
+     of `MBEDTLS_SSL_MAJOR_VERSION_3` and `MBEDTLS_SSL_MINOR_VERSION_1`
+
 = mbed TLS 2.1.7 branch released 2017-03-08
 
 Security

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7181,8 +7181,8 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
          * Default
          */
         default:
-            conf->min_major_ver = MBEDTLS_SSL_MAJOR_VERSION_3;
-            conf->min_minor_ver = MBEDTLS_SSL_MINOR_VERSION_1; /* TLS 1.0 */
+            conf->min_major_ver = MBEDTLS_SSL_MIN_MAJOR_VERSION;
+            conf->min_minor_ver = MBEDTLS_SSL_MIN_MINOR_VERSION;
             conf->max_major_ver = MBEDTLS_SSL_MAX_MAJOR_VERSION;
             conf->max_minor_ver = MBEDTLS_SSL_MAX_MINOR_VERSION;
 


### PR DESCRIPTION
Set `MBEDTLS_SSL_MIN_MAJOR_VERSION` and `MBEDTLS_SSL_MIN_MINOR_VERSION`
instead of `MBEDTLS_SSL_MAJOR_VERSION_3` and `MBEDTLS_SSL_MINOR_VERSION_1`

Backport to 2.1 of PR #939 