### PR TITLE
Build option for platforms without 64-bit division

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@ Changes
    * Clarify ECDSA documentation and improve the sample code to avoid
      misunderstandings and potentially dangerous use of the API. Pointed out
      by Jean-Philippe Aumasson.
+   * Added config.h option MBEDTLS_NO_INT64_DIVISION, to prevent the use of
+     64-bit division.
 
 = mbed TLS 2.5.0 branch released 2017-05-17
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Changes
    * Clarify ECDSA documentation and improve the sample code to avoid
      misunderstandings and potentially dangerous use of the API. Pointed out
      by Jean-Philippe Aumasson.
-   * Added config.h option MBEDTLS_NO_INT64_DIVISION, to prevent the use of
+   * Added config.h option MBEDTLS_NO_UDBL_DIVISION, to prevent the use of
      64-bit division.
 
 = mbed TLS 2.5.0 branch released 2017-05-17

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -107,32 +107,36 @@
  * by defining MBEDTLS_HAVE_INT32 and undefining MBEDTLS_HAVE_ASM
  */
 #if ( ! defined(MBEDTLS_HAVE_INT32) && \
-        defined(_MSC_VER) && defined(_M_AMD64) )
+      defined(_MSC_VER) && defined(_M_AMD64) )
   #define MBEDTLS_HAVE_INT64
   typedef  int64_t mbedtls_mpi_sint;
   typedef uint64_t mbedtls_mpi_uint;
-#else
-  #if ( ! defined(MBEDTLS_HAVE_INT32) &&               \
+#elif ( ! defined(MBEDTLS_HAVE_INT32) &&               \
         defined(__GNUC__) && (                          \
         defined(__amd64__) || defined(__x86_64__)    || \
         defined(__ppc64__) || defined(__powerpc64__) || \
         defined(__ia64__)  || defined(__alpha__)     || \
         (defined(__sparc__) && defined(__arch64__))  || \
         defined(__s390x__) || defined(__mips64) ) )
-     #define MBEDTLS_HAVE_INT64
-     typedef  int64_t mbedtls_mpi_sint;
-     typedef uint64_t mbedtls_mpi_uint;
-     /* mbedtls_t_udbl defined as 128-bit unsigned int */
-     typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
-     #define MBEDTLS_HAVE_UDBL
-  #else
-     #define MBEDTLS_HAVE_INT32
-     typedef  int32_t mbedtls_mpi_sint;
-     typedef uint32_t mbedtls_mpi_uint;
-     typedef uint64_t mbedtls_t_udbl;
-     #define MBEDTLS_HAVE_UDBL
-  #endif /* !MBEDTLS_HAVE_INT32 && __GNUC__ && 64-bit platform */
-#endif /* !MBEDTLS_HAVE_INT32 && _MSC_VER && _M_AMD64 */
+  #define MBEDTLS_HAVE_INT64
+  typedef  int64_t mbedtls_mpi_sint;
+  typedef uint64_t mbedtls_mpi_uint;
+  /* mbedtls_t_udbl defined as 128-bit unsigned int */
+  typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
+  #define MBEDTLS_HAVE_UDBL
+#else /* defined(MBEDTLS_HAVE_INT32) || platform_lacks_int64 */
+  #if ! defined(MBEDTLS_HAVE_INT32)
+    #define MBEDTLS_HAVE_INT32
+  #endif
+  typedef  int32_t mbedtls_mpi_sint;
+  typedef uint32_t mbedtls_mpi_uint;
+  #if defined(MBEDTLS_NO_INT64_DIVISION)
+    #undef MBEDTLS_HAVE_UDBL
+  #else /* !defined(MBEDTLS_NO_INT64_DIVISION) */
+    typedef uint64_t mbedtls_t_udbl;
+    #define MBEDTLS_HAVE_UDBL
+  #endif /* !defined(MBEDTLS_NO_INT64_DIVISION) */
+#endif /* 128-bit and 64-bit type availability analysis */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -135,7 +135,7 @@
   #if ! defined(MBEDTLS_NO_UDBL_DIVISION)
     typedef uint64_t mbedtls_t_udbl;
     #define MBEDTLS_HAVE_UDBL
-  #endif /* !defined(MBEDTLS_NO_INT64_DIVISION) */
+  #endif /* !defined(MBEDTLS_NO_UDBL_DIVISION) */
 #endif /* 128-bit and 64-bit type availability analysis */
 
 #ifdef __cplusplus

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -121,18 +121,18 @@
   #define MBEDTLS_HAVE_INT64
   typedef  int64_t mbedtls_mpi_sint;
   typedef uint64_t mbedtls_mpi_uint;
-  /* mbedtls_t_udbl defined as 128-bit unsigned int */
-  typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
-  #define MBEDTLS_HAVE_UDBL
+  #if ! defined(MBEDTLS_NO_UDBL_DIVISION)
+    /* mbedtls_t_udbl defined as 128-bit unsigned int */
+    typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
+    #define MBEDTLS_HAVE_UDBL
+  #endif
 #else /* defined(MBEDTLS_HAVE_INT32) || platform_lacks_int64 */
   #if ! defined(MBEDTLS_HAVE_INT32)
     #define MBEDTLS_HAVE_INT32
   #endif
   typedef  int32_t mbedtls_mpi_sint;
   typedef uint32_t mbedtls_mpi_uint;
-  #if defined(MBEDTLS_NO_INT64_DIVISION)
-    #undef MBEDTLS_HAVE_UDBL
-  #else /* !defined(MBEDTLS_NO_INT64_DIVISION) */
+  #if ! defined(MBEDTLS_NO_UDBL_DIVISION)
     typedef uint64_t mbedtls_t_udbl;
     #define MBEDTLS_HAVE_UDBL
   #endif /* !defined(MBEDTLS_NO_INT64_DIVISION) */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -56,20 +56,29 @@
 #define MBEDTLS_HAVE_ASM
 
 /**
- * \def MBEDTLS_NO_INT64_DIVISION
+ * \def MBEDTLS_NO_UDBL_DIVISION
  *
- * The platform lacks support for 64-bit division.
+ * The platform lacks support for double-width integer division (64-bit
+ * division on a 32-bit platform, 128-bit division on a 64-bit platform).
  *
  * Used in:
  *      include/mbedtls/bignum.h
  *      library/bignum.c
  *
- * Uncomment to prevent the use of 64-bit division, even if a 64-bit type
- * is available. This allows building for a platform that lacks a hardware
- * 64-bit division, if linking with a software implementation of division
- * is not desired. Note that 32-bit division is required.
+ * The bignum code uses double-width division to speed up some operations.
+ * Double-width division is often implemented in software that needs to
+ * be linked with the program. The presence of a double-width integer
+ * type is usually detected automatically through preprocessor macros,
+ * but the automatic detection cannot know whether the code needs to
+ * and can be linked with an implementation of division for that type.
+ * By default division is assumed to be usable if the type is present.
+ * Uncomment this option to prevent the use of double-width division.
+ *
+ * Note that division for the native integer type is always required.
+ * Furthermore, a 64-bit type is always required even on a 32-bit
+ * platform, but it need not support multiplication or division.
  */
-//#define MBEDTLS_NO_INT64_DIVISION
+//#define MBEDTLS_NO_UDBL_DIVISION
 
 /**
  * \def MBEDTLS_HAVE_SSE2

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -56,6 +56,22 @@
 #define MBEDTLS_HAVE_ASM
 
 /**
+ * \def MBEDTLS_NO_INT64_DIVISION
+ *
+ * The platform lacks support for 64-bit division.
+ *
+ * Used in:
+ *      include/mbedtls/bignum.h
+ *      library/bignum.c
+ *
+ * Uncomment to prevent the use of 64-bit division, even if a 64-bit type
+ * is available. This allows building for a platform that lacks a hardware
+ * 64-bit division, if linking with a software implementation of division
+ * is not desired. Note that 32-bit division is required.
+ */
+//#define MBEDTLS_NO_INT64_DIVISION
+
+/**
  * \def MBEDTLS_HAVE_SSE2
  *
  * CPU supports SSE2 instruction set.

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -36,6 +36,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_HAVE_ASM)
     "MBEDTLS_HAVE_ASM",
 #endif /* MBEDTLS_HAVE_ASM */
+#if defined(MBEDTLS_NO_INT64_DIVISION)
+    "MBEDTLS_NO_INT64_DIVISION",
+#endif /* MBEDTLS_NO_INT64_DIVISION */
 #if defined(MBEDTLS_HAVE_SSE2)
     "MBEDTLS_HAVE_SSE2",
 #endif /* MBEDTLS_HAVE_SSE2 */

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -36,9 +36,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_HAVE_ASM)
     "MBEDTLS_HAVE_ASM",
 #endif /* MBEDTLS_HAVE_ASM */
-#if defined(MBEDTLS_NO_INT64_DIVISION)
-    "MBEDTLS_NO_INT64_DIVISION",
-#endif /* MBEDTLS_NO_INT64_DIVISION */
+#if defined(MBEDTLS_NO_UDBL_DIVISION)
+    "MBEDTLS_NO_UDBL_DIVISION",
+#endif /* MBEDTLS_NO_UDBL_DIVISION */
 #if defined(MBEDTLS_HAVE_SSE2)
     "MBEDTLS_HAVE_SSE2",
 #endif /* MBEDTLS_HAVE_SSE2 */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -457,9 +457,9 @@ scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
 
-msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_INT64_DIVISION, make" # ~ 10s
+msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
 cleanup
-scripts/config.pl set MBEDTLS_NO_INT64_DIVISION
+scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
 echo "Checking that software 64-bit division is not required"
 ! grep __aeabi_uldiv library/*.o

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -457,6 +457,13 @@ scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
 
+msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_INT64_DIVISION, make" # ~ 10s
+cleanup
+scripts/config.pl set MBEDTLS_NO_INT64_DIVISION
+CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' make lib
+echo "Checking that software 64-bit division is not required"
+! grep __aeabi_uldiv library/*.o
+
 msg "build: ARM Compiler 5, make"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"


### PR DESCRIPTION
Added config.h option MBEDTLS_NO_INT64_DIVISION, to prevent the use of
64-bit division. 64-bit division remains used by default, and 32-bit
division and a 64-bit type remain required.

Addresses issue #708 