### PR TITLE
Add `MBEDTLS_SELF_TEST` check in header files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ API Changes
      Therefore, mbedtls_platform_zeroize() is moved to the platform module to
      facilitate testing and maintenance.
 
+Bugfix
+   * Add `MBEDTLS_SELF_TEST` for the mbedtls_self_test functions
+     in the header files, which missed the precompilation check. #971
+
 = mbed TLS 2.9.0 branch released 2018-04-30
 
 Security

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -400,6 +400,8 @@ MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+
+#if defined(MBEDTLS_SELF_TEST)
 /**
  * \brief          Checkup routine.
  *
@@ -407,6 +409,8 @@ MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
  * \return         \c 1 on failure.
  */
 int mbedtls_aes_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -122,6 +122,8 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
 int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
                 unsigned char *output );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
@@ -133,6 +135,8 @@ int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned
  *
  */
 int mbedtls_arc4_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/base64.h
+++ b/include/mbedtls/base64.h
@@ -75,12 +75,15 @@ int mbedtls_base64_encode( unsigned char *dst, size_t dlen, size_t *olen,
 int mbedtls_base64_decode( unsigned char *dst, size_t dlen, size_t *olen,
                    const unsigned char *src, size_t slen );
 
+#if defined(MBEDTLS_SELF_TEST)
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_base64_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -758,12 +758,16 @@ int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int dh_flag,
                    int (*f_rng)(void *, unsigned char *, size_t),
                    void *p_rng );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_mpi_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -215,12 +215,16 @@ int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
                        unsigned char *output );
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_camellia_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -310,6 +310,8 @@ int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char 
 int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief               The CTR_DRBG checkup routine.
  *
@@ -317,6 +319,8 @@ int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char
  * \return              \c 1 on failure.
  */
 int mbedtls_ctr_drbg_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 /* Internal functions (do not call directly) */
 int mbedtls_ctr_drbg_seed_entropy_len( mbedtls_ctr_drbg_context *,

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -336,12 +336,16 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
 void mbedtls_des_setkey( uint32_t SK[32],
                          const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_des_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -295,6 +295,8 @@ int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_ASN1_PARSE_C */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          The DMH checkup routine.
  *
@@ -303,6 +305,7 @@ int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
  */
 int mbedtls_dhm_self_test( int verbose );
 
+#endif /* MBEDTLS_SELF_TEST */
 #ifdef __cplusplus
 }
 #endif

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -250,6 +250,8 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
  */
 void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          The GCM checkup routine.
  *
@@ -257,6 +259,8 @@ void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
  * \return         \c 1 on failure.
  */
 int mbedtls_gcm_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -282,6 +282,8 @@ MBEDTLS_DEPRECATED void mbedtls_md2( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
@@ -293,6 +295,8 @@ MBEDTLS_DEPRECATED void mbedtls_md2( const unsigned char *input,
  *
  */
 int mbedtls_md2_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -287,6 +287,8 @@ MBEDTLS_DEPRECATED void mbedtls_md4( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
@@ -298,6 +300,8 @@ MBEDTLS_DEPRECATED void mbedtls_md4( const unsigned char *input,
  *
  */
 int mbedtls_md4_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -287,6 +287,8 @@ MBEDTLS_DEPRECATED void mbedtls_md5( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
@@ -298,6 +300,8 @@ MBEDTLS_DEPRECATED void mbedtls_md5( const unsigned char *input,
  *
  */
 int mbedtls_md5_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/pkcs5.h
+++ b/include/mbedtls/pkcs5.h
@@ -81,12 +81,16 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
                        unsigned int iteration_count,
                        uint32_t key_length, unsigned char *output );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_pkcs5_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -217,12 +217,16 @@ MBEDTLS_DEPRECATED void mbedtls_ripemd160( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_ripemd160_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -1116,6 +1116,8 @@ int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src )
  */
 void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          The RSA checkup routine.
  *
@@ -1123,6 +1125,8 @@ void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
  * \return         \c 1 on failure.
  */
 int mbedtls_rsa_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -304,6 +304,8 @@ MBEDTLS_DEPRECATED void mbedtls_sha1( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          The SHA-1 checkup routine.
  *
@@ -316,6 +318,8 @@ MBEDTLS_DEPRECATED void mbedtls_sha1( const unsigned char *input,
  *
  */
 int mbedtls_sha1_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -257,6 +257,8 @@ MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          The SHA-224 and SHA-256 checkup routine.
  *
@@ -264,6 +266,8 @@ MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
  * \return         \c 1 on failure.
  */
 int mbedtls_sha256_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -230,6 +230,7 @@ int mbedtls_sha512_ret( const unsigned char *input,
 #else
 #define MBEDTLS_DEPRECATED
 #endif
+
 /**
  * \brief          This function calculates the SHA-512 or SHA-384
  *                 checksum of a buffer.
@@ -255,6 +256,9 @@ MBEDTLS_DEPRECATED void mbedtls_sha512( const unsigned char *input,
 
 #undef MBEDTLS_DEPRECATED
 #endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+#if defined(MBEDTLS_SELF_TEST)
+
  /**
  * \brief          The SHA-384 or SHA-512 checkup routine.
  *
@@ -262,6 +266,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha512( const unsigned char *input,
  * \return         \c 1 on failure.
  */
 int mbedtls_sha512_self_test( int verbose );
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -269,12 +269,16 @@ int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
  */
 int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_x509_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 /*
  * Internal module functions. You probably do not want to use these unless you

--- a/include/mbedtls/xtea.h
+++ b/include/mbedtls/xtea.h
@@ -119,12 +119,16 @@ int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx,
                     unsigned char *output);
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
+#if defined(MBEDTLS_SELF_TEST)
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_xtea_self_test( int verbose );
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add the `MBEDTLS_SELF_TEST` precompilation surrounding the self test functions,
which were missing this check in the header files. ( most of the header files were missing this check).
Addresses issue #971