### PR TITLE
return internal error code, if failed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Bugfix
      in X.509 module. Fixes #2212.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Return error code of mbedtls_aes_crypt_ecb() if failed, when calling it from
+     other modes and ciphers. Fix for #1092 reported by adustm.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -109,9 +109,8 @@ int mbedtls_ctr_drbg_seed_entropy_len(
     }
 
     if( ( ret = mbedtls_ctr_drbg_reseed( ctx, custom, len ) ) != 0 )
-    {
         return( ret );
-    }
+
     return( 0 );
 }
 
@@ -354,7 +353,7 @@ int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
                                  size_t add_len )
 {
     unsigned char add_input[MBEDTLS_CTR_DRBG_SEEDLEN];
-    int ret;
+    int ret = 0;
 
     if( add_len == 0 )
         return( 0 );
@@ -538,7 +537,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
 exit:
     mbedtls_platform_zeroize( add_input, sizeof( add_input ) );
     mbedtls_platform_zeroize( tmp, sizeof( tmp ) );
-    return( 0 );
+    return( ret );
 }
 
 int mbedtls_ctr_drbg_random( void *p_rng, unsigned char *output,


### PR DESCRIPTION
## Description
in case `mbedtls_aes_crypt_ecb` failed, return an error from other modes
calling it
Resolves #1092 

## Status
**READY**

## Requires Backporting
Yes 
Which branch?
mbedtls-2.1
mbedtls-1.3

## Migrations
NO


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported

