### PR TITLE
Fix for dh_server example program

### DIFF
--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -234,6 +234,7 @@ int main( void )
 
     memset( buf, 0, sizeof( buf ) );
 
+    n = dhm.len;
     if( ( ret = mbedtls_net_recv( &client_fd, buf, n ) ) != (int) n )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_recv returned %d\n\n", ret );


### PR DESCRIPTION
The example programs `dh_server` and `dh_client` do not work out of the box. The client sends 256 bytes, the length of the public key, but the server (wrongly) expects 519 bytes, which is the total length of the DH parameters structure.

This fixes initialises the value of `n` in `dh_server.c` in a similar fashion as is done in `dh_client.c`.