### PR TITLE
Use current source paths for config file creation command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Perl)
 if(PERL_FOUND)
 
     # If NULL Entropy is configured, display an appropriate warning
-    execute_process(COMMAND ${PERL_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/config.pl -f ${CMAKE_SOURCE_DIR}/include/mbedtls/config.h get MBEDTLS_TEST_NULL_ENTROPY
+    execute_process(COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/config.pl -f ${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/config.h get MBEDTLS_TEST_NULL_ENTROPY
                         RESULT_VARIABLE result)
     if(${result} EQUAL 0)
         message(WARNING ${NULL_ENTROPY_WARNING})


### PR DESCRIPTION


## Description
Cmake works nicely with subproject by simply dropping said project in a subdirectory and using the add_subdirectory() command on it, then using the targets in the top-level project. This works almost with mbedtls:  if you try to use mbedtls in a subdirectory and use add_subdirectory(), you would get issues with perl script being not found in top level of the project:
```
[...]
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Found Perl: /usr/bin/perl (found version "5.20.2") 
Can't open perl script "/path/myproject/scripts/config.pl": No such file or directory
```

This can be resolved by simply using the relative project path variable when looking for config.pl and the header template, not the toplevel ones.

## Status
READY

## Requires Backporting
NO, enhancement.

## Migrations
NO

## Additional comments
Contributor agreement accepted (account volat)
Build & testsuite OK on my development system.

## Todos
- [ ] Tests
- [ ] Changelog updated


## Steps to test or reproduce
This can be tested by creating an emtpy dir and a CMakeLists.txt file with the following content:
```
cmake_minimum_required(VERSION 2.6)
project(testproj C)
add_subdirectory(path_to_mbedtls)
```
then the usual
```
mkdir build
cd build
cmake ..
```
will report the mentionned issue.