### PR TITLE
Redirect failed test suite output to stderr

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -99,7 +99,15 @@ typedef UINT32 uint32_t;
 /*----------------------------------------------------------------------------*/
 /* Global variables */
 
-static int test_errors = 0;
+
+static struct
+{
+    int failed;
+    const char *test;
+    const char *filename;
+    int line_no;
+}
+test_info;
 
 
 /*----------------------------------------------------------------------------*/
@@ -395,10 +403,9 @@ static int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
 
 static void test_fail( const char *test, int line_no, const char* filename )
 {
-    test_errors++;
-    if( test_errors == 1 )
-        mbedtls_fprintf( stdout, "FAILED\n" );
-    mbedtls_fprintf( stdout, "  %s\n  at line %d, %s\n", test, line_no,
-                        filename );
+    test_info.failed = 1;
+    test_info.test = test;
+    test_info.line_no = line_no;
+    test_info.filename = filename;
 }
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -339,6 +339,9 @@ int main(int argc, const char *argv[])
         testfile_count = 1;
     }
 
+    /* Initialize the struct that holds information about the last test */
+    memset( &test_info, 0, sizeof( test_info ) );
+
     /* Now begin to execute the tests in the testfiles */
     for ( testfile_index = 0;
           testfile_index < testfile_count;
@@ -369,7 +372,7 @@ int main(int argc, const char *argv[])
 
             if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
                 break;
-            mbedtls_fprintf( stdout, "%s%.66s", test_errors ? "\n" : "", buf );
+            mbedtls_fprintf( stdout, "%s%.66s", test_info.failed ? "\n" : "", buf );
             mbedtls_fprintf( stdout, " " );
             for( i = strlen( buf ) + 1; i < 67; i++ )
                 mbedtls_fprintf( stdout, "." );
@@ -409,11 +412,11 @@ int main(int argc, const char *argv[])
                     break;
                 cnt = parse_arguments( buf, strlen(buf), params );
             }
- 
+
             // If there are no unmet dependencies execute the test
             if( unmet_dep_count == 0 )
             {
-                test_errors = 0;
+                test_info.failed = 0;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
                 /* Suppress all output from the library unless we're verbose
@@ -467,9 +470,20 @@ int main(int argc, const char *argv[])
 
                 unmet_dep_count = 0;
             }
-            else if( ret == DISPATCH_TEST_SUCCESS && test_errors == 0 )
+            else if( ret == DISPATCH_TEST_SUCCESS )
             {
-                mbedtls_fprintf( stdout, "PASS\n" );
+                if( test_info.failed == 0 )
+                {
+                    mbedtls_fprintf( stdout, "PASS\n" );
+                }
+                else
+                {
+                    total_errors++;
+                    mbedtls_fprintf( stdout, "FAILED\n" );
+                    mbedtls_fprintf( stdout, "  %s\n  at line %d, %s\n",
+                                     test_info.test, test_info.line_no,
+                                     test_info.filename );
+                }
                 fflush( stdout );
             }
             else if( ret == DISPATCH_INVALID_TEST_DATA )


### PR DESCRIPTION
The change modifies the template code in tests/suites/helpers.function
so that error messages are printed to stderr. This makes errors visible
regardless of the --verbose flag being passed or not to the test
suite programs.

**NOTES:**
* This change fixes https://github.com/ARMmbed/mbedtls/issues/820.
* The change does not need to be backported to mbed TLS 1.3 or mbed TLS 2.1 as the test suite output is not redirected to `/dev/null` in those library versions.