### PR TITLE
Ensure deterministic error code generation

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -40,6 +40,8 @@ my @high_level_modules = ( "PEM", "X509", "DHM", "RSA", "ECP", "MD", "CIPHER", "
 my $line_separator = $/;
 undef $/;
 
+$ENV{'LC_ALL'} = 'C';
+
 open(FORMAT_FILE, "$error_format_file") or die "Opening error format file '$error_format_file': $!";
 my $error_format = <FORMAT_FILE>;
 close(FORMAT_FILE);


### PR DESCRIPTION
## Description
The script `scripts/generate_errors.pl` uses `grep` to find header files. The order in which the header files are found will affect the ordering of statements in the generated `library/error.c` file.

Different locale settings can affect the order that `grep` finds files. On my (British) system, `grep` finds `pk.h` after `pkcs5.h`, whereas in a US locale (which Travis CI uses) the opposite is true. It comes down to whether periods are considered greater or smaller than alphabetic characters.

Forcing LC_ALL=C creates a consistent approach to code generation in all locales.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
NO

## Steps to reproduce

To reproduce the original problem, try running the `check-generated-files.sh` test under a British locale:

    LC_ALL="en_GB.UTF-8" ./tests/scripts/check-generated-files.sh

This will generate the error file in a different order, causing the script to fail.

With my updated script, the above test would pass.