### PR TITLE
Backport 2.1: Simplify ECC and ALPN list size handling in ssl_client2 and ssl_server2

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -274,6 +274,9 @@ int main( void )
     "    force_ciphersuite=<name>    default: all enabled\n"\
     " acceptable ciphersuite names:\n"
 
+#define ALPN_LIST_SIZE  10
+#define CURVE_LIST_SIZE 20
+
 /*
  * global options
  */
@@ -427,10 +430,10 @@ int main( int argc, char *argv[] )
     size_t psk_len = 0;
 #endif
 #if defined(MBEDTLS_SSL_ALPN)
-    const char *alpn_list[10];
+    const char *alpn_list[ALPN_LIST_SIZE];
 #endif
 #if defined(MBEDTLS_ECP_C)
-    mbedtls_ecp_group_id curve_list[20];
+    mbedtls_ecp_group_id curve_list[CURVE_LIST_SIZE];
     const mbedtls_ecp_curve_info *curve_cur;
 #endif
 
@@ -956,8 +959,7 @@ int main( int argc, char *argv[] )
         else if( strcmp( p, "default" ) != 0 )
         {
             /* Leave room for a final NULL in curve list */
-            while( i < (int) ( sizeof( curve_list ) / sizeof( *curve_list ) ) - 1
-                   && *p != '\0' )
+            while( i < CURVE_LIST_SIZE - 1 && *p != '\0' )
             {
                 q = p;
 
@@ -988,11 +990,10 @@ int main( int argc, char *argv[] )
 
             mbedtls_printf("Number of curves: %d\n", i );
 
-            if( i == (int) ( sizeof( curve_list ) / sizeof( *curve_list ) ) - 1
-                && *p != '\0' )
+            if( i == CURVE_LIST_SIZE - 1 && *p != '\0' )
             {
-                mbedtls_printf( "curves list too long, maximum %zu",
-                                (size_t) ( sizeof( curve_list ) / sizeof( *curve_list ) - 1 ) );
+                mbedtls_printf( "curves list too long, maximum %d",
+                                CURVE_LIST_SIZE - 1 );
                 goto exit;
             }
 
@@ -1008,7 +1009,7 @@ int main( int argc, char *argv[] )
         i = 0;
 
         /* Leave room for a final NULL in alpn_list */
-        while( i < (int) sizeof alpn_list - 1 && *p != '\0' )
+        while( i < ALPN_LIST_SIZE - 1 && *p != '\0' )
         {
             alpn_list[i++] = p;
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -360,6 +360,9 @@ int main( void )
     " acceptable ciphersuite names:\n"
 
 
+#define ALPN_LIST_SIZE  10
+#define CURVE_LIST_SIZE 20
+
 #define PUT_UINT64_BE(out_be,in_le,i)                                   \
 {                                                                       \
     (out_be)[(i) + 0] = (unsigned char)( ( (in_le) >> 56 ) & 0xFF );    \
@@ -869,11 +872,11 @@ int main( int argc, char *argv[] )
     sni_entry *sni_info = NULL;
 #endif
 #if defined(MBEDTLS_ECP_C)
-    mbedtls_ecp_group_id     curve_list[20];
+    mbedtls_ecp_group_id curve_list[CURVE_LIST_SIZE];
     const mbedtls_ecp_curve_info * curve_cur;
 #endif
 #if defined(MBEDTLS_SSL_ALPN)
-    const char *alpn_list[10];
+    const char *alpn_list[ALPN_LIST_SIZE];
 #endif
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     unsigned char alloc_buf[100000];
@@ -1426,8 +1429,7 @@ int main( int argc, char *argv[] )
         else if( strcmp( p, "default" ) != 0 )
         {
             /* Leave room for a final NULL in curve list */
-            while( i < (int) ( sizeof( curve_list ) / sizeof( *curve_list ) ) - 1
-                   && *p != '\0' )
+            while( i < CURVE_LIST_SIZE - 1 && *p != '\0' )
             {
                 q = p;
 
@@ -1458,11 +1460,10 @@ int main( int argc, char *argv[] )
 
             mbedtls_printf("Number of curves: %d\n", i );
 
-            if( i == (int) ( sizeof( curve_list ) / sizeof( *curve_list ) ) - 1
-                && *p != '\0' )
+            if( i == CURVE_LIST_SIZE - 1 && *p != '\0' )
             {
-                mbedtls_printf( "curves list too long, maximum %zu",
-                                (size_t) ( sizeof( curve_list ) / sizeof( *curve_list ) - 1 ) );
+                mbedtls_printf( "curves list too long, maximum %d",
+                                CURVE_LIST_SIZE - 1  );
                 goto exit;
             }
 
@@ -1478,7 +1479,7 @@ int main( int argc, char *argv[] )
         i = 0;
 
         /* Leave room for a final NULL in alpn_list */
-        while( i < (int) sizeof alpn_list - 1 && *p != '\0' )
+        while( i < ALPN_LIST_SIZE - 1 && *p != '\0' )
         {
             alpn_list[i++] = p;
 


### PR DESCRIPTION
This is the backport of #958 to mbed TLS 2.1.