### PR TITLE
Add configuration file in md.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,8 @@ Bugfix
    * Fix a potential integer overflow in the version verification for DER
      encoded X509 certificates. The overflow would enable maliciously
      constructed certificates to bypass the certificate verification check.
+   * Include configuration file in md.h, to fix compilation warnings.
+     Reported by aaronmdjones in #1001
 
 Changes
    * Added config.h option MBEDTLS_NO_UDBL_DIVISION, to prevent the use of

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -27,6 +27,12 @@
 
 #include <stddef.h>
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */


### PR DESCRIPTION
## Description
include *`config.h`* in md.h as MACROS in the header file get ignored.
Fix for #1001.


## Status
**READY**

## Requires Backporting
Yes  
mbedtls-2.1

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported

