### PR TITLE
Backport 2.1:Add configuration file in md.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Include configuration file in md.h, to fix compilation warnings.
+     Reported by aaronmdjones in #1001
+     
 = mbed TLS 2.1.9 branch released 2017-08-10
 
 Security

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -27,6 +27,12 @@
 
 #include <stddef.h>
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */


### PR DESCRIPTION
* This is just a template, so feel free to use/remove the unnecessary things
## Description
include *`config.h`* in md.h as MACROS in the header file get ignored.
Fix for #1001.
Backport of #1055 to mbedtls-2.1

## Status
**READY**

