### PR TITLE
Backport 2.1: Correct RSA key generation test in case of missing entropy

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -60,6 +60,9 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
 {
     memset( ctx, 0, sizeof(mbedtls_entropy_context) );
 
+     /* Reminder: Update ENTROPY_HAVE_STRONG in the test files
+      * when adding more strong entropy sources here. */
+
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );
 #endif

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -194,7 +194,7 @@ END
 # and make check code
 my $dep_check_code;
 
-my @res = $test_data =~ /^depends_on:([\w:]+)/msg;
+my @res = $test_data =~ /^depends_on:([!:\w]+)/msg;
 my %case_deps;
 foreach my $deps (@res)
 {
@@ -205,7 +205,23 @@ foreach my $deps (@res)
 }
 while( my ($key, $value) = each(%case_deps) )
 {
-    $dep_check_code .= << "END";
+    if( substr($key, 0, 1) eq "!" )
+    {
+        my $key = substr($key, 1);
+        $dep_check_code .= << "END";
+    if( strcmp( str, "!$key" ) == 0 )
+    {
+#if !defined($key)
+        return( 0 );
+#else
+        return( 1 );
+#endif
+    }
+END
+    }
+    else
+    {
+        $dep_check_code .= << "END";
     if( strcmp( str, "$key" ) == 0 )
     {
 #if defined($key)
@@ -215,6 +231,7 @@ while( my ($key, $value) = each(%case_deps) )
 #endif
     }
 END
+    }
 }
 
 # Make mapping code

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -59,11 +59,10 @@ typedef UINT32 uint32_t;
 
 /* Indicates whether we expect mbedtls_entropy_init
  * to initialize some strong entropy source. */
-#if defined(MBEDTLS_TEST_NULL_ENTROPY) ||             \
-    ( !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
-      ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||     \
-         defined(MBEDTLS_HAVEGE_C)             ||     \
-         defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ) )
+#if !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) &&     \
+    ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||         \
+       defined(MBEDTLS_HAVEGE_C)             ||         \
+       defined(MBEDTLS_ENTROPY_HARDWARE_ALT) )
 #define ENTROPY_HAVE_STRONG
 #endif
 

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -55,6 +55,18 @@ typedef UINT32 uint32_t;
 }
 #endif
 
+/* Helper flags for complex dependencies */
+
+/* Indicates whether we expect mbedtls_entropy_init
+ * to initialize some strong entropy source. */
+#if defined(MBEDTLS_TEST_NULL_ENTROPY) ||             \
+    ( !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
+      ( !defined(MBEDTLS_NO_PLATFORM_ENTROPY)  ||     \
+         defined(MBEDTLS_HAVEGE_C)             ||     \
+         defined(MBEDTLS_ENTROPY_HARDWARE_ALT) ) )
+#define ENTROPY_HAVE_STRONG
+#endif
+
 static int unhexify( unsigned char *obuf, const char *ibuf )
 {
     unsigned char c, c2;

--- a/tests/suites/test_suite_entropy.data
+++ b/tests/suites/test_suite_entropy.data
@@ -31,10 +31,10 @@ entropy_threshold:16:2:8
 Entropy threshold #2
 entropy_threshold:32:1:32
 
-Entropy thershold #3
+Entropy threshold #3
 entropy_threshold:16:0:MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
 
-Entropy thershold #4
+Entropy threshold #4
 entropy_threshold:1024:1:MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
 
 Entropy self test

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -40,7 +40,7 @@ static int entropy_dummy_source( void *data, unsigned char *output,
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO */
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:ENTROPY_HAVE_STRONG */
 void entropy_seed_file( char *path, int ret )
 {
     mbedtls_entropy_context ctx;
@@ -80,7 +80,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:ENTROPY_HAVE_STRONG */
 void entropy_func_len( int len, int ret )
 {
     mbedtls_entropy_context ctx;
@@ -141,7 +141,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:ENTROPY_HAVE_STRONG */
 void entropy_threshold( int threshold, int chunk_size, int result )
 {
     mbedtls_entropy_context ctx;
@@ -172,7 +172,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST:ENTROPY_HAVE_STRONG */
 void entropy_selftest( )
 {
     TEST_ASSERT( mbedtls_entropy_self_test( 0 ) == 0 );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -667,12 +667,11 @@ void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
     const char *pers = "test_suite_rsa";
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
-
     mbedtls_entropy_init( &entropy );
+    mbedtls_rsa_init ( &ctx, 0, 0 );
+
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy,
                                 (const unsigned char *) pers, strlen( pers ) ) == 0 );
-
-    mbedtls_rsa_init( &ctx, 0, 0 );
 
     TEST_ASSERT( mbedtls_rsa_gen_key( &ctx, mbedtls_ctr_drbg_random, &ctr_drbg, nrbits, exponent ) == result );
     if( result == 0 )

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -658,7 +658,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C */
+/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
 void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
 {
     mbedtls_rsa_context ctx;


### PR DESCRIPTION
This is the backport of #1025 to Mbed TLS 2.1.

Differences from development PR: 
1. `NV_SEED` not present, hence removed from `ENTROPY_HAVE_STRONG`
1. `TEST_NULL_ENTROPY` not present, hence removed from `ENTROPY_HAVE_STRONG`.
1. `DEPENDENCY_[NOT_]SUPPORTED` not present, instead `0/1` used in test files.
1. Omitted some style changes.
1. `entropy_seed_file` test needed guard by `ENTROPY_HAVE_STRONG` that wasn't needed in development as it is already guarded by `MBEDTLS_ENTROPY_NV_SEED` there.

__Internal reference:__ IOTSSL-1580.