### PR TITLE
Backport 2.1: Fix typo in asn1.h

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -59,7 +59,7 @@
 
 /**
  * \name DER constants
- * These constants comply with DER encoded the ANS1 type tags.
+ * These constants comply with the DER encoded ASN.1 type tags.
  * DER encoding uses hexadecimal representation.
  * An example DER sequence is:\n
  * - 0x02 -- tag indicating INTEGER


### PR DESCRIPTION
## Status
**READY**

This is a backport of https://github.com/ARMmbed/mbedtls/pull/1065 to mbed TLS 2.1