### PR TITLE
Backport 1.3:Add configuration file in md.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.xx branch released xxxx-xx-xx
+
+Bugfix
+    * Include configuration file in md.h, to fix compilation warnings.
+      Reported by aaronmdjones in #1001
+
 = mbed TLS 1.3.21 branch released 2017-08-10
 
 Security

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -33,6 +33,12 @@
 #define inline __inline
 #endif
 
+#if !defined(POLARSSL_CONFIG_FILE)
+#include "config.h"
+#else
+#include POLARSSL_CONFIG_FILE
+#endif
+
 #define POLARSSL_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define POLARSSL_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
 #define POLARSSL_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -27,16 +27,15 @@
 #define POLARSSL_MD_H
 
 #include <stddef.h>
-
-#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
-    !defined(inline) && !defined(__cplusplus)
-#define inline __inline
-#endif
-
 #if !defined(POLARSSL_CONFIG_FILE)
 #include "config.h"
 #else
 #include POLARSSL_CONFIG_FILE
+#endif
+
+#if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
+    !defined(inline) && !defined(__cplusplus)
+#define inline __inline
 #endif
 
 #define POLARSSL_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */


### PR DESCRIPTION
include *`config.h`* in md.h as MACROS in the header file get ignored. Backport to
Backport of #1055 to mbedtls-1.3
