### PR TITLE
Change PK module preprocessor check on word size

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -29,8 +29,6 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/pk_internal.h"
 
-#include "mbedtls/bignum.h"
-
 #if defined(MBEDTLS_RSA_C)
 #include "mbedtls/rsa.h"
 #endif
@@ -42,6 +40,7 @@
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
@@ -213,10 +212,10 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
         int ret;
         const mbedtls_pk_rsassa_pss_options *pss_opts;
 
-#if defined(MBEDTLS_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
         if( md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len )
             return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#endif /* MBEDTLS_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
         if( options == NULL )
             return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -30,7 +30,6 @@
 
 /* Even if RSA not activated, for the sake of RSA-alt */
 #include "mbedtls/rsa.h"
-#include "mbedtls/bignum.h"
 
 #include <string.h>
 
@@ -51,6 +50,7 @@
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /* Implementation that should never be optimized out by the compiler */
@@ -77,10 +77,10 @@ static int rsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 {
     int ret;
 
-#if defined(MBEDTLS_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#endif /* MBEDTLS_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     if( sig_len < ((mbedtls_rsa_context *) ctx)->len )
         return( MBEDTLS_ERR_RSA_VERIFY_FAILED );
@@ -101,10 +101,10 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-#if defined(MBEDTLS_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( md_alg == MBEDTLS_MD_NONE && UINT_MAX < hash_len )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#endif /* MBEDTLS_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = ((mbedtls_rsa_context *) ctx)->len;
 
@@ -415,10 +415,10 @@ static int rsa_alt_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 {
     mbedtls_rsa_alt_context *rsa_alt = (mbedtls_rsa_alt_context *) ctx;
 
-#if defined(MBEDTLS_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( UINT_MAX < hash_len )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#endif /* MBEDTLS_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = rsa_alt->key_len_func( rsa_alt->key );
 


### PR DESCRIPTION
## Description
There were preprocessor directives in pk.c and pk_wrap.c that cheked
whether the bit length of size_t was greater than that of unsigned int.
However, the check relied on the MBEDTLS_HAVE_INT64 macro being defined
which is not directly related to size_t. This might result in errors in
some platforms. This change modifies the check to use the macros
SIZE_MAX and UINT_MAX instead making the code more robust.

**NOTE:**
* This change is related to https://github.com/ARMmbed/mbedtls/pull/900

## Status
**READY**

## Requires Backporting
**Yes**

Which branch?
* mbedtls-2.1
* mbedtls-1.3

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [x] Backported