### PR TITLE
Remove use of size zero array in ECJPAKE test suite

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Remove invalid use of size zero arrays in ECJPAKE test suite.
+
 = mbed TLS 2.5.0 branch released 2017-05-17
 
 Security

--- a/tests/suites/test_suite_ecjpake.function
+++ b/tests/suites/test_suite_ecjpake.function
@@ -109,7 +109,10 @@ void ecjpake_selftest()
 void read_round_one( int role, char *data, int ref_ret )
 {
     mbedtls_ecjpake_context ctx;
-    const unsigned char pw[] = {};
+
+    const unsigned char * pw = NULL;
+    const size_t pw_len = 0;
+
     unsigned char *msg;
     size_t len;
 
@@ -119,7 +122,7 @@ void read_round_one( int role, char *data, int ref_ret )
     TEST_ASSERT( msg != NULL );
 
     TEST_ASSERT( mbedtls_ecjpake_setup( &ctx, role,
-                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, 0 ) == 0 );
+                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, pw_len ) == 0 );
 
     TEST_ASSERT( mbedtls_ecjpake_read_round_one( &ctx, msg, len ) == ref_ret );
 
@@ -133,7 +136,10 @@ exit:
 void read_round_two_cli( char *data, int ref_ret )
 {
     mbedtls_ecjpake_context ctx;
-    const unsigned char pw[] = {};
+
+    const unsigned char * pw = NULL;
+    const size_t pw_len = 0;
+
     unsigned char *msg;
     size_t len;
 
@@ -143,7 +149,7 @@ void read_round_two_cli( char *data, int ref_ret )
     TEST_ASSERT( msg != NULL );
 
     TEST_ASSERT( mbedtls_ecjpake_setup( &ctx, MBEDTLS_ECJPAKE_CLIENT,
-                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, 0 ) == 0 );
+                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, pw_len ) == 0 );
 
     TEST_ASSERT( ecjpake_test_load( &ctx,
                  ADD_SIZE( ecjpake_test_x1 ), ADD_SIZE( ecjpake_test_x2 ),
@@ -163,7 +169,10 @@ exit:
 void read_round_two_srv( char *data, int ref_ret )
 {
     mbedtls_ecjpake_context ctx;
-    const unsigned char pw[] = {};
+
+    const unsigned char * pw = NULL;
+    const size_t pw_len = 0;
+
     unsigned char *msg;
     size_t len;
 
@@ -173,7 +182,7 @@ void read_round_two_srv( char *data, int ref_ret )
     TEST_ASSERT( msg != NULL );
 
     TEST_ASSERT( mbedtls_ecjpake_setup( &ctx, MBEDTLS_ECJPAKE_SERVER,
-                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, 0 ) == 0 );
+                 MBEDTLS_MD_SHA256, MBEDTLS_ECP_DP_SECP256R1, pw, pw_len ) == 0 );
 
     TEST_ASSERT( ecjpake_test_load( &ctx,
                  ADD_SIZE( ecjpake_test_x3 ), ADD_SIZE( ecjpake_test_x4 ),


### PR DESCRIPTION
__Changes:__ This PR corrects in invalid use of size zero arrays in the ECJPAKE test suite that triggers a compilation error on Visual Studio 2015 (but can also be observed with GCC or Clang when using the compilation flag `-Wpedantic`).

__Internal reference:__ IOTSSL-1242

__Backports:__ ECJPAKE not present in mbed TLS 1.3 or mbed TLS 2.1, so no backports needed.