### PR TITLE
Backport 1.3: Change PK module preprocessor check on word size

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -30,8 +30,6 @@
 #include "polarssl/pk.h"
 #include "polarssl/pk_wrap.h"
 
-#include "polarssl/bignum.h"
-
 #if defined(POLARSSL_RSA_C)
 #include "polarssl/rsa.h"
 #endif
@@ -43,6 +41,7 @@
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /* Implementation that should never be optimized out by the compiler */
 static void polarssl_zeroize( void *v, size_t n ) {
@@ -212,10 +211,10 @@ int pk_verify_ext( pk_type_t type, const void *options,
         int ret;
         const pk_rsassa_pss_options *pss_opts;
 
-#if defined(POLARSSL_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
         if( md_alg == POLARSSL_MD_NONE && UINT_MAX < hash_len )
             return( POLARSSL_ERR_PK_BAD_INPUT_DATA );
-#endif /* POLARSSL_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
         if( options == NULL )
             return( POLARSSL_ERR_PK_BAD_INPUT_DATA );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -31,7 +31,6 @@
 
 /* Even if RSA not activated, for the sake of RSA-alt */
 #include "polarssl/rsa.h"
-#include "polarssl/bignum.h"
 
 #include <string.h>
 
@@ -52,6 +51,7 @@
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /* Implementation that should never be optimized out by the compiler */
 static void polarssl_zeroize( void *v, size_t n ) {
@@ -76,10 +76,10 @@ static int rsa_verify_wrap( void *ctx, md_type_t md_alg,
 {
     int ret;
 
-#if defined(POLARSSL_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( md_alg == POLARSSL_MD_NONE && UINT_MAX < hash_len )
         return( POLARSSL_ERR_PK_BAD_INPUT_DATA );
-#endif /* POLARSSL_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     if( sig_len < ((rsa_context *) ctx)->len )
         return( POLARSSL_ERR_RSA_VERIFY_FAILED );
@@ -100,10 +100,10 @@ static int rsa_sign_wrap( void *ctx, md_type_t md_alg,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-#if defined(POLARSSL_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( md_alg == POLARSSL_MD_NONE && UINT_MAX < hash_len )
         return( POLARSSL_ERR_PK_BAD_INPUT_DATA );
-#endif /* POLARSSL_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = ((rsa_context *) ctx)->len;
 
@@ -424,10 +424,10 @@ static int rsa_alt_sign_wrap( void *ctx, md_type_t md_alg,
 {
     rsa_alt_context *rsa_alt = (rsa_alt_context *) ctx;
 
-#if defined(POLARSSL_HAVE_INT64)
+#if SIZE_MAX > UINT_MAX
     if( UINT_MAX < hash_len )
         return( POLARSSL_ERR_PK_BAD_INPUT_DATA );
-#endif /* POLARSSL_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
 
     *sig_len = rsa_alt->key_len_func( rsa_alt->key );
 


### PR DESCRIPTION
## Description
There were preprocessor directives in pk.c and pk_wrap.c that checked
whether the bit length of size_t was greater than that of unsigned int.
However, the check relied on the POLARSSL_HAVE_INT64 macro being
defined which is not directly related to size_t. This might result in
errors in some platforms. This change modifies the check to use the
macros SIZE_MAX and UINT_MAX instead making the code more robust.

**NOTE:**
* This is a backport of https://github.com/ARMmbed/mbedtls/pull/1043 to mbed TLS 1.3

## Status
**READY**