### PR TITLE
Minor: Fix typos in program comments

### DIFF
--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -204,7 +204,7 @@ int main( int argc, char *argv[] )
     mbedtls_printf( " ok\n" );
 
     /*
-     * Verification: are the computed secret equal?
+     * Verification: are the computed secrets equal?
      */
     mbedtls_printf( "  . Checking if both computed secrets are equal..." );
     fflush( stdout );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2168,7 +2168,7 @@ handshake:
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     /*
-     * 5. Verify the server certificate
+     * 5. Verify the client certificate
      */
     mbedtls_printf( "  . Verifying peer X.509 certificate..." );
 


### PR DESCRIPTION
Fix a couple of typos and writer's mistakes,
in some reference program applications
This PR fixes issue #932 and also takes the fix from #956 by mwarning