### PR TITLE
Fix ssl_server2 sample application prompt

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -326,7 +326,7 @@ int main( void )
 #define USAGE \
     "\n usage: ssl_server2 param=<>...\n"                   \
     "\n acceptable parameters:\n"                           \
-    "    server_addr=%%d      default: (all interfaces)\n"  \
+    "    server_addr=%%s      default: (all interfaces)\n"  \
     "    server_port=%%d      default: 4433\n"              \
     "    debug_level=%%d      default: 0 (disabled)\n"      \
     "    nbio=%%d             default: 0 (blocking I/O)\n"  \


### PR DESCRIPTION
## Description
FIx the type of server_addr parameter from %d to %s.
Issue reported by Email by Bei Jin


## Status
**READY**

## Requires Backporting

Yes 
Which branch?
mbedtls-2.1
mbedtls-1.3

## Migrations
If there is any API change, what's the incentive and logic for it.

 NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

