### PR TITLE
Remove mutexes from ECP hardware acceleration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.x.x released xxxx-xx-xx
+
+Changes
+   * Removed mutexes from ECP hardware accelerator code. Now all hardware
+     accelerator code in the library leaves concurrency handling to the
+     platform. Reported by Steven Cooreman. #863
+
 = mbed TLS 2.5.1 released xxxx-xx-xx
 
 Security

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -97,9 +97,6 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
-#if defined(MBEDTLS_ECP_INTERNAL_ALT)
-extern mbedtls_threading_mutex_t mbedtls_threading_ecp_mutex;
-#endif
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1690,11 +1690,6 @@ int mbedtls_ecp_mul( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
         return( ret );
 
 #if defined(MBEDTLS_ECP_INTERNAL_ALT)
-#if defined(MBEDTLS_THREADING_C)
-    if( mbedtls_mutex_lock( &mbedtls_threading_ecp_mutex ) != 0 )
-        return ( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-
-#endif
     if ( is_grp_capable = mbedtls_internal_ecp_grp_capable( grp )  )
     {
         MBEDTLS_MPI_CHK( mbedtls_internal_ecp_init( grp ) );
@@ -1719,11 +1714,6 @@ cleanup:
         mbedtls_internal_ecp_free( grp );
     }
 
-#if defined(MBEDTLS_THREADING_C)
-    if( mbedtls_mutex_unlock( &mbedtls_threading_ecp_mutex ) != 0 )
-        return ( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-
-#endif
 #endif /* MBEDTLS_ECP_INTERNAL_ALT */
     return( ret );
 }
@@ -1831,11 +1821,6 @@ int mbedtls_ecp_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     MBEDTLS_MPI_CHK( mbedtls_ecp_mul_shortcuts( grp, R,   n, Q ) );
 
 #if defined(MBEDTLS_ECP_INTERNAL_ALT)
-#if defined(MBEDTLS_THREADING_C)
-    if( mbedtls_mutex_lock( &mbedtls_threading_ecp_mutex ) != 0 )
-        return ( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-
-#endif
     if (  is_grp_capable = mbedtls_internal_ecp_grp_capable( grp )  )
     {
         MBEDTLS_MPI_CHK( mbedtls_internal_ecp_init( grp ) );
@@ -1853,11 +1838,6 @@ cleanup:
         mbedtls_internal_ecp_free( grp );
     }
 
-#if defined(MBEDTLS_THREADING_C)
-    if( mbedtls_mutex_unlock( &mbedtls_threading_ecp_mutex ) != 0 )
-        return ( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-
-#endif
 #endif /* MBEDTLS_ECP_INTERNAL_ALT */
     mbedtls_ecp_point_free( &mP );
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -113,9 +113,6 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
     mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
-#if defined(MBEDTLS_ECP_INTERNAL_ALT)
-    mbedtls_mutex_init( &mbedtls_threading_ecp_mutex );
-#endif
 }
 
 /*
@@ -125,9 +122,6 @@ void mbedtls_threading_free_alt( void )
 {
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
     mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
-#if defined(MBEDTLS_ECP_INTERNAL_ALT)
-    mbedtls_mutex_free( &mbedtls_threading_ecp_mutex );
-#endif
 }
 #endif /* MBEDTLS_THREADING_ALT */
 
@@ -139,8 +133,5 @@ void mbedtls_threading_free_alt( void )
 #endif
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
-#if defined(MBEDTLS_ECP_INTERNAL_ALT)
-mbedtls_threading_mutex_t mbedtls_threading_ecp_mutex MUTEX_INIT;
-#endif
 
 #endif /* MBEDTLS_THREADING_C */


### PR DESCRIPTION
Protecting the ECP hardware acceleratior with mutexes is inconsistent with the
philosophy of the library. Pre-existing hardware accelerator interfaces
leave concurrency support to the underlying platform.

Fixes #863