### PR TITLE
Support for large entropy length

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Bugfix
      in X.509 module. Fixes #2212.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Fix issue in seeding HMAC DRBG when MBEDTLS_SHA512_C is disabled.
+     Reported by dbedev. Fixes #770.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -176,6 +176,10 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
                         identifiers. Can be NULL.
  * \param len           The length of the personalization data.
  *
+ * \warning             \p f_entropy MUST fill the buffer with full entropy
+ *                      and MUST be able to do so for buffer lengths up to
+ *                      at least `MBEDTLS_ENTROPY_BLOCK_SIZE` bytes.
+ *
  * \return              \c 0 on success.
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on failure.
  */

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -132,6 +132,10 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
  *                      256 bits if md_alg is SHA-256 or higher.
  *                      Note that SHA-256 is just as efficient as SHA-224.
  *
+ * \warning             \p f_entropy MUST fill the buffer with full entropy
+ *                      and MUST be able to do so for buffer lengths up to
+ *                      at least `MBEDTLS_ENTROPY_BLOCK_SIZE` bytes.
+ *
  * \return              0 if successful, or
  *                      MBEDTLS_ERR_MD_BAD_INPUT_DATA, or
  *                      MBEDTLS_ERR_MD_ALLOC_FAILED, or

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -34,6 +34,7 @@
 
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/platform_util.h"
+#include "mbedtls/entropy.h"
 
 #include <string.h>
 
@@ -398,7 +399,8 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
                      const unsigned char *additional, size_t len )
 {
     unsigned char seed[MBEDTLS_CTR_DRBG_MAX_SEED_INPUT];
-    size_t seedlen = 0;
+    unsigned char *p = seed;
+    size_t seedlen = 0, remaining_entropy_len, size_to_gather;
     int ret;
 
     if( ctx->entropy_len > MBEDTLS_CTR_DRBG_MAX_SEED_INPUT ||
@@ -407,13 +409,23 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
 
     memset( seed, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
 
-    /*
-     * Gather entropy_len bytes of entropy to seed state
-     */
-    if( 0 != ctx->f_entropy( ctx->p_entropy, seed,
-                             ctx->entropy_len ) )
+    remaining_entropy_len = ctx->entropy_len;
+
+    while( remaining_entropy_len > 0 )
     {
-        return( MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED );
+        size_to_gather = ( remaining_entropy_len > MBEDTLS_ENTROPY_BLOCK_SIZE ) ?
+                           MBEDTLS_ENTROPY_BLOCK_SIZE : remaining_entropy_len;
+        /*
+         * Gather entropy_len bytes of entropy to seed state
+         */
+        if( 0 != ctx->f_entropy( ctx->p_entropy, p,
+                                 size_to_gather ) )
+        {
+            return( MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED );
+        }
+
+        remaining_entropy_len -= size_to_gather;
+        p += size_to_gather;
     }
 
     seedlen += ctx->entropy_len;

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -35,7 +35,7 @@
 
 #include "mbedtls/hmac_drbg.h"
 #include "mbedtls/platform_util.h"
-
+#include "mbedtls/entropy.h"
 #include <string.h>
 
 #if defined(MBEDTLS_FS_IO)
@@ -155,7 +155,8 @@ int mbedtls_hmac_drbg_reseed( mbedtls_hmac_drbg_context *ctx,
                       const unsigned char *additional, size_t len )
 {
     unsigned char seed[MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT];
-    size_t seedlen;
+    unsigned char *p = seed;
+    size_t seedlen, remaining_entropy_len, size_to_gather;
     int ret;
 
     /* III. Check input length */
@@ -167,10 +168,20 @@ int mbedtls_hmac_drbg_reseed( mbedtls_hmac_drbg_context *ctx,
 
     memset( seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT );
 
-    /* IV. Gather entropy_len bytes of entropy for the seed */
-    if( ( ret = ctx->f_entropy( ctx->p_entropy,
-                                seed, ctx->entropy_len ) ) != 0 )
-        return( MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED );
+    remaining_entropy_len = ctx->entropy_len;
+
+    while( remaining_entropy_len > 0 )
+    {
+        size_to_gather = ( remaining_entropy_len > MBEDTLS_ENTROPY_BLOCK_SIZE ) ?
+                         MBEDTLS_ENTROPY_BLOCK_SIZE : remaining_entropy_len;
+        /* IV. Gather entropy_len bytes of entropy for the seed */
+        if( ( ret = ctx->f_entropy( ctx->p_entropy,
+                                    p, size_to_gather ) ) != 0 )
+            return( MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED );
+
+        remaining_entropy_len -= size_to_gather;
+        p += size_to_gather;
+    }
 
     seedlen = ctx->entropy_len;
 

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -270,6 +270,11 @@ void ctr_drbg_entropy_usage(  )
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
     TEST_ASSERT( test_offset_idx - last_idx == 13 );
 
+    mbedtls_ctr_drbg_set_entropy_len( &ctx, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
+    last_idx = test_offset_idx;
+    TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
+    TEST_ASSERT( test_offset_idx - last_idx == MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
+
 exit:
     mbedtls_ctr_drbg_free( &ctx );
 }

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -19,6 +19,10 @@ static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len
     const unsigned char *p = (unsigned char *) data;
     if( test_offset_idx + len > test_max_idx )
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+
+    if( len > MBEDTLS_ENTROPY_BLOCK_SIZE )
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+
     memcpy( buf, p + test_offset_idx, len );
     test_offset_idx += len;
     return( 0 );

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -1,4 +1,5 @@
 /* BEGIN_HEADER */
+#include "mbedtls/entropy.h"
 #include "mbedtls/hmac_drbg.h"
 #include "string.h"
 
@@ -14,6 +15,9 @@ static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len
 
     if( len > ctx->len )
         return( -1 );
+
+    if( len > MBEDTLS_ENTROPY_BLOCK_SIZE )
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
 
     memcpy( buf, ctx->p, len );
 

--- a/tests/suites/test_suite_hmac_drbg.misc.data
+++ b/tests/suites/test_suite_hmac_drbg.misc.data
@@ -10,6 +10,10 @@ HMAC_DRBG entropy usage SHA-256
 depends_on:MBEDTLS_SHA256_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA256
 
+HMAC_DRBG entropy usage SHA-256 accumulator
+depends_on:MBEDTLS_SHA256_C:!MBEDTLS_SHA512_C
+hmac_drbg_entropy_usage:MBEDTLS_MD_SHA256
+
 HMAC_DRBG entropy usage SHA-384
 depends_on:MBEDTLS_SHA512_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA384
@@ -17,6 +21,10 @@ hmac_drbg_entropy_usage:MBEDTLS_MD_SHA384
 HMAC_DRBG entropy usage SHA-512
 depends_on:MBEDTLS_SHA512_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA512
+
+HMAC_DRBG NIST CAVS 14.3 No Reseed no SHA-512(SHA-256,256+128,0,0)
+depends_on:MBEDTLS_SHA256_C:!MBEDTLS_SHA512_C
+hmac_drbg_no_reseed:MBEDTLS_MD_SHA256:"ca851911349384bffe89de1cbdc46e6831e44d34a4fb935ee285dd14b71a7488659ba96c601dc69fc902940805ec0ca8":"":"":"":"e528e9abf2dece54d47c7e75e5fe302149f817ea9fb4bee6f4199697d04d5b89d54fbb978a15b5c443c9ec21036d2460b6f73ebad0dc2aba6e624abf07745bc107694bb7547bb0995f70de25d6b29e2d3011bb19d27676c07162c8b5ccde0668961df86803482cb37ed6d5c0bb8d50cf1f50d476aa0458bdaba806f48be9dcb8"
 
 HMAC_DRBG write/update seed file SHA-1
 depends_on:MBEDTLS_SHA1_C


### PR DESCRIPTION
## Description
Loop on the entropy `len` until the whole output buffer is filled.
Don't return an error if `len` > `MBEDTLS_ENTROPY_BLOCK_SIZE`.
Fixes #770



## Status
**READY**

## Requires Backporting

Yes
mbedtls-2.1
mbedtls-1.3

## Migrations
NO

## Additional comments
fixes an issue where only `MBEDTLS_SHA256_C` is defined, and the desired entropy length in hmac_drbg is larger than `MBEDTLS_ENTROPY_BLOCK_SIZE`

## Todos
- [ ] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
* set `MBEDTLS_SHA256_C` only in *config.h*
* use `mbedtls_entropy_func` as the entropy function callback, for `mbedtls_hmac_drbg_seed`
* use hmac_drbg as RNG
