### PR TITLE
Backport 1.3 - Rename time and index parameter to avoid name conflict.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,11 @@ Bugfix
      to bypass the version verification check. Found by Peng Li/Yueh-Hsun Lin,
      KNOX Security, Samsung Research America
 
+Changes
+   * Avoid shadowing of time and index functions through mbed TLS function
+     arguments. Found by inestlerode. Fixes #557.
+
+
 = mbed TLS 1.3.20 branch released 2017-06-21
 
 Security
@@ -174,9 +179,9 @@ Changes
 = mbed TLS 1.3.17 branch 2016-06-28
 
 Security
-   * Fix missing padding length check in mbedtls_rsa_rsaes_pkcs1_v15_decrypt 
+   * Fix missing padding length check in mbedtls_rsa_rsaes_pkcs1_v15_decrypt
      required by PKCS1 v2.2
-   * Fix a potential integer underflow to buffer overread in 
+   * Fix a potential integer underflow to buffer overread in
      mbedtls_rsa_rsaes_oaep_decrypt. It is not triggerable remotely in
      SSL/TLS.
    * Fix potential integer overflow to buffer overflow in
@@ -1207,7 +1212,7 @@ Security
 Changes
    * Allow enabling of dummy error_strerror() to support some use-cases
    * Debug messages about padding errors during SSL message decryption are
-     disabled by default and can be enabled with POLARSSL_SSL_DEBUG_ALL 
+     disabled by default and can be enabled with POLARSSL_SSL_DEBUG_ALL
    * Sending of security-relevant alert messages that do not break
      interoperability can be switched on/off with the flag
      POLARSSL_SSL_ALL_ALERT_MESSAGES
@@ -1236,7 +1241,7 @@ Bugfix
 Changes
    * Added p_hw_data to ssl_context for context specific hardware acceleration
      data
-   * During verify trust-CA is only checked for expiration and CRL presence  
+   * During verify trust-CA is only checked for expiration and CRL presence
 
 Bugfixes
    * Fixed client authentication compatibility
@@ -1534,9 +1539,9 @@ Features
      with random data (Fixed ticket #10)
 
 Changes
-   * Debug print of MPI now removes leading zero octets and 
+   * Debug print of MPI now removes leading zero octets and
      displays actual bit size of the value.
-   * x509parse_key() (and as a consequence x509parse_keyfile()) 
+   * x509parse_key() (and as a consequence x509parse_keyfile())
      does not zeroize memory in advance anymore. Use rsa_init()
      before parsing a key or keyfile!
 
@@ -1558,7 +1563,7 @@ Features
      printing of X509 CRLs from file
 
 Changes
-   * Parsing of PEM files moved to separate module (Fixes 
+   * Parsing of PEM files moved to separate module (Fixes
      ticket #13). Also possible to remove PEM support for
      systems only using DER encoding
 
@@ -1701,7 +1706,7 @@ Bug fixes
    * Fixed HMAC-MD2 by modifying md2_starts(), so that the
      required HMAC ipad and opad variables are not cleared.
      (found by code coverage tests)
-   * Prevented use of long long in bignum if 
+   * Prevented use of long long in bignum if
      POLARSSL_HAVE_LONGLONG not defined (found by Giles
      Bathgate).
    * Fixed incorrect handling of negative strings in
@@ -1742,7 +1747,7 @@ Bug fixes
    * Made definition of net_htons() endian-clean for big endian
      systems (Found by Gernot).
    * Undefining POLARSSL_HAVE_ASM now also handles prevents asm in
-     padlock and timing code. 
+     padlock and timing code.
    * Fixed an off-by-one buffer allocation in ssl_set_hostname()
      responsible for crashes and unwanted behaviour.
    * Added support for Certificate Revocation List (CRL) parsing.
@@ -1916,4 +1921,3 @@ XySSL ChangeLog
     who maintains the Debian package :-)
 
 = Version 0.1 released on 2006-11-01
-

--- a/include/polarssl/ecp.h
+++ b/include/polarssl/ecp.h
@@ -460,7 +460,7 @@ int ecp_group_read_string( ecp_group *grp, int radix,
  * \brief           Set a group using well-known domain parameters
  *
  * \param grp       Destination group
- * \param index     Index in the list of well-known domain parameters
+ * \param id        Index in the list of well-known domain parameters
  *
  * \return          0 if successful,
  *                  POLARSSL_ERR_MPI_XXX if initialization failed
@@ -469,7 +469,7 @@ int ecp_group_read_string( ecp_group *grp, int radix,
  * \note            Index should be a value of RFC 4492's enum NamdeCurve,
  *                  possibly in the form of a POLARSSL_ECP_DP_XXX macro.
  */
-int ecp_use_known_dp( ecp_group *grp, ecp_group_id index );
+int ecp_use_known_dp( ecp_group *grp, ecp_group_id id );
 
 /**
  * \brief           Set a group from a TLS ECParameters record

--- a/include/polarssl/x509.h
+++ b/include/polarssl/x509.h
@@ -271,23 +271,23 @@ int x509_oid_get_numeric_string( char *buf, size_t size, x509_buf *oid ) DEPRECA
  * \brief          Check a given x509_time against the system time and check
  *                 if it is not expired.
  *
- * \param time     x509_time to check
+ * \param tm       x509_time to check
  *
  * \return         0 if the x509_time is still valid,
  *                 1 otherwise.
  */
-int x509_time_expired( const x509_time *time );
+int x509_time_expired( const x509_time *tm );
 
 /**
  * \brief          Check a given x509_time against the system time and check
  *                 if it is not from the future.
  *
- * \param time     x509_time to check
+ * \param tm       x509_time to check
  *
  * \return         0 if the x509_time is already valid,
  *                 1 otherwise.
  */
-int x509_time_future( const x509_time *time );
+int x509_time_future( const x509_time *tm );
 
 /**
  * \brief          Checkup routine
@@ -316,7 +316,7 @@ int x509_get_sig_alg( const x509_buf *sig_oid, const x509_buf *sig_params,
                       md_type_t *md_alg, pk_type_t *pk_alg,
                       void **sig_opts );
 int x509_get_time( unsigned char **p, const unsigned char *end,
-                   x509_time *time );
+                   x509_time *t );
 int x509_get_serial( unsigned char **p, const unsigned char *end,
                      x509_buf *serial );
 int x509_get_ext( unsigned char **p, const unsigned char *end,

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -104,23 +104,23 @@ int entropy_add_source( entropy_context *ctx,
                         f_source_ptr f_source, void *p_source,
                         size_t threshold )
 {
-    int index, ret = 0;
+    int idx, ret = 0;
 
 #if defined(POLARSSL_THREADING_C)
     if( ( ret = polarssl_mutex_lock( &ctx->mutex ) ) != 0 )
         return( ret );
 #endif
 
-    index = ctx->source_count;
-    if( index >= ENTROPY_MAX_SOURCES )
+    idx = ctx->source_count;
+    if( idx >= ENTROPY_MAX_SOURCES )
     {
         ret = POLARSSL_ERR_ENTROPY_MAX_SOURCES;
         goto exit;
     }
 
-    ctx->source[index].f_source = f_source;
-    ctx->source[index].p_source = p_source;
-    ctx->source[index].threshold = threshold;
+    ctx->source[idx].f_source  = f_source;
+    ctx->source[idx].p_source  = p_source;
+    ctx->source[idx].threshold = threshold;
 
     ctx->source_count++;
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -490,25 +490,25 @@ static int x509_parse_int(unsigned char **p, unsigned n, int *res){
     return 0;
 }
 
-static int x509_date_is_valid(const x509_time *time)
+static int x509_date_is_valid(const x509_time *t)
 {
     int ret = POLARSSL_ERR_X509_INVALID_DATE;
 
-    CHECK_RANGE( 0, 9999, time->year );
-    CHECK_RANGE( 0, 23,   time->hour );
-    CHECK_RANGE( 0, 59,   time->min  );
-    CHECK_RANGE( 0, 59,   time->sec  );
+    CHECK_RANGE( 0, 9999, t->year );
+    CHECK_RANGE( 0, 23,   t->hour );
+    CHECK_RANGE( 0, 59,   t->min  );
+    CHECK_RANGE( 0, 59,   t->sec  );
 
-    switch( time->mon )
+    switch( t->mon )
     {
         case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-            CHECK_RANGE( 1, 31, time->day );
+            CHECK_RANGE( 1, 31, t->day );
             break;
         case 4: case 6: case 9: case 11:
-            CHECK_RANGE( 1, 30, time->day );
+            CHECK_RANGE( 1, 30, t->day );
             break;
         case 2:
-            CHECK_RANGE( 1, 28 + (time->year % 4 == 0), time->day );
+            CHECK_RANGE( 1, 28 + (t->year % 4 == 0), t->day );
             break;
         default:
             return( ret );
@@ -520,7 +520,8 @@ static int x509_date_is_valid(const x509_time *time)
 /*
  * Parse an ASN1_UTC_TIME (yearlen=2) or ASN1_GENERALIZED_TIME (yearlen=4) field.
  */
-static int x509_parse_time( unsigned char **p, size_t len, unsigned int yearlen, x509_time *time )
+static int x509_parse_time( unsigned char **p, size_t len, size_t yearlen,
+                            x509_time *tm )
 {
     int ret;
 
@@ -534,26 +535,26 @@ static int x509_parse_time( unsigned char **p, size_t len, unsigned int yearlen,
     /*
      * parse year, month, day, hour, minute
      */
-    CHECK( x509_parse_int( p, yearlen, &time->year ) );
+    CHECK( x509_parse_int( p, yearlen, &tm->year ) );
     if ( 2 == yearlen )
     {
-        if ( time->year < 50 )
-            time->year += 100;
+        if ( tm->year < 50 )
+            tm->year += 100;
 
-        time->year += 1900;
+        tm->year += 1900;
     }
 
-    CHECK( x509_parse_int( p, 2, &time->mon ) );
-    CHECK( x509_parse_int( p, 2, &time->day ) );
-    CHECK( x509_parse_int( p, 2, &time->hour ) );
-    CHECK( x509_parse_int( p, 2, &time->min ) );
+    CHECK( x509_parse_int( p, 2, &tm->mon ) );
+    CHECK( x509_parse_int( p, 2, &tm->day ) );
+    CHECK( x509_parse_int( p, 2, &tm->hour ) );
+    CHECK( x509_parse_int( p, 2, &tm->min ) );
 
     /*
-     * parse seconds if present 
+     * parse seconds if present
      */
     if ( len >= 2 && **p >= '0' && **p <= '9' )
     {
-        CHECK( x509_parse_int( p, 2, &time->sec ) );
+        CHECK( x509_parse_int( p, 2, &tm->sec ) );
         len -= 2;
     }
     else
@@ -562,7 +563,7 @@ static int x509_parse_time( unsigned char **p, size_t len, unsigned int yearlen,
         /*
          * if relaxed mode, allow seconds to be absent
          */
-        time->sec = 0;
+        tm->sec = 0;
 #else
         return POLARSSL_ERR_X509_INVALID_DATE;
 #endif
@@ -605,7 +606,7 @@ static int x509_parse_time( unsigned char **p, size_t len, unsigned int yearlen,
  *       generalTime    GeneralizedTime }
  */
 int x509_get_time( unsigned char **p, const unsigned char *end,
-                   x509_time *time )
+                   x509_time *tm )
 {
     int ret;
     size_t len;
@@ -624,9 +625,9 @@ int x509_get_time( unsigned char **p, const unsigned char *end,
         if( ret != 0 )
             return( POLARSSL_ERR_X509_INVALID_DATE + ret );
 
-        CHECK( x509_parse_time( p, len, 2, time ) );
+        CHECK( x509_parse_time( p, len, 2, tm ) );
 
-        CHECK( x509_date_is_valid( time ) );
+        CHECK( x509_date_is_valid( tm ) );
 
         return( 0 );
     }
@@ -637,9 +638,9 @@ int x509_get_time( unsigned char **p, const unsigned char *end,
         if( ret != 0 )
             return( POLARSSL_ERR_X509_INVALID_DATE + ret );
 
-        CHECK( x509_parse_time( p, len, 4, time ) );
+        CHECK( x509_parse_time( p, len, 4, tm ) );
 
-        CHECK( x509_date_is_valid( time ) );
+        CHECK( x509_date_is_valid( tm ) );
 
         return( 0 );
     }

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -259,7 +259,7 @@ int x509write_crt_set_ns_cert_type( x509write_cert *ctx,
 }
 
 static int x509_write_time( unsigned char **p, unsigned char *start,
-                            const char *time, size_t size )
+                            const char *t, size_t size )
 {
     int ret;
     size_t len = 0;
@@ -267,10 +267,10 @@ static int x509_write_time( unsigned char **p, unsigned char *start,
     /*
      * write ASN1_UTC_TIME if year < 2050 (2 bytes shorter)
      */
-    if( time[0] == '2' && time[1] == '0' && time [2] < '5' )
+    if( t[0] == '2' && t[1] == '0' && t[2] < '5' )
     {
         ASN1_CHK_ADD( len, asn1_write_raw_buffer( p, start,
-                                             (const unsigned char *) time + 2,
+                                             (const unsigned char *) t + 2,
                                              size - 2 ) );
         ASN1_CHK_ADD( len, asn1_write_len( p, start, len ) );
         ASN1_CHK_ADD( len, asn1_write_tag( p, start, ASN1_UTC_TIME ) );
@@ -278,7 +278,7 @@ static int x509_write_time( unsigned char **p, unsigned char *start,
     else
     {
         ASN1_CHK_ADD( len, asn1_write_raw_buffer( p, start,
-                                                  (const unsigned char *) time,
+                                                  (const unsigned char *) t,
                                                   size ) );
         ASN1_CHK_ADD( len, asn1_write_len( p, start, len ) );
         ASN1_CHK_ADD( len, asn1_write_tag( p, start, ASN1_GENERALIZED_TIME ) );


### PR DESCRIPTION
This is the backport of #886 to mbed TLS 1.3.