### PR TITLE
Initialise pointers to avoid IAR compiler warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x released xxxx-xx-xx
+
+Bugfix
+   * Fix variable used before assignment compilation warnings with IAR
+     toolchain. Found by gkerrien38.
+
 = mbed TLS 2.5.1 released xxxx-xx-xx
 
 Security

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2258,7 +2258,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
     int ret;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info =
         ssl->transform_negotiate->ciphersuite_info;
-    unsigned char *p, *end;
+    unsigned char *p = NULL, *end = NULL;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse server key exchange" ) );
 


### PR DESCRIPTION
When either of MBEDTLS_KEY_EXCHANGE_RSA_ENABLED, MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED and MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED are defined, the IAR compiler throws a variable use before set warning because of the statements:
```
((void) p);
((void) end);
```
These lines are included because it is possible that in some configurations the variables `p` and `end` are defined and assigned to but never referenced, which could cause yet more warnings in some compilers. Therefore, I have initialized them the value `NULL` when defining to remove the IAR compiler warning.

This PR fixes issue https://github.com/ARMmbed/mbedtls/issues/875