### PR TITLE
Allow alternate implementation of GCM

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Features
+   * Add support for alternative implementations of GCM, selected by the
+     configuration flag MBEDTLS_GCM_ALT in config.h
+
 = mbed TLS 2.6.0 branch released 2017-08-10
 
 Security

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -267,6 +267,7 @@
 //#define MBEDTLS_BLOWFISH_ALT
 //#define MBEDTLS_CAMELLIA_ALT
 //#define MBEDTLS_DES_ALT
+//#define MBEDTLS_GCM_ALT
 //#define MBEDTLS_XTEA_ALT
 //#define MBEDTLS_MD2_ALT
 //#define MBEDTLS_MD4_ALT

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -33,6 +33,8 @@
 #define MBEDTLS_ERR_GCM_AUTH_FAILED                       -0x0012  /**< Authenticated decryption failed. */
 #define MBEDTLS_ERR_GCM_BAD_INPUT                         -0x0014  /**< Bad input parameters to function. */
 
+#if !defined(MBEDTLS_GCM_ALT)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -206,6 +208,18 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
  */
 void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
 
+#ifdef __cplusplus
+}
+#endif
+
+#else  /* !MBEDTLS_GCM_ALT */
+#include "gcm_alt.h"
+#endif /* !MBEDTLS_GCM_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \brief          Checkup routine
  *
@@ -216,5 +230,6 @@ int mbedtls_gcm_self_test( int verbose );
 #ifdef __cplusplus
 }
 #endif
+
 
 #endif /* gcm.h */

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -54,6 +54,8 @@
 #endif /* MBEDTLS_PLATFORM_C */
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
 
+#if !defined(MBEDTLS_GCM_ALT)
+
 /*
  * 32-bit integer manipulation macros (big endian)
  */
@@ -507,6 +509,8 @@ void mbedtls_gcm_free( mbedtls_gcm_context *ctx )
     mbedtls_cipher_free( &ctx->cipher_ctx );
     mbedtls_zeroize( ctx, sizeof( mbedtls_gcm_context ) );
 }
+
+#endif /* !MBEDTLS_GCM_ALT */
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 /*

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -99,6 +99,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DES_ALT)
     "MBEDTLS_DES_ALT",
 #endif /* MBEDTLS_DES_ALT */
+#if defined(MBEDTLS_GCM_ALT)
+    "MBEDTLS_GCM_ALT",
+#endif /* MBEDTLS_GCM_ALT */
 #if defined(MBEDTLS_XTEA_ALT)
     "MBEDTLS_XTEA_ALT",
 #endif /* MBEDTLS_XTEA_ALT */


### PR DESCRIPTION
Provide the ability to use an alternative implementation of GCM in place
of the library provide implementation.

NOTES:
- This is a new feature and does not need to be backported.
- This does not follow Ron's `ALT` style (https://github.com/ARMmbed/mbedtls/pull/867)
- Tested with "alternate" software implementation of GCM that's actually just the library implementation (https://github.com/Patater/mbedtls/commits/gcm-alt-test)

```
test_suite_aes.cbc ................................................ PASS
test_suite_aes.cfb ................................................ PASS
test_suite_aes.ecb ................................................ PASS
test_suite_aes.rest ............................................... PASS
test_suite_arc4 ................................................... PASS
test_suite_asn1write .............................................. PASS
test_suite_base64 ................................................. PASS
test_suite_blowfish ............................................... PASS
test_suite_camellia ............................................... PASS
test_suite_ccm .................................................... PASS
test_suite_cipher.aes ............................................. PASS
test_suite_cipher.arc4 ............................................ PASS
test_suite_cipher.blowfish ........................................ PASS
test_suite_cipher.camellia ........................................ PASS
test_suite_cipher.ccm ............................................. PASS
test_suite_cipher.des ............................................. PASS
test_suite_cipher.gcm ............................................. PASS
test_suite_cipher.null ............................................ PASS
test_suite_cipher.padding ......................................... PASS
test_suite_cmac ................................................... PASS
test_suite_ctr_drbg ............................................... PASS
test_suite_debug .................................................. PASS
test_suite_des .................................................... PASS
test_suite_dhm .................................................... PASS
test_suite_ecdh ................................................... PASS
test_suite_ecdsa .................................................. PASS
test_suite_ecjpake ................................................ PASS
test_suite_ecp .................................................... PASS
test_suite_entropy ................................................ PASS
test_suite_error .................................................. PASS
test_suite_gcm.aes128_de .......................................... PASS
test_suite_gcm.aes128_en .......................................... PASS
test_suite_gcm.aes192_de .......................................... PASS
test_suite_gcm.aes192_en .......................................... PASS
test_suite_gcm.aes256_de .......................................... PASS
test_suite_gcm.aes256_en .......................................... PASS
test_suite_gcm.camellia ........................................... PASS
test_suite_hmac_drbg.misc ......................................... PASS
test_suite_hmac_drbg.no_reseed .................................... PASS
test_suite_hmac_drbg.nopr ......................................... PASS
test_suite_hmac_drbg.pr ........................................... PASS
test_suite_md ..................................................... PASS
test_suite_mdx .................................................... PASS
test_suite_memory_buffer_alloc .................................... PASS
test_suite_mpi .................................................... PASS
test_suite_pem .................................................... PASS
test_suite_pk ..................................................... PASS
test_suite_pkcs1_v15 .............................................. PASS
test_suite_pkcs1_v21 .............................................. PASS
test_suite_pkcs5 .................................................. PASS
test_suite_pkparse ................................................ PASS
test_suite_pkwrite ................................................ PASS
test_suite_rsa .................................................... PASS
test_suite_shax ................................................... PASS
test_suite_ssl .................................................... PASS
test_suite_timing ................................................. PASS
test_suite_version ................................................ PASS
test_suite_x509parse .............................................. PASS
test_suite_x509write .............................................. PASS
test_suite_xtea ................................................... PASS
------------------------------------------------------------------------
PASSED (60 suites, 6109 tests run)
```