### PR TITLE
Fix compilation error with Mingw32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix compilation error on Mingw32 when `_TRUNCATE` is defined. Use `_TRUNCATE`
+     only if `__MINGW32__` not defined. Fix suggested by Thomas Glanzmann and
+     Nick Wilson on issue #355
+
 = mbed TLS 2.6.0 branch released 2017-08-10
 
 Security

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,8 +3,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix compilation error on Mingw32 when `_TRUNCATE` is defined. Use `_TRUNCATE`
-     only if `__MINGW32__` not defined. Fix suggested by Thomas Glanzmann and
+   * Fix compilation error on Mingw32 when _TRUNCATE is defined. Use _TRUNCATE
+     only if __MINGW32__ not defined. Fix suggested by Thomas Glanzmann and
      Nick Wilson on issue #355
 
 = mbed TLS 2.6.0 branch released 2017-08-10

--- a/library/debug.c
+++ b/library/debug.c
@@ -91,7 +91,7 @@ void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
 
     va_start( argp, format );
 #if defined(_WIN32)
-#if defined(_TRUNCATE)
+#if defined(_TRUNCATE) && !defined(__MINGW32__)
     ret = _vsnprintf_s( str, DEBUG_BUF_SIZE, _TRUNCATE, format, argp );
 #else
     ret = _vsnprintf( str, DEBUG_BUF_SIZE, format, argp );

--- a/library/platform.c
+++ b/library/platform.c
@@ -74,7 +74,7 @@ int mbedtls_platform_win32_snprintf( char *s, size_t n, const char *fmt, ... )
         return( -1 );
 
     va_start( argp, fmt );
-#if defined(_TRUNCATE)
+#if defined(_TRUNCATE) && !defined(__MINGW32__)
     ret = _vsnprintf_s( s, n, _TRUNCATE, fmt, argp );
 #else
     ret = _vsnprintf( s, n, fmt, argp );


### PR DESCRIPTION
## Description
Fix compilation error on Mingw32 when `_TRUNCATE` is defined. Use
`_TRUNCATE` only if `__MINGW32__` not defined. Fix suggested by
Thomas Glanzmann and Nick Wilson on issue and closes #355
As mentioned in #355:
> It is used because _TRUNCATE is defined in
/usr/i686-w64-mingw32/include/_mingw.h

## Status
**READY**

## Requires Backporting
Yes 
Which branch?
mbedtls-2.1

## Migrations
NO

## Additional comments
I don't have the right environment and couldn't test it. The fix was taken from issue #355 
I suspect this change affects all mingw32 builds

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
