### PR TITLE
Enable MBEDTLS_AES_ROM_TABLES in config-no-entropy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x released xxxx-xx-xx
+
+Changes
+   * Define the macro MBEDTLS_AES_ROM_TABLES in the configuration file
+     config-no-entropy.h to reduce the RAM footprint.
+
 = mbed TLS 2.5.1 released xxxx-xx-xx
 
 Security

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -80,6 +80,9 @@
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_CRL_PARSE_C
 
+/* Miscellaneous options */
+#define MBEDTLS_AES_ROM_TABLES
+
 #include "check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
Enable the MBEDTLS_AES_ROM_TABLES option in the
configs/config-no-entropy.h to place AES lookup tables in ROM. This
saves considerable RAM space, a resource that is very limited in small
devices that use this configuration.

**NOTES:**
* This change does not need to be backported to mbed TLS 1.3 and 2.1
* This change is related to [this mbed OS PR](https://github.com/ARMmbed/mbed-os/pull/4498) that requires MBEDTLS_AES_ROM_TABLES to be defined for some tests to pass due to limited RAM in some devices.