### PR TITLE
Backport 1.3: Fix corner case uses of memory_buffer_alloc.c

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,8 @@ Bugfix
    * Fix issue in RSA key generation program programs/x509/rsa_genkey
      where the failure of CTR DRBG initialization lead to freeing an
      RSA context without proper initialization beforehand.
+   * Fix memory allocation corner cases in memory_buffer_alloc.c module. Found
+     by Guido Vranken. #639
 
 Changes
    * Extend cert_write example program by options to set the CRT version

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -244,7 +244,9 @@ static void *buffer_alloc_malloc( size_t len )
     if( heap.buf == NULL || heap.first == NULL )
         return( NULL );
 
-    if( len > (size_t)-POLARSSL_MEMORY_ALIGN_MULTIPLE )
+    if( len == 0 )
+        return( NULL );
+    else if( len > (size_t)-POLARSSL_MEMORY_ALIGN_MULTIPLE )
         return( NULL );
 
     if( len % POLARSSL_MEMORY_ALIGN_MULTIPLE )

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -544,17 +544,22 @@ void memory_buffer_alloc_cur_get( size_t *cur_used, size_t *cur_blocks )
 static void *buffer_alloc_malloc_mutexed( size_t len )
 {
     void *buf;
-    polarssl_mutex_lock( &heap.mutex );
+    if( polarssl_mutex_lock( &heap.mutex ) != 0 )
+        return( NULL );
     buf = buffer_alloc_malloc( len );
-    polarssl_mutex_unlock( &heap.mutex );
+    if( polarssl_mutex_unlock( &heap.mutex ) != 0 )
+        return( NULL );
     return( buf );
 }
 
 static void buffer_alloc_free_mutexed( void *ptr )
 {
-    polarssl_mutex_lock( &heap.mutex );
+    /* We have no good option here, but corrupting the heap seems
+     * worse than loosing memory. */
+    if( polarssl_mutex_lock( &heap.mutex ) != 0 )
+        return;
     buffer_alloc_free( ptr );
-    polarssl_mutex_unlock( &heap.mutex );
+    (void) polarssl_mutex_unlock( &heap.mutex );
 }
 #endif /* POLARSSL_THREADING_C */
 

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -185,7 +185,7 @@ static int verify_chain()
 {
     memory_header *prv = heap.first, *cur;
 
-    if( heap.first == NULL || verify_header( heap.first ) != 0 )
+    if( prv == NULL || verify_header( prv ) != 0 )
     {
 #if defined(POLARSSL_MEMORY_DEBUG)
         polarssl_fprintf( stderr, "FATAL: verification of first header "

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -574,7 +574,7 @@ int memory_buffer_alloc_init( unsigned char *buf, size_t len )
 #endif
 
     if( len < sizeof( memory_header ) + POLARSSL_MEMORY_ALIGN_MULTIPLE )
-        return;
+        return( -1 );
     else if( (size_t) buf % POLARSSL_MEMORY_ALIGN_MULTIPLE )
     {
         /* Adjust len first since buf is used in the computation */

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -412,6 +412,12 @@ static void buffer_alloc_free( void *ptr )
     heap.total_used -= hdr->size;
 #endif
 
+#if defined(POLARSSL_MEMORY_BACKTRACE)
+    free( hdr->trace );
+    hdr->trace = NULL;
+    hdr->trace_count = 0;
+#endif
+
     // Regroup with block before
     //
     if( hdr->prev != NULL && hdr->prev->alloc == 0 )
@@ -427,9 +433,6 @@ static void buffer_alloc_free( void *ptr )
         if( hdr->next != NULL )
             hdr->next->prev = hdr;
 
-#if defined(POLARSSL_MEMORY_BACKTRACE)
-        free( old->trace );
-#endif
         memset( old, 0, sizeof(memory_header) );
     }
 
@@ -469,9 +472,6 @@ static void buffer_alloc_free( void *ptr )
         if( hdr->next != NULL )
             hdr->next->prev = hdr;
 
-#if defined(POLARSSL_MEMORY_BACKTRACE)
-        free( old->trace );
-#endif
         memset( old, 0, sizeof(memory_header) );
     }
 
@@ -485,11 +485,6 @@ static void buffer_alloc_free( void *ptr )
             heap.first_free->prev_free = hdr;
         heap.first_free = hdr;
     }
-
-#if defined(POLARSSL_MEMORY_BACKTRACE)
-    hdr->trace = NULL;
-    hdr->trace_count = 0;
-#endif
 
     if( ( heap.verify & MEMORY_VERIFY_FREE ) && verify_chain() != 0 )
         polarssl_exit( 1 );

--- a/library/pem.c
+++ b/library/pem.c
@@ -422,7 +422,7 @@ int pem_write_buffer( const char *header, const char *footer,
                       unsigned char *buf, size_t buf_len, size_t *olen )
 {
     int ret;
-    unsigned char *encode_buf, *c, *p = buf;
+    unsigned char *encode_buf = NULL, *c, *p = buf;
     size_t len = 0, use_len = 0, add_len = 0;
 
     base64_encode( NULL, &use_len, der_data, der_len );
@@ -434,7 +434,7 @@ int pem_write_buffer( const char *header, const char *footer,
         return( POLARSSL_ERR_BASE64_BUFFER_TOO_SMALL );
     }
 
-    if( ( encode_buf = polarssl_malloc( use_len ) ) == NULL )
+    if( use_len != 0 && ( encode_buf = polarssl_malloc( use_len ) ) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_encode( encode_buf, &use_len, der_data,

--- a/library/pem.c
+++ b/library/pem.c
@@ -434,7 +434,8 @@ int pem_write_buffer( const char *header, const char *footer,
         return( POLARSSL_ERR_BASE64_BUFFER_TOO_SMALL );
     }
 
-    if( use_len != 0 && ( encode_buf = polarssl_malloc( use_len ) ) == NULL )
+    if( use_len != 0 &&
+        ( ( encode_buf = polarssl_malloc( use_len ) ) == NULL ) )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_encode( encode_buf, &use_len, der_data,

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1169,6 +1169,9 @@ int pk_parse_key( pk_context *pk,
     {
         unsigned char *key_copy;
 
+        if( keylen == 0 )
+            return( POLARSSL_ERR_PK_KEY_INVALID_FORMAT );
+
         if( ( key_copy = polarssl_malloc( keylen ) ) == NULL )
             return( POLARSSL_ERR_PK_MALLOC_FAILED );
 

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -297,7 +297,9 @@ int x509_crl_parse_der( x509_crl *chain,
      */
     if( buflen == 0 )
         return( POLARSSL_ERR_X509_INVALID_FORMAT );
-    else if( ( p = polarssl_malloc( buflen ) ) == NULL )
+
+    p = polarssl_malloc( buflen );
+    if( p == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -259,7 +259,7 @@ int x509_crl_parse_der( x509_crl *chain,
 {
     int ret;
     size_t len;
-    unsigned char *p, *end;
+    unsigned char *p = NULL, *end;
     x509_buf sig_params1, sig_params2;
     x509_crl *crl = chain;
 
@@ -295,7 +295,7 @@ int x509_crl_parse_der( x509_crl *chain,
     /*
      * Copy raw DER-encoded CRL
      */
-    if( ( p = polarssl_malloc( buflen ) ) == NULL )
+    if( buflen != 0 && ( p = polarssl_malloc( buflen ) ) == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -259,7 +259,7 @@ int x509_crl_parse_der( x509_crl *chain,
 {
     int ret;
     size_t len;
-    unsigned char *p = NULL, *end;
+    unsigned char *p = NULL, *end = NULL;
     x509_buf sig_params1, sig_params2;
     x509_crl *crl = chain;
 
@@ -295,7 +295,7 @@ int x509_crl_parse_der( x509_crl *chain,
     /*
      * Copy raw DER-encoded CRL
      */
-    if( buflen != 0 && ( p = polarssl_malloc( buflen ) ) == NULL )
+    if( buflen != 0 && ( ( p = polarssl_malloc( buflen ) ) == NULL ) )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -295,7 +295,9 @@ int x509_crl_parse_der( x509_crl *chain,
     /*
      * Copy raw DER-encoded CRL
      */
-    if( buflen != 0 && ( ( p = polarssl_malloc( buflen ) ) == NULL ) )
+    if( buflen == 0 )
+        return( POLARSSL_ERR_X509_INVALID_FORMAT );
+    else if( ( p = polarssl_malloc( buflen ) ) == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
 
     memcpy( p, buf, buflen );

--- a/tests/suites/test_suite_memory_buffer_alloc.data
+++ b/tests/suites/test_suite_memory_buffer_alloc.data
@@ -1,2 +1,8 @@
 Memory buffer alloc self test
 memory_buffer_alloc_self_test:
+
+Memory buffer small buffer
+memory_buffer_small_buffer:
+
+Memory buffer underalloc
+memory_buffer_underalloc:

--- a/tests/suites/test_suite_memory_buffer_alloc.function
+++ b/tests/suites/test_suite_memory_buffer_alloc.function
@@ -15,7 +15,7 @@ void memory_buffer_alloc_self_test( )
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_MEMORY_DEBUG */
+/* BEGIN_CASE depends_on:POLARSSL_MEMORY_DEBUG */
 void memory_buffer_small_buffer( )
 {
     unsigned char buf[1];
@@ -25,7 +25,7 @@ void memory_buffer_small_buffer( )
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_MEMORY_DEBUG */
+/* BEGIN_CASE depends_on:POLARSSL_MEMORY_DEBUG */
 void memory_buffer_underalloc( )
 {
     unsigned char buf[100];
@@ -34,7 +34,7 @@ void memory_buffer_underalloc( )
     memory_buffer_alloc_init( buf, sizeof( buf ) );
     for( i = 1; i < POLARSSL_MEMORY_ALIGN_MULTIPLE; i++ )
     {
-        TEST_ASSERT( polarssl_malloc( 1,
+        TEST_ASSERT( polarssl_malloc(
                      (size_t)-( POLARSSL_MEMORY_ALIGN_MULTIPLE - i ) ) == NULL );
         TEST_ASSERT( memory_buffer_alloc_verify() == 0 );
     }

--- a/tests/suites/test_suite_memory_buffer_alloc.function
+++ b/tests/suites/test_suite_memory_buffer_alloc.function
@@ -14,3 +14,32 @@ void memory_buffer_alloc_self_test( )
     TEST_ASSERT( memory_buffer_alloc_self_test( 0 ) == 0 );
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_MEMORY_DEBUG */
+void memory_buffer_small_buffer( )
+{
+    unsigned char buf[1];
+
+    memory_buffer_alloc_init( buf, sizeof( buf ) );
+    TEST_ASSERT( memory_buffer_alloc_verify() != 0 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_MEMORY_DEBUG */
+void memory_buffer_underalloc( )
+{
+    unsigned char buf[100];
+    size_t i;
+
+    memory_buffer_alloc_init( buf, sizeof( buf ) );
+    for( i = 1; i < POLARSSL_MEMORY_ALIGN_MULTIPLE; i++ )
+    {
+        TEST_ASSERT( polarssl_malloc( 1,
+                     (size_t)-( POLARSSL_MEMORY_ALIGN_MULTIPLE - i ) ) == NULL );
+        TEST_ASSERT( memory_buffer_alloc_verify() == 0 );
+    }
+
+exit:
+    memory_buffer_alloc_free();
+}
+/* END_CASE */


### PR DESCRIPTION
This change fixes the following corner cases in memory_buffer_alloc.c:
* Calling `verify_chain()` on an uninitialized chain. Would previously cause a `NULL` dereference.
* Allocating a memory block large enough to overflow the length variable.
* Initializing the allocator with a buffer smaller than the size of a memory header.

This PR is based on the information recorded in https://github.com/ARMmbed/mbedtls/issues/639.

**NOTES:**
* This PR includes tests.
* This is a backport for #778