### PR TITLE
Fix typo in configs/README.txt file

### DIFF
--- a/configs/README.txt
+++ b/configs/README.txt
@@ -8,7 +8,7 @@ These files are complete replacements for the default config.h. To use one of
 them, you can pick one of the following methods:
 
 1. Replace the default file include/mbedtls/config.h with the chosen one.
-   (Depending on your compiler, you may need to ajust the line with
+   (Depending on your compiler, you may need to adjust the line with
    #include "mbedtls/check_config.h" then.)
 
 2. Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.


### PR DESCRIPTION
## Description
Fix typo in Readme file: ajust->adjust


## Status
**READY**

## Requires Backporting
 NO  

## Migrations
NO

## Additional comments
Reported by Colin Foster in Email
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
N/A
