### PR TITLE
Correct RSA key generation test in case of missing entropy

### DIFF
--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -55,6 +55,16 @@
 #define MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE              -0x003D  /**< No strong sources have been added to poll. */
 #define MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR                 -0x003F  /**< Read/write error in file. */
 
+/* Indicates whether at least one standard strong entropy source is enabled. */
+#if defined(MBEDTLS_TEST_NULL_ENTROPY) ||             \
+    ( !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
+      ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||     \
+         defined(MBEDTLS_HAVEGE_C)             ||     \
+         defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||     \
+         defined(ENTROPY_NV_SEED) ) )
+#define MBEDTLS_ENTROPY_HAVE_STRONG
+#endif
+
 /**
  * \name SECTION: Module settings
  *

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -55,16 +55,6 @@
 #define MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE              -0x003D  /**< No strong sources have been added to poll. */
 #define MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR                 -0x003F  /**< Read/write error in file. */
 
-/* Indicates whether at least one standard strong entropy source is enabled. */
-#if defined(MBEDTLS_TEST_NULL_ENTROPY) ||             \
-    ( !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
-      ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||     \
-         defined(MBEDTLS_HAVEGE_C)             ||     \
-         defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||     \
-         defined(ENTROPY_NV_SEED) ) )
-#define MBEDTLS_ENTROPY_HAVE_STRONG
-#endif
-
 /**
  * \name SECTION: Module settings
  *

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -83,6 +83,9 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
     mbedtls_havege_init( &ctx->havege_data );
 #endif
 
+    /* Reminder: Update MBEDTLS_ENTROPY_HAVE_STRONG when
+     *           adding more strong entropy sources here. */
+
 #if defined(MBEDTLS_TEST_NULL_ENTROPY)
     mbedtls_entropy_add_source( ctx, mbedtls_null_entropy_poll, NULL,
                                 1, MBEDTLS_ENTROPY_SOURCE_STRONG );

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -83,7 +83,7 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
     mbedtls_havege_init( &ctx->havege_data );
 #endif
 
-    /* Reminder: Update MBEDTLS_ENTROPY_HAVE_STRONG in the test files
+    /* Reminder: Update ENTROPY_HAVE_STRONG in the test files
      *           when adding more strong entropy sources here. */
 
 #if defined(MBEDTLS_TEST_NULL_ENTROPY)

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -83,8 +83,8 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
     mbedtls_havege_init( &ctx->havege_data );
 #endif
 
-    /* Reminder: Update MBEDTLS_ENTROPY_HAVE_STRONG when
-     *           adding more strong entropy sources here. */
+    /* Reminder: Update MBEDTLS_ENTROPY_HAVE_STRONG in the test files
+     *           when adding more strong entropy sources here. */
 
 #if defined(MBEDTLS_TEST_NULL_ENTROPY)
     mbedtls_entropy_add_source( ctx, mbedtls_null_entropy_poll, NULL,

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -312,7 +312,7 @@ END
 # and make check code
 my $dep_check_code;
 
-my @res = $test_data =~ /^depends_on:([\w:]+)/msg;
+my @res = $test_data =~ /^depends_on:([!:\w]+)/msg;
 my %case_deps;
 foreach my $deps (@res)
 {
@@ -323,7 +323,23 @@ foreach my $deps (@res)
 }
 while( my ($key, $value) = each(%case_deps) )
 {
-    $dep_check_code .= << "END";
+    if( substr($key, 0, 1) eq "!" )
+    {
+        my $key = substr($key, 1);
+        $dep_check_code .= << "END";
+    if( strcmp( str, "!$key" ) == 0 )
+    {
+#if !defined($key)
+        return( DEPENDENCY_SUPPORTED );
+#else
+        return( DEPENDENCY_NOT_SUPPORTED );
+#endif
+    }
+END
+    }
+    else
+    {
+        $dep_check_code .= << "END";
     if( strcmp( str, "$key" ) == 0 )
     {
 #if defined($key)
@@ -333,6 +349,7 @@ while( my ($key, $value) = each(%case_deps) )
 #endif
     }
 END
+    }
 }
 
 # Make mapping code

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -103,6 +103,21 @@ static int test_errors = 0;
 
 
 /*----------------------------------------------------------------------------*/
+/* Helper flags for complex dependencies */
+
+/* Indicates whether we expect mbedtls_entropy_init
+ * to initialize some strong entropy source. */
+#if defined(MBEDTLS_TEST_NULL_ENTROPY) ||             \
+    ( !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
+      ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||     \
+         defined(MBEDTLS_HAVEGE_C)             ||     \
+         defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||     \
+         defined(ENTROPY_NV_SEED) ) )
+#define MBEDTLS_ENTROPY_HAVE_STRONG
+#endif
+
+
+/*----------------------------------------------------------------------------*/
 /* Helper Functions */
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
@@ -401,4 +416,3 @@ static void test_fail( const char *test, int line_no, const char* filename )
     mbedtls_fprintf( stdout, "  %s\n  at line %d, %s\n", test, line_no,
                         filename );
 }
-

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -113,7 +113,7 @@ static int test_errors = 0;
          defined(MBEDTLS_HAVEGE_C)             ||     \
          defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ||     \
          defined(ENTROPY_NV_SEED) ) )
-#define MBEDTLS_ENTROPY_HAVE_STRONG
+#define ENTROPY_HAVE_STRONG
 #endif
 
 

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -432,24 +432,24 @@ int main(int argc, const char *argv[])
             if( unmet_dep_count > 0 || ret == DISPATCH_UNSUPPORTED_SUITE )
             {
                 total_skipped++;
-                mbedtls_fprintf( stdout, "----\n" );
+                mbedtls_fprintf( stdout, "----" );
 
                 if( 1 == option_verbose && ret == DISPATCH_UNSUPPORTED_SUITE )
                 {
-                    mbedtls_fprintf( stdout, "   Test Suite not enabled" );
+                    mbedtls_fprintf( stdout, "\n   Test Suite not enabled" );
                 }
 
                 if( 1 == option_verbose && unmet_dep_count > 0 )
                 {
-                    mbedtls_fprintf( stdout, "   Unmet dependencies: " );
+                    mbedtls_fprintf( stdout, "\n   Unmet dependencies: " );
                     for( i = 0; i < unmet_dep_count; i++ )
                     {
                         mbedtls_fprintf(stdout, "%s  ",
                                         unmet_dependencies[i]);
                         free(unmet_dependencies[i]);
                     }
-                    mbedtls_fprintf( stdout, "\n" );
                 }
+                mbedtls_fprintf( stdout, "\n" );
                 fflush( stdout );
 
                 unmet_dep_count = 0;

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -396,7 +396,7 @@ int main(int argc, const char *argv[])
                     break;
                 cnt = parse_arguments( buf, strlen(buf), params );
             }
- 
+
             // If there are no unmet dependencies execute the test
             if( unmet_dep_count == 0 )
             {
@@ -462,22 +462,22 @@ int main(int argc, const char *argv[])
             else if( ret == DISPATCH_INVALID_TEST_DATA )
             {
                 mbedtls_fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
-                fclose(file);
+                fclose( file );
                 mbedtls_exit( 2 );
             }
             else
                 total_errors++;
 
-            if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
+            if( ( ret = get_line( file, buf, sizeof( buf ) ) ) != 0 )
                 break;
-            if( strlen(buf) != 0 )
+            if( strlen( buf ) != 0 )
             {
                 mbedtls_fprintf( stderr, "Should be empty %d\n",
-                                 (int) strlen(buf) );
+                                 (int) strlen( buf ) );
                 return( 1 );
             }
         }
-        fclose(file);
+        fclose( file );
 
         /* In case we encounter early end of file */
         for( i = 0; i < unmet_dep_count; i++ )
@@ -508,4 +508,3 @@ int main(int argc, const char *argv[])
 
     return( total_errors != 0 );
 }
-

--- a/tests/suites/test_suite_entropy.data
+++ b/tests/suites/test_suite_entropy.data
@@ -34,10 +34,10 @@ entropy_threshold:16:2:8
 Entropy threshold #2
 entropy_threshold:32:1:32
 
-Entropy thershold #3
+Entropy threshold #3
 entropy_threshold:16:0:MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
 
-Entropy thershold #4
+Entropy threshold #4
 entropy_threshold:1024:1:MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
 
 Check NV seed standard IO

--- a/tests/suites/test_suite_entropy.data
+++ b/tests/suites/test_suite_entropy.data
@@ -52,13 +52,9 @@ entropy_nv_seed:"000000000000000000000000000000000000000000000000000000000000000
 Check NV seed manually #3
 entropy_nv_seed:"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 
-Entropy self test (with strong entropy)
-depends_on:!MBEDTLS_TEST_NULL_ENTROPY:MBEDTLS_ENTROPY_HAVE_STRONG
+Entropy self test
+depends_on:!MBEDTLS_TEST_NULL_ENTROPY
 entropy_selftest:0
-
-Entropy self test (without strong entropy)
-depends_on:!MBEDTLS_TEST_NULL_ENTROPY:!MBEDTLS_ENTROPY_HAVE_STRONG
-entropy_selftest:1
 
 Entropy self test (MBEDTLS_TEST_NULL_ENTROPY)
 depends_on:MBEDTLS_TEST_NULL_ENTROPY

--- a/tests/suites/test_suite_entropy.data
+++ b/tests/suites/test_suite_entropy.data
@@ -52,9 +52,13 @@ entropy_nv_seed:"000000000000000000000000000000000000000000000000000000000000000
 Check NV seed manually #3
 entropy_nv_seed:"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 
-Entropy self test
-depends_on:!MBEDTLS_TEST_NULL_ENTROPY
+Entropy self test (with strong entropy)
+depends_on:!MBEDTLS_TEST_NULL_ENTROPY:MBEDTLS_ENTROPY_HAVE_STRONG
 entropy_selftest:0
+
+Entropy self test (without strong entropy)
+depends_on:!MBEDTLS_TEST_NULL_ENTROPY:!MBEDTLS_ENTROPY_HAVE_STRONG
+entropy_selftest:1
 
 Entropy self test (MBEDTLS_TEST_NULL_ENTROPY)
 depends_on:MBEDTLS_TEST_NULL_ENTROPY

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -163,7 +163,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG */
 void entropy_func_len( int len, int ret )
 {
     mbedtls_entropy_context ctx;
@@ -224,7 +224,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG */
 void entropy_threshold( int threshold, int chunk_size, int result )
 {
     mbedtls_entropy_context ctx;
@@ -377,7 +377,7 @@ void entropy_nv_seed( char *read_seed_str )
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG:MBEDTLS_SELF_TEST */
 void entropy_selftest( int result )
 {
     TEST_ASSERT( mbedtls_entropy_self_test( 1 ) == result );

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -163,7 +163,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:ENTROPY_HAVE_STRONG */
 void entropy_func_len( int len, int ret )
 {
     mbedtls_entropy_context ctx;
@@ -224,7 +224,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:ENTROPY_HAVE_STRONG */
 void entropy_threshold( int threshold, int chunk_size, int result )
 {
     mbedtls_entropy_context ctx;
@@ -377,7 +377,7 @@ void entropy_nv_seed( char *read_seed_str )
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_HAVE_STRONG:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:ENTROPY_HAVE_STRONG:MBEDTLS_SELF_TEST */
 void entropy_selftest( int result )
 {
     TEST_ASSERT( mbedtls_entropy_self_test( 1 ) == result );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -659,7 +659,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:MBEDTLS_ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
 void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
 {
     mbedtls_rsa_context ctx;

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -658,7 +658,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C */
+/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:MBEDTLS_ENTROPY_HAVE_STRONG */
 void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
 {
     mbedtls_rsa_context ctx;

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -667,12 +667,11 @@ void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
     const char *pers = "test_suite_rsa";
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
-
     mbedtls_entropy_init( &entropy );
+    mbedtls_rsa_init ( &ctx, 0, 0 );
+
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy,
                                 (const unsigned char *) pers, strlen( pers ) ) == 0 );
-
-    mbedtls_rsa_init( &ctx, 0, 0 );
 
     TEST_ASSERT( mbedtls_rsa_gen_key( &ctx, mbedtls_ctr_drbg_random, &ctr_drbg, nrbits, exponent ) == result );
     if( result == 0 )

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -8,6 +8,7 @@
 #include "mbedtls/sha512.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES


### PR DESCRIPTION
__Context:__ Fixes #1023 and #1024.

__Summary:__ This PR addresses the following problems:
1. The RSA key generation test initializes the RSA context after seeding the CTR DRBG random number generator. If no strong entropy is present on the system, e.g. because the configuration flag `MBEDTLS_NO_PLATFORM_ENTROPY` is set and no other sources are provided, the seeding fails and leads to an attempt to free the uninitialized RSA context in the cleanup section - this most likely results in a segmentation fault, as originally observed in #1023 and #1024.
2. The entropy self-test should also catch the problem but doesn't because the conditional `depends_on:!MBEDTLS_TEST_NULL_ENTROPY` is not parsed correctly leading to the test case being dropped.
3. In light of the _expected_ failure of the RSA key generation test when no strong entropy is present, the test must be made conditional on the presence of strong entropy. 

Fixing (1) is a line swap in `tests/suites/test_suite_rsa.function`. For (2), test suite generation script `tests/scripts/generate_code.pl` is adapted. For (3), an internal convenience preprocessor flag `MBEDTLS_ENTROPY_HAVE_STRONG` is introduced in the testfiles capturing whether some of the default strong entropy sources considered in `mbedtls_entropy_init` is enabled in the configuration, and the RSA key generation tests are made dependent on this flag.

__Internal references:__ IOTSSL-1580 and IOTSSL-1581.

__Comment for reviewing:__ There is no significant reverting of earlier changes in later commits so far, and reviewing commit-by-commit should be fine.