### PR TITLE
Backport 2.1:Remove duplicated def. of PRINT_ERROR

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -129,15 +129,6 @@ do {                                                                    \
                      ( mbedtls_timing_hardclock() - tsc ) / ( jj * BUFSIZE ) );         \
 } while( 0 )
 
-#if defined(MBEDTLS_ERROR_C)
-#define PRINT_ERROR                                                     \
-        mbedtls_strerror( ret, ( char * )tmp, sizeof( tmp ) );          \
-        mbedtls_printf( "FAILED: %s\n", tmp );
-#else
-#define PRINT_ERROR                                                     \
-        mbedtls_printf( "FAILED: -0x%04x\n", -ret );
-#endif
-
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && defined(MBEDTLS_MEMORY_DEBUG)
 
 #define MEMORY_MEASURE_INIT                                             \


### PR DESCRIPTION
Backport of #1036 to mbed TLS 2.1 branch.
Remove duplicate definition of PRINT_ERROR
in the benchmark sample application

## Status
**READ**
