### PR TITLE
Remove duplicated definition of PRINT_ERROR

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -131,15 +131,6 @@ do {                                                                    \
                      ( mbedtls_timing_hardclock() - tsc ) / ( jj * BUFSIZE ) );         \
 } while( 0 )
 
-#if defined(MBEDTLS_ERROR_C)
-#define PRINT_ERROR                                                     \
-        mbedtls_strerror( ret, ( char * )tmp, sizeof( tmp ) );          \
-        mbedtls_printf( "FAILED: %s\n", tmp );
-#else
-#define PRINT_ERROR                                                     \
-        mbedtls_printf( "FAILED: -0x%04x\n", -ret );
-#endif
-
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && defined(MBEDTLS_MEMORY_DEBUG)
 
 #define MEMORY_MEASURE_INIT                                             \


### PR DESCRIPTION
## Description
The PRINT_ERROR macros are already defined exactly the same in line
101ff, so we can remove them here.

## Status
**READY**
## Requires Backporting
NO
## Migrations
NO
## Additional comments
None
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
Done - Username: PeterHuewe