### PR TITLE
Write correct number of ciphersuites in log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
-mbed TLS ChangeLog (Sorted per branch, date)
+﻿mbed TLS ChangeLog (Sorted per branch, date)
+
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Log correct number of ciphersuites used in Client Hello message. Fix for #918.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -891,6 +891,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
+	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, got %d ciphersuites", n));
+
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
      */
@@ -916,8 +918,6 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
 
     *q++ = (unsigned char)( n >> 7 );
     *q++ = (unsigned char)( n << 1 );
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites", n ) );
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     offer_compress = 1;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -891,7 +891,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
-	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, got %d ciphersuites", n));
+	MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
 
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
@@ -900,6 +900,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     if( ssl->renego_status == MBEDTLS_SSL_INITIAL_HANDSHAKE )
 #endif
     {
+		MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO >> 8 );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO      );
         n++;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -891,7 +891,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
-	MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
 
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
@@ -900,7 +900,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     if( ssl->renego_status == MBEDTLS_SSL_INITIAL_HANDSHAKE )
 #endif
     {
-		MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO >> 8 );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO      );
         n++;


### PR DESCRIPTION
## Description
Change location of log, to fit the correct number of used ciphersuites
Fixes #918

## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
mbedtls-1.3
mbedtls-2.1

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
use a small amount of ciphersuites, enable SSL_RENEGOTIATION and\or SSL_FALLBACK_SCSV and look at log
