### PR TITLE
Adding support for server name information in ssl session caching,

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -601,10 +601,10 @@ struct mbedtls_ssl_config
     int  (*f_rng)(void *, unsigned char *, size_t);
     void *p_rng;                    /*!< context for the RNG function       */
 
-    /** Callback to retrieve a session from the cache                       */
-    int (*f_get_cache)(void *, mbedtls_ssl_session *);
+    /** Callback to retrieve a session from the cache,                      */
+    int (*f_get_cache)(void *, const mbedtls_x509_crt *, mbedtls_ssl_session *);
     /** Callback to store a session into the cache                          */
-    int (*f_set_cache)(void *, const mbedtls_ssl_session *);
+    int (*f_set_cache)(void *, const mbedtls_x509_crt *, const mbedtls_ssl_session *);
     void *p_cache;                  /*!< context for cache callbacks        */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -1506,8 +1506,8 @@ void mbedtls_ssl_conf_handshake_timeout( mbedtls_ssl_config *conf, uint32_t min,
  */
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
         void *p_cache,
-        int (*f_get_cache)(void *, mbedtls_ssl_session *),
-        int (*f_set_cache)(void *, const mbedtls_ssl_session *) );
+        int (*f_get_cache)(void *, const mbedtls_x509_crt *, mbedtls_ssl_session *),
+        int (*f_set_cache)(void *, const mbedtls_x509_crt *, const mbedtls_ssl_session *) );
 #endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_CLI_C)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2452,7 +2452,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 #endif
         ssl->session_negotiate->id_len != 0 &&
         ssl->conf->f_get_cache != NULL &&
-        ssl->conf->f_get_cache( ssl->conf->p_cache, ssl->session_negotiate ) == 0 )
+        ssl->conf->f_get_cache( ssl->conf->p_cache, ssl->handshake->key_cert->cert, ssl->session_negotiate ) == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "session successfully restored from cache" ) );
         ssl->handshake->resume = 1;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5202,7 +5202,7 @@ void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         ssl->session->id_len != 0 &&
         resume == 0 )
     {
-        if( ssl->conf->f_set_cache( ssl->conf->p_cache, ssl->session ) != 0 )
+        if( ssl->conf->f_set_cache( ssl->conf->p_cache, ssl->handshake->key_cert->cert, ssl->session ) != 0 )
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "cache did not store session" ) );
     }
 
@@ -5874,8 +5874,8 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_SRV_C)
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
         void *p_cache,
-        int (*f_get_cache)(void *, mbedtls_ssl_session *),
-        int (*f_set_cache)(void *, const mbedtls_ssl_session *) )
+        int (*f_get_cache)(void *, const mbedtls_x509_crt *, mbedtls_ssl_session *),
+        int (*f_set_cache)(void *, const mbedtls_x509_crt *, const mbedtls_ssl_session *) )
 {
     conf->p_cache = p_cache;
     conf->f_get_cache = f_get_cache;


### PR DESCRIPTION
This allow to prevent a client to try to restore another virtual server session. 
the implementation can then ensure that ssl session cache are isolated
between virtual servers. it may rely on the certificate serial number or cn as
a key to multiple session caches. 

This allows to fix a real situation problem described here : https://tls.mbed.org/discussions/bug-report-issues/server-ssl-session-resume-sni

Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
READY

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

 NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES 

Yes, the ssl session cache set/get callback functions now have a const mbedtls_x509_crt * parameter, allowing for the implementation to know what virtual server ssl session cache should be used. the certification serial number or cn can be used as a key to identify the right ssl session cache to use. 
the user implementation may simply ignore the parameter if ssl seesion isolation is considered useless.

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
use a server with 2 certificates, use a client to connect using sni server1, with ssl session caching enabled, then try to connect again using sni server2, and trying to resume the previous ssl session, it should obviously not be resumed, but the default implementation allows it. with the proposed evolution, the implementation can instanciate multiple ssl session cache and choose the proper one based on the chosed server certificate passed to the callbacks
