### PR TITLE
mbed TLS 1.3: Fix compilation warnings with VS2015 x64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 1.3.x released xxxx-xx-xx
+
+Bugfix
+   * Fix Visual Studio implicit cast compilation warnings in the net.c and
+     x509.c modules and some sample applications.
+
 = mbed TLS 1.3.20 released 2017-06-21
 
 Security

--- a/library/net.c
+++ b/library/net.c
@@ -92,6 +92,14 @@ static int wsa_init_done = 0;
 
 #endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
 
+/* Some MS functions want int and MSVC warns if we pass size_t,
+ * but the standard fucntions use socklen_t, so cast only for MSVC */
+#if defined(_MSC_VER)
+#define MSVC_INT_CAST   (int)
+#else
+#define MSVC_INT_CAST
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -202,7 +210,7 @@ int net_connect( int *fd, const char *host, int port )
             continue;
         }
 
-        if( connect( *fd, cur->ai_addr, cur->ai_addrlen ) == 0 )
+        if( connect( *fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) == 0 )
         {
             ret = 0;
             break;
@@ -299,7 +307,7 @@ int net_bind( int *fd, const char *bind_ip, int port )
             continue;
         }
 
-        if( bind( *fd, cur->ai_addr, cur->ai_addrlen ) != 0 )
+        if( bind( *fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) != 0 )
         {
             close( *fd );
             ret = POLARSSL_ERR_NET_BIND_FAILED;

--- a/library/net.c
+++ b/library/net.c
@@ -93,7 +93,7 @@ static int wsa_init_done = 0;
 #endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
 
 /* Some MS functions want int and MSVC warns if we pass size_t,
- * but the standard fucntions use socklen_t, so cast only for MSVC */
+ * but the standard functions use socklen_t, so cast only for MSVC */
 #if defined(_MSC_VER)
 #define MSVC_INT_CAST   (int)
 #else

--- a/library/net.c
+++ b/library/net.c
@@ -55,8 +55,8 @@
 #endif
 #endif /* _MSC_VER */
 
-#define read(fd,buf,len)        recv(fd,(char*)buf,(int) len,0)
-#define write(fd,buf,len)       send(fd,(char*)buf,(int) len,0)
+#define read(fd,buf,len)        recv( fd, (char*)( buf ), (int)( len ), 0 )
+#define write(fd,buf,len)       send( fd, (char*)( buf ), (int)( len ), 0 )
 #define close(fd)               closesocket(fd)
 
 static int wsa_init_done = 0;

--- a/library/x509.c
+++ b/library/x509.c
@@ -480,7 +480,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
     }
 }
 
-static int x509_parse_int(unsigned char **p, unsigned n, int *res){
+static int x509_parse_int(unsigned char **p, size_t n, int *res){
     *res = 0;
     for( ; n > 0; --n ){
         if( ( **p < '0') || ( **p > '9' ) ) return POLARSSL_ERR_X509_INVALID_DATE;

--- a/library/x509.c
+++ b/library/x509.c
@@ -480,14 +480,20 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
     }
 }
 
-static int x509_parse_int(unsigned char **p, size_t n, int *res){
+static int x509_parse_int( unsigned char **p, size_t n, int *res )
+{
     *res = 0;
-    for( ; n > 0; --n ){
-        if( ( **p < '0') || ( **p > '9' ) ) return POLARSSL_ERR_X509_INVALID_DATE;
+
+    for( ; n > 0; --n )
+    {
+        if( ( **p < '0') || ( **p > '9' ) )
+            return( POLARSSL_ERR_X509_INVALID_DATE );
+
         *res *= 10;
-        *res += (*(*p)++ - '0');
+        *res += ( *(*p)++ - '0' );
     }
-    return 0;
+
+    return( 0 );
 }
 
 static int x509_date_is_valid(const x509_time *time)

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1267,7 +1267,7 @@ send_request:
 
     len = polarssl_snprintf( (char *) buf, sizeof(buf) - 1, GET_REQUEST,
                     opt.request_page );
-    tail_len = strlen( GET_REQUEST_END );
+    tail_len = (int) strlen( GET_REQUEST_END );
 
     /* Add padding to GET request to reach opt.request_size in length */
     if( opt.request_size != DFL_REQUEST_SIZE &&

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -57,8 +57,8 @@
 #include <unistd.h>
 #else
 #include <io.h>
-#define read _read
-#define write _write
+#define read(fd, buf, len)  _read( fd, (void *)buf, (unsigned int)len )
+#define write(fd, buf, len) _write( fd, (const void *)buf, (unsigned int)len )
 #endif
 
 #if defined(_WIN32) || defined(_WIN32_WCE)

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -57,8 +57,10 @@
 #include <unistd.h>
 #else
 #include <io.h>
-#define read(fd, buf, len)  _read( fd, (void *)buf, (unsigned int)len )
-#define write(fd, buf, len) _write( fd, (const void *)buf, (unsigned int)len )
+#define read(fd, buf, len)                                      \
+    _read( fd, (void *)( buf ), (unsigned int)( len ) )
+#define write(fd, buf, len)                                     \
+    _write( fd, (const void *)( buf ), (unsigned int)( len ) )
 #endif
 
 #if defined(_WIN32) || defined(_WIN32_WCE)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1791,7 +1791,7 @@ data_exchange:
             unsigned char *larger_buf;
 
             ori_len = ret;
-            extra_len = ssl_get_bytes_avail( &ssl );
+            extra_len = (int) ssl_get_bytes_avail( &ssl );
 
             larger_buf = polarssl_malloc( ori_len + extra_len + 1 );
             if( larger_buf == NULL )


### PR DESCRIPTION
Fix 6 compilation warnings in mbed TLS 1.3 in the sample programs and the net.c module. All the warnings are related to conversions from size_t to int, which can result in a loss of data. The fixes are essentially small backports from the code in the mbed TLS development branch.