### PR TITLE
MD API changes to introduce int return codes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,27 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x released xxxx-xx-xx
+
+Bugfix
+   * Fix the entropy.c module to not call mbedtls_sha256_starts() or
+     mbedtls_sha512_starts() in the mbedtls_entropy_init() function.
+   * Fix the entropy.c module to ensure that mbedtls_sha256_init() or
+     mbedtls_sha512_init() is called before operating on the relevant context
+     structure. Also, ensure that message digest contexts are freed when
+     calling mbedtls_entropy_free().
+
+API Changes
+   * The following functions in the MD2, MD4, MD5, SHA1, SHA256 and SHA512
+     modules have been deprecated and replaced as shown below. The new
+     functions change the return type from void to int to allow returning error
+     codes when using MBEDTLS_<MODULE>_ALT.
+     mbedtls_<MODULE>_starts() -> mbedtls_<MODULE>_starts_ext()
+     mbedtls_<MODULE>_update() -> mbedtls_<MODULE>_update_ext()
+     mbedtls_<MODULE>_finish() -> mbedtls_<MODULE>_finish_ext()
+     mbedtls_<MODULE>_process() -> mbedtls_internal_<MODULE>_process()
+     The type of the function pointers in the mbedtls_md_info_t struct have
+     also been modified taking into account the functions return code.
+
 = mbed TLS 2.5.1 released 2017-06-21
 
 Security

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,10 @@ API Changes
      mbedtls_<MODULE>_finish() -> mbedtls_<MODULE>_finish_ext()
      mbedtls_<MODULE>_process() -> mbedtls_internal_<MODULE>_process()
      The type of the function pointers in the mbedtls_md_info_t struct have
-     also been modified taking into account the functions return code.
+     also been modified taking into account the functions return code. Every
+     usage of the deprecated functions was updated. Furthermore, the MD return
+     codes are checked for error after every usage, except in the ssl_tls.c
+     module.
 
 = mbed TLS 2.5.1 released 2017-06-21
 

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -121,6 +121,7 @@ mbedtls_entropy_source_state;
  */
 typedef struct
 {
+    int accumulator_started;
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     mbedtls_sha512_context  accumulator;
 #else

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -31,6 +31,11 @@
 
 #include <stddef.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_MD2_ALT)
 // Regular implementation
 //
@@ -78,8 +83,10 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  * \brief          MD2 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \return         0 if successful
  */
-void mbedtls_md2_starts( mbedtls_md2_context *ctx );
+int mbedtls_md2_starts_ext( mbedtls_md2_context *ctx );
 
 /**
  * \brief          MD2 process buffer
@@ -87,16 +94,99 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  * \param ctx      MD2 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen );
+int mbedtls_md2_update_ext( mbedtls_md2_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen );
 
 /**
  * \brief          MD2 final digest
  *
  * \param ctx      MD2 context
  * \param output   MD2 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] );
+int mbedtls_md2_finish_ext( mbedtls_md2_context *ctx,
+                            unsigned char output[16] );
+
+/**
+ * \brief          MD2 process data block (internal use only)
+ *
+ * \param ctx      MD2 context
+ *
+ * \return         0 if successful
+ */
+int mbedtls_md2_process_ext( mbedtls_md2_context *ctx );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          MD2 context setup
+ *
+ * \deprecated     Superseded by mbedtls_md2_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md2_starts(
+                                                    mbedtls_md2_context *ctx )
+{
+    mbedtls_md2_starts_ext( ctx );
+}
+
+/**
+ * \brief          MD2 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_md2_update_ext() in 2.5.0
+ *
+ * \param ctx      MD2 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md2_update(
+                                                mbedtls_md2_context *ctx,
+                                                const unsigned char *input,
+                                                size_t ilen )
+{
+    mbedtls_md2_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          MD2 final digest
+ *
+ * \deprecated     Superseded by mbedtls_md2_finish_ext() in 2.5.0
+ *
+ * \param ctx      MD2 context
+ * \param output   MD2 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md2_finish(
+                                                    mbedtls_md2_context *ctx,
+                                                    unsigned char output[16] )
+{
+    mbedtls_md2_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          MD2 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_md2_process_ext() in 2.5.0
+ *
+ * \param ctx      MD2 context
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md2_process(
+                                                    mbedtls_md2_context *ctx )
+{
+    mbedtls_md2_process_ext( ctx );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -117,7 +207,36 @@ extern "C" {
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
  */
-void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
+int mbedtls_md2_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = MD2( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_md2() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   MD2 checksum result
+ *
+ * \return         0 if successful
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md2( const unsigned char *input,
+                                                   size_t ilen,
+                                                   unsigned char output[16] )
+{
+    mbedtls_md2_ext( input, ilen, output );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine
@@ -125,9 +244,6 @@ void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_md2_self_test( int verbose );
-
-/* Internal use */
-void mbedtls_md2_process( mbedtls_md2_context *ctx );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -119,7 +119,7 @@ int mbedtls_md2_finish_ext( mbedtls_md2_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_md2_process_ext( mbedtls_md2_context *ctx );
+int mbedtls_internal_md2_process( mbedtls_md2_context *ctx );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -175,14 +175,14 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md2_finish(
 /**
  * \brief          MD2 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_md2_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_md2_process() in 2.5.0
  *
  * \param ctx      MD2 context
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_md2_process(
                                                     mbedtls_md2_context *ctx )
 {
-    mbedtls_md2_process_ext( ctx );
+    mbedtls_internal_md2_process( ctx );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -225,8 +225,6 @@ int mbedtls_md2_ext( const unsigned char *input,
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
- *
- * \return         0 if successful
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_md2( const unsigned char *input,
                                                    size_t ilen,

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -92,7 +92,7 @@ int mbedtls_md2_starts_ext( mbedtls_md2_context *ctx );
  * \brief          MD2 process buffer
  *
  * \param ctx      MD2 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -146,7 +146,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md2_starts(
  * \deprecated     Superseded by mbedtls_md2_update_ext() in 2.5.0
  *
  * \param ctx      MD2 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_md2_update(
@@ -203,7 +203,7 @@ extern "C" {
 /**
  * \brief          Output = MD2( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
  */
@@ -222,7 +222,7 @@ int mbedtls_md2_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_md2() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
  */

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -32,6 +32,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_MD4_ALT)
 // Regular implementation
 //
@@ -78,8 +83,10 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  * \brief          MD4 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \return         0 if successful
  */
-void mbedtls_md4_starts( mbedtls_md4_context *ctx );
+int mbedtls_md4_starts_ext( mbedtls_md4_context *ctx );
 
 /**
  * \brief          MD4 process buffer
@@ -87,16 +94,103 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx );
  * \param ctx      MD4 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen );
+int mbedtls_md4_update_ext( mbedtls_md4_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen );
 
 /**
  * \brief          MD4 final digest
  *
  * \param ctx      MD4 context
  * \param output   MD4 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] );
+int mbedtls_md4_finish_ext( mbedtls_md4_context *ctx,
+                            unsigned char output[16] );
+
+/**
+ * \brief          MD4 process data block (internal use only)
+ *
+ * \param ctx      MD4 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_md4_process_ext( mbedtls_md4_context *ctx,
+                             const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          MD4 context setup
+ *
+ * \deprecated     Superseded by mbedtls_md4_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md4_starts(
+                                                    mbedtls_md4_context *ctx )
+{
+    mbedtls_md4_starts_ext( ctx );
+}
+
+/**
+ * \brief          MD4 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_md4_update_ext() in 2.5.0
+ *
+ * \param ctx      MD4 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md4_update(
+                                                    mbedtls_md4_context *ctx,
+                                                    const unsigned char *input,
+                                                    size_t ilen )
+{
+    mbedtls_md4_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          MD4 final digest
+ *
+ * \deprecated     Superseded by mbedtls_md4_finish_ext() in 2.5.0
+ *
+ * \param ctx      MD4 context
+ * \param output   MD4 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md4_finish(
+                                                    mbedtls_md4_context *ctx,
+                                                    unsigned char output[16] )
+{
+    mbedtls_md4_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          MD4 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_md4_process_ext() in 2.5.0
+ *
+ * \param ctx      MD4 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md4_process(
+                                                mbedtls_md4_context *ctx,
+                                                const unsigned char data[64] )
+{
+    mbedtls_md4_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -116,8 +210,37 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
+int mbedtls_md4_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = MD4( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_md4_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   MD4 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md4( const unsigned char *input,
+                                                   size_t ilen,
+                                                   unsigned char output[16] )
+{
+    mbedtls_md4_ext( input, ilen, output );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine
@@ -125,9 +248,6 @@ void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_md4_self_test( int verbose );
-
-/* Internal use */
-void mbedtls_md4_process( mbedtls_md4_context *ctx, const unsigned char data[64] );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -92,7 +92,7 @@ int mbedtls_md4_starts_ext( mbedtls_md4_context *ctx );
  * \brief          MD4 process buffer
  *
  * \param ctx      MD4 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -148,7 +148,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md4_starts(
  * \deprecated     Superseded by mbedtls_md4_update_ext() in 2.5.0
  *
  * \param ctx      MD4 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_md4_update(
@@ -207,7 +207,7 @@ extern "C" {
 /**
  * \brief          Output = MD4( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
  *
@@ -228,7 +228,7 @@ int mbedtls_md4_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_md4_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
  */

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -120,8 +120,8 @@ int mbedtls_md4_finish_ext( mbedtls_md4_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_md4_process_ext( mbedtls_md4_context *ctx,
-                             const unsigned char data[64] );
+int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
+                                  const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -177,7 +177,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md4_finish(
 /**
  * \brief          MD4 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_md4_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_md4_process() in 2.5.0
  *
  * \param ctx      MD4 context
  * \param data     buffer holding one block of data
@@ -186,7 +186,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md4_process(
                                                 mbedtls_md4_context *ctx,
                                                 const unsigned char data[64] )
 {
-    mbedtls_md4_process_ext( ctx, data );
+    mbedtls_internal_md4_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -87,7 +87,7 @@ int mbedtls_md5_starts_ext( mbedtls_md5_context *ctx );
  * \brief          MD5 process buffer
  *
  * \param ctx      MD5 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -143,7 +143,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md5_starts(
  * \deprecated     Superseded by mbedtls_md5_update_ext() in 2.5.0
  *
  * \param ctx      MD5 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_md5_update(
@@ -202,7 +202,7 @@ extern "C" {
 /**
  * \brief          Output = MD5( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
  *
@@ -223,7 +223,7 @@ int mbedtls_md5_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_md5_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
  */

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -78,8 +78,10 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  * \brief          MD5 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \return         0 if successful
  */
-void mbedtls_md5_starts( mbedtls_md5_context *ctx );
+int mbedtls_md5_starts_ext( mbedtls_md5_context *ctx );
 
 /**
  * \brief          MD5 process buffer
@@ -87,19 +89,103 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx );
  * \param ctx      MD5 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
+int mbedtls_md5_update_ext( mbedtls_md5_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen );
 
 /**
  * \brief          MD5 final digest
  *
  * \param ctx      MD5 context
  * \param output   MD5 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );
+int mbedtls_md5_finish_ext( mbedtls_md5_context *ctx,
+                            unsigned char output[16] );
 
-/* Internal use */
-void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64] );
+/**
+ * \brief          MD5 process data block (internal use only)
+ *
+ * \param ctx      MD5 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_md5_process_ext( mbedtls_md5_context *ctx,
+                             const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          MD5 context setup
+ *
+ * \deprecated     Superseded by mbedtls_md5_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md5_starts(
+                                                    mbedtls_md5_context *ctx )
+{
+    mbedtls_md5_starts_ext( ctx );
+}
+
+/**
+ * \brief          MD5 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_md5_update_ext() in 2.5.0
+ *
+ * \param ctx      MD5 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md5_update(
+                                                    mbedtls_md5_context *ctx,
+                                                    const unsigned char *input,
+                                                    size_t ilen )
+{
+    mbedtls_md5_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          MD5 final digest
+ *
+ * \deprecated     Superseded by mbedtls_md5_finish_ext() in 2.5.0
+ *
+ * \param ctx      MD5 context
+ * \param output   MD5 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md5_finish(
+                                                    mbedtls_md5_context *ctx,
+                                                    unsigned char output[16] )
+{
+    mbedtls_md5_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          MD5 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_md5_process_ext() in 2.5.0
+ *
+ * \param ctx      MD5 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md5_process(
+                                                mbedtls_md5_context *ctx,
+                                                const unsigned char data[64] )
+{
+    mbedtls_md5_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -119,8 +205,37 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
+int mbedtls_md5_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = MD5( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_md5_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   MD5 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_md5( const unsigned char *input,
+                                                   size_t ilen,
+                                                   unsigned char output[16] )
+{
+    mbedtls_md5_ext( input, ilen, output );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -115,8 +115,8 @@ int mbedtls_md5_finish_ext( mbedtls_md5_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_md5_process_ext( mbedtls_md5_context *ctx,
-                             const unsigned char data[64] );
+int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
+                                  const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -172,7 +172,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md5_finish(
 /**
  * \brief          MD5 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_md5_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_md5_process() in 2.5.0
  *
  * \param ctx      MD5 context
  * \param data     buffer holding one block of data
@@ -181,7 +181,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_md5_process(
                                                 mbedtls_md5_context *ctx,
                                                 const unsigned char data[64] )
 {
-    mbedtls_md5_process_ext( ctx, data );
+    mbedtls_internal_md5_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/md_internal.h
+++ b/include/mbedtls/md_internal.h
@@ -58,17 +58,17 @@ struct mbedtls_md_info_t
     int block_size;
 
     /** Digest initialisation function */
-    void (*starts_func)( void *ctx );
+    int (*starts_func)( void *ctx );
 
     /** Digest update function */
-    void (*update_func)( void *ctx, const unsigned char *input, size_t ilen );
+    int (*update_func)( void *ctx, const unsigned char *input, size_t ilen );
 
     /** Digest finalisation function */
-    void (*finish_func)( void *ctx, unsigned char *output );
+    int (*finish_func)( void *ctx, unsigned char *output );
 
     /** Generic digest function */
-    void (*digest_func)( const unsigned char *input, size_t ilen,
-                         unsigned char *output );
+    int (*digest_func)( const unsigned char *input, size_t ilen,
+                        unsigned char *output );
 
     /** Allocate a new context */
     void * (*ctx_alloc_func)( void );
@@ -80,7 +80,7 @@ struct mbedtls_md_info_t
     void (*clone_func)( void *dst, const void *src );
 
     /** Internal use only */
-    void (*process_func)( void *ctx, const unsigned char *input );
+    int (*process_func)( void *ctx, const unsigned char *input );
 };
 
 #if defined(MBEDTLS_MD2_C)

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -92,7 +92,7 @@ int mbedtls_ripemd160_starts_ext( mbedtls_ripemd160_context *ctx );
  * \brief          RIPEMD-160 process buffer
  *
  * \param ctx      RIPEMD-160 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -148,7 +148,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_starts(
  * \deprecated     Superseded by mbedtls_ripemd160_update_ext() in 2.5.0
  *
  * \param ctx      RIPEMD-160 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_update(
@@ -207,7 +207,7 @@ extern "C" {
 /**
  * \brief          Output = RIPEMD-160( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   RIPEMD-160 checksum result
  *
@@ -228,7 +228,7 @@ int mbedtls_ripemd160_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_ripemd160_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   RIPEMD-160 checksum result
  */

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -32,6 +32,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_RIPEMD160_ALT)
 // Regular implementation
 //
@@ -78,8 +83,10 @@ void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
  * \brief          RIPEMD-160 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \return         0 if successful
  */
-void mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx );
+int mbedtls_ripemd160_starts_ext( mbedtls_ripemd160_context *ctx );
 
 /**
  * \brief          RIPEMD-160 process buffer
@@ -87,20 +94,103 @@ void mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx );
  * \param ctx      RIPEMD-160 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
-                       const unsigned char *input, size_t ilen );
+int mbedtls_ripemd160_update_ext( mbedtls_ripemd160_context *ctx,
+                                  const unsigned char *input,
+                                  size_t ilen );
 
 /**
  * \brief          RIPEMD-160 final digest
  *
  * \param ctx      RIPEMD-160 context
  * \param output   RIPEMD-160 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx, unsigned char output[20] );
+int mbedtls_ripemd160_finish_ext( mbedtls_ripemd160_context *ctx,
+                                  unsigned char output[20] );
 
-/* Internal use */
-void mbedtls_ripemd160_process( mbedtls_ripemd160_context *ctx, const unsigned char data[64] );
+/**
+ * \brief          RIPEMD-160 process data block (internal use only)
+ *
+ * \param ctx      RIPEMD-160 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_ripemd160_process_ext( mbedtls_ripemd160_context *ctx,
+                                   const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          RIPEMD-160 context setup
+ *
+ * \deprecated     Superseded by mbedtls_ripemd160_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_starts(
+                                            mbedtls_ripemd160_context *ctx )
+{
+    mbedtls_ripemd160_starts_ext( ctx );
+}
+
+/**
+ * \brief          RIPEMD-160 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_ripemd160_update_ext() in 2.5.0
+ *
+ * \param ctx      RIPEMD-160 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_update(
+                                                mbedtls_ripemd160_context *ctx,
+                                                const unsigned char *input,
+                                                size_t ilen )
+{
+    mbedtls_ripemd160_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          RIPEMD-160 final digest
+ *
+ * \deprecated     Superseded by mbedtls_ripemd160_finish_ext() in 2.5.0
+ *
+ * \param ctx      RIPEMD-160 context
+ * \param output   RIPEMD-160 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_finish(
+                                                mbedtls_ripemd160_context *ctx,
+                                                unsigned char output[20] )
+{
+    mbedtls_ripemd160_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          RIPEMD-160 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_ripemd160_process_ext() in 2.5.0
+ *
+ * \param ctx      RIPEMD-160 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_process(
+                                            mbedtls_ripemd160_context *ctx,
+                                            const unsigned char data[64] )
+{
+    mbedtls_ripemd160_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -120,9 +210,38 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   RIPEMD-160 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_ripemd160( const unsigned char *input, size_t ilen,
-                unsigned char output[20] );
+int mbedtls_ripemd160_ext( const unsigned char *input,
+                           size_t ilen,
+                           unsigned char output[20] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = RIPEMD-160( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_ripemd160_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   RIPEMD-160 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160(
+                                                    const unsigned char *input,
+                                                    size_t ilen,
+                                                    unsigned char output[20] )
+{
+    mbedtls_ripemd160_ext( input, ilen, output );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -120,8 +120,8 @@ int mbedtls_ripemd160_finish_ext( mbedtls_ripemd160_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_process_ext( mbedtls_ripemd160_context *ctx,
-                                   const unsigned char data[64] );
+int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
+                                        const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -177,7 +177,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_finish(
 /**
  * \brief          RIPEMD-160 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_ripemd160_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_ripemd160_process() in 2.5.0
  *
  * \param ctx      RIPEMD-160 context
  * \param data     buffer holding one block of data
@@ -186,7 +186,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_ripemd160_process(
                                             mbedtls_ripemd160_context *ctx,
                                             const unsigned char data[64] )
 {
-    mbedtls_ripemd160_process_ext( ctx, data );
+    mbedtls_internal_ripemd160_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -32,6 +32,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_SHA1_ALT)
 // Regular implementation
 //
@@ -78,8 +83,10 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \brief          SHA-1 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
+int mbedtls_sha1_starts_ext( mbedtls_sha1_context *ctx );
 
 /**
  * \brief          SHA-1 process buffer
@@ -87,19 +94,103 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
  * \param ctx      SHA-1 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
+int mbedtls_sha1_update_ext( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen );
 
 /**
  * \brief          SHA-1 final digest
  *
  * \param ctx      SHA-1 context
  * \param output   SHA-1 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
+int mbedtls_sha1_finish_ext( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] );
 
-/* Internal use */
-void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] );
+/**
+ * \brief          SHA-1 process data block (internal use only)
+ *
+ * \param ctx      SHA-1 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_sha1_process_ext( mbedtls_sha1_context *ctx,
+                              const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          SHA-1 context setup
+ *
+ * \deprecated     Superseded by mbedtls_sha1_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha1_starts(
+                                                mbedtls_sha1_context *ctx )
+{
+    mbedtls_sha1_starts_ext( ctx );
+}
+
+/**
+ * \brief          SHA-1 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_sha1_update_ext() in 2.5.0
+ *
+ * \param ctx      SHA-1 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha1_update(
+                                                mbedtls_sha1_context *ctx,
+                                                const unsigned char *input,
+                                                size_t ilen )
+{
+    mbedtls_sha1_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          SHA-1 final digest
+ *
+ * \deprecated     Superseded by mbedtls_sha1_finish_ext() in 2.5.0
+ *
+ * \param ctx      SHA-1 context
+ * \param output   SHA-1 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha1_finish(
+                                                mbedtls_sha1_context *ctx,
+                                                unsigned char output[20] )
+{
+    mbedtls_sha1_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          SHA-1 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_sha1_process_ext() in 2.5.0
+ *
+ * \param ctx      SHA-1 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha1_process(
+                                                mbedtls_sha1_context *ctx,
+                                                const unsigned char data[64] )
+{
+    mbedtls_sha1_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -119,8 +210,37 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
+int mbedtls_sha1_ext( const unsigned char *input,
+                      size_t ilen,
+                      unsigned char output[20] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = SHA-1( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_sha1_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-1 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha1( const unsigned char *input,
+                                                    size_t ilen,
+                                                    unsigned char output[20] )
+{
+    mbedtls_sha1_ext( input, ilen, output );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -120,8 +120,8 @@ int mbedtls_sha1_finish_ext( mbedtls_sha1_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_sha1_process_ext( mbedtls_sha1_context *ctx,
-                              const unsigned char data[64] );
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -177,7 +177,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha1_finish(
 /**
  * \brief          SHA-1 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_sha1_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_sha1_process() in 2.5.0
  *
  * \param ctx      SHA-1 context
  * \param data     buffer holding one block of data
@@ -186,7 +186,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha1_process(
                                                 mbedtls_sha1_context *ctx,
                                                 const unsigned char data[64] )
 {
-    mbedtls_sha1_process_ext( ctx, data );
+    mbedtls_internal_sha1_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -92,7 +92,7 @@ int mbedtls_sha1_starts_ext( mbedtls_sha1_context *ctx );
  * \brief          SHA-1 process buffer
  *
  * \param ctx      SHA-1 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -148,7 +148,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha1_starts(
  * \deprecated     Superseded by mbedtls_sha1_update_ext() in 2.5.0
  *
  * \param ctx      SHA-1 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_sha1_update(
@@ -207,7 +207,7 @@ extern "C" {
 /**
  * \brief          Output = SHA-1( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
  *
@@ -228,7 +228,7 @@ int mbedtls_sha1_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_sha1_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
  */

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -32,6 +32,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_SHA256_ALT)
 // Regular implementation
 //
@@ -80,8 +85,10 @@ void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
  *
  * \param ctx      context to be initialized
  * \param is224    0 = use SHA256, 1 = use SHA224
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 );
+int mbedtls_sha256_starts_ext( mbedtls_sha256_context *ctx, int is224 );
 
 /**
  * \brief          SHA-256 process buffer
@@ -89,20 +96,105 @@ void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 );
  * \param ctx      SHA-256 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *input,
-                    size_t ilen );
+int mbedtls_sha256_update_ext( mbedtls_sha256_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen );
 
 /**
  * \brief          SHA-256 final digest
  *
  * \param ctx      SHA-256 context
  * \param output   SHA-224/256 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32] );
+int mbedtls_sha256_finish_ext( mbedtls_sha256_context *ctx,
+                               unsigned char output[32] );
 
-/* Internal use */
-void mbedtls_sha256_process( mbedtls_sha256_context *ctx, const unsigned char data[64] );
+/**
+ * \brief          SHA-256 process data block (internal use only)
+ *
+ * \param ctx      SHA-256 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_sha256_process_ext( mbedtls_sha256_context *ctx,
+                                const unsigned char data[64] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          SHA-256 context setup
+ *
+ * \deprecated     Superseded by mbedtls_sha256_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ * \param is224    0 = use SHA256, 1 = use SHA224
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha256_starts(
+                                                mbedtls_sha256_context *ctx,
+                                                int is224 )
+{
+    mbedtls_sha256_starts_ext( ctx, is224 );
+}
+
+/**
+ * \brief          SHA-256 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_sha256_update_ext() in 2.5.0
+ *
+ * \param ctx      SHA-256 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha256_update(
+                                                mbedtls_sha256_context *ctx,
+                                                const unsigned char *input,
+                                                size_t ilen )
+{
+    mbedtls_sha256_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          SHA-256 final digest
+ *
+ * \deprecated     Superseded by mbedtls_sha256_finish_ext() in 2.5.0
+ *
+ * \param ctx      SHA-256 context
+ * \param output   SHA-224/256 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha256_finish(
+                                                mbedtls_sha256_context *ctx,
+                                                unsigned char output[32] )
+{
+    mbedtls_sha256_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          SHA-256 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_sha256_process_ext() in 2.5.0
+ *
+ * \param ctx      SHA-256 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha256_process(
+                                                mbedtls_sha256_context *ctx,
+                                                const unsigned char data[64] )
+{
+    mbedtls_sha256_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -123,9 +215,41 @@ extern "C" {
  * \param ilen     length of the input data
  * \param output   SHA-224/256 checksum result
  * \param is224    0 = use SHA256, 1 = use SHA224
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha256( const unsigned char *input, size_t ilen,
-           unsigned char output[32], int is224 );
+int mbedtls_sha256_ext( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[32],
+                        int is224 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = SHA-256( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_sha256_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-224/256 checksum result
+ * \param is224    0 = use SHA256, 1 = use SHA224
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha256(
+                                                    const unsigned char *input,
+                                                    size_t ilen,
+                                                    unsigned char output[32],
+                                                    int is224 )
+{
+    mbedtls_sha256_ext( input, ilen, output, is224 );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -122,8 +122,8 @@ int mbedtls_sha256_finish_ext( mbedtls_sha256_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_sha256_process_ext( mbedtls_sha256_context *ctx,
-                                const unsigned char data[64] );
+int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
+                                     const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -181,7 +181,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha256_finish(
 /**
  * \brief          SHA-256 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_sha256_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_sha256_process() in 2.5.0
  *
  * \param ctx      SHA-256 context
  * \param data     buffer holding one block of data
@@ -190,7 +190,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha256_process(
                                                 mbedtls_sha256_context *ctx,
                                                 const unsigned char data[64] )
 {
-    mbedtls_sha256_process_ext( ctx, data );
+    mbedtls_internal_sha256_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -94,7 +94,7 @@ int mbedtls_sha256_starts_ext( mbedtls_sha256_context *ctx, int is224 );
  * \brief          SHA-256 process buffer
  *
  * \param ctx      SHA-256 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -152,7 +152,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha256_starts(
  * \deprecated     Superseded by mbedtls_sha256_update_ext() in 2.5.0
  *
  * \param ctx      SHA-256 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_sha256_update(
@@ -211,7 +211,7 @@ extern "C" {
 /**
  * \brief          Output = SHA-256( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-224/256 checksum result
  * \param is224    0 = use SHA256, 1 = use SHA224
@@ -234,7 +234,7 @@ int mbedtls_sha256_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_sha256_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-224/256 checksum result
  * \param is224    0 = use SHA256, 1 = use SHA224

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -32,6 +32,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if !defined(MBEDTLS_SHA512_ALT)
 // Regular implementation
 //
@@ -80,8 +85,10 @@ void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
  *
  * \param ctx      context to be initialized
  * \param is384    0 = use SHA512, 1 = use SHA384
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 );
+int mbedtls_sha512_starts_ext( mbedtls_sha512_context *ctx, int is384 );
 
 /**
  * \brief          SHA-512 process buffer
@@ -89,17 +96,105 @@ void mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 );
  * \param ctx      SHA-512 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha512_update( mbedtls_sha512_context *ctx, const unsigned char *input,
-                    size_t ilen );
+int mbedtls_sha512_update_ext( mbedtls_sha512_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen );
 
 /**
  * \brief          SHA-512 final digest
  *
  * \param ctx      SHA-512 context
  * \param output   SHA-384/512 checksum result
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha512_finish( mbedtls_sha512_context *ctx, unsigned char output[64] );
+int mbedtls_sha512_finish_ext( mbedtls_sha512_context *ctx,
+                               unsigned char output[64] );
+
+/**
+ * \brief          SHA-512 process data block (internal use only)
+ *
+ * \param ctx      SHA-512 context
+ * \param data     buffer holding one block of data
+ *
+ * \return         0 if successful
+ */
+int mbedtls_sha512_process_ext( mbedtls_sha512_context *ctx,
+                                const unsigned char data[128] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          SHA-512 context setup
+ *
+ * \deprecated     Superseded by mbedtls_sha512_starts_ext() in 2.5.0
+ *
+ * \param ctx      context to be initialized
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha512_starts(
+                                                mbedtls_sha512_context *ctx,
+                                                int is384 )
+{
+    mbedtls_sha512_starts_ext( ctx, is384 );
+}
+
+/**
+ * \brief          SHA-512 process buffer
+ *
+ * \deprecated     Superseded by mbedtls_sha512_update_ext() in 2.5.0
+ *
+ * \param ctx      SHA-512 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha512_update(
+                                                mbedtls_sha512_context *ctx,
+                                                const unsigned char *input,
+                                                size_t ilen )
+{
+    mbedtls_sha512_update_ext( ctx, input, ilen );
+}
+
+/**
+ * \brief          SHA-512 final digest
+ *
+ * \deprecated     Superseded by mbedtls_sha512_finish_ext() in 2.5.0
+ *
+ * \param ctx      SHA-512 context
+ * \param output   SHA-384/512 checksum result
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha512_finish(
+                                                mbedtls_sha512_context *ctx,
+                                                unsigned char output[64] )
+{
+    mbedtls_sha512_finish_ext( ctx, output );
+}
+
+/**
+ * \brief          SHA-512 process data block (internal use only)
+ *
+ * \deprecated     Superseded by mbedtls_sha512_process_ext() in 2.5.0
+ *
+ * \param ctx      SHA-512 context
+ * \param data     buffer holding one block of data
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha512_process(
+                                            mbedtls_sha512_context *ctx,
+                                            const unsigned char data[128] )
+{
+    mbedtls_sha512_process_ext( ctx, data );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }
@@ -120,9 +215,41 @@ extern "C" {
  * \param ilen     length of the input data
  * \param output   SHA-384/512 checksum result
  * \param is384    0 = use SHA512, 1 = use SHA384
+ *
+ * \return         0 if successful
  */
-void mbedtls_sha512( const unsigned char *input, size_t ilen,
-             unsigned char output[64], int is384 );
+int mbedtls_sha512_ext( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[64],
+                        int is384 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief          Output = SHA-512( input buffer )
+ *
+ * \deprecated     Superseded by mbedtls_sha512_ext() in 2.5.0
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-384/512 checksum result
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ */
+MBEDTLS_DEPRECATED static inline void mbedtls_sha512(
+                                                    const unsigned char *input,
+                                                    size_t ilen,
+                                                    unsigned char output[64],
+                                                    int is384 )
+{
+    mbedtls_sha512_ext( input, ilen, output, is384 );
+}
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          Checkup routine
@@ -130,9 +257,6 @@ void mbedtls_sha512( const unsigned char *input, size_t ilen,
  * \return         0 if successful, or 1 if the test failed
  */
 int mbedtls_sha512_self_test( int verbose );
-
-/* Internal use */
-void mbedtls_sha512_process( mbedtls_sha512_context *ctx, const unsigned char data[128] );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -94,7 +94,7 @@ int mbedtls_sha512_starts_ext( mbedtls_sha512_context *ctx, int is384 );
  * \brief          SHA-512 process buffer
  *
  * \param ctx      SHA-512 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  *
  * \return         0 if successful
@@ -152,7 +152,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha512_starts(
  * \deprecated     Superseded by mbedtls_sha512_update_ext() in 2.5.0
  *
  * \param ctx      SHA-512 context
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  */
 MBEDTLS_DEPRECATED static inline void mbedtls_sha512_update(
@@ -211,7 +211,7 @@ extern "C" {
 /**
  * \brief          Output = SHA-512( input buffer )
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-384/512 checksum result
  * \param is384    0 = use SHA512, 1 = use SHA384
@@ -234,7 +234,7 @@ int mbedtls_sha512_ext( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_sha512_ext() in 2.5.0
  *
- * \param input    buffer holding the  data
+ * \param input    buffer holding the data
  * \param ilen     length of the input data
  * \param output   SHA-384/512 checksum result
  * \param is384    0 = use SHA512, 1 = use SHA384

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -122,8 +122,8 @@ int mbedtls_sha512_finish_ext( mbedtls_sha512_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_sha512_process_ext( mbedtls_sha512_context *ctx,
-                                const unsigned char data[128] );
+int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
+                                     const unsigned char data[128] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -181,7 +181,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha512_finish(
 /**
  * \brief          SHA-512 process data block (internal use only)
  *
- * \deprecated     Superseded by mbedtls_sha512_process_ext() in 2.5.0
+ * \deprecated     Superseded by mbedtls_internal_sha512_process() in 2.5.0
  *
  * \param ctx      SHA-512 context
  * \param data     buffer holding one block of data
@@ -190,7 +190,7 @@ MBEDTLS_DEPRECATED static inline void mbedtls_sha512_process(
                                             mbedtls_sha512_context *ctx,
                                             const unsigned char data[128] )
 {
-    mbedtls_sha512_process_ext( ctx, data );
+    mbedtls_internal_sha512_process( ctx, data );
 }
 
 #undef MBEDTLS_DEPRECATED

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -610,6 +610,23 @@ static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t
     return( diff );
 }
 
+#if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_1)
+int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
+                                        unsigned char *output,
+                                        unsigned char *data, size_t data_len );
+#endif /* MBEDTLS_SSL_PROTO_SSL3 || MBEDTLS_SSL_PROTO_TLS1 || \
+          MBEDTLS_SSL_PROTO_TLS1_1 */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
+    defined(MBEDTLS_SSL_PROTO_TLS1_2)
+int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
+                                        unsigned char *output,
+                                        unsigned char *data, size_t data_len,
+                                        mbedtls_md_type_t md_alg );
+#endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \
+          MBEDTLS_SSL_PROTO_TLS1_2 */
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -366,6 +366,11 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    /*
+     * Note that at this stage it is assumed that the accumulator was started
+     * in a previous call to entropy_update(). If this is not guaranteed, the
+     * code below will fail.
+     */
     if( ( ret = mbedtls_sha512_finish_ext( &ctx->accumulator, buf ) ) != 0 )
         goto exit;
 

--- a/library/md.c
+++ b/library/md.c
@@ -436,7 +436,8 @@ int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
         goto cleanup;
     if( ( ret = mbedtls_md_hmac_update( &ctx, input, ilen ) ) != 0 )
         goto cleanup;
-    ret = mbedtls_md_hmac_finish( &ctx, output );
+    if( ( ret = mbedtls_md_hmac_finish( &ctx, output ) ) != 0 )
+        goto cleanup;
 
 cleanup:
     mbedtls_md_free( &ctx );

--- a/library/md.c
+++ b/library/md.c
@@ -358,8 +358,9 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
 
     if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
         goto cleanup;
-    ret = ctx->md_info->update_func( ctx->md_ctx, ipad,
-                                     ctx->md_info->block_size );
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, ipad,
+                                           ctx->md_info->block_size ) ) != 0 )
+        goto cleanup;
 
 cleanup:
     mbedtls_zeroize( sum, sizeof( sum ) );

--- a/library/md.c
+++ b/library/md.c
@@ -250,9 +250,7 @@ int mbedtls_md_starts( mbedtls_md_context_t *ctx )
     if( ctx == NULL || ctx->md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    ctx->md_info->starts_func( ctx->md_ctx );
-
-    return( 0 );
+    return( ctx->md_info->starts_func( ctx->md_ctx ) );
 }
 
 int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen )
@@ -260,9 +258,7 @@ int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, si
     if( ctx == NULL || ctx->md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    ctx->md_info->update_func( ctx->md_ctx, input, ilen );
-
-    return( 0 );
+    return( ctx->md_info->update_func( ctx->md_ctx, input, ilen ) );
 }
 
 int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output )
@@ -270,9 +266,7 @@ int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output )
     if( ctx == NULL || ctx->md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    ctx->md_info->finish_func( ctx->md_ctx, output );
-
-    return( 0 );
+    return( ctx->md_info->finish_func( ctx->md_ctx, output ) );
 }
 
 int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
@@ -281,9 +275,7 @@ int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, si
     if( md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    md_info->digest_func( input, ilen, output );
-
-    return( 0 );
+    return( md_info->digest_func( input, ilen, output ) );
 }
 
 #if defined(MBEDTLS_FS_IO)
@@ -306,10 +298,12 @@ int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path, unsigne
     if( ( ret = mbedtls_md_setup( &ctx, md_info, 0 ) ) != 0 )
         goto cleanup;
 
-    md_info->starts_func( ctx.md_ctx );
+    if( ( ret = md_info->starts_func( ctx.md_ctx ) ) != 0 )
+        goto cleanup;
 
     while( ( n = fread( buf, 1, sizeof( buf ), f ) ) > 0 )
-        md_info->update_func( ctx.md_ctx, buf, n );
+        if( ( ret = md_info->update_func( ctx.md_ctx, buf, n ) ) != 0 )
+            goto cleanup;
 
     if( ferror( f ) != 0 )
     {
@@ -317,7 +311,7 @@ int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path, unsigne
         goto cleanup;
     }
 
-    md_info->finish_func( ctx.md_ctx, output );
+    ret = md_info->finish_func( ctx.md_ctx, output );
 
 cleanup:
     fclose( f );
@@ -329,6 +323,7 @@ cleanup:
 
 int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key, size_t keylen )
 {
+    int ret;
     unsigned char sum[MBEDTLS_MD_MAX_SIZE];
     unsigned char *ipad, *opad;
     size_t i;
@@ -338,9 +333,12 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
 
     if( keylen > (size_t) ctx->md_info->block_size )
     {
-        ctx->md_info->starts_func( ctx->md_ctx );
-        ctx->md_info->update_func( ctx->md_ctx, key, keylen );
-        ctx->md_info->finish_func( ctx->md_ctx, sum );
+        if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+            goto cleanup;
+        if( ( ret = ctx->md_info->update_func( ctx->md_ctx, key, keylen ) ) != 0 )
+            goto cleanup;
+        if( ( ret = ctx->md_info->finish_func( ctx->md_ctx, sum ) ) != 0 )
+            goto cleanup;
 
         keylen = ctx->md_info->size;
         key = sum;
@@ -358,12 +356,15 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
         opad[i] = (unsigned char)( opad[i] ^ key[i] );
     }
 
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        goto cleanup;
+    ret = ctx->md_info->update_func( ctx->md_ctx, ipad,
+                                     ctx->md_info->block_size );
+
+cleanup:
     mbedtls_zeroize( sum, sizeof( sum ) );
 
-    ctx->md_info->starts_func( ctx->md_ctx );
-    ctx->md_info->update_func( ctx->md_ctx, ipad, ctx->md_info->block_size );
-
-    return( 0 );
+    return( ret );
 }
 
 int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen )
@@ -371,13 +372,12 @@ int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *inpu
     if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    ctx->md_info->update_func( ctx->md_ctx, input, ilen );
-
-    return( 0 );
+    return( ctx->md_info->update_func( ctx->md_ctx, input, ilen ) );
 }
 
 int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output )
 {
+    int ret;
     unsigned char tmp[MBEDTLS_MD_MAX_SIZE];
     unsigned char *opad;
 
@@ -386,17 +386,22 @@ int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output )
 
     opad = (unsigned char *) ctx->hmac_ctx + ctx->md_info->block_size;
 
-    ctx->md_info->finish_func( ctx->md_ctx, tmp );
-    ctx->md_info->starts_func( ctx->md_ctx );
-    ctx->md_info->update_func( ctx->md_ctx, opad, ctx->md_info->block_size );
-    ctx->md_info->update_func( ctx->md_ctx, tmp, ctx->md_info->size );
-    ctx->md_info->finish_func( ctx->md_ctx, output );
-
-    return( 0 );
+    if( ( ret = ctx->md_info->finish_func( ctx->md_ctx, tmp ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, opad,
+                                           ctx->md_info->block_size ) ) != 0 )
+        return( ret );
+    if( ( ret = ctx->md_info->update_func( ctx->md_ctx, tmp,
+                                           ctx->md_info->size ) ) != 0 )
+        return( ret );
+    return( ctx->md_info->finish_func( ctx->md_ctx, output ) );
 }
 
 int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx )
 {
+    int ret;
     unsigned char *ipad;
 
     if( ctx == NULL || ctx->md_info == NULL || ctx->hmac_ctx == NULL )
@@ -404,15 +409,16 @@ int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx )
 
     ipad = (unsigned char *) ctx->hmac_ctx;
 
-    ctx->md_info->starts_func( ctx->md_ctx );
-    ctx->md_info->update_func( ctx->md_ctx, ipad, ctx->md_info->block_size );
-
-    return( 0 );
+    if( ( ret = ctx->md_info->starts_func( ctx->md_ctx ) ) != 0 )
+        return( ret );
+    return( ctx->md_info->update_func( ctx->md_ctx, ipad,
+                                       ctx->md_info->block_size ) );
 }
 
-int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key, size_t keylen,
-                const unsigned char *input, size_t ilen,
-                unsigned char *output )
+int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
+                     const unsigned char *key, size_t keylen,
+                     const unsigned char *input, size_t ilen,
+                     unsigned char *output )
 {
     mbedtls_md_context_t ctx;
     int ret;
@@ -423,15 +429,18 @@ int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key,
     mbedtls_md_init( &ctx );
 
     if( ( ret = mbedtls_md_setup( &ctx, md_info, 1 ) ) != 0 )
-        return( ret );
+        goto cleanup;
 
-    mbedtls_md_hmac_starts( &ctx, key, keylen );
-    mbedtls_md_hmac_update( &ctx, input, ilen );
-    mbedtls_md_hmac_finish( &ctx, output );
+    if( ( ret = mbedtls_md_hmac_starts( &ctx, key, keylen ) ) != 0 )
+        goto cleanup;
+    if( ( ret = mbedtls_md_hmac_update( &ctx, input, ilen ) ) != 0 )
+        goto cleanup;
+    ret = mbedtls_md_hmac_finish( &ctx, output );
 
+cleanup:
     mbedtls_md_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data )
@@ -439,9 +448,7 @@ int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data )
     if( ctx == NULL || ctx->md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    ctx->md_info->process_func( ctx->md_ctx, data );
-
-    return( 0 );
+    return( ctx->md_info->process_func( ctx->md_ctx, data ) );
 }
 
 unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info )

--- a/library/md2.c
+++ b/library/md2.c
@@ -248,7 +248,7 @@ exit:
 /*
  * RFC 1319 test vectors
  */
-static const char md2_test_str[7][81] =
+static const unsigned char md2_test_str[7][81] =
 {
     { "" },
     { "a" },
@@ -256,8 +256,13 @@ static const char md2_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012" \
+    { "12345678901234567890123456789012345678901234567890123456789012"
       "345678901234567890" }
+};
+
+static const size_t md2_test_strlen[7] =
+{
+    0, 1, 3, 14, 26, 62, 80
 };
 
 static const unsigned char md2_test_sum[7][16] =
@@ -283,7 +288,7 @@ static const unsigned char md2_test_sum[7][16] =
  */
 int mbedtls_md2_self_test( int verbose )
 {
-    int i;
+    int i, ret = 0;
     unsigned char md2sum[16];
 
     for( i = 0; i < 7; i++ )
@@ -291,12 +296,15 @@ int mbedtls_md2_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD2 test #%d: ", i + 1 );
 
-        if( mbedtls_md2_ext( (unsigned char *)md2_test_str[i],
-                             strlen( md2_test_str[i] ), md2sum ) != 0 )
+        ret = mbedtls_md2_ext( md2_test_str[i], md2_test_strlen[i], md2sum );
+        if( ret != 0 )
             goto fail;
 
         if( memcmp( md2sum, md2_test_sum[i], 16 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -311,7 +319,7 @@ fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
 
-    return( 1 );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md2.c
+++ b/library/md2.c
@@ -105,16 +105,18 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
 /*
  * MD2 context setup
  */
-void mbedtls_md2_starts( mbedtls_md2_context *ctx )
+int mbedtls_md2_starts_ext( mbedtls_md2_context *ctx )
 {
     memset( ctx->cksum, 0, 16 );
     memset( ctx->state, 0, 46 );
     memset( ctx->buffer, 0, 16 );
     ctx->left = 0;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_MD2_PROCESS_ALT)
-void mbedtls_md2_process( mbedtls_md2_context *ctx )
+int mbedtls_md2_process_ext( mbedtls_md2_context *ctx )
 {
     int i, j;
     unsigned char t = 0;
@@ -146,14 +148,19 @@ void mbedtls_md2_process( mbedtls_md2_context *ctx )
            ( ctx->cksum[i] ^ PI_SUBST[ctx->buffer[i] ^ t] );
         t  = ctx->cksum[i];
     }
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 /*
  * MD2 process buffer
  */
-void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen )
+int mbedtls_md2_update_ext( mbedtls_md2_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen )
 {
+    int ret;
     size_t fill;
 
     while( ilen > 0 )
@@ -172,16 +179,21 @@ void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, s
         if( ctx->left == 16 )
         {
             ctx->left = 0;
-            mbedtls_md2_process( ctx );
+            if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+                return( ret );
         }
     }
+
+    return( 0 );
 }
 
 /*
  * MD2 final digest
  */
-void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] )
+int mbedtls_md2_finish_ext( mbedtls_md2_context *ctx,
+                            unsigned char output[16] )
 {
+    int ret;
     size_t i;
     unsigned char x;
 
@@ -190,12 +202,16 @@ void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] )
     for( i = ctx->left; i < 16; i++ )
         ctx->buffer[i] = x;
 
-    mbedtls_md2_process( ctx );
+    if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+        return( ret );
 
     memcpy( ctx->buffer, ctx->cksum, 16 );
-    mbedtls_md2_process( ctx );
+    if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+        return( ret );
 
     memcpy( output, ctx->state, 16 );
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_MD2_ALT */
@@ -203,15 +219,28 @@ void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] )
 /*
  * output = MD2( input buffer )
  */
-void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[16] )
+int mbedtls_md2_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] )
 {
+    int ret;
     mbedtls_md2_context ctx;
 
     mbedtls_md2_init( &ctx );
-    mbedtls_md2_starts( &ctx );
-    mbedtls_md2_update( &ctx, input, ilen );
-    mbedtls_md2_finish( &ctx, output );
+
+    if( ( ret = mbedtls_md2_starts_ext( &ctx ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_md2_update_ext( &ctx, input, ilen ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_md2_finish_ext( &ctx, output ) ) != 0 )
+        return( ret );
+
+
     mbedtls_md2_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -262,16 +291,12 @@ int mbedtls_md2_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD2 test #%d: ", i + 1 );
 
-        mbedtls_md2( (unsigned char *) md2_test_str[i],
-             strlen( md2_test_str[i] ), md2sum );
+        if( mbedtls_md2_ext( (unsigned char *)md2_test_str[i],
+                             strlen( md2_test_str[i] ), md2sum ) != 0 )
+            goto fail;
 
         if( memcmp( md2sum, md2_test_sum[i], 16 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            return( 1 );
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -281,6 +306,12 @@ int mbedtls_md2_self_test( int verbose )
         mbedtls_printf( "\n" );
 
     return( 0 );
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    return( 1 );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md2.c
+++ b/library/md2.c
@@ -229,18 +229,18 @@ int mbedtls_md2_ext( const unsigned char *input,
     mbedtls_md2_init( &ctx );
 
     if( ( ret = mbedtls_md2_starts_ext( &ctx ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md2_update_ext( &ctx, input, ilen ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md2_finish_ext( &ctx, output ) ) != 0 )
-        return( ret );
+        goto exit;
 
-
+exit:
     mbedtls_md2_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/md2.c
+++ b/library/md2.c
@@ -116,7 +116,7 @@ int mbedtls_md2_starts_ext( mbedtls_md2_context *ctx )
 }
 
 #if !defined(MBEDTLS_MD2_PROCESS_ALT)
-int mbedtls_md2_process_ext( mbedtls_md2_context *ctx )
+int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
 {
     int i, j;
     unsigned char t = 0;
@@ -179,7 +179,7 @@ int mbedtls_md2_update_ext( mbedtls_md2_context *ctx,
         if( ctx->left == 16 )
         {
             ctx->left = 0;
-            if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+            if( ( ret = mbedtls_internal_md2_process( ctx ) ) != 0 )
                 return( ret );
         }
     }
@@ -202,11 +202,11 @@ int mbedtls_md2_finish_ext( mbedtls_md2_context *ctx,
     for( i = ctx->left; i < 16; i++ )
         ctx->buffer[i] = x;
 
-    if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+    if( ( ret = mbedtls_internal_md2_process( ctx ) ) != 0 )
         return( ret );
 
     memcpy( ctx->buffer, ctx->cksum, 16 );
-    if( ( ret = mbedtls_md2_process_ext( ctx ) ) != 0 )
+    if( ( ret = mbedtls_internal_md2_process( ctx ) ) != 0 )
         return( ret );
 
     memcpy( output, ctx->state, 16 );

--- a/library/md4.c
+++ b/library/md4.c
@@ -352,7 +352,7 @@ exit:
 /*
  * RFC 1320 test vectors
  */
-static const char md4_test_str[7][81] =
+static const unsigned char md4_test_str[7][81] =
 {
     { "" },
     { "a" },
@@ -360,8 +360,13 @@ static const char md4_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012" \
+    { "12345678901234567890123456789012345678901234567890123456789012"
       "345678901234567890" }
+};
+
+static const size_t md4_test_strlen[7] =
+{
+    0, 1, 3, 14, 26, 62, 80
 };
 
 static const unsigned char md4_test_sum[7][16] =
@@ -387,7 +392,7 @@ static const unsigned char md4_test_sum[7][16] =
  */
 int mbedtls_md4_self_test( int verbose )
 {
-    int i;
+    int i, ret = 0;
     unsigned char md4sum[16];
 
     for( i = 0; i < 7; i++ )
@@ -395,12 +400,15 @@ int mbedtls_md4_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD4 test #%d: ", i + 1 );
 
-        if( mbedtls_md4_ext( (unsigned char *) md4_test_str[i],
-                             strlen( md4_test_str[i] ), md4sum ) != 0 )
+        ret = mbedtls_md4_ext( md4_test_str[i], md4_test_strlen[i], md4sum );
+        if( ret != 0 )
             goto fail;
 
         if( memcmp( md4sum, md4_test_sum[i], 16 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -415,7 +423,7 @@ fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
 
-    return( 1 );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md4.c
+++ b/library/md4.c
@@ -333,17 +333,18 @@ int mbedtls_md4_ext( const unsigned char *input,
     mbedtls_md4_init( &ctx );
 
     if( ( ret = mbedtls_md4_starts_ext( &ctx ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md4_update_ext( &ctx, input, ilen ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md4_finish_ext( &ctx, output ) ) != 0 )
-        return( ret );
+        goto exit;
 
+exit:
     mbedtls_md4_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/md4.c
+++ b/library/md4.c
@@ -112,8 +112,8 @@ int mbedtls_md4_starts_ext( mbedtls_md4_context *ctx )
 }
 
 #if !defined(MBEDTLS_MD4_PROCESS_ALT)
-int mbedtls_md4_process_ext( mbedtls_md4_context *ctx,
-                             const unsigned char data[64] )
+int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
+                                  const unsigned char data[64] )
 {
     uint32_t X[16], A, B, C, D;
 
@@ -247,7 +247,7 @@ int mbedtls_md4_update_ext( mbedtls_md4_context *ctx,
         memcpy( (void *) (ctx->buffer + left),
                 (void *) input, fill );
 
-        if( ( ret = mbedtls_md4_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_md4_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -257,7 +257,7 @@ int mbedtls_md4_update_ext( mbedtls_md4_context *ctx,
 
     while( ilen >= 64 )
     {
-        if( ( ret = mbedtls_md4_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_md4_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 64;

--- a/library/md4.c
+++ b/library/md4.c
@@ -98,7 +98,7 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
 /*
  * MD4 context setup
  */
-void mbedtls_md4_starts( mbedtls_md4_context *ctx )
+int mbedtls_md4_starts_ext( mbedtls_md4_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -107,10 +107,13 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx )
     ctx->state[1] = 0xEFCDAB89;
     ctx->state[2] = 0x98BADCFE;
     ctx->state[3] = 0x10325476;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_MD4_PROCESS_ALT)
-void mbedtls_md4_process( mbedtls_md4_context *ctx, const unsigned char data[64] )
+int mbedtls_md4_process_ext( mbedtls_md4_context *ctx,
+                             const unsigned char data[64] )
 {
     uint32_t X[16], A, B, C, D;
 
@@ -211,19 +214,24 @@ void mbedtls_md4_process( mbedtls_md4_context *ctx, const unsigned char data[64]
     ctx->state[1] += B;
     ctx->state[2] += C;
     ctx->state[3] += D;
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 /*
  * MD4 process buffer
  */
-void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen )
+int mbedtls_md4_update_ext( mbedtls_md4_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen )
 {
+    int ret;
     size_t fill;
     uint32_t left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = ctx->total[0] & 0x3F;
     fill = 64 - left;
@@ -238,7 +246,10 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
     {
         memcpy( (void *) (ctx->buffer + left),
                 (void *) input, fill );
-        mbedtls_md4_process( ctx, ctx->buffer );
+
+        if( ( ret = mbedtls_md4_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -246,7 +257,9 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
 
     while( ilen >= 64 )
     {
-        mbedtls_md4_process( ctx, input );
+        if( ( ret = mbedtls_md4_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 64;
         ilen  -= 64;
     }
@@ -256,6 +269,8 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
         memcpy( (void *) (ctx->buffer + left),
                 (void *) input, ilen );
     }
+
+    return( 0 );
 }
 
 static const unsigned char md4_padding[64] =
@@ -269,8 +284,10 @@ static const unsigned char md4_padding[64] =
 /*
  * MD4 final digest
  */
-void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] )
+int mbedtls_md4_finish_ext( mbedtls_md4_context *ctx,
+                            unsigned char output[16] )
 {
+    int ret;
     uint32_t last, padn;
     uint32_t high, low;
     unsigned char msglen[8];
@@ -285,13 +302,20 @@ void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] )
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    mbedtls_md4_update( ctx, (unsigned char *) md4_padding, padn );
-    mbedtls_md4_update( ctx, msglen, 8 );
+    ret = mbedtls_md4_update_ext( ctx, (unsigned char *)md4_padding, padn );
+    if( ret != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_md4_update_ext( ctx, msglen, 8 ) ) != 0 )
+        return( ret );
+
 
     PUT_UINT32_LE( ctx->state[0], output,  0 );
     PUT_UINT32_LE( ctx->state[1], output,  4 );
     PUT_UINT32_LE( ctx->state[2], output,  8 );
     PUT_UINT32_LE( ctx->state[3], output, 12 );
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_MD4_ALT */
@@ -299,15 +323,27 @@ void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] )
 /*
  * output = MD4( input buffer )
  */
-void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[16] )
+int mbedtls_md4_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] )
 {
+    int ret;
     mbedtls_md4_context ctx;
 
     mbedtls_md4_init( &ctx );
-    mbedtls_md4_starts( &ctx );
-    mbedtls_md4_update( &ctx, input, ilen );
-    mbedtls_md4_finish( &ctx, output );
+
+    if( ( ret = mbedtls_md4_starts_ext( &ctx ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_md4_update_ext( &ctx, input, ilen ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_md4_finish_ext( &ctx, output ) ) != 0 )
+        return( ret );
+
     mbedtls_md4_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -358,16 +394,12 @@ int mbedtls_md4_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD4 test #%d: ", i + 1 );
 
-        mbedtls_md4( (unsigned char *) md4_test_str[i],
-             strlen( md4_test_str[i] ), md4sum );
+        if( mbedtls_md4_ext( (unsigned char *) md4_test_str[i],
+                             strlen( md4_test_str[i] ), md4sum ) != 0 )
+            goto fail;
 
         if( memcmp( md4sum, md4_test_sum[i], 16 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            return( 1 );
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -377,6 +409,12 @@ int mbedtls_md4_self_test( int verbose )
         mbedtls_printf( "\n" );
 
     return( 0 );
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    return( 1 );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md5.c
+++ b/library/md5.c
@@ -347,17 +347,18 @@ int mbedtls_md5_ext( const unsigned char *input,
     mbedtls_md5_init( &ctx );
 
     if( ( ret = mbedtls_md5_starts_ext( &ctx ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md5_update_ext( &ctx, input, ilen ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_md5_finish_ext( &ctx, output ) ) != 0 )
-            return( ret );
+        goto exit;
 
+exit:
     mbedtls_md5_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/md5.c
+++ b/library/md5.c
@@ -373,11 +373,11 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012" \
+    { "12345678901234567890123456789012345678901234567890123456789012"
       "345678901234567890" }
 };
 
-static const int md5_test_buflen[7] =
+static const size_t md5_test_buflen[7] =
 {
     0, 1, 3, 14, 26, 62, 80
 };
@@ -405,7 +405,7 @@ static const unsigned char md5_test_sum[7][16] =
  */
 int mbedtls_md5_self_test( int verbose )
 {
-    int i;
+    int i, ret = 0;
     unsigned char md5sum[16];
 
     for( i = 0; i < 7; i++ )
@@ -413,12 +413,15 @@ int mbedtls_md5_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD5 test #%d: ", i + 1 );
 
-        if( mbedtls_md5_ext( md5_test_buf[i],
-                             md5_test_buflen[i], md5sum ) != 0 )
+        ret = mbedtls_md5_ext( md5_test_buf[i], md5_test_buflen[i], md5sum );
+        if( ret != 0 )
             goto fail;
 
         if( memcmp( md5sum, md5_test_sum[i], 16 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -433,7 +436,7 @@ fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
 
-    return( 1 );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md5.c
+++ b/library/md5.c
@@ -111,8 +111,8 @@ int mbedtls_md5_starts_ext( mbedtls_md5_context *ctx )
 }
 
 #if !defined(MBEDTLS_MD5_PROCESS_ALT)
-int mbedtls_md5_process_ext( mbedtls_md5_context *ctx,
-                             const unsigned char data[64] )
+int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
+                                  const unsigned char data[64] )
 {
     uint32_t X[16], A, B, C, D;
 
@@ -264,7 +264,7 @@ int mbedtls_md5_update_ext( mbedtls_md5_context *ctx,
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        if( ( ret = mbedtls_md5_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_md5_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -274,7 +274,7 @@ int mbedtls_md5_update_ext( mbedtls_md5_context *ctx,
 
     while( ilen >= 64 )
     {
-        if( ( ret = mbedtls_md5_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_md5_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 64;

--- a/library/md5.c
+++ b/library/md5.c
@@ -97,7 +97,7 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
 /*
  * MD5 context setup
  */
-void mbedtls_md5_starts( mbedtls_md5_context *ctx )
+int mbedtls_md5_starts_ext( mbedtls_md5_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -106,10 +106,13 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx )
     ctx->state[1] = 0xEFCDAB89;
     ctx->state[2] = 0x98BADCFE;
     ctx->state[3] = 0x10325476;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_MD5_PROCESS_ALT)
-void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64] )
+int mbedtls_md5_process_ext( mbedtls_md5_context *ctx,
+                             const unsigned char data[64] )
 {
     uint32_t X[16], A, B, C, D;
 
@@ -230,19 +233,24 @@ void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64]
     ctx->state[1] += B;
     ctx->state[2] += C;
     ctx->state[3] += D;
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 /*
  * MD5 process buffer
  */
-void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen )
+int mbedtls_md5_update_ext( mbedtls_md5_context *ctx,
+                            const unsigned char *input,
+                            size_t ilen )
 {
+    int ret;
     size_t fill;
     uint32_t left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = ctx->total[0] & 0x3F;
     fill = 64 - left;
@@ -256,7 +264,9 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        mbedtls_md5_process( ctx, ctx->buffer );
+        if( ( ret = mbedtls_md5_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -264,7 +274,9 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
 
     while( ilen >= 64 )
     {
-        mbedtls_md5_process( ctx, input );
+        if( ( ret = mbedtls_md5_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 64;
         ilen  -= 64;
     }
@@ -273,6 +285,8 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
     {
         memcpy( (void *) (ctx->buffer + left), input, ilen );
     }
+
+    return( 0 );
 }
 
 static const unsigned char md5_padding[64] =
@@ -286,8 +300,10 @@ static const unsigned char md5_padding[64] =
 /*
  * MD5 final digest
  */
-void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
+int mbedtls_md5_finish_ext( mbedtls_md5_context *ctx,
+                            unsigned char output[16] )
 {
+    int ret;
     uint32_t last, padn;
     uint32_t high, low;
     unsigned char msglen[8];
@@ -302,13 +318,18 @@ void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    mbedtls_md5_update( ctx, md5_padding, padn );
-    mbedtls_md5_update( ctx, msglen, 8 );
+    if( ( ret = mbedtls_md5_update_ext( ctx, md5_padding, padn ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_md5_update_ext( ctx, msglen, 8 ) ) != 0 )
+            return( ret );
 
     PUT_UINT32_LE( ctx->state[0], output,  0 );
     PUT_UINT32_LE( ctx->state[1], output,  4 );
     PUT_UINT32_LE( ctx->state[2], output,  8 );
     PUT_UINT32_LE( ctx->state[3], output, 12 );
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_MD5_ALT */
@@ -316,15 +337,27 @@ void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
 /*
  * output = MD5( input buffer )
  */
-void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] )
+int mbedtls_md5_ext( const unsigned char *input,
+                     size_t ilen,
+                     unsigned char output[16] )
 {
+    int ret;
     mbedtls_md5_context ctx;
 
     mbedtls_md5_init( &ctx );
-    mbedtls_md5_starts( &ctx );
-    mbedtls_md5_update( &ctx, input, ilen );
-    mbedtls_md5_finish( &ctx, output );
+
+    if( ( ret = mbedtls_md5_starts_ext( &ctx ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_md5_update_ext( &ctx, input, ilen ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_md5_finish_ext( &ctx, output ) ) != 0 )
+            return( ret );
+
     mbedtls_md5_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -379,15 +412,12 @@ int mbedtls_md5_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD5 test #%d: ", i + 1 );
 
-        mbedtls_md5( md5_test_buf[i], md5_test_buflen[i], md5sum );
+        if( mbedtls_md5_ext( md5_test_buf[i],
+                             md5_test_buflen[i], md5sum ) != 0 )
+            goto fail;
 
         if( memcmp( md5sum, md5_test_sum[i], 16 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            return( 1 );
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -397,6 +427,12 @@ int mbedtls_md5_self_test( int verbose )
         mbedtls_printf( "\n" );
 
     return( 0 );
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    return( 1 );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -71,20 +71,20 @@
 
 #if defined(MBEDTLS_MD2_C)
 
-static void md2_starts_wrap( void *ctx )
+static int md2_starts_wrap( void *ctx )
 {
-    mbedtls_md2_starts( (mbedtls_md2_context *) ctx );
+    return( mbedtls_md2_starts_ext( (mbedtls_md2_context *) ctx ) );
 }
 
-static void md2_update_wrap( void *ctx, const unsigned char *input,
+static int md2_update_wrap( void *ctx, const unsigned char *input,
                              size_t ilen )
 {
-    mbedtls_md2_update( (mbedtls_md2_context *) ctx, input, ilen );
+    return( mbedtls_md2_update_ext( (mbedtls_md2_context *) ctx, input, ilen ) );
 }
 
-static void md2_finish_wrap( void *ctx, unsigned char *output )
+static int md2_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_md2_finish( (mbedtls_md2_context *) ctx, output );
+    return( mbedtls_md2_finish_ext( (mbedtls_md2_context *) ctx, output ) );
 }
 
 static void *md2_ctx_alloc( void )
@@ -109,11 +109,11 @@ static void md2_clone_wrap( void *dst, const void *src )
                  (const mbedtls_md2_context *) src );
 }
 
-static void md2_process_wrap( void *ctx, const unsigned char *data )
+static int md2_process_wrap( void *ctx, const unsigned char *data )
 {
     ((void) data);
 
-    mbedtls_md2_process( (mbedtls_md2_context *) ctx );
+    return( mbedtls_internal_md2_process( (mbedtls_md2_context *) ctx ) );
 }
 
 const mbedtls_md_info_t mbedtls_md2_info = {
@@ -124,7 +124,7 @@ const mbedtls_md_info_t mbedtls_md2_info = {
     md2_starts_wrap,
     md2_update_wrap,
     md2_finish_wrap,
-    mbedtls_md2,
+    mbedtls_md2_ext,
     md2_ctx_alloc,
     md2_ctx_free,
     md2_clone_wrap,
@@ -135,20 +135,20 @@ const mbedtls_md_info_t mbedtls_md2_info = {
 
 #if defined(MBEDTLS_MD4_C)
 
-static void md4_starts_wrap( void *ctx )
+static int md4_starts_wrap( void *ctx )
 {
-    mbedtls_md4_starts( (mbedtls_md4_context *) ctx );
+    return( mbedtls_md4_starts_ext( (mbedtls_md4_context *) ctx ) );
 }
 
-static void md4_update_wrap( void *ctx, const unsigned char *input,
+static int md4_update_wrap( void *ctx, const unsigned char *input,
                              size_t ilen )
 {
-    mbedtls_md4_update( (mbedtls_md4_context *) ctx, input, ilen );
+    return( mbedtls_md4_update_ext( (mbedtls_md4_context *) ctx, input, ilen ) );
 }
 
-static void md4_finish_wrap( void *ctx, unsigned char *output )
+static int md4_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_md4_finish( (mbedtls_md4_context *) ctx, output );
+    return( mbedtls_md4_finish_ext( (mbedtls_md4_context *) ctx, output ) );
 }
 
 static void *md4_ctx_alloc( void )
@@ -170,12 +170,12 @@ static void md4_ctx_free( void *ctx )
 static void md4_clone_wrap( void *dst, const void *src )
 {
     mbedtls_md4_clone( (mbedtls_md4_context *) dst,
-                 (const mbedtls_md4_context *) src );
+                       (const mbedtls_md4_context *) src );
 }
 
-static void md4_process_wrap( void *ctx, const unsigned char *data )
+static int md4_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_md4_process( (mbedtls_md4_context *) ctx, data );
+    return( mbedtls_internal_md4_process( (mbedtls_md4_context *) ctx, data ) );
 }
 
 const mbedtls_md_info_t mbedtls_md4_info = {
@@ -186,7 +186,7 @@ const mbedtls_md_info_t mbedtls_md4_info = {
     md4_starts_wrap,
     md4_update_wrap,
     md4_finish_wrap,
-    mbedtls_md4,
+    mbedtls_md4_ext,
     md4_ctx_alloc,
     md4_ctx_free,
     md4_clone_wrap,
@@ -197,20 +197,20 @@ const mbedtls_md_info_t mbedtls_md4_info = {
 
 #if defined(MBEDTLS_MD5_C)
 
-static void md5_starts_wrap( void *ctx )
+static int md5_starts_wrap( void *ctx )
 {
-    mbedtls_md5_starts( (mbedtls_md5_context *) ctx );
+    return( mbedtls_md5_starts_ext( (mbedtls_md5_context *) ctx ) );
 }
 
-static void md5_update_wrap( void *ctx, const unsigned char *input,
+static int md5_update_wrap( void *ctx, const unsigned char *input,
                              size_t ilen )
 {
-    mbedtls_md5_update( (mbedtls_md5_context *) ctx, input, ilen );
+    return( mbedtls_md5_update_ext( (mbedtls_md5_context *) ctx, input, ilen ) );
 }
 
-static void md5_finish_wrap( void *ctx, unsigned char *output )
+static int md5_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_md5_finish( (mbedtls_md5_context *) ctx, output );
+    return( mbedtls_md5_finish_ext( (mbedtls_md5_context *) ctx, output ) );
 }
 
 static void *md5_ctx_alloc( void )
@@ -232,12 +232,12 @@ static void md5_ctx_free( void *ctx )
 static void md5_clone_wrap( void *dst, const void *src )
 {
     mbedtls_md5_clone( (mbedtls_md5_context *) dst,
-                 (const mbedtls_md5_context *) src );
+                       (const mbedtls_md5_context *) src );
 }
 
-static void md5_process_wrap( void *ctx, const unsigned char *data )
+static int md5_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_md5_process( (mbedtls_md5_context *) ctx, data );
+    return( mbedtls_internal_md5_process( (mbedtls_md5_context *) ctx, data ) );
 }
 
 const mbedtls_md_info_t mbedtls_md5_info = {
@@ -248,7 +248,7 @@ const mbedtls_md_info_t mbedtls_md5_info = {
     md5_starts_wrap,
     md5_update_wrap,
     md5_finish_wrap,
-    mbedtls_md5,
+    mbedtls_md5_ext,
     md5_ctx_alloc,
     md5_ctx_free,
     md5_clone_wrap,
@@ -259,20 +259,22 @@ const mbedtls_md_info_t mbedtls_md5_info = {
 
 #if defined(MBEDTLS_RIPEMD160_C)
 
-static void ripemd160_starts_wrap( void *ctx )
+static int ripemd160_starts_wrap( void *ctx )
 {
-    mbedtls_ripemd160_starts( (mbedtls_ripemd160_context *) ctx );
+    return( mbedtls_ripemd160_starts_ext( (mbedtls_ripemd160_context *) ctx ) );
 }
 
-static void ripemd160_update_wrap( void *ctx, const unsigned char *input,
+static int ripemd160_update_wrap( void *ctx, const unsigned char *input,
                                    size_t ilen )
 {
-    mbedtls_ripemd160_update( (mbedtls_ripemd160_context *) ctx, input, ilen );
+    return( mbedtls_ripemd160_update_ext( (mbedtls_ripemd160_context *) ctx,
+                                          input, ilen ) );
 }
 
-static void ripemd160_finish_wrap( void *ctx, unsigned char *output )
+static int ripemd160_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_ripemd160_finish( (mbedtls_ripemd160_context *) ctx, output );
+    return( mbedtls_ripemd160_finish_ext( (mbedtls_ripemd160_context *) ctx,
+                                          output ) );
 }
 
 static void *ripemd160_ctx_alloc( void )
@@ -297,9 +299,10 @@ static void ripemd160_clone_wrap( void *dst, const void *src )
                        (const mbedtls_ripemd160_context *) src );
 }
 
-static void ripemd160_process_wrap( void *ctx, const unsigned char *data )
+static int ripemd160_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_ripemd160_process( (mbedtls_ripemd160_context *) ctx, data );
+    return( mbedtls_internal_ripemd160_process(
+                                (mbedtls_ripemd160_context *) ctx, data ) );
 }
 
 const mbedtls_md_info_t mbedtls_ripemd160_info = {
@@ -310,7 +313,7 @@ const mbedtls_md_info_t mbedtls_ripemd160_info = {
     ripemd160_starts_wrap,
     ripemd160_update_wrap,
     ripemd160_finish_wrap,
-    mbedtls_ripemd160,
+    mbedtls_ripemd160_ext,
     ripemd160_ctx_alloc,
     ripemd160_ctx_free,
     ripemd160_clone_wrap,
@@ -321,20 +324,21 @@ const mbedtls_md_info_t mbedtls_ripemd160_info = {
 
 #if defined(MBEDTLS_SHA1_C)
 
-static void sha1_starts_wrap( void *ctx )
+static int sha1_starts_wrap( void *ctx )
 {
-    mbedtls_sha1_starts( (mbedtls_sha1_context *) ctx );
+    return( mbedtls_sha1_starts_ext( (mbedtls_sha1_context *) ctx ) );
 }
 
-static void sha1_update_wrap( void *ctx, const unsigned char *input,
+static int sha1_update_wrap( void *ctx, const unsigned char *input,
                               size_t ilen )
 {
-    mbedtls_sha1_update( (mbedtls_sha1_context *) ctx, input, ilen );
+    return( mbedtls_sha1_update_ext( (mbedtls_sha1_context *) ctx,
+                                     input, ilen ) );
 }
 
-static void sha1_finish_wrap( void *ctx, unsigned char *output )
+static int sha1_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_sha1_finish( (mbedtls_sha1_context *) ctx, output );
+    return( mbedtls_sha1_finish_ext( (mbedtls_sha1_context *) ctx, output ) );
 }
 
 static void *sha1_ctx_alloc( void )
@@ -359,9 +363,10 @@ static void sha1_ctx_free( void *ctx )
     mbedtls_free( ctx );
 }
 
-static void sha1_process_wrap( void *ctx, const unsigned char *data )
+static int sha1_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_sha1_process( (mbedtls_sha1_context *) ctx, data );
+    return( mbedtls_internal_sha1_process( (mbedtls_sha1_context *) ctx,
+                                           data ) );
 }
 
 const mbedtls_md_info_t mbedtls_sha1_info = {
@@ -372,7 +377,7 @@ const mbedtls_md_info_t mbedtls_sha1_info = {
     sha1_starts_wrap,
     sha1_update_wrap,
     sha1_finish_wrap,
-    mbedtls_sha1,
+    mbedtls_sha1_ext,
     sha1_ctx_alloc,
     sha1_ctx_free,
     sha1_clone_wrap,
@@ -386,26 +391,28 @@ const mbedtls_md_info_t mbedtls_sha1_info = {
  */
 #if defined(MBEDTLS_SHA256_C)
 
-static void sha224_starts_wrap( void *ctx )
+static int sha224_starts_wrap( void *ctx )
 {
-    mbedtls_sha256_starts( (mbedtls_sha256_context *) ctx, 1 );
+    return( mbedtls_sha256_starts_ext( (mbedtls_sha256_context *) ctx, 1 ) );
 }
 
-static void sha224_update_wrap( void *ctx, const unsigned char *input,
+static int sha224_update_wrap( void *ctx, const unsigned char *input,
                                 size_t ilen )
 {
-    mbedtls_sha256_update( (mbedtls_sha256_context *) ctx, input, ilen );
+    return( mbedtls_sha256_update_ext( (mbedtls_sha256_context *) ctx,
+                                       input, ilen ) );
 }
 
-static void sha224_finish_wrap( void *ctx, unsigned char *output )
+static int sha224_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_sha256_finish( (mbedtls_sha256_context *) ctx, output );
+    return( mbedtls_sha256_finish_ext( (mbedtls_sha256_context *) ctx,
+                                       output ) );
 }
 
-static void sha224_wrap( const unsigned char *input, size_t ilen,
-                    unsigned char *output )
+static int sha224_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
 {
-    mbedtls_sha256( input, ilen, output, 1 );
+    return( mbedtls_sha256_ext( input, ilen, output, 1 ) );
 }
 
 static void *sha224_ctx_alloc( void )
@@ -430,9 +437,10 @@ static void sha224_clone_wrap( void *dst, const void *src )
                     (const mbedtls_sha256_context *) src );
 }
 
-static void sha224_process_wrap( void *ctx, const unsigned char *data )
+static int sha224_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_sha256_process( (mbedtls_sha256_context *) ctx, data );
+    return( mbedtls_internal_sha256_process( (mbedtls_sha256_context *) ctx,
+                                             data ) );
 }
 
 const mbedtls_md_info_t mbedtls_sha224_info = {
@@ -450,15 +458,15 @@ const mbedtls_md_info_t mbedtls_sha224_info = {
     sha224_process_wrap,
 };
 
-static void sha256_starts_wrap( void *ctx )
+static int sha256_starts_wrap( void *ctx )
 {
-    mbedtls_sha256_starts( (mbedtls_sha256_context *) ctx, 0 );
+    return( mbedtls_sha256_starts_ext( (mbedtls_sha256_context *) ctx, 0 ) );
 }
 
-static void sha256_wrap( const unsigned char *input, size_t ilen,
-                    unsigned char *output )
+static int sha256_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
 {
-    mbedtls_sha256( input, ilen, output, 0 );
+    return( mbedtls_sha256_ext( input, ilen, output, 0 ) );
 }
 
 const mbedtls_md_info_t mbedtls_sha256_info = {
@@ -480,26 +488,28 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
 
 #if defined(MBEDTLS_SHA512_C)
 
-static void sha384_starts_wrap( void *ctx )
+static int sha384_starts_wrap( void *ctx )
 {
-    mbedtls_sha512_starts( (mbedtls_sha512_context *) ctx, 1 );
+    return( mbedtls_sha512_starts_ext( (mbedtls_sha512_context *) ctx, 1 ) );
 }
 
-static void sha384_update_wrap( void *ctx, const unsigned char *input,
-                                size_t ilen )
+static int sha384_update_wrap( void *ctx, const unsigned char *input,
+                               size_t ilen )
 {
-    mbedtls_sha512_update( (mbedtls_sha512_context *) ctx, input, ilen );
+    return( mbedtls_sha512_update_ext( (mbedtls_sha512_context *) ctx,
+                                       input, ilen ) );
 }
 
-static void sha384_finish_wrap( void *ctx, unsigned char *output )
+static int sha384_finish_wrap( void *ctx, unsigned char *output )
 {
-    mbedtls_sha512_finish( (mbedtls_sha512_context *) ctx, output );
+    return( mbedtls_sha512_finish_ext( (mbedtls_sha512_context *) ctx,
+                                       output ) );
 }
 
-static void sha384_wrap( const unsigned char *input, size_t ilen,
-                    unsigned char *output )
+static int sha384_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
 {
-    mbedtls_sha512( input, ilen, output, 1 );
+    return( mbedtls_sha512_ext( input, ilen, output, 1 ) );
 }
 
 static void *sha384_ctx_alloc( void )
@@ -524,9 +534,10 @@ static void sha384_clone_wrap( void *dst, const void *src )
                     (const mbedtls_sha512_context *) src );
 }
 
-static void sha384_process_wrap( void *ctx, const unsigned char *data )
+static int sha384_process_wrap( void *ctx, const unsigned char *data )
 {
-    mbedtls_sha512_process( (mbedtls_sha512_context *) ctx, data );
+    return( mbedtls_internal_sha512_process( (mbedtls_sha512_context *) ctx,
+                                             data ) );
 }
 
 const mbedtls_md_info_t mbedtls_sha384_info = {
@@ -544,15 +555,15 @@ const mbedtls_md_info_t mbedtls_sha384_info = {
     sha384_process_wrap,
 };
 
-static void sha512_starts_wrap( void *ctx )
+static int sha512_starts_wrap( void *ctx )
 {
-    mbedtls_sha512_starts( (mbedtls_sha512_context *) ctx, 0 );
+    return( mbedtls_sha512_starts_ext( (mbedtls_sha512_context *) ctx, 0 ) );
 }
 
-static void sha512_wrap( const unsigned char *input, size_t ilen,
-                    unsigned char *output )
+static int sha512_wrap( const unsigned char *input, size_t ilen,
+                        unsigned char *output )
 {
-    mbedtls_sha512( input, ilen, output, 0 );
+    return( mbedtls_sha512_ext( input, ilen, output, 0 ) );
 }
 
 const mbedtls_md_info_t mbedtls_sha512_info = {

--- a/library/pem.c
+++ b/library/pem.c
@@ -82,31 +82,33 @@ static int pem_get_iv( const unsigned char *s, unsigned char *iv,
     return( 0 );
 }
 
-static void pem_pbkdf1( unsigned char *key, size_t keylen,
-                        unsigned char *iv,
-                        const unsigned char *pwd, size_t pwdlen )
+static int pem_pbkdf1( unsigned char *key, size_t keylen,
+                       unsigned char *iv,
+                       const unsigned char *pwd, size_t pwdlen )
 {
     mbedtls_md5_context md5_ctx;
     unsigned char md5sum[16];
     size_t use_len;
+    int ret;
 
     mbedtls_md5_init( &md5_ctx );
 
     /*
      * key[ 0..15] = MD5(pwd || IV)
      */
-    mbedtls_md5_starts( &md5_ctx );
-    mbedtls_md5_update( &md5_ctx, pwd, pwdlen );
-    mbedtls_md5_update( &md5_ctx, iv,  8 );
-    mbedtls_md5_finish( &md5_ctx, md5sum );
+    if( ( ret = mbedtls_md5_starts_ext( &md5_ctx ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_update_ext( &md5_ctx, pwd, pwdlen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_update_ext( &md5_ctx, iv,  8 ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_finish_ext( &md5_ctx, md5sum ) ) != 0 )
+        goto exit;
 
     if( keylen <= 16 )
     {
         memcpy( key, md5sum, keylen );
-
-        mbedtls_md5_free( &md5_ctx );
-        mbedtls_zeroize( md5sum, 16 );
-        return;
+        goto exit;
     }
 
     memcpy( key, md5sum, 16 );
@@ -114,11 +116,16 @@ static void pem_pbkdf1( unsigned char *key, size_t keylen,
     /*
      * key[16..23] = MD5(key[ 0..15] || pwd || IV])
      */
-    mbedtls_md5_starts( &md5_ctx );
-    mbedtls_md5_update( &md5_ctx, md5sum,  16 );
-    mbedtls_md5_update( &md5_ctx, pwd, pwdlen );
-    mbedtls_md5_update( &md5_ctx, iv,  8 );
-    mbedtls_md5_finish( &md5_ctx, md5sum );
+    if( ( ret = mbedtls_md5_starts_ext( &md5_ctx ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_update_ext( &md5_ctx, md5sum, 16 ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_update_ext( &md5_ctx, pwd, pwdlen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_update_ext( &md5_ctx, iv, 8 ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md5_finish_ext( &md5_ctx, md5sum ) ) != 0 )
+        goto exit;
 
     use_len = 16;
     if( keylen < 32 )
@@ -126,53 +133,66 @@ static void pem_pbkdf1( unsigned char *key, size_t keylen,
 
     memcpy( key + 16, md5sum, use_len );
 
+exit:
     mbedtls_md5_free( &md5_ctx );
     mbedtls_zeroize( md5sum, 16 );
+
+    return( ret );
 }
 
 #if defined(MBEDTLS_DES_C)
 /*
  * Decrypt with DES-CBC, using PBKDF1 for key derivation
  */
-static void pem_des_decrypt( unsigned char des_iv[8],
-                               unsigned char *buf, size_t buflen,
-                               const unsigned char *pwd, size_t pwdlen )
+static int pem_des_decrypt( unsigned char des_iv[8],
+                            unsigned char *buf, size_t buflen,
+                            const unsigned char *pwd, size_t pwdlen )
 {
     mbedtls_des_context des_ctx;
     unsigned char des_key[8];
+    int ret;
 
     mbedtls_des_init( &des_ctx );
 
-    pem_pbkdf1( des_key, 8, des_iv, pwd, pwdlen );
+    if( ( ret = pem_pbkdf1( des_key, 8, des_iv, pwd, pwdlen ) ) != 0 )
+        goto exit;
 
     mbedtls_des_setkey_dec( &des_ctx, des_key );
     mbedtls_des_crypt_cbc( &des_ctx, MBEDTLS_DES_DECRYPT, buflen,
                      des_iv, buf, buf );
 
+exit:
     mbedtls_des_free( &des_ctx );
     mbedtls_zeroize( des_key, 8 );
+
+    return( ret );
 }
 
 /*
  * Decrypt with 3DES-CBC, using PBKDF1 for key derivation
  */
-static void pem_des3_decrypt( unsigned char des3_iv[8],
-                               unsigned char *buf, size_t buflen,
-                               const unsigned char *pwd, size_t pwdlen )
+static int pem_des3_decrypt( unsigned char des3_iv[8],
+                             unsigned char *buf, size_t buflen,
+                             const unsigned char *pwd, size_t pwdlen )
 {
     mbedtls_des3_context des3_ctx;
     unsigned char des3_key[24];
+    int ret;
 
     mbedtls_des3_init( &des3_ctx );
 
-    pem_pbkdf1( des3_key, 24, des3_iv, pwd, pwdlen );
+    if( ( ret = pem_pbkdf1( des3_key, 24, des3_iv, pwd, pwdlen ) ) != 0 )
+        goto exit;
 
     mbedtls_des3_set3key_dec( &des3_ctx, des3_key );
     mbedtls_des3_crypt_cbc( &des3_ctx, MBEDTLS_DES_DECRYPT, buflen,
                      des3_iv, buf, buf );
 
+exit:
     mbedtls_des3_free( &des3_ctx );
     mbedtls_zeroize( des3_key, 24 );
+
+    return( ret );
 }
 #endif /* MBEDTLS_DES_C */
 
@@ -180,23 +200,28 @@ static void pem_des3_decrypt( unsigned char des3_iv[8],
 /*
  * Decrypt with AES-XXX-CBC, using PBKDF1 for key derivation
  */
-static void pem_aes_decrypt( unsigned char aes_iv[16], unsigned int keylen,
-                               unsigned char *buf, size_t buflen,
-                               const unsigned char *pwd, size_t pwdlen )
+static int pem_aes_decrypt( unsigned char aes_iv[16], unsigned int keylen,
+                            unsigned char *buf, size_t buflen,
+                            const unsigned char *pwd, size_t pwdlen )
 {
     mbedtls_aes_context aes_ctx;
     unsigned char aes_key[32];
+    int ret;
 
     mbedtls_aes_init( &aes_ctx );
 
-    pem_pbkdf1( aes_key, keylen, aes_iv, pwd, pwdlen );
+    if( ( ret = pem_pbkdf1( aes_key, keylen, aes_iv, pwd, pwdlen ) ) != 0 )
+        goto exit;
 
     mbedtls_aes_setkey_dec( &aes_ctx, aes_key, keylen * 8 );
     mbedtls_aes_crypt_cbc( &aes_ctx, MBEDTLS_AES_DECRYPT, buflen,
                      aes_iv, buf, buf );
 
+exit:
     mbedtls_aes_free( &aes_ctx );
     mbedtls_zeroize( aes_key, keylen );
+
+    return( ret );
 }
 #endif /* MBEDTLS_AES_C */
 
@@ -345,21 +370,29 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
             return( MBEDTLS_ERR_PEM_PASSWORD_REQUIRED );
         }
 
+        ret = 0;
+
 #if defined(MBEDTLS_DES_C)
         if( enc_alg == MBEDTLS_CIPHER_DES_EDE3_CBC )
-            pem_des3_decrypt( pem_iv, buf, len, pwd, pwdlen );
+            ret = pem_des3_decrypt( pem_iv, buf, len, pwd, pwdlen );
         else if( enc_alg == MBEDTLS_CIPHER_DES_CBC )
-            pem_des_decrypt( pem_iv, buf, len, pwd, pwdlen );
+            ret = pem_des_decrypt( pem_iv, buf, len, pwd, pwdlen );
 #endif /* MBEDTLS_DES_C */
 
 #if defined(MBEDTLS_AES_C)
         if( enc_alg == MBEDTLS_CIPHER_AES_128_CBC )
-            pem_aes_decrypt( pem_iv, 16, buf, len, pwd, pwdlen );
+            ret = pem_aes_decrypt( pem_iv, 16, buf, len, pwd, pwdlen );
         else if( enc_alg == MBEDTLS_CIPHER_AES_192_CBC )
-            pem_aes_decrypt( pem_iv, 24, buf, len, pwd, pwdlen );
+            ret = pem_aes_decrypt( pem_iv, 24, buf, len, pwd, pwdlen );
         else if( enc_alg == MBEDTLS_CIPHER_AES_256_CBC )
-            pem_aes_decrypt( pem_iv, 32, buf, len, pwd, pwdlen );
+            ret = pem_aes_decrypt( pem_iv, 32, buf, len, pwd, pwdlen );
 #endif /* MBEDTLS_AES_C */
+
+        if( ret != 0 )
+        {
+            mbedtls_free( buf );
+            return( ret );
+        }
 
         /*
          * The result will be ASN.1 starting with a SEQUENCE tag, with 1 to 3

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -406,17 +406,18 @@ int mbedtls_ripemd160_ext( const unsigned char *input,
     mbedtls_ripemd160_init( &ctx );
 
     if( ( ret = mbedtls_ripemd160_starts_ext( &ctx ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_ripemd160_update_ext( &ctx, input, ilen ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_ripemd160_finish_ext( &ctx, output ) ) != 0 )
-            return( ret );
+        goto exit;
 
+exit:
     mbedtls_ripemd160_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -464,7 +464,7 @@ static const unsigned char ripemd160_test_md[TESTS][20] =
  */
 int mbedtls_ripemd160_self_test( int verbose )
 {
-    int i, ret;
+    int i, ret = 0;
     unsigned char output[20];
 
     memset( output, 0, sizeof output );
@@ -481,7 +481,10 @@ int mbedtls_ripemd160_self_test( int verbose )
             goto fail;
 
         if( memcmp( output, ripemd160_test_md[i], 20 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -496,7 +499,7 @@ fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
 
-    return( 1 );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -426,18 +426,22 @@ exit:
  * http://homes.esat.kuleuven.be/~bosselae/mbedtls_ripemd160.html#HMAC
  */
 #define TESTS   8
-#define KEYS    2
-static const char *ripemd160_test_input[TESTS] =
+static const unsigned char ripemd160_test_str[TESTS][81] =
 {
-    "",
-    "a",
-    "abc",
-    "message digest",
-    "abcdefghijklmnopqrstuvwxyz",
-    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
-    "1234567890123456789012345678901234567890"
-        "1234567890123456789012345678901234567890",
+    { "" },
+    { "a" },
+    { "abc" },
+    { "message digest" },
+    { "abcdefghijklmnopqrstuvwxyz" },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
+    { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
+    { "12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890" },
+};
+
+static const size_t ripemd160_test_strlen[TESTS] =
+{
+    0, 1, 3, 14, 26, 56, 62, 80
 };
 
 static const unsigned char ripemd160_test_md[TESTS][20] =
@@ -475,9 +479,8 @@ int mbedtls_ripemd160_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  RIPEMD-160 test #%d: ", i + 1 );
 
-        ret = mbedtls_ripemd160_ext(
-                                (const unsigned char *)ripemd160_test_input[i],
-                                strlen( ripemd160_test_input[i] ), output );
+        ret = mbedtls_ripemd160_ext( ripemd160_test_str[i],
+                                     ripemd160_test_strlen[i], output );
         if( ret != 0 )
             goto fail;
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -96,7 +96,7 @@ void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
 /*
  * RIPEMD-160 context setup
  */
-void mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx )
+int mbedtls_ripemd160_starts_ext( mbedtls_ripemd160_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -106,13 +106,16 @@ void mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx )
     ctx->state[2] = 0x98BADCFE;
     ctx->state[3] = 0x10325476;
     ctx->state[4] = 0xC3D2E1F0;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_RIPEMD160_PROCESS_ALT)
 /*
  * Process one block
  */
-void mbedtls_ripemd160_process( mbedtls_ripemd160_context *ctx, const unsigned char data[64] )
+int mbedtls_ripemd160_process_ext( mbedtls_ripemd160_context *ctx,
+                                   const unsigned char data[64] )
 {
     uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
 
@@ -287,20 +290,24 @@ void mbedtls_ripemd160_process( mbedtls_ripemd160_context *ctx, const unsigned c
     ctx->state[3] = ctx->state[4] + A + Bp;
     ctx->state[4] = ctx->state[0] + B + Cp;
     ctx->state[0] = C;
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_RIPEMD160_PROCESS_ALT */
 
 /*
  * RIPEMD-160 process buffer
  */
-void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
-                       const unsigned char *input, size_t ilen )
+int mbedtls_ripemd160_update_ext( mbedtls_ripemd160_context *ctx,
+                                  const unsigned char *input,
+                                  size_t ilen )
 {
+    int ret;
     size_t fill;
     uint32_t left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = ctx->total[0] & 0x3F;
     fill = 64 - left;
@@ -314,7 +321,10 @@ void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        mbedtls_ripemd160_process( ctx, ctx->buffer );
+
+        if( ( ret = mbedtls_ripemd160_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -322,7 +332,9 @@ void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
 
     while( ilen >= 64 )
     {
-        mbedtls_ripemd160_process( ctx, input );
+        if( ( ret = mbedtls_ripemd160_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 64;
         ilen  -= 64;
     }
@@ -331,6 +343,8 @@ void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
     {
         memcpy( (void *) (ctx->buffer + left), input, ilen );
     }
+
+    return( 0 );
 }
 
 static const unsigned char ripemd160_padding[64] =
@@ -344,8 +358,10 @@ static const unsigned char ripemd160_padding[64] =
 /*
  * RIPEMD-160 final digest
  */
-void mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx, unsigned char output[20] )
+int mbedtls_ripemd160_finish_ext( mbedtls_ripemd160_context *ctx,
+                                  unsigned char output[20] )
 {
+    int ret;
     uint32_t last, padn;
     uint32_t high, low;
     unsigned char msglen[8];
@@ -360,29 +376,47 @@ void mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx, unsigned char out
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    mbedtls_ripemd160_update( ctx, ripemd160_padding, padn );
-    mbedtls_ripemd160_update( ctx, msglen, 8 );
+    ret = mbedtls_ripemd160_update_ext( ctx, ripemd160_padding, padn );
+    if( ret != 0 )
+            return( ret );
+
+    ret = mbedtls_ripemd160_update_ext( ctx, msglen, 8 );
+    if( ret != 0 )
+            return( ret );
 
     PUT_UINT32_LE( ctx->state[0], output,  0 );
     PUT_UINT32_LE( ctx->state[1], output,  4 );
     PUT_UINT32_LE( ctx->state[2], output,  8 );
     PUT_UINT32_LE( ctx->state[3], output, 12 );
     PUT_UINT32_LE( ctx->state[4], output, 16 );
+
+    return( 0 );
 }
 
 /*
  * output = RIPEMD-160( input buffer )
  */
-void mbedtls_ripemd160( const unsigned char *input, size_t ilen,
-                unsigned char output[20] )
+int mbedtls_ripemd160_ext( const unsigned char *input,
+                           size_t ilen,
+                           unsigned char output[20] )
 {
+    int ret;
     mbedtls_ripemd160_context ctx;
 
     mbedtls_ripemd160_init( &ctx );
-    mbedtls_ripemd160_starts( &ctx );
-    mbedtls_ripemd160_update( &ctx, input, ilen );
-    mbedtls_ripemd160_finish( &ctx, output );
+
+    if( ( ret = mbedtls_ripemd160_starts_ext( &ctx ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_ripemd160_update_ext( &ctx, input, ilen ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_ripemd160_finish_ext( &ctx, output ) ) != 0 )
+            return( ret );
+
     mbedtls_ripemd160_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -430,7 +464,7 @@ static const unsigned char ripemd160_test_md[TESTS][20] =
  */
 int mbedtls_ripemd160_self_test( int verbose )
 {
-    int i;
+    int i, ret;
     unsigned char output[20];
 
     memset( output, 0, sizeof output );
@@ -440,17 +474,14 @@ int mbedtls_ripemd160_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  RIPEMD-160 test #%d: ", i + 1 );
 
-        mbedtls_ripemd160( (const unsigned char *) ripemd160_test_input[i],
-                   strlen( ripemd160_test_input[i] ),
-                   output );
+        ret = mbedtls_ripemd160_ext(
+                                (const unsigned char *)ripemd160_test_input[i],
+                                strlen( ripemd160_test_input[i] ), output );
+        if( ret != 0 )
+            goto fail;
 
         if( memcmp( output, ripemd160_test_md[i], 20 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            return( 1 );
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -460,6 +491,12 @@ int mbedtls_ripemd160_self_test( int verbose )
         mbedtls_printf( "\n" );
 
     return( 0 );
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    return( 1 );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -114,8 +114,8 @@ int mbedtls_ripemd160_starts_ext( mbedtls_ripemd160_context *ctx )
 /*
  * Process one block
  */
-int mbedtls_ripemd160_process_ext( mbedtls_ripemd160_context *ctx,
-                                   const unsigned char data[64] )
+int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
+                                        const unsigned char data[64] )
 {
     uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
 
@@ -322,7 +322,7 @@ int mbedtls_ripemd160_update_ext( mbedtls_ripemd160_context *ctx,
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
 
-        if( ( ret = mbedtls_ripemd160_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_ripemd160_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -332,7 +332,7 @@ int mbedtls_ripemd160_update_ext( mbedtls_ripemd160_context *ctx,
 
     while( ilen >= 64 )
     {
-        if( ( ret = mbedtls_ripemd160_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_ripemd160_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 64;

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -378,11 +378,11 @@ int mbedtls_ripemd160_finish_ext( mbedtls_ripemd160_context *ctx,
 
     ret = mbedtls_ripemd160_update_ext( ctx, ripemd160_padding, padn );
     if( ret != 0 )
-            return( ret );
+        return( ret );
 
     ret = mbedtls_ripemd160_update_ext( ctx, msglen, 8 );
     if( ret != 0 )
-            return( ret );
+        return( ret );
 
     PUT_UINT32_LE( ctx->state[0], output,  0 );
     PUT_UINT32_LE( ctx->state[1], output,  4 );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -566,7 +566,7 @@ cleanup:
  * \param slen      length of the source buffer
  * \param md_ctx    message digest context to use
  */
-static void mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
+static int mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
                       size_t slen, mbedtls_md_context_t *md_ctx )
 {
     unsigned char mask[MBEDTLS_MD_MAX_SIZE];
@@ -574,6 +574,7 @@ static void mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
     unsigned char *p;
     unsigned int hlen;
     size_t i, use_len;
+    int ret;
 
     memset( mask, 0, MBEDTLS_MD_MAX_SIZE );
     memset( counter, 0, 4 );
@@ -589,10 +590,14 @@ static void mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
         if( dlen < hlen )
             use_len = dlen;
 
-        mbedtls_md_starts( md_ctx );
-        mbedtls_md_update( md_ctx, src, slen );
-        mbedtls_md_update( md_ctx, counter, 4 );
-        mbedtls_md_finish( md_ctx, mask );
+        if( ( ret = mbedtls_md_starts( md_ctx ) ) != 0 )
+            goto exit;
+        if( ( ret = mbedtls_md_update( md_ctx, src, slen ) ) != 0 )
+            goto exit;
+        if( ( ret = mbedtls_md_update( md_ctx, counter, 4 ) ) != 0 )
+            goto exit;
+        if( ( ret = mbedtls_md_finish( md_ctx, mask ) ) != 0 )
+            goto exit;
 
         for( i = 0; i < use_len; ++i )
             *p++ ^= mask[i];
@@ -602,7 +607,10 @@ static void mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
         dlen -= use_len;
     }
 
+exit:
     mbedtls_zeroize( mask, sizeof( mask ) );
+
+    return( ret );
 }
 #endif /* MBEDTLS_PKCS1_V21 */
 
@@ -654,7 +662,8 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     p += hlen;
 
     /* Construct DB */
-    mbedtls_md( md_info, label, label_len, p );
+    if( ( ret = mbedtls_md( md_info, label, label_len, p ) ) != 0 )
+        return( ret );
     p += hlen;
     p += olen - 2 * hlen - 2 - ilen;
     *p++ = 1;
@@ -662,20 +671,23 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
 
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
-    {
-        mbedtls_md_free( &md_ctx );
-        return( ret );
-    }
+        goto exit;
 
     /* maskedDB: Apply dbMask to DB */
-    mgf_mask( output + hlen + 1, olen - hlen - 1, output + 1, hlen,
-               &md_ctx );
+    if( ( ret = mgf_mask( output + hlen + 1, olen - hlen - 1, output + 1, hlen,
+                          &md_ctx ) ) != 0 )
+        goto exit;
 
     /* maskedSeed: Apply seedMask to seed */
-    mgf_mask( output + 1, hlen, output + hlen + 1, olen - hlen - 1,
-               &md_ctx );
+    if( ( ret = mgf_mask( output + 1, hlen, output + hlen + 1, olen - hlen - 1,
+                          &md_ctx ) ) != 0 )
+        goto exit;
 
+exit:
     mbedtls_md_free( &md_ctx );
+
+    if( ret != 0 )
+        return( ret );
 
     return( ( mode == MBEDTLS_RSA_PUBLIC )
             ? mbedtls_rsa_public(  ctx, output, output )
@@ -843,19 +855,22 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
         goto cleanup;
     }
 
-
-    /* Generate lHash */
-    mbedtls_md( md_info, label, label_len, lhash );
-
     /* seed: Apply seedMask to maskedSeed */
-    mgf_mask( buf + 1, hlen, buf + hlen + 1, ilen - hlen - 1,
-               &md_ctx );
-
+    if( ( ret = mgf_mask( buf + 1, hlen, buf + hlen + 1, ilen - hlen - 1,
+                          &md_ctx ) ) != 0 ||
     /* DB: Apply dbMask to maskedDB */
-    mgf_mask( buf + hlen + 1, ilen - hlen - 1, buf + 1, hlen,
-               &md_ctx );
+        ( ret = mgf_mask( buf + hlen + 1, ilen - hlen - 1, buf + 1, hlen,
+                          &md_ctx ) ) != 0 )
+    {
+        mbedtls_md_free( &md_ctx );
+        goto cleanup;
+    }
 
     mbedtls_md_free( &md_ctx );
+
+    /* Generate lHash */
+    if( ( ret = mbedtls_md( md_info, label, label_len, lhash ) ) != 0 )
+        goto cleanup;
 
     /*
      * Check contents, in "constant-time"
@@ -1107,34 +1122,42 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
 
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
-    {
-        mbedtls_md_free( &md_ctx );
-        /* No need to zeroize salt: we didn't use it. */
-        return( ret );
-    }
+        goto exit;
 
     /* Generate H = Hash( M' ) */
-    mbedtls_md_starts( &md_ctx );
-    mbedtls_md_update( &md_ctx, p, 8 );
-    mbedtls_md_update( &md_ctx, hash, hashlen );
-    mbedtls_md_update( &md_ctx, salt, slen );
-    mbedtls_md_finish( &md_ctx, p );
-    mbedtls_zeroize( salt, sizeof( salt ) );
+    if( ( ret = mbedtls_md_starts( &md_ctx ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, p, 8 ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, hash, hashlen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, salt, slen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_finish( &md_ctx, p ) ) != 0 )
+        goto exit;
 
     /* Compensate for boundary condition when applying mask */
     if( msb % 8 == 0 )
         offset = 1;
 
     /* maskedDB: Apply dbMask to DB */
-    mgf_mask( sig + offset, olen - hlen - 1 - offset, p, hlen, &md_ctx );
-
-    mbedtls_md_free( &md_ctx );
+    if( ( ret = mgf_mask( sig + offset, olen - hlen - 1 - offset, p, hlen,
+                          &md_ctx ) ) != 0 )
+        goto exit;
 
     msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;
     sig[0] &= 0xFF >> ( olen * 8 - msb );
 
     p += hlen;
     *p++ = 0xBC;
+
+    mbedtls_zeroize( salt, sizeof( salt ) );
+
+exit:
+    mbedtls_md_free( &md_ctx );
+
+    if( ret != 0 )
+        return( ret );
 
     return( ( mode == MBEDTLS_RSA_PUBLIC )
             ? mbedtls_rsa_public(  ctx, sig, sig )
@@ -1382,23 +1405,21 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
 
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
-    {
-        mbedtls_md_free( &md_ctx );
-        return( ret );
-    }
+        goto exit;
 
-    mgf_mask( p, siglen - hlen - 1, p + siglen - hlen - 1, hlen, &md_ctx );
+    if( ( ret = mgf_mask( p, siglen - hlen - 1, p + siglen - hlen - 1, hlen,
+                          &md_ctx ) ) != 0 )
+        goto exit;
 
     buf[0] &= 0xFF >> ( siglen * 8 - msb );
 
     while( p < buf + siglen && *p == 0 )
         p++;
 
-    if( p == buf + siglen ||
-        *p++ != 0x01 )
+    if( p == buf + siglen || *p++ != 0x01 )
     {
-        mbedtls_md_free( &md_ctx );
-        return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto exit;
     }
 
     /* Actual salt len */
@@ -1407,25 +1428,31 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     if( expected_salt_len != MBEDTLS_RSA_SALT_LEN_ANY &&
         slen != (size_t) expected_salt_len )
     {
-        mbedtls_md_free( &md_ctx );
-        return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+        ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        goto exit;
     }
 
     /*
      * Generate H = Hash( M' )
      */
-    mbedtls_md_starts( &md_ctx );
-    mbedtls_md_update( &md_ctx, zeros, 8 );
-    mbedtls_md_update( &md_ctx, hash, hashlen );
-    mbedtls_md_update( &md_ctx, p, slen );
-    mbedtls_md_finish( &md_ctx, result );
+    if( ( ret = mbedtls_md_starts( &md_ctx ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, zeros, 8 ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, hash, hashlen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_update( &md_ctx, p, slen ) ) != 0 )
+        goto exit;
+    if( ( ret = mbedtls_md_finish( &md_ctx, result ) ) != 0 )
+        goto exit;
 
+    if( ( ret = memcmp( p + slen, result, hlen ) ) != 0 )
+        ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+
+exit:
     mbedtls_md_free( &md_ctx );
 
-    if( memcmp( p + slen, result, hlen ) == 0 )
-        return( 0 );
-    else
-        return( MBEDTLS_ERR_RSA_VERIFY_FAILED );
+    return( ret );
 }
 
 /*
@@ -1829,7 +1856,13 @@ int mbedtls_rsa_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "  PKCS#1 data sign  : " );
 
-    mbedtls_sha1( rsa_plaintext, PT_LEN, sha1sum );
+    if( mbedtls_sha1_ext( rsa_plaintext, PT_LEN, sha1sum ) != 0 )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "failed\n" );
+
+        return( 1 );
+    }
 
     if( mbedtls_rsa_pkcs1_sign( &rsa, myrand, NULL, MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA1, 0,
                         sha1sum, rsa_ciphertext ) != 0 )

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -574,7 +574,7 @@ static int mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
     unsigned char *p;
     unsigned int hlen;
     size_t i, use_len;
-    int ret;
+    int ret = 0;
 
     memset( mask, 0, MBEDTLS_MD_MAX_SIZE );
     memset( counter, 0, 4 );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1446,8 +1446,11 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     if( ( ret = mbedtls_md_finish( &md_ctx, result ) ) != 0 )
         goto exit;
 
-    if( ( ret = memcmp( p + slen, result, hlen ) ) != 0 )
+    if( memcmp( p + slen, result, hlen ) != 0 )
+    {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
+        goto exit;
+    }
 
 exit:
     mbedtls_md_free( &md_ctx );

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -405,7 +405,7 @@ static const unsigned char sha1_test_buf[3][57] =
     { "" }
 };
 
-static const int sha1_test_buflen[3] =
+static const size_t sha1_test_buflen[3] =
 {
     3, 56, 1000
 };

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -97,7 +97,7 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
 /*
  * SHA-1 context setup
  */
-void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
+int mbedtls_sha1_starts_ext( mbedtls_sha1_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -107,10 +107,13 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
     ctx->state[2] = 0x98BADCFE;
     ctx->state[3] = 0x10325476;
     ctx->state[4] = 0xC3D2E1F0;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_SHA1_PROCESS_ALT)
-void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] )
+int mbedtls_sha1_process_ext( mbedtls_sha1_context *ctx,
+                              const unsigned char data[64] )
 {
     uint32_t temp, W[16], A, B, C, D, E;
 
@@ -264,19 +267,24 @@ void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[6
     ctx->state[2] += C;
     ctx->state[3] += D;
     ctx->state[4] += E;
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 /*
  * SHA-1 process buffer
  */
-void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen )
+int mbedtls_sha1_update_ext( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen )
 {
+    int ret;
     size_t fill;
     uint32_t left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = ctx->total[0] & 0x3F;
     fill = 64 - left;
@@ -290,7 +298,10 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        mbedtls_sha1_process( ctx, ctx->buffer );
+
+        if( ( ret = mbedtls_sha1_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -298,13 +309,17 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
 
     while( ilen >= 64 )
     {
-        mbedtls_sha1_process( ctx, input );
+        if( ( ret = mbedtls_sha1_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 64;
         ilen  -= 64;
     }
 
     if( ilen > 0 )
         memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
 }
 
 static const unsigned char sha1_padding[64] =
@@ -318,8 +333,10 @@ static const unsigned char sha1_padding[64] =
 /*
  * SHA-1 final digest
  */
-void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
+int mbedtls_sha1_finish_ext( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] )
 {
+    int ret;
     uint32_t last, padn;
     uint32_t high, low;
     unsigned char msglen[8];
@@ -334,14 +351,18 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    mbedtls_sha1_update( ctx, sha1_padding, padn );
-    mbedtls_sha1_update( ctx, msglen, 8 );
+    if( ( ret = mbedtls_sha1_update_ext( ctx, sha1_padding, padn ) ) != 0 )
+        return( ret );
+    if( ( ret = mbedtls_sha1_update_ext( ctx, msglen, 8 ) ) != 0 )
+        return( ret );
 
     PUT_UINT32_BE( ctx->state[0], output,  0 );
     PUT_UINT32_BE( ctx->state[1], output,  4 );
     PUT_UINT32_BE( ctx->state[2], output,  8 );
     PUT_UINT32_BE( ctx->state[3], output, 12 );
     PUT_UINT32_BE( ctx->state[4], output, 16 );
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_SHA1_ALT */
@@ -349,15 +370,27 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
 /*
  * output = SHA-1( input buffer )
  */
-void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] )
+int mbedtls_sha1_ext( const unsigned char *input,
+                      size_t ilen,
+                      unsigned char output[20] )
 {
+    int ret;
     mbedtls_sha1_context ctx;
 
     mbedtls_sha1_init( &ctx );
-    mbedtls_sha1_starts( &ctx );
-    mbedtls_sha1_update( &ctx, input, ilen );
-    mbedtls_sha1_finish( &ctx, output );
+
+    if( ( ret = mbedtls_sha1_starts_ext( &ctx ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_sha1_update_ext( &ctx, input, ilen ) ) != 0 )
+        return( ret );
+
+    if( ( ret = mbedtls_sha1_finish_ext( &ctx, output ) ) != 0 )
+        return( ret );
+
     mbedtls_sha1_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -406,29 +439,30 @@ int mbedtls_sha1_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-1 test #%d: ", i + 1 );
 
-        mbedtls_sha1_starts( &ctx );
+        if( mbedtls_sha1_starts_ext( &ctx ) != 0 )
+            goto fail;
 
         if( i == 2 )
         {
             memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
-                mbedtls_sha1_update( &ctx, buf, buflen );
+            {
+                if( mbedtls_sha1_update_ext( &ctx, buf, buflen ) != 0 )
+                    goto fail;
+            }
         }
         else
-            mbedtls_sha1_update( &ctx, sha1_test_buf[i],
-                               sha1_test_buflen[i] );
+        {
+            if( mbedtls_sha1_update_ext( &ctx, sha1_test_buf[i],
+                                         sha1_test_buflen[i] ) != 0 )
+                goto fail;
+        }
 
-        mbedtls_sha1_finish( &ctx, sha1sum );
+        mbedtls_sha1_finish_ext( &ctx, sha1sum );
 
         if( memcmp( sha1sum, sha1_test_sum[i], 20 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            ret = 1;
             goto exit;
-        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -436,6 +470,14 @@ int mbedtls_sha1_self_test( int verbose )
 
     if( verbose != 0 )
         mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    ret = 1;
 
 exit:
     mbedtls_sha1_free( &ctx );

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -380,17 +380,18 @@ int mbedtls_sha1_ext( const unsigned char *input,
     mbedtls_sha1_init( &ctx );
 
     if( ( ret = mbedtls_sha1_starts_ext( &ctx ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha1_update_ext( &ctx, input, ilen ) ) != 0 )
-        return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha1_finish_ext( &ctx, output ) ) != 0 )
-        return( ret );
+        goto exit;
 
+exit:
     mbedtls_sha1_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -439,7 +439,7 @@ int mbedtls_sha1_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-1 test #%d: ", i + 1 );
 
-        if( mbedtls_sha1_starts_ext( &ctx ) != 0 )
+        if( ( ret = mbedtls_sha1_starts_ext( &ctx ) ) != 0 )
             goto fail;
 
         if( i == 2 )
@@ -448,21 +448,27 @@ int mbedtls_sha1_self_test( int verbose )
 
             for( j = 0; j < 1000; j++ )
             {
-                if( mbedtls_sha1_update_ext( &ctx, buf, buflen ) != 0 )
+                ret = mbedtls_sha1_update_ext( &ctx, buf, buflen );
+                if( ret != 0 )
                     goto fail;
             }
         }
         else
         {
-            if( mbedtls_sha1_update_ext( &ctx, sha1_test_buf[i],
-                                         sha1_test_buflen[i] ) != 0 )
+            ret = mbedtls_sha1_update_ext( &ctx, sha1_test_buf[i],
+                                           sha1_test_buflen[i] );
+            if( ret != 0 )
                 goto fail;
         }
 
-        mbedtls_sha1_finish_ext( &ctx, sha1sum );
+        if( ( ret = mbedtls_sha1_finish_ext( &ctx, sha1sum ) ) != 0 )
+            goto fail;
 
         if( memcmp( sha1sum, sha1_test_sum[i], 20 ) != 0 )
-            goto exit;
+        {
+            ret = 1;
+            goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -476,8 +482,6 @@ int mbedtls_sha1_self_test( int verbose )
 fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
-
-    ret = 1;
 
 exit:
     mbedtls_sha1_free( &ctx );

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -112,8 +112,8 @@ int mbedtls_sha1_starts_ext( mbedtls_sha1_context *ctx )
 }
 
 #if !defined(MBEDTLS_SHA1_PROCESS_ALT)
-int mbedtls_sha1_process_ext( mbedtls_sha1_context *ctx,
-                              const unsigned char data[64] )
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] )
 {
     uint32_t temp, W[16], A, B, C, D, E;
 
@@ -299,7 +299,7 @@ int mbedtls_sha1_update_ext( mbedtls_sha1_context *ctx,
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
 
-        if( ( ret = mbedtls_sha1_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -309,7 +309,7 @@ int mbedtls_sha1_update_ext( mbedtls_sha1_context *ctx,
 
     while( ilen >= 64 )
     {
-        if( ( ret = mbedtls_sha1_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha1_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 64;

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -448,7 +448,7 @@ int mbedtls_sha256_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 256 - k * 32, j + 1 );
 
-        if( mbedtls_sha256_starts_ext( &ctx, k ) != 0 )
+        if( ( ret = mbedtls_sha256_starts_ext( &ctx, k ) ) != 0 )
             goto fail;
 
         if( j == 2 )
@@ -456,23 +456,30 @@ int mbedtls_sha256_self_test( int verbose )
             memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
-                if( mbedtls_sha256_update_ext( &ctx, buf, buflen ) != 0 )
+            {
+                ret = mbedtls_sha256_update_ext( &ctx, buf, buflen );
+                if( ret != 0 )
                     goto fail;
+            }
 
         }
         else
         {
-           if(  mbedtls_sha256_update_ext( &ctx, sha256_test_buf[j],
-                                           sha256_test_buflen[j] ) != 0 )
-                goto fail;
+            ret = mbedtls_sha256_update_ext( &ctx, sha256_test_buf[j],
+                                             sha256_test_buflen[j] );
+            if( ret != 0 )
+                 goto fail;
         }
 
-        if( mbedtls_sha256_finish_ext( &ctx, sha256sum ) != 0 )
+        if( ( ret = mbedtls_sha256_finish_ext( &ctx, sha256sum ) ) != 0 )
             goto fail;
 
 
         if( memcmp( sha256sum, sha256_test_sum[i], 32 - k * 4 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -486,8 +493,6 @@ int mbedtls_sha256_self_test( int verbose )
 fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
-
-    ret = 1;
 
 exit:
     mbedtls_sha256_free( &ctx );

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -100,7 +100,7 @@ void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
 /*
  * SHA-256 context setup
  */
-void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 )
+int mbedtls_sha256_starts_ext( mbedtls_sha256_context *ctx, int is224 )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -131,6 +131,8 @@ void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 )
     }
 
     ctx->is224 = is224;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_SHA256_PROCESS_ALT)
@@ -179,7 +181,8 @@ static const uint32_t K[] =
     d += temp1; h = temp1 + temp2;              \
 }
 
-void mbedtls_sha256_process( mbedtls_sha256_context *ctx, const unsigned char data[64] )
+int mbedtls_sha256_process_ext( mbedtls_sha256_context *ctx,
+                                const unsigned char data[64] )
 {
     uint32_t temp1, temp2, W[64];
     uint32_t A[8];
@@ -232,20 +235,24 @@ void mbedtls_sha256_process( mbedtls_sha256_context *ctx, const unsigned char da
 
     for( i = 0; i < 8; i++ )
         ctx->state[i] += A[i];
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 /*
  * SHA-256 process buffer
  */
-void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *input,
-                    size_t ilen )
+int mbedtls_sha256_update_ext( mbedtls_sha256_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen )
 {
+    int ret;
     size_t fill;
     uint32_t left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = ctx->total[0] & 0x3F;
     fill = 64 - left;
@@ -259,7 +266,10 @@ void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *in
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        mbedtls_sha256_process( ctx, ctx->buffer );
+
+        if( ( ret = mbedtls_sha256_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -267,13 +277,17 @@ void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *in
 
     while( ilen >= 64 )
     {
-        mbedtls_sha256_process( ctx, input );
+        if( ( ret = mbedtls_sha256_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 64;
         ilen  -= 64;
     }
 
     if( ilen > 0 )
         memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
 }
 
 static const unsigned char sha256_padding[64] =
@@ -287,8 +301,10 @@ static const unsigned char sha256_padding[64] =
 /*
  * SHA-256 final digest
  */
-void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32] )
+int mbedtls_sha256_finish_ext( mbedtls_sha256_context *ctx,
+                               unsigned char output[32] )
 {
+    int ret;
     uint32_t last, padn;
     uint32_t high, low;
     unsigned char msglen[8];
@@ -303,8 +319,11 @@ void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    mbedtls_sha256_update( ctx, sha256_padding, padn );
-    mbedtls_sha256_update( ctx, msglen, 8 );
+    if( ( ret = mbedtls_sha256_update_ext( ctx, sha256_padding, padn ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha256_update_ext( ctx, msglen, 8 ) ) != 0 )
+            return( ret );
 
     PUT_UINT32_BE( ctx->state[0], output,  0 );
     PUT_UINT32_BE( ctx->state[1], output,  4 );
@@ -316,6 +335,8 @@ void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32
 
     if( ctx->is224 == 0 )
         PUT_UINT32_BE( ctx->state[7], output, 28 );
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_SHA256_ALT */
@@ -323,16 +344,28 @@ void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32
 /*
  * output = SHA-256( input buffer )
  */
-void mbedtls_sha256( const unsigned char *input, size_t ilen,
-             unsigned char output[32], int is224 )
+int mbedtls_sha256_ext( const unsigned char *input,
+                        size_t ilen,
+                        unsigned char output[32],
+                        int is224 )
 {
+    int ret;
     mbedtls_sha256_context ctx;
 
     mbedtls_sha256_init( &ctx );
-    mbedtls_sha256_starts( &ctx, is224 );
-    mbedtls_sha256_update( &ctx, input, ilen );
-    mbedtls_sha256_finish( &ctx, output );
+
+    if( ( ret = mbedtls_sha256_starts_ext( &ctx, is224 ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha256_update_ext( &ctx, input, ilen ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha256_finish_ext( &ctx, output ) ) != 0 )
+            return( ret );
+
     mbedtls_sha256_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -415,29 +448,31 @@ int mbedtls_sha256_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 256 - k * 32, j + 1 );
 
-        mbedtls_sha256_starts( &ctx, k );
+        if( mbedtls_sha256_starts_ext( &ctx, k ) != 0 )
+            goto fail;
 
         if( j == 2 )
         {
             memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
-                mbedtls_sha256_update( &ctx, buf, buflen );
+                if( mbedtls_sha256_update_ext( &ctx, buf, buflen ) != 0 )
+                    goto fail;
+
         }
         else
-            mbedtls_sha256_update( &ctx, sha256_test_buf[j],
-                                 sha256_test_buflen[j] );
+        {
+           if(  mbedtls_sha256_update_ext( &ctx, sha256_test_buf[j],
+                                           sha256_test_buflen[j] ) != 0 )
+                goto fail;
+        }
 
-        mbedtls_sha256_finish( &ctx, sha256sum );
+        if( mbedtls_sha256_finish_ext( &ctx, sha256sum ) != 0 )
+            goto fail;
+
 
         if( memcmp( sha256sum, sha256_test_sum[i], 32 - k * 4 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            ret = 1;
-            goto exit;
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -445,6 +480,14 @@ int mbedtls_sha256_self_test( int verbose )
 
     if( verbose != 0 )
         mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    ret = 1;
 
 exit:
     mbedtls_sha256_free( &ctx );

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -320,10 +320,10 @@ int mbedtls_sha256_finish_ext( mbedtls_sha256_context *ctx,
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
     if( ( ret = mbedtls_sha256_update_ext( ctx, sha256_padding, padn ) ) != 0 )
-            return( ret );
+        return( ret );
 
     if( ( ret = mbedtls_sha256_update_ext( ctx, msglen, 8 ) ) != 0 )
-            return( ret );
+        return( ret );
 
     PUT_UINT32_BE( ctx->state[0], output,  0 );
     PUT_UINT32_BE( ctx->state[1], output,  4 );

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -181,7 +181,7 @@ static const uint32_t K[] =
     d += temp1; h = temp1 + temp2;              \
 }
 
-int mbedtls_sha256_process_ext( mbedtls_sha256_context *ctx,
+int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                 const unsigned char data[64] )
 {
     uint32_t temp1, temp2, W[64];
@@ -267,7 +267,7 @@ int mbedtls_sha256_update_ext( mbedtls_sha256_context *ctx,
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
 
-        if( ( ret = mbedtls_sha256_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -277,7 +277,7 @@ int mbedtls_sha256_update_ext( mbedtls_sha256_context *ctx,
 
     while( ilen >= 64 )
     {
-        if( ( ret = mbedtls_sha256_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha256_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 64;

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -380,7 +380,7 @@ static const unsigned char sha256_test_buf[3][57] =
     { "" }
 };
 
-static const int sha256_test_buflen[3] =
+static const size_t sha256_test_buflen[3] =
 {
     3, 56, 1000
 };

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -355,17 +355,18 @@ int mbedtls_sha256_ext( const unsigned char *input,
     mbedtls_sha256_init( &ctx );
 
     if( ( ret = mbedtls_sha256_starts_ext( &ctx, is224 ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha256_update_ext( &ctx, input, ilen ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha256_finish_ext( &ctx, output ) ) != 0 )
-            return( ret );
+        goto exit;
 
+exit:
     mbedtls_sha256_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -114,7 +114,7 @@ void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
 /*
  * SHA-512 context setup
  */
-void mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 )
+int mbedtls_sha512_starts_ext( mbedtls_sha512_context *ctx, int is384 )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -145,6 +145,8 @@ void mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 )
     }
 
     ctx->is384 = is384;
+
+    return( 0 );
 }
 
 #if !defined(MBEDTLS_SHA512_PROCESS_ALT)
@@ -196,7 +198,8 @@ static const uint64_t K[80] =
     UL64(0x5FCB6FAB3AD6FAEC),  UL64(0x6C44198C4A475817)
 };
 
-void mbedtls_sha512_process( mbedtls_sha512_context *ctx, const unsigned char data[128] )
+int mbedtls_sha512_process_ext( mbedtls_sha512_context *ctx,
+                                const unsigned char data[128] )
 {
     int i;
     uint64_t temp1, temp2, W[80];
@@ -263,20 +266,24 @@ void mbedtls_sha512_process( mbedtls_sha512_context *ctx, const unsigned char da
     ctx->state[5] += F;
     ctx->state[6] += G;
     ctx->state[7] += H;
+
+    return( 0 );
 }
 #endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 /*
  * SHA-512 process buffer
  */
-void mbedtls_sha512_update( mbedtls_sha512_context *ctx, const unsigned char *input,
-                    size_t ilen )
+int mbedtls_sha512_update_ext( mbedtls_sha512_context *ctx,
+                               const unsigned char *input,
+                               size_t ilen )
 {
+    int ret;
     size_t fill;
     unsigned int left;
 
     if( ilen == 0 )
-        return;
+        return( 0 );
 
     left = (unsigned int) (ctx->total[0] & 0x7F);
     fill = 128 - left;
@@ -289,7 +296,10 @@ void mbedtls_sha512_update( mbedtls_sha512_context *ctx, const unsigned char *in
     if( left && ilen >= fill )
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
-        mbedtls_sha512_process( ctx, ctx->buffer );
+
+        if( ( ret = mbedtls_sha512_process_ext( ctx, ctx->buffer ) ) != 0 )
+            return( ret );
+
         input += fill;
         ilen  -= fill;
         left = 0;
@@ -297,13 +307,17 @@ void mbedtls_sha512_update( mbedtls_sha512_context *ctx, const unsigned char *in
 
     while( ilen >= 128 )
     {
-        mbedtls_sha512_process( ctx, input );
+        if( ( ret = mbedtls_sha512_process_ext( ctx, input ) ) != 0 )
+            return( ret );
+
         input += 128;
         ilen  -= 128;
     }
 
     if( ilen > 0 )
         memcpy( (void *) (ctx->buffer + left), input, ilen );
+
+    return( 0 );
 }
 
 static const unsigned char sha512_padding[128] =
@@ -321,8 +335,10 @@ static const unsigned char sha512_padding[128] =
 /*
  * SHA-512 final digest
  */
-void mbedtls_sha512_finish( mbedtls_sha512_context *ctx, unsigned char output[64] )
+int mbedtls_sha512_finish_ext( mbedtls_sha512_context *ctx,
+                               unsigned char output[64] )
 {
+    int ret;
     size_t last, padn;
     uint64_t high, low;
     unsigned char msglen[16];
@@ -337,8 +353,11 @@ void mbedtls_sha512_finish( mbedtls_sha512_context *ctx, unsigned char output[64
     last = (size_t)( ctx->total[0] & 0x7F );
     padn = ( last < 112 ) ? ( 112 - last ) : ( 240 - last );
 
-    mbedtls_sha512_update( ctx, sha512_padding, padn );
-    mbedtls_sha512_update( ctx, msglen, 16 );
+    if( ( ret = mbedtls_sha512_update_ext( ctx, sha512_padding, padn ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha512_update_ext( ctx, msglen, 16 ) ) != 0 )
+            return( ret );
 
     PUT_UINT64_BE( ctx->state[0], output,  0 );
     PUT_UINT64_BE( ctx->state[1], output,  8 );
@@ -352,6 +371,8 @@ void mbedtls_sha512_finish( mbedtls_sha512_context *ctx, unsigned char output[64
         PUT_UINT64_BE( ctx->state[6], output, 48 );
         PUT_UINT64_BE( ctx->state[7], output, 56 );
     }
+
+    return( 0 );
 }
 
 #endif /* !MBEDTLS_SHA512_ALT */
@@ -359,16 +380,28 @@ void mbedtls_sha512_finish( mbedtls_sha512_context *ctx, unsigned char output[64
 /*
  * output = SHA-512( input buffer )
  */
-void mbedtls_sha512( const unsigned char *input, size_t ilen,
-             unsigned char output[64], int is384 )
+int mbedtls_sha512_ext( const unsigned char *input,
+                    size_t ilen,
+                    unsigned char output[64],
+                    int is384 )
 {
+    int ret;
     mbedtls_sha512_context ctx;
 
     mbedtls_sha512_init( &ctx );
-    mbedtls_sha512_starts( &ctx, is384 );
-    mbedtls_sha512_update( &ctx, input, ilen );
-    mbedtls_sha512_finish( &ctx, output );
+
+    if( ( ret = mbedtls_sha512_starts_ext( &ctx, is384 ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha512_update_ext( &ctx, input, ilen ) ) != 0 )
+            return( ret );
+
+    if( ( ret = mbedtls_sha512_finish_ext( &ctx, output ) ) != 0 )
+            return( ret );
+
     mbedtls_sha512_free( &ctx );
+
+    return( 0 );
 }
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -471,29 +504,29 @@ int mbedtls_sha512_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
 
-        mbedtls_sha512_starts( &ctx, k );
+        if( mbedtls_sha512_starts_ext( &ctx, k ) != 0 )
+            goto fail;
 
         if( j == 2 )
         {
             memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
-                mbedtls_sha512_update( &ctx, buf, buflen );
+                if( mbedtls_sha512_update_ext( &ctx, buf, buflen ) != 0 )
+                    goto fail;
         }
         else
-            mbedtls_sha512_update( &ctx, sha512_test_buf[j],
-                                 sha512_test_buflen[j] );
+        {
+            if( mbedtls_sha512_update_ext( &ctx, sha512_test_buf[j],
+                                           sha512_test_buflen[j] ) != 0 )
+                goto fail;
+        }
 
-        mbedtls_sha512_finish( &ctx, sha512sum );
+        if( mbedtls_sha512_finish_ext( &ctx, sha512sum ) != 0 )
+            goto fail;
 
         if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )
-        {
-            if( verbose != 0 )
-                mbedtls_printf( "failed\n" );
-
-            ret = 1;
-            goto exit;
-        }
+            goto fail;
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -501,6 +534,14 @@ int mbedtls_sha512_self_test( int verbose )
 
     if( verbose != 0 )
         mbedtls_printf( "\n" );
+
+    goto exit;
+
+fail:
+    if( verbose != 0 )
+        mbedtls_printf( "failed\n" );
+
+    ret = 1;
 
 exit:
     mbedtls_sha512_free( &ctx );

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -504,7 +504,7 @@ int mbedtls_sha512_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
 
-        if( mbedtls_sha512_starts_ext( &ctx, k ) != 0 )
+        if( ( ret = mbedtls_sha512_starts_ext( &ctx, k ) ) != 0 )
             goto fail;
 
         if( j == 2 )
@@ -512,21 +512,28 @@ int mbedtls_sha512_self_test( int verbose )
             memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
-                if( mbedtls_sha512_update_ext( &ctx, buf, buflen ) != 0 )
+            {
+                ret = mbedtls_sha512_update_ext( &ctx, buf, buflen );
+                if( ret != 0 )
                     goto fail;
+            }
         }
         else
         {
-            if( mbedtls_sha512_update_ext( &ctx, sha512_test_buf[j],
-                                           sha512_test_buflen[j] ) != 0 )
+            ret = mbedtls_sha512_update_ext( &ctx, sha512_test_buf[j],
+                                             sha512_test_buflen[j] );
+            if( ret != 0 )
                 goto fail;
         }
 
-        if( mbedtls_sha512_finish_ext( &ctx, sha512sum ) != 0 )
+        if( ( ret = mbedtls_sha512_finish_ext( &ctx, sha512sum ) ) != 0 )
             goto fail;
 
         if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )
+        {
+            ret = 1;
             goto fail;
+        }
 
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
@@ -540,8 +547,6 @@ int mbedtls_sha512_self_test( int verbose )
 fail:
     if( verbose != 0 )
         mbedtls_printf( "failed\n" );
-
-    ret = 1;
 
 exit:
     mbedtls_sha512_free( &ctx );

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -418,7 +418,7 @@ static const unsigned char sha512_test_buf[3][113] =
     { "" }
 };
 
-static const int sha512_test_buflen[3] =
+static const size_t sha512_test_buflen[3] =
 {
     3, 112, 1000
 };

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -391,17 +391,18 @@ int mbedtls_sha512_ext( const unsigned char *input,
     mbedtls_sha512_init( &ctx );
 
     if( ( ret = mbedtls_sha512_starts_ext( &ctx, is384 ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha512_update_ext( &ctx, input, ilen ) ) != 0 )
-            return( ret );
+        goto exit;
 
     if( ( ret = mbedtls_sha512_finish_ext( &ctx, output ) ) != 0 )
-            return( ret );
+        goto exit;
 
+exit:
     mbedtls_sha512_free( &ctx );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -198,8 +198,8 @@ static const uint64_t K[80] =
     UL64(0x5FCB6FAB3AD6FAEC),  UL64(0x6C44198C4A475817)
 };
 
-int mbedtls_sha512_process_ext( mbedtls_sha512_context *ctx,
-                                const unsigned char data[128] )
+int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
+                                     const unsigned char data[128] )
 {
     int i;
     uint64_t temp1, temp2, W[80];
@@ -297,7 +297,7 @@ int mbedtls_sha512_update_ext( mbedtls_sha512_context *ctx,
     {
         memcpy( (void *) (ctx->buffer + left), input, fill );
 
-        if( ( ret = mbedtls_sha512_process_ext( ctx, ctx->buffer ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
         input += fill;
@@ -307,7 +307,7 @@ int mbedtls_sha512_update_ext( mbedtls_sha512_context *ctx,
 
     while( ilen >= 128 )
     {
-        if( ( ret = mbedtls_sha512_process_ext( ctx, input ) ) != 0 )
+        if( ( ret = mbedtls_internal_sha512_process( ctx, input ) ) != 0 )
             return( ret );
 
         input += 128;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2490,60 +2490,11 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
         if( md_alg == MBEDTLS_MD_NONE )
         {
-            mbedtls_md5_context mbedtls_md5;
-            mbedtls_sha1_context mbedtls_sha1;
-
-            mbedtls_md5_init( &mbedtls_md5 );
-
             hashlen = 36;
-
-            /*
-             * digitally-signed struct {
-             *     opaque md5_hash[16];
-             *     opaque sha_hash[20];
-             * };
-             *
-             * md5_hash
-             *     MD5(ClientHello.random + ServerHello.random
-             *                            + ServerParams);
-             * sha_hash
-             *     SHA(ClientHello.random + ServerHello.random
-             *                            + ServerParams);
-             */
-            if( ( ret = mbedtls_md5_starts_ext( &mbedtls_md5 ) ) != 0      ||
-                ( ret = mbedtls_md5_update_ext( &mbedtls_md5,
-                                    ssl->handshake->randbytes, 64 ) ) != 0 ||
-                ( ret = mbedtls_md5_update_ext( &mbedtls_md5, params,
-                                                params_len ) ) != 0        ||
-                ( ret = mbedtls_md5_finish_ext( &mbedtls_md5, hash ) ) != 0 )
-            {
-                mbedtls_md5_free( &mbedtls_md5 );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md5_*", ret );
-                mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-                                                MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );
+            ret = mbedtls_ssl_get_key_exchange_md_ssl_tls( ssl, hash, params,
+                                                           params_len );
+            if( ret != 0 )
                 return( ret );
-            }
-
-            mbedtls_md5_free( &mbedtls_md5 );
-
-            mbedtls_sha1_init( &mbedtls_sha1 );
-
-            if( ( ret = mbedtls_sha1_starts_ext( &mbedtls_sha1 ) ) != 0    ||
-                ( ret = mbedtls_sha1_update_ext( &mbedtls_sha1,
-                                    ssl->handshake->randbytes, 64 ) ) != 0 ||
-                ( ret = mbedtls_sha1_update_ext( &mbedtls_sha1, params,
-                                                 params_len ) ) != 0       ||
-                ( ret = mbedtls_sha1_finish_ext( &mbedtls_sha1,
-                                                 hash + 16 ) ) != 0 )
-            {
-                mbedtls_sha1_free( &mbedtls_sha1 );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha1_*", ret );
-                mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-                                                MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );
-                return( ret );
-            }
-
-            mbedtls_sha1_free( &mbedtls_sha1 );
         }
         else
 #endif /* MBEDTLS_SSL_PROTO_SSL3 || MBEDTLS_SSL_PROTO_TLS1 || \
@@ -2552,36 +2503,12 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
         if( md_alg != MBEDTLS_MD_NONE )
         {
-            mbedtls_md_context_t ctx;
-            const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type( md_alg );
-
-            mbedtls_md_init( &ctx );
-
             /* Info from md_alg will be used instead */
             hashlen = 0;
-
-            /*
-             * digitally-signed struct {
-             *     opaque client_random[32];
-             *     opaque server_random[32];
-             *     ServerDHParams params;
-             * };
-             */
-            if( ( ret = mbedtls_md_setup( &ctx, md_info, 0 ) ) != 0          ||
-                ( ret = mbedtls_md_starts( &ctx ) ) != 0                     ||
-                ( ret = mbedtls_md_update( &ctx,
-                                    ssl->handshake->randbytes, 64 ) ) != 0   ||
-                ( ret = mbedtls_md_update( &ctx, params, params_len ) ) != 0 ||
-                ( ret = mbedtls_md_finish( &ctx, hash ) ) != 0 )
-            {
-                mbedtls_md_free( &ctx );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_*", ret );
-                mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-                                                MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );
+            ret = mbedtls_ssl_get_key_exchange_md_tls1_2( ssl, hash, params,
+                                                          params_len, md_alg );
+            if( ret != 0 )
                 return( ret );
-            }
-
-            mbedtls_md_free( &ctx );
         }
         else
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3096,57 +3096,12 @@ curve_matching_done:
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
         if( md_alg == MBEDTLS_MD_NONE )
         {
-            mbedtls_md5_context mbedtls_md5;
-            mbedtls_sha1_context mbedtls_sha1;
-
-            mbedtls_md5_init( &mbedtls_md5 );
-
-            /*
-             * digitally-signed struct {
-             *     opaque md5_hash[16];
-             *     opaque sha_hash[20];
-             * };
-             *
-             * md5_hash
-             *     MD5(ClientHello.random + ServerHello.random
-             *                            + ServerParams);
-             * sha_hash
-             *     SHA(ClientHello.random + ServerHello.random
-             *                            + ServerParams);
-             */
-
-            if( ( ret = mbedtls_md5_starts_ext( &mbedtls_md5 ) ) != 0      ||
-                ( ret = mbedtls_md5_update_ext( &mbedtls_md5,
-                                    ssl->handshake->randbytes, 64 ) ) != 0 ||
-                ( ret = mbedtls_md5_update_ext( &mbedtls_md5, dig_signed,
-                                                dig_signed_len ) ) != 0    ||
-                ( ret = mbedtls_md5_finish_ext( &mbedtls_md5, hash ) ) != 0 )
-            {
-                mbedtls_md5_free( &mbedtls_md5 );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md5_*", ret );
-                return( ret );
-            }
-
-            mbedtls_md5_free( &mbedtls_md5 );
-
-            mbedtls_sha1_init( &mbedtls_sha1 );
-
-            if( ( ret = mbedtls_sha1_starts_ext( &mbedtls_sha1 ) ) != 0    ||
-                ( ret = mbedtls_sha1_update_ext( &mbedtls_sha1,
-                                    ssl->handshake->randbytes, 64 ) ) != 0 ||
-                ( ret = mbedtls_sha1_update_ext( &mbedtls_sha1, dig_signed,
-                                                 dig_signed_len ) ) != 0   ||
-                ( ret = mbedtls_sha1_finish_ext( &mbedtls_sha1,
-                                                 hash + 16 ) ) != 0 )
-            {
-                mbedtls_sha1_free( &mbedtls_sha1 );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_sha1_*", ret );
-                return( ret );
-            }
-
-            mbedtls_sha1_free( &mbedtls_sha1 );
-
             hashlen = 36;
+            ret = mbedtls_ssl_get_key_exchange_md_ssl_tls( ssl, hash,
+                                                           dig_signed,
+                                                           dig_signed_len );
+            if( ret != 0 )
+                return( ret );
         }
         else
 #endif /* MBEDTLS_SSL_PROTO_SSL3 || MBEDTLS_SSL_PROTO_TLS1 || \
@@ -3155,36 +3110,14 @@ curve_matching_done:
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
         if( md_alg != MBEDTLS_MD_NONE )
         {
-            mbedtls_md_context_t ctx;
-            const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type( md_alg );
-
-            mbedtls_md_init( &ctx );
-
             /* Info from md_alg will be used instead */
             hashlen = 0;
-
-            /*
-             * digitally-signed struct {
-             *     opaque client_random[32];
-             *     opaque server_random[32];
-             *     ServerDHParams params;
-             * };
-             */
-            if( ( ret = mbedtls_md_setup( &ctx, md_info, 0 ) ) != 0          ||
-                ( ret = mbedtls_md_starts( &ctx ) ) != 0                     ||
-                ( ret = mbedtls_md_update( &ctx,
-                                    ssl->handshake->randbytes, 64 ) ) != 0   ||
-                ( ret = mbedtls_md_update( &ctx, dig_signed,
-                                           dig_signed_len ) ) != 0           ||
-                ( ret = mbedtls_md_finish( &ctx, hash ) ) != 0 )
-            {
-                mbedtls_md_free( &ctx );
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_md_*", ret );
+            ret = mbedtls_ssl_get_key_exchange_md_tls1_2( ssl, hash,
+                                                          dig_signed,
+                                                          dig_signed_len,
+                                                          md_alg );
+            if( ret != 0 )
                 return( ret );
-            }
-
-
-            mbedtls_md_free( &ctx );
         }
         else
 #endif /* MBEDTLS_SSL_PROTO_TLS1 || MBEDTLS_SSL_PROTO_TLS1_1 || \

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -221,7 +221,7 @@ static int ssl3_prf( const unsigned char *secret, size_t slen,
                      const unsigned char *random, size_t rlen,
                      unsigned char *dstbuf, size_t dlen )
 {
-    int ret;
+    int ret = 0;
     size_t i;
     mbedtls_md5_context md5;
     mbedtls_sha1_context sha1;

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -177,8 +177,11 @@ int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ct
     memset( buf, 0, sizeof(buf) );
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_pk_write_pubkey( &c, buf, ctx->subject_key ) );
 
-    mbedtls_sha1( buf + sizeof(buf) - len, len, buf + sizeof(buf) - 20 );
-    c = buf + sizeof(buf) - 20;
+    ret = mbedtls_sha1_ext( buf + sizeof( buf ) - len, len,
+                            buf + sizeof( buf ) - 20 );
+    if( ret != 0 )
+        return( ret );
+    c = buf + sizeof( buf ) - 20;
     len = 20;
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
@@ -199,8 +202,11 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
     memset( buf, 0, sizeof(buf) );
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_pk_write_pubkey( &c, buf, ctx->issuer_key ) );
 
-    mbedtls_sha1( buf + sizeof(buf) - len, len, buf + sizeof(buf) - 20 );
-    c = buf + sizeof(buf) - 20;
+    ret = mbedtls_sha1_ext( buf + sizeof( buf ) - len, len,
+                            buf + sizeof( buf ) - 20 );
+    if( ret != 0 )
+        return( ret );
+    c = buf + sizeof( buf ) - 20;
     len = 20;
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
@@ -398,7 +404,11 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx, unsigned char *buf, 
     /*
      * Make signature
      */
-    mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    if( ( ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c,
+                            len, hash ) ) != 0 )
+    {
+        return( ret );
+    }
 
     if( ( ret = mbedtls_pk_sign( ctx->issuer_key, ctx->md_alg, hash, 0, sig, &sig_len,
                          f_rng, p_rng ) ) != 0 )

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -29,7 +29,9 @@
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
-#define mbedtls_printf     printf
+#define mbedtls_printf       printf
+#define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
+#define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
 
 #if defined(MBEDTLS_MD5_C)
@@ -45,13 +47,14 @@ int main( void )
 #else
 int main( void )
 {
-    int i;
+    int i, ret;
     unsigned char digest[16];
     char str[] = "Hello, world!";
 
     mbedtls_printf( "\n  MD5('%s') = ", str );
 
-    mbedtls_md5( (unsigned char *) str, 13, digest );
+    if( ( ret = mbedtls_md5_ext( (unsigned char *) str, 13, digest ) ) != 0 )
+        return( MBEDTLS_EXIT_FAILURE );
 
     for( i = 0; i < 16; i++ )
         mbedtls_printf( "%02x", digest[i] );
@@ -63,6 +66,6 @@ int main( void )
     fflush( stdout ); getchar();
 #endif
 
-    return( 0 );
+    return( MBEDTLS_EXIT_SUCCESS );
 }
 #endif /* MBEDTLS_MD5_C */

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -28,6 +28,7 @@
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
+#include <stdlib.h>
 #include <stdio.h>
 #define mbedtls_printf       printf
 #define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -212,7 +212,11 @@ int main( void )
         goto exit;
     }
 
-    mbedtls_sha1( buf, (int)( p - 2 - buf ), hash );
+    if( ( ret = mbedtls_sha1_ext( buf, (int)( p - 2 - buf ), hash ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! mbedtls_sha1_ext returned %d\n\n", ret );
+        goto exit;
+    }
 
     if( ( ret = mbedtls_rsa_pkcs1_verify( &rsa, NULL, NULL, MBEDTLS_RSA_PUBLIC,
                                   MBEDTLS_MD_SHA256, 0, hash, p ) ) != 0 )

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -203,7 +203,11 @@ int main( void )
     /*
      * 5. Sign the parameters and send them
      */
-    mbedtls_sha1( buf, n, hash );
+    if( ( ret = mbedtls_sha1_ext( buf, n, hash ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! mbedtls_sha1_ext returned %d\n\n", ret );
+        goto exit;
+    }
 
     buf[n    ] = (unsigned char)( rsa.len >> 8 );
     buf[n + 1] = (unsigned char)( rsa.len      );

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -102,7 +102,6 @@ int main( int argc, char *argv[] )
     mbedtls_ecdsa_context ctx_sign, ctx_verify;
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctr_drbg;
-    mbedtls_sha256_context sha256_ctx;
     unsigned char message[100];
     unsigned char hash[32];
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
@@ -113,7 +112,6 @@ int main( int argc, char *argv[] )
     mbedtls_ecdsa_init( &ctx_sign );
     mbedtls_ecdsa_init( &ctx_verify );
     mbedtls_ctr_drbg_init( &ctr_drbg );
-    mbedtls_sha256_init( &sha256_ctx );
 
     memset( sig, 0, sizeof( sig ) );
     memset( message, 0x25, sizeof( message ) );
@@ -165,9 +163,11 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Computing message hash..." );
     fflush( stdout );
 
-    mbedtls_sha256_starts( &sha256_ctx, 0 );
-    mbedtls_sha256_update( &sha256_ctx, message, sizeof( message ) );
-    mbedtls_sha256_finish( &sha256_ctx, hash );
+    if( ( ret = mbedtls_sha256_ext( message, sizeof( message ), hash, 0 ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! mbedtls_sha256_ext returned %d\n", ret );
+        goto exit;
+    }
 
     mbedtls_printf( " ok\n" );
 
@@ -242,7 +242,6 @@ exit:
     mbedtls_ecdsa_free( &ctx_sign );
     mbedtls_ctr_drbg_free( &ctr_drbg );
     mbedtls_entropy_free( &entropy );
-    mbedtls_sha256_free( &sha256_ctx );
 
     return( ret );
 }

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -327,32 +327,32 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_MD4_C)
     if( todo.md4 )
-        TIME_AND_TSC( "MD4", mbedtls_md4( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "MD4", mbedtls_md4_ext( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_MD5_C)
     if( todo.md5 )
-        TIME_AND_TSC( "MD5", mbedtls_md5( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "MD5", mbedtls_md5_ext( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_RIPEMD160_C)
     if( todo.ripemd160 )
-        TIME_AND_TSC( "RIPEMD160", mbedtls_ripemd160( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "RIPEMD160", mbedtls_ripemd160_ext( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_SHA1_C)
     if( todo.sha1 )
-        TIME_AND_TSC( "SHA-1", mbedtls_sha1( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "SHA-1", mbedtls_sha1_ext( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
     if( todo.sha256 )
-        TIME_AND_TSC( "SHA-256", mbedtls_sha256( buf, BUFSIZE, tmp, 0 ) );
+        TIME_AND_TSC( "SHA-256", mbedtls_sha256_ext( buf, BUFSIZE, tmp, 0 ) );
 #endif
 
 #if defined(MBEDTLS_SHA512_C)
     if( todo.sha512 )
-        TIME_AND_TSC( "SHA-512", mbedtls_sha512( buf, BUFSIZE, tmp, 0 ) );
+        TIME_AND_TSC( "SHA-512", mbedtls_sha512_ext( buf, BUFSIZE, tmp, 0 ) );
 #endif
 
 #if defined(MBEDTLS_ARC4_C)

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -8,6 +8,7 @@
 /* BEGIN_CASE depends_on:MBEDTLS_MD2_C */
 void md2_text( char *text_src_string, char *hex_hash_string )
 {
+    int ret;
     unsigned char src_str[100];
     unsigned char hash_str[33];
     unsigned char output[16];
@@ -18,7 +19,8 @@ void md2_text( char *text_src_string, char *hex_hash_string )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    mbedtls_md2( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md2_ext( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( ret == 0 ) ;
     hexify( hash_str, output, sizeof  output );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -28,6 +30,7 @@ void md2_text( char *text_src_string, char *hex_hash_string )
 /* BEGIN_CASE depends_on:MBEDTLS_MD4_C */
 void md4_text( char *text_src_string, char *hex_hash_string )
 {
+    int ret;
     unsigned char src_str[100];
     unsigned char hash_str[33];
     unsigned char output[16];
@@ -38,7 +41,8 @@ void md4_text( char *text_src_string, char *hex_hash_string )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    mbedtls_md4( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md4_ext( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( ret == 0 );
     hexify( hash_str, output, sizeof  output );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -48,6 +52,7 @@ void md4_text( char *text_src_string, char *hex_hash_string )
 /* BEGIN_CASE depends_on:MBEDTLS_MD5_C */
 void md5_text( char *text_src_string, char *hex_hash_string )
 {
+    int ret;
     unsigned char src_str[100];
     unsigned char hash_str[33];
     unsigned char output[16];
@@ -58,7 +63,8 @@ void md5_text( char *text_src_string, char *hex_hash_string )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    mbedtls_md5( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md5_ext( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( ret == 0 );
     hexify( hash_str, output, sizeof  output );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -68,6 +74,7 @@ void md5_text( char *text_src_string, char *hex_hash_string )
 /* BEGIN_CASE depends_on:MBEDTLS_RIPEMD160_C */
 void ripemd160_text( char *text_src_string, char *hex_hash_string )
 {
+    int ret;
     unsigned char src_str[100];
     unsigned char hash_str[41];
     unsigned char output[20];
@@ -78,7 +85,8 @@ void ripemd160_text( char *text_src_string, char *hex_hash_string )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    mbedtls_ripemd160( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_ripemd160_ext( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( ret == 0 );
     hexify( hash_str, output, sizeof output );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -18,7 +18,7 @@ void mbedtls_sha1( char *hex_src_string, char *hex_hash_string )
 
     src_len = unhexify( src_str, hex_src_string );
 
-    mbedtls_sha1( src_str, src_len, output );
+    TEST_ASSERT( mbedtls_sha1_ext( src_str, src_len, output ) == 0 );
     hexify( hash_str, output, 20 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -39,7 +39,7 @@ void sha224(char *hex_src_string, char *hex_hash_string )
 
     src_len = unhexify( src_str, hex_src_string );
 
-    mbedtls_sha256( src_str, src_len, output, 1 );
+    TEST_ASSERT( mbedtls_sha256_ext( src_str, src_len, output, 1 ) == 0 );
     hexify( hash_str, output, 28 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -60,7 +60,7 @@ void mbedtls_sha256(char *hex_src_string, char *hex_hash_string )
 
     src_len = unhexify( src_str, hex_src_string );
 
-    mbedtls_sha256( src_str, src_len, output, 0 );
+    TEST_ASSERT( mbedtls_sha256_ext( src_str, src_len, output, 0 ) == 0 );
     hexify( hash_str, output, 32 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -81,7 +81,7 @@ void sha384(char *hex_src_string, char *hex_hash_string )
 
     src_len = unhexify( src_str, hex_src_string );
 
-    mbedtls_sha512( src_str, src_len, output, 1 );
+    TEST_ASSERT( mbedtls_sha512_ext( src_str, src_len, output, 1 ) == 0 );
     hexify( hash_str, output, 48 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );
@@ -102,7 +102,7 @@ void mbedtls_sha512(char *hex_src_string, char *hex_hash_string )
 
     src_len = unhexify( src_str, hex_src_string );
 
-    mbedtls_sha512( src_str, src_len, output, 0);
+    TEST_ASSERT( mbedtls_sha512_ext( src_str, src_len, output, 0 ) == 0 );
     hexify( hash_str, output, 64 );
 
     TEST_ASSERT( strcmp( (char *) hash_str, hex_hash_string ) == 0 );


### PR DESCRIPTION
This PR deprecated functions from the existing MD APIs and replaces then with the functions listed below:
* `mbedtls_<MODULE>_starts()` -> `mbedtls_<MODULE>_starts_ext()`
* `mbedtls_<MODULE>_update()` -> `mbedtls_<MODULE>_update_ext()`
* `mbedtls_<MODULE>_finish()` -> `mbedtls_<MODULE>_finish_ext()`
* `mbedtls_<MODULE>_process()` -> `mbedtls_internal_<MODULE>_process()`

The new functions have return codes, which is useful for hardware acceleration as operations can now fail. The mbedtls_md_info_t struct has also seen its function pointers modified because these need to take into account the int return value.

This PR also updates all reference in the library to the deprecated functions.

**NOTES:**
* Related to https://github.com/ARMmbed/mbedtls/issues/817
* This is a new feature and does not need to be backported.