### PR TITLE
Backport 2.1: Add documentation warnings for weak algorithms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Changes
+   * Add explicit warnings for the use of MD2, MD4, MD5,
+     SHA-1 and ARC4 throughout the library.
+
 = mbed TLS 2.1.9 branch released 2017-08-10
 
 Security

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -20,9 +20,8 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning   ARC4 is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  *
  */
 #ifndef MBEDTLS_ARC4_H
@@ -47,9 +46,8 @@ extern "C" {
 /**
  * \brief     ARC4 context structure
  *
- * \warning   ARC4 is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  *
  */
 typedef struct
@@ -65,9 +63,9 @@ mbedtls_arc4_context;
  *
  * \param ctx      ARC4 context to be initialized
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
@@ -77,9 +75,9 @@ void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
  *
  * \param ctx      ARC4 context to be cleared
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
@@ -91,9 +89,9 @@ void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
  * \param key      the secret key
  * \param keylen   length of the key, in bytes
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
@@ -109,9 +107,9 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
  *
  * \return         0 if successful
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
@@ -134,9 +132,9 @@ extern "C" {
  *
  * \return         0 if successful, or 1 if the test failed
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 int mbedtls_arc4_self_test( int verbose );

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -45,7 +45,7 @@ extern "C" {
 #endif
 
 /**
- * \brief          ARC4 context structure
+ * \brief     ARC4 context structure
  *
  * \warning   ARC4 is considered a weak cipher and its use
  *            constitutes a security risk. It is recommended

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -54,6 +54,11 @@ mbedtls_arc4_context;
  * \brief          Initialize ARC4 context
  *
  * \param ctx      ARC4 context to be initialized
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use e.g. AES instead.
+ *
  */
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
 
@@ -61,6 +66,11 @@ void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
  * \brief          Clear ARC4 context
  *
  * \param ctx      ARC4 context to be cleared
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use e.g. AES instead.
+ *
  */
 void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
 
@@ -70,6 +80,11 @@ void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
  * \param ctx      ARC4 context to be setup
  * \param key      the secret key
  * \param keylen   length of the key, in bytes
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use e.g. AES instead.
+ *
  */
 void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
                  unsigned int keylen );
@@ -83,6 +98,11 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
  * \param output   buffer for the output data
  *
  * \return         0 if successful
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use e.g. AES instead.
+ *
  */
 int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
                 unsigned char *output );

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  *
  */
 #ifndef MBEDTLS_ARC4_H
@@ -47,9 +47,9 @@ extern "C" {
 /**
  * \brief          ARC4 context structure
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  *
  */
 typedef struct
@@ -67,7 +67,7 @@ mbedtls_arc4_context;
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
@@ -79,7 +79,7 @@ void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
@@ -93,7 +93,7 @@ void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
@@ -111,7 +111,7 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
@@ -136,7 +136,7 @@ extern "C" {
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 int mbedtls_arc4_self_test( int verbose );

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 #ifndef MBEDTLS_ARC4_H
 #define MBEDTLS_ARC4_H
@@ -41,6 +46,11 @@ extern "C" {
 
 /**
  * \brief          ARC4 context structure
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 typedef struct
 {

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -133,6 +133,11 @@ extern "C" {
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 int mbedtls_arc4_self_test( int verbose );
 

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -57,7 +57,7 @@ mbedtls_arc4_context;
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use e.g. AES instead.
+ *                 to use a strong cipher instead.
  *
  */
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
@@ -69,7 +69,7 @@ void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use e.g. AES instead.
+ *                 to use a strong cipher instead.
  *
  */
 void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
@@ -83,7 +83,7 @@ void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use e.g. AES instead.
+ *                 to use a strong cipher instead.
  *
  */
 void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
@@ -101,7 +101,7 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use e.g. AES instead.
+ *                 to use a strong cipher instead.
  *
  */
 int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -69,8 +69,8 @@ extern "C" {
  * \brief     Enumeration of supported ciphers
  *
  * \warning   ARC4 and DES are considered weak ciphers and their use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
  */
 typedef enum {
     MBEDTLS_CIPHER_ID_NONE = 0,
@@ -87,9 +87,8 @@ typedef enum {
  * \brief     Enumeration of supported (cipher,mode) pairs
  *
  * \warning   ARC4 and DES are considered weak ciphers and their use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
- *
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
  */
 typedef enum {
     MBEDTLS_CIPHER_NONE = 0,

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -83,6 +83,14 @@ typedef enum {
     MBEDTLS_CIPHER_ID_ARC4,
 } mbedtls_cipher_id_t;
 
+/*
+ * \brief     Enumeration of supported (cipher,mode) pairs
+ *
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
+ *
+ */
 typedef enum {
     MBEDTLS_CIPHER_NONE = 0,
     MBEDTLS_CIPHER_NULL,

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -68,7 +68,7 @@ extern "C" {
 /*
  * \brief     Enumeration of supported ciphers
  *
- * \warning   ARC4 is considered a weak cipher and its use
+ * \warning   ARC4 and DES are considered weak ciphers and their use
  *            constitutes a security risk. It is recommended
  *            alternative ciphers should be considered instead.
  */
@@ -86,7 +86,7 @@ typedef enum {
 /*
  * \brief     Enumeration of supported (cipher,mode) pairs
  *
- * \warning   ARC4 is considered a weak cipher and its use
+ * \warning   ARC4 and DES are considered weak ciphers and their use
  *            constitutes a security risk. It is recommended
  *            alternative ciphers should be considered instead.
  *

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -65,6 +65,13 @@
 extern "C" {
 #endif
 
+/*
+ * \brief     Enumeration of supported ciphers
+ *
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            to use a strong cipher instead.
+ */
 typedef enum {
     MBEDTLS_CIPHER_ID_NONE = 0,
     MBEDTLS_CIPHER_ID_NULL,

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -70,7 +70,7 @@ extern "C" {
  *
  * \warning   ARC4 is considered a weak cipher and its use
  *            constitutes a security risk. It is recommended
- *            to use a strong cipher instead.
+ *            alternative ciphers should be considered instead.
  */
 typedef enum {
     MBEDTLS_CIPHER_ID_NONE = 0,

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -226,9 +226,9 @@
  * module.
  *
  * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
- *            use constitutes a security risk. If possible, it is recommended to
- *            avoid dependencies on them and alternative message digests resp.
- *            ciphers should be considered instead.
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
  *
  */
 //#define MBEDTLS_AES_ALT
@@ -268,10 +268,10 @@
  * Uncomment a macro to enable alternate implementation of the corresponding
  * function.
  *
- * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their
- *            use constitutes a security risk. If possible, it is recommended
- *            to avoid dependencies on them and alternative message digests
- *            resp. ciphers should be considered instead.
+ * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, we recommend avoiding
+ *            dependencies on them, and considering stronger message digests
+ *            and ciphers instead.
  *
  */
 //#define MBEDTLS_MD2_PROCESS_ALT
@@ -403,9 +403,8 @@
  *
  * Uncomment this macro to enable weak ciphersuites
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 //#define MBEDTLS_ENABLE_WEAK_CIPHERSUITES
 
@@ -1433,10 +1432,9 @@
  *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
  *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. If possible, it is
- *                 recommended to avoid dependencies on it and that
- *                 alternative ciphers should be considered instead.
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. If possible, we recommend avoidng dependencies on
+ *            it, and considering stronger ciphers instead.
  *
  */
 #define MBEDTLS_ARC4_C
@@ -1651,9 +1649,8 @@
  *
  * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 #define MBEDTLS_DES_C
 
@@ -1814,10 +1811,9 @@
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
  *
- * \warning MD2 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
  *
  */
 //#define MBEDTLS_MD2_C
@@ -1832,10 +1828,9 @@
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
  *
- * \warning MD4 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
  *
  */
 //#define MBEDTLS_MD4_C
@@ -1855,10 +1850,9 @@
  * checking MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
  * encrypted keys.
  *
- * \warning MD5 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. If possible, we recommend avoiding dependencies on
+ *            it, and considering stronger message digests instead.
  *
  */
 #define MBEDTLS_MD5_C
@@ -2114,10 +2108,9 @@
  * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
  * depending on the handshake parameters, and for SHA1-signed certificates.
  *
- * \warning SHA-1 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
  *
  */
 #define MBEDTLS_SHA1_C
@@ -2486,10 +2479,9 @@
  * recommended because of it is possible to generate SHA-1 collisions, however
  * this may be safe for legacy infrastructure where additional controls apply.
  *
- * \warning SHA-1 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
  *
  */
 // #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
@@ -2504,10 +2496,9 @@
  * to preserve compatibility with existing peers, but the general
  * warning applies nonetheless:
  *
- * \warning SHA-1 is considered a weak message digest and its use
- *          constitutes a security risk. If possible, it recommended
- *          to avoid dependencies on it and alternative message digests
- *          should be considered instead.
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. If possible, we recommend avoiding dependencies
+ *            on it, and considering stronger message digests instead.
  *
  */
 #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -225,10 +225,10 @@
  * Uncomment a macro to enable alternate implementation of the corresponding
  * module.
  *
- * \warning  MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their
- *           use constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on them and to use strong message
- *           digests resp. ciphers instead.
+ * \warning   MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, it is recommended to
+ *            avoid dependencies on them and alternative message digests resp.
+ *            ciphers should be considered instead.
  *
  */
 //#define MBEDTLS_AES_ALT
@@ -268,10 +268,10 @@
  * Uncomment a macro to enable alternate implementation of the corresponding
  * function.
  *
- * \warning  MD2, MD4, MD5 and SHA-1 are considered weak message digests and their
- *           use constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on them and to use a strong message
- *           digest instead.
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
+ *            and their use constitutes a security risk. If possible, it is
+ *            recommended to avoid dependencies on them and alternative message
+ *            digests should be considered instead.
  *
  */
 //#define MBEDTLS_MD2_PROCESS_ALT
@@ -1429,9 +1429,10 @@
  *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
  *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
  *
- * \warning  ARC4 is considered a weak cipher and its use constitutes
- *           a security risk. If possible, it is recommended to avoid dependencies
- *           on it and to use a strong cipher instead.
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. If possible, it is
+ *                 recommended to avoid dependencies on it and that
+ *                 alternative ciphers should be considered instead.
  *
  */
 #define MBEDTLS_ARC4_C
@@ -1805,10 +1806,10 @@
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
  *
- * \warning  MD2 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning MD2 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 //#define MBEDTLS_MD2_C
@@ -1823,10 +1824,10 @@
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
  *
- * \warning  MD4 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning MD4 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 //#define MBEDTLS_MD4_C
@@ -1846,10 +1847,10 @@
  * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
  * encrypted keys.
  *
- * \warning  MD5 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning MD5 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 #define MBEDTLS_MD5_C
@@ -2105,10 +2106,10 @@
  * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
  * depending on the handshake parameters, and for SHA1-signed certificates.
  *
- * \warning  SHA-1 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning SHA-1 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 #define MBEDTLS_SHA1_C
@@ -2477,10 +2478,10 @@
  * recommended because of it is possible to generate SHA-1 collisions, however
  * this may be safe for legacy infrastructure where additional controls apply.
  *
- * \warning  SHA-1 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning SHA-1 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 // #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
@@ -2495,10 +2496,10 @@
  * to preserve compatibility with existing peers, but the general
  * warning applies nonetheless:
  *
- * \warning  SHA-1 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ * \warning SHA-1 is considered a weak message digest and its use
+ *          constitutes a security risk. If possible, it recommended
+ *          to avoid dependencies on it and alternative message digests
+ *          should be considered instead.
  *
  */
 #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1792,6 +1792,11 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
+ *
+ * \warning  MD2 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use SHA-256 or SHA-512 instead.
+ *
  */
 //#define MBEDTLS_MD2_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2090,7 +2090,7 @@
  * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
  * depending on the handshake parameters, and for SHA1-signed certificates.
  *
- * \warning  SHA1 is considered a weak message digest and its use
+ * \warning  SHA-1 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
  *           to avoid dependencies on it and to use SHA-256 / SHA-512 instead.
  *
@@ -2458,7 +2458,7 @@
  * Allow SHA-1 in the default TLS configuration for certificate signing.
  * Without this build-time option, SHA-1 support must be activated explicitly
  * through mbedtls_ssl_conf_cert_profile. Turning on this option is not
- * recommended because of it is possible to generte SHA-1 collisions, however
+ * recommended because of it is possible to generate SHA-1 collisions, however
  * this may be safe for legacy infrastructure where additional controls apply.
  */
 // #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -227,7 +227,7 @@
  *
  * \warning  MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their
  *           use constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on them and to use a strong message
+ *           to avoid dependencies on them and to use strong message
  *           digests resp. ciphers instead.
  *
  */
@@ -267,6 +267,12 @@
  *
  * Uncomment a macro to enable alternate implementation of the corresponding
  * function.
+ *
+ * \warning  MD2, MD4, MD5 and SHA-1 are considered weak message digests and their
+ *           use constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on them and to use a strong message
+ *           digest instead.
+ *
  */
 //#define MBEDTLS_MD2_PROCESS_ALT
 //#define MBEDTLS_MD4_PROCESS_ALT

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2464,6 +2464,12 @@
  * through mbedtls_ssl_conf_cert_profile. Turning on this option is not
  * recommended because of it is possible to generate SHA-1 collisions, however
  * this may be safe for legacy infrastructure where additional controls apply.
+ *
+ * \warning  SHA-1 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 // #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
 
@@ -2474,7 +2480,14 @@
  * The use of SHA-1 in TLS <= 1.1 and in HMAC-SHA-1 is always allowed by
  * default. At the time of writing, there is no practical attack on the use
  * of SHA-1 in handshake signatures, hence this option is turned on by default
- * for compatibility with existing peers.
+ * to preserve compatibility with existing peers, but the general
+ * warning applies nonetheless:
+ *
+ * \warning  SHA-1 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 #define MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_KEY_EXCHANGE
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -225,8 +225,8 @@
  * Uncomment a macro to enable alternate implementation of the corresponding
  * module.
  *
- * \warning   MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their use
- *            constitutes a security risk. If possible, it is recommended to
+ * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, it is recommended to
  *            avoid dependencies on them and alternative message digests resp.
  *            ciphers should be considered instead.
  *
@@ -268,10 +268,10 @@
  * Uncomment a macro to enable alternate implementation of the corresponding
  * function.
  *
- * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
- *            and their use constitutes a security risk. If possible, it is
- *            recommended to avoid dependencies on them and alternative message
- *            digests should be considered instead.
+ * \warning   MD2, MD4, MD5, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, it is recommended
+ *            to avoid dependencies on them and alternative message digests
+ *            resp. ciphers should be considered instead.
  *
  */
 //#define MBEDTLS_MD2_PROCESS_ALT
@@ -402,6 +402,10 @@
  *      MBEDTLS_TLS_DHE_RSA_WITH_DES_CBC_SHA
  *
  * Uncomment this macro to enable weak ciphersuites
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  */
 //#define MBEDTLS_ENABLE_WEAK_CIPHERSUITES
 
@@ -1646,6 +1650,10 @@
  *      MBEDTLS_TLS_PSK_WITH_3DES_EDE_CBC_SHA
  *
  * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  */
 #define MBEDTLS_DES_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2089,6 +2089,11 @@
  *
  * This module is required for SSL/TLS up to version 1.1, for TLS 1.2
  * depending on the handshake parameters, and for SHA1-signed certificates.
+ *
+ * \warning  SHA1 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use SHA-256 / SHA-512 instead.
+ *
  */
 #define MBEDTLS_SHA1_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -224,6 +224,12 @@
  *
  * Uncomment a macro to enable alternate implementation of the corresponding
  * module.
+ *
+ * \warning  MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their
+ *           use constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on them and to use a strong message
+ *           digests resp. ciphers instead.
+ *
  */
 //#define MBEDTLS_AES_ALT
 //#define MBEDTLS_ARC4_ALT

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1850,9 +1850,9 @@
  *          library/pem.c
  *          library/ssl_tls.c
  *
- * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
- * depending on the handshake parameters. Further, it is used for checking
- * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * This module is required for SSL/TLS up to version 1.1, and it can be used in
+ * TLS 1.2 through the choice on handshake parameters. Further, it is used for
+ * checking MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
  * encrypted keys.
  *
  * \warning MD5 is considered a weak message digest and its use

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1416,6 +1416,11 @@
  *      MBEDTLS_TLS_RSA_WITH_RC4_128_MD5
  *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
  *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+ *
+ * \warning  ARC4 is considered a weak cipher and its use constitutes
+ *           a security risk. If possible, it is recommended to avoid dependencies
+ *           on it and to use e.g. AES instead.
+ *
  */
 #define MBEDTLS_ARC4_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1809,6 +1809,11 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
+ *
+ * \warning  MD4 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use SHA-256 or SHA-512 instead.
+ *
  */
 //#define MBEDTLS_MD4_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1419,7 +1419,7 @@
  *
  * \warning  ARC4 is considered a weak cipher and its use constitutes
  *           a security risk. If possible, it is recommended to avoid dependencies
- *           on it and to use e.g. AES instead.
+ *           on it and to use a strong cipher instead.
  *
  */
 #define MBEDTLS_ARC4_C
@@ -1795,7 +1795,8 @@
  *
  * \warning  MD2 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use SHA-256 or SHA-512 instead.
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
  *
  */
 //#define MBEDTLS_MD2_C
@@ -1812,7 +1813,8 @@
  *
  * \warning  MD4 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use SHA-256 or SHA-512 instead.
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
  *
  */
 //#define MBEDTLS_MD4_C
@@ -1834,7 +1836,8 @@
  *
  * \warning  MD5 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use SHA-256 / SHA-512 instead.
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
  *
  */
 #define MBEDTLS_MD5_C
@@ -2092,7 +2095,8 @@
  *
  * \warning  SHA-1 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use SHA-256 / SHA-512 instead.
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
  *
  */
 #define MBEDTLS_SHA1_C

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1827,8 +1827,15 @@
  *          library/pem.c
  *          library/ssl_tls.c
  *
- * This module is required for SSL/TLS and X.509.
- * PEM_PARSE uses MD5 for decrypting encrypted keys.
+ * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
+ * depending on the handshake parameters. Further, it is used for checking
+ * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * encrypted keys.
+ *
+ * \warning  MD5 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use SHA-256 / SHA-512 instead.
+ *
  */
 #define MBEDTLS_MD5_C
 

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers
+ *            instead.
  *
  */
 #ifndef MBEDTLS_DES_H
@@ -55,9 +55,9 @@ extern "C" {
 /**
  * \brief          DES context structure
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 typedef struct
 {
@@ -79,9 +79,9 @@ mbedtls_des3_context;
  *
  * \param ctx      DES context to be initialized
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void mbedtls_des_init( mbedtls_des_context *ctx );
 
@@ -90,9 +90,9 @@ void mbedtls_des_init( mbedtls_des_context *ctx );
  *
  * \param ctx      DES context to be cleared
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void mbedtls_des_free( mbedtls_des_context *ctx );
 
@@ -118,9 +118,9 @@ void mbedtls_des3_free( mbedtls_des3_context *ctx );
  *
  * \param key      8-byte secret key
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -134,9 +134,9 @@ void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  *
  * \return         0 is parity was ok, 1 if parity was not correct.
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -147,9 +147,9 @@ int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SI
  *
  * \return         0 if no weak key was found, 1 if a weak key was identified.
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -161,9 +161,9 @@ int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  *
  * \return         0
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -175,9 +175,9 @@ int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MB
  *
  * \return         0
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -234,9 +234,9 @@ int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
  *
  * \return         0 if successful
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
                     const unsigned char input[8],
@@ -261,9 +261,9 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
  * \param input    buffer holding the input data
  * \param output   buffer holding the output data
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
                     int mode,
@@ -323,9 +323,9 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
  * \param SK       Round keys
  * \param key      Base key
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void mbedtls_des_setkey( uint32_t SK[32],
                          const unsigned char key[MBEDTLS_DES_KEY_SIZE] );

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
+ *
  */
 #ifndef MBEDTLS_DES_H
 #define MBEDTLS_DES_H
@@ -49,6 +54,10 @@ extern "C" {
 
 /**
  * \brief          DES context structure
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 typedef struct
 {
@@ -69,6 +78,10 @@ mbedtls_des3_context;
  * \brief          Initialize DES context
  *
  * \param ctx      DES context to be initialized
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void mbedtls_des_init( mbedtls_des_context *ctx );
 
@@ -76,6 +89,10 @@ void mbedtls_des_init( mbedtls_des_context *ctx );
  * \brief          Clear DES context
  *
  * \param ctx      DES context to be cleared
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void mbedtls_des_free( mbedtls_des_context *ctx );
 
@@ -100,6 +117,10 @@ void mbedtls_des3_free( mbedtls_des3_context *ctx );
  *                 a parity bit to allow verification.
  *
  * \param key      8-byte secret key
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -112,6 +133,10 @@ void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0 is parity was ok, 1 if parity was not correct.
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -121,6 +146,10 @@ int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SI
  * \param key      8-byte secret key
  *
  * \return         0 if no weak key was found, 1 if a weak key was identified.
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -131,6 +160,10 @@ int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -141,6 +174,10 @@ int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MB
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
@@ -196,6 +233,10 @@ int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
  * \param output   64-bit output block
  *
  * \return         0 if successful
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
                     const unsigned char input[8],
@@ -219,6 +260,10 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
  * \param iv       initialization vector (updated after use)
  * \param input    buffer holding the input data
  * \param output   buffer holding the output data
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
                     int mode,
@@ -277,6 +322,10 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
  *
  * \param SK       Round keys
  * \param key      Base key
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void mbedtls_des_setkey( uint32_t SK[32],
                          const unsigned char key[MBEDTLS_DES_KEY_SIZE] );

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -39,9 +39,9 @@ extern "C" {
 /*
  * \brief     Enumeration of supported message digests
  *
- * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
- *            and their use constitutes a security risk. It is recommended
- *            alternative message digests should be considered instead.
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests and
+ *            their use constitutes a security risk. We recommend considering
+ *            stronger message digests instead.
  *
  */
 typedef enum {

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -41,7 +41,8 @@ extern "C" {
  *
  * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
  *            and their use constitutes a security risk. It is recommended
- *            to use strong message digests instead.
+ *            alternative message digests should be considered instead.
+ *
  */
 typedef enum {
     MBEDTLS_MD_NONE=0,

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -36,6 +36,13 @@
 extern "C" {
 #endif
 
+/*
+ * \brief     Enumeration of supported message digests
+ *
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
+ *            and their use constitutes a security risk. It is recommended
+ *            to use strong message digests instead.
+ */
 typedef enum {
     MBEDTLS_MD_NONE=0,
     MBEDTLS_MD_MD2,

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -115,7 +115,8 @@ const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
 /**
  * \brief           Initialize a md_context (as NONE)
  *                  This should always be called first.
- *                  Prepares the context for mbedtls_md_setup() or mbedtls_md_free().
+ *                  Prepares the context for mbedtls_md_setup()
+8                   or mbedtls_md_free().
  */
 void mbedtls_md_init( mbedtls_md_context_t *ctx );
 
@@ -134,8 +135,9 @@ void mbedtls_md_free( mbedtls_md_context_t *ctx );
 #endif
 /**
  * \brief           Select MD to use and allocate internal structures.
- *                  Should be called after mbedtls_md_init() or mbedtls_md_free().
- *                  Makes it necessary to call mbedtls_md_free() later.
+ *                  Should be called after mbedtls_md_init() or
+ *                  mbedtls_md_free(). Makes it necessary to call
+ *                  mbedtls_md_free() later.
  *
  * \deprecated      Superseded by mbedtls_md_setup() in 2.0.0
  *
@@ -146,14 +148,16 @@ void mbedtls_md_free( mbedtls_md_context_t *ctx );
  *                  \c MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter failure,
  *                  \c MBEDTLS_ERR_MD_ALLOC_FAILED memory allocation failure.
  */
-int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
+int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx,
+                         const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
 #undef MBEDTLS_DEPRECATED
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief           Select MD to use and allocate internal structures.
- *                  Should be called after mbedtls_md_init() or mbedtls_md_free().
- *                  Makes it necessary to call mbedtls_md_free() later.
+ *                  Should be called after mbedtls_md_init() or
+ *                  mbedtls_md_free(). Makes it necessary to call
+ *                  mbedtls_md_free() later.
  *
  * \param ctx       Context to set up.
  * \param md_info   Message digest to use.
@@ -164,7 +168,8 @@ int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_
  *                  \c MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter failure,
  *                  \c MBEDTLS_ERR_MD_ALLOC_FAILED memory allocation failure.
  */
-int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac );
+int mbedtls_md_setup( mbedtls_md_context_t *ctx,
+                      const mbedtls_md_info_t *md_info, int hmac );
 
 /**
  * \brief           Clone the state of an MD context
@@ -212,8 +217,8 @@ const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info );
 
 /**
  * \brief           Prepare the context to digest a new message.
- *                  Generally called after mbedtls_md_setup() or mbedtls_md_finish().
- *                  Followed by mbedtls_md_update().
+ *                  Generally called after mbedtls_md_setup() or
+ *                  mbedtls_md_finish(). Followed by mbedtls_md_update().
  *
  * \param ctx       generic message digest context.
  *
@@ -234,12 +239,14 @@ int mbedtls_md_starts( mbedtls_md_context_t *ctx );
  * \returns         0 on success, MBEDTLS_ERR_MD_BAD_INPUT_DATA if parameter
  *                  verification fails.
  */
-int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen );
+int mbedtls_md_update( mbedtls_md_context_t *ctx,
+                       const unsigned char *input, size_t ilen );
 
 /**
  * \brief           Generic message digest final digest
  *                  Called after mbedtls_md_update().
- *                  Usually followed by mbedtls_md_free() or mbedtls_md_starts().
+ *                  Usually followed by mbedtls_md_free() or
+ *                  mbedtls_md_starts().
  *
  * \param ctx       Generic message digest context
  * \param output    Generic message digest checksum result
@@ -260,8 +267,9 @@ int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output );
  * \returns        0 on success, MBEDTLS_ERR_MD_BAD_INPUT_DATA if parameter
  *                 verification fails.
  */
-int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
-        unsigned char *output );
+int mbedtls_md( const mbedtls_md_info_t *md_info,
+                const unsigned char *input, size_t ilen,
+                unsigned char *output );
 
 #if defined(MBEDTLS_FS_IO)
 /**
@@ -281,7 +289,8 @@ int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
 
 /**
  * \brief           Set HMAC key and prepare to authenticate a new message.
- *                  Usually called after mbedtls_md_setup() or mbedtls_md_hmac_finish().
+ *                  Usually called after mbedtls_md_setup() or
+ *                  mbedtls_md_hmac_finish().
  *
  * \param ctx       HMAC context
  * \param key       HMAC secret key
@@ -295,8 +304,8 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
 
 /**
  * \brief           Generic HMAC process buffer.
- *                  Called between mbedtls_md_hmac_starts() or mbedtls_md_hmac_reset()
- *                  and mbedtls_md_hmac_finish().
+ *                  Called between mbedtls_md_hmac_starts() or
+ *                  mbedtls_md_hmac_reset() and mbedtls_md_hmac_finish().
  *                  May be called repeatedly.
  *
  * \param ctx       HMAC context
@@ -306,8 +315,9 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
  * \returns         0 on success, MBEDTLS_ERR_MD_BAD_INPUT_DATA if parameter
  *                  verification fails.
  */
-int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input,
-                    size_t ilen );
+int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx,
+                            const unsigned char *input,
+                            size_t ilen );
 
 /**
  * \brief           Output HMAC.
@@ -347,9 +357,10 @@ int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx );
  * \returns        0 on success, MBEDTLS_ERR_MD_BAD_INPUT_DATA if parameter
  *                 verification fails.
  */
-int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key, size_t keylen,
-                const unsigned char *input, size_t ilen,
-                unsigned char *output );
+int mbedtls_md_hmac( const mbedtls_md_info_t *md_info,
+                     const unsigned char *key, size_t keylen,
+                     const unsigned char *input, size_t ilen,
+                     unsigned char *output );
 
 /* Internal use */
 int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data );

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message
+ *            digests instead.
  *
  */
 #ifndef MBEDTLS_MD2_H
@@ -48,8 +48,8 @@ extern "C" {
  * \brief          MD2 context structure
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md2_context;
  * \param ctx      MD2 context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_init( mbedtls_md2_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md2_init( mbedtls_md2_context *ctx );
  * \param ctx      MD2 context to be cleared
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_free( mbedtls_md2_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md2_free( mbedtls_md2_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_clone( mbedtls_md2_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_starts( mbedtls_md2_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_update( mbedtls_md2_context *ctx,
@@ -134,8 +134,8 @@ void mbedtls_md2_update( mbedtls_md2_context *ctx,
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] );
@@ -160,8 +160,8 @@ extern "C" {
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -172,8 +172,8 @@ void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int mbedtls_md2_self_test( int verbose );

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -21,8 +21,8 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef MBEDTLS_MD2_H
@@ -48,8 +48,8 @@ extern "C" {
  * \brief          MD2 context structure
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md2_context;
  * \param ctx      MD2 context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_init( mbedtls_md2_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md2_init( mbedtls_md2_context *ctx );
  * \param ctx      MD2 context to be cleared
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_free( mbedtls_md2_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md2_free( mbedtls_md2_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_clone( mbedtls_md2_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_starts( mbedtls_md2_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen );
@@ -132,8 +132,8 @@ void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, s
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] );
@@ -158,8 +158,8 @@ extern "C" {
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -170,8 +170,8 @@ void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int mbedtls_md2_self_test( int verbose );

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -55,6 +55,11 @@ mbedtls_md2_context;
  * \brief          Initialize MD2 context
  *
  * \param ctx      MD2 context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md2_init( mbedtls_md2_context *ctx );
 
@@ -62,6 +67,11 @@ void mbedtls_md2_init( mbedtls_md2_context *ctx );
  * \brief          Clear MD2 context
  *
  * \param ctx      MD2 context to be cleared
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md2_free( mbedtls_md2_context *ctx );
 
@@ -70,6 +80,11 @@ void mbedtls_md2_free( mbedtls_md2_context *ctx );
  *
  * \param dst      The destination context
  * \param src      The context to be cloned
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md2_clone( mbedtls_md2_context *dst,
                         const mbedtls_md2_context *src );
@@ -78,6 +93,11 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  * \brief          MD2 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md2_starts( mbedtls_md2_context *ctx );
 
@@ -87,6 +107,11 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  * \param ctx      MD2 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen );
 

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -58,7 +58,7 @@ mbedtls_md2_context;
  *
  * \warning        MD2 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md2_init( mbedtls_md2_context *ctx );
@@ -70,7 +70,7 @@ void mbedtls_md2_init( mbedtls_md2_context *ctx );
  *
  * \warning        MD2 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md2_free( mbedtls_md2_context *ctx );
@@ -83,7 +83,7 @@ void mbedtls_md2_free( mbedtls_md2_context *ctx );
  *
  * \warning        MD2 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md2_clone( mbedtls_md2_context *dst,
@@ -96,7 +96,7 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  *
  * \warning        MD2 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md2_starts( mbedtls_md2_context *ctx );
@@ -110,7 +110,7 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  *
  * \warning        MD2 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen );

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -123,7 +123,9 @@ void mbedtls_md2_starts( mbedtls_md2_context *ctx );
  *                 message digests should be considered instead.
  *
  */
-void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, size_t ilen );
+void mbedtls_md2_update( mbedtls_md2_context *ctx,
+                         const unsigned char *input,
+                         size_t ilen );
 
 /**
  * \brief          MD2 final digest

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -130,6 +130,11 @@ void mbedtls_md2_update( mbedtls_md2_context *ctx, const unsigned char *input, s
  *
  * \param ctx      MD2 context
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void mbedtls_md2_finish( mbedtls_md2_context *ctx, unsigned char output[16] );
 
@@ -151,6 +156,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -158,6 +168,11 @@ void mbedtls_md2( const unsigned char *input, size_t ilen, unsigned char output[
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int mbedtls_md2_self_test( int verbose );
 

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef MBEDTLS_MD2_H
 #define MBEDTLS_MD2_H
@@ -41,6 +46,11 @@ extern "C" {
 
 /**
  * \brief          MD2 context structure
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message
+ *            digests instead.
  *
  */
 #ifndef MBEDTLS_MD4_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          MD4 context structure
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md4_context;
  * \param ctx      MD4 context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4_init( mbedtls_md4_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md4_init( mbedtls_md4_context *ctx );
  * \param ctx      MD4 context to be cleared
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4_free( mbedtls_md4_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md4_free( mbedtls_md4_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4_clone( mbedtls_md4_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  */
 void mbedtls_md4_starts( mbedtls_md4_context *ctx );
 
@@ -118,8 +118,8 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen );
@@ -131,8 +131,8 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] );
@@ -157,8 +157,8 @@ extern "C" {
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -169,8 +169,8 @@ void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int mbedtls_md4_self_test( int verbose );

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -55,6 +55,11 @@ mbedtls_md4_context;
  * \brief          Initialize MD4 context
  *
  * \param ctx      MD4 context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md4_init( mbedtls_md4_context *ctx );
 
@@ -62,6 +67,11 @@ void mbedtls_md4_init( mbedtls_md4_context *ctx );
  * \brief          Clear MD4 context
  *
  * \param ctx      MD4 context to be cleared
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md4_free( mbedtls_md4_context *ctx );
 
@@ -70,6 +80,11 @@ void mbedtls_md4_free( mbedtls_md4_context *ctx );
  *
  * \param dst      The destination context
  * \param src      The context to be cloned
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md4_clone( mbedtls_md4_context *dst,
                         const mbedtls_md4_context *src );
@@ -78,6 +93,10 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  * \brief          MD4 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
  */
 void mbedtls_md4_starts( mbedtls_md4_context *ctx );
 
@@ -87,6 +106,11 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx );
  * \param ctx      MD4 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -95,6 +119,11 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
  *
  * \param ctx      MD4 context
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] );
 

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -58,7 +58,7 @@ mbedtls_md4_context;
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md4_init( mbedtls_md4_context *ctx );
@@ -70,7 +70,7 @@ void mbedtls_md4_init( mbedtls_md4_context *ctx );
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md4_free( mbedtls_md4_context *ctx );
@@ -83,7 +83,7 @@ void mbedtls_md4_free( mbedtls_md4_context *ctx );
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md4_clone( mbedtls_md4_context *dst,
@@ -96,7 +96,7 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  */
 void mbedtls_md4_starts( mbedtls_md4_context *ctx );
 
@@ -109,7 +109,7 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx );
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen );
@@ -122,7 +122,7 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
  *
  * \warning        MD4 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] );

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef MBEDTLS_MD4_H
 #define MBEDTLS_MD4_H
@@ -42,6 +47,11 @@ extern "C" {
 
 /**
  * \brief          MD4 context structure
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -21,8 +21,8 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef MBEDTLS_MD4_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          MD4 context structure
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md4_context;
  * \param ctx      MD4 context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4_init( mbedtls_md4_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md4_init( mbedtls_md4_context *ctx );
  * \param ctx      MD4 context to be cleared
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4_free( mbedtls_md4_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md4_free( mbedtls_md4_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4_clone( mbedtls_md4_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  */
 void mbedtls_md4_starts( mbedtls_md4_context *ctx );
 
@@ -118,8 +118,8 @@ void mbedtls_md4_starts( mbedtls_md4_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, size_t ilen );
@@ -131,8 +131,8 @@ void mbedtls_md4_update( mbedtls_md4_context *ctx, const unsigned char *input, s
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4_finish( mbedtls_md4_context *ctx, unsigned char output[16] );
@@ -157,8 +157,8 @@ extern "C" {
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -169,8 +169,8 @@ void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int mbedtls_md4_self_test( int verbose );

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -155,6 +155,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -162,6 +167,11 @@ void mbedtls_md4( const unsigned char *input, size_t ilen, unsigned char output[
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int mbedtls_md4_self_test( int verbose );
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message
+ *            digests instead.
  *
  */
 #ifndef MBEDTLS_MD5_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          MD5 context structure
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md5_context;
  * \param ctx      MD5 context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_init( mbedtls_md5_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md5_init( mbedtls_md5_context *ctx );
  * \param ctx      MD5 context to be cleared
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_free( mbedtls_md5_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md5_free( mbedtls_md5_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_clone( mbedtls_md5_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_starts( mbedtls_md5_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
@@ -132,8 +132,8 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );
@@ -161,8 +161,8 @@ extern "C" {
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -173,8 +173,8 @@ void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int mbedtls_md5_self_test( int verbose );

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -58,7 +58,7 @@ mbedtls_md5_context;
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_init( mbedtls_md5_context *ctx );
@@ -70,7 +70,7 @@ void mbedtls_md5_init( mbedtls_md5_context *ctx );
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_free( mbedtls_md5_context *ctx );
@@ -83,7 +83,7 @@ void mbedtls_md5_free( mbedtls_md5_context *ctx );
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_clone( mbedtls_md5_context *dst,
@@ -96,7 +96,7 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_starts( mbedtls_md5_context *ctx );
@@ -110,7 +110,7 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx );
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
@@ -123,7 +123,7 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
  *
  * \warning        MD5 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -21,8 +21,8 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef MBEDTLS_MD5_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          MD5 context structure
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_md5_context;
  * \param ctx      MD5 context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_init( mbedtls_md5_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_md5_init( mbedtls_md5_context *ctx );
  * \param ctx      MD5 context to be cleared
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_free( mbedtls_md5_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_md5_free( mbedtls_md5_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_clone( mbedtls_md5_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_starts( mbedtls_md5_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
@@ -132,8 +132,8 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );
@@ -161,8 +161,8 @@ extern "C" {
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -173,8 +173,8 @@ void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int mbedtls_md5_self_test( int verbose );

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef MBEDTLS_MD5_H
 #define MBEDTLS_MD5_H
@@ -42,6 +47,11 @@ extern "C" {
 
 /**
  * \brief          MD5 context structure
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -55,6 +55,11 @@ mbedtls_md5_context;
  * \brief          Initialize MD5 context
  *
  * \param ctx      MD5 context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_init( mbedtls_md5_context *ctx );
 
@@ -62,6 +67,11 @@ void mbedtls_md5_init( mbedtls_md5_context *ctx );
  * \brief          Clear MD5 context
  *
  * \param ctx      MD5 context to be cleared
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_free( mbedtls_md5_context *ctx );
 
@@ -70,6 +80,11 @@ void mbedtls_md5_free( mbedtls_md5_context *ctx );
  *
  * \param dst      The destination context
  * \param src      The context to be cloned
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_clone( mbedtls_md5_context *dst,
                         const mbedtls_md5_context *src );
@@ -78,6 +93,11 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  * \brief          MD5 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_starts( mbedtls_md5_context *ctx );
 
@@ -87,6 +107,11 @@ void mbedtls_md5_starts( mbedtls_md5_context *ctx );
  * \param ctx      MD5 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -95,6 +120,11 @@ void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, s
  *
  * \param ctx      MD5 context
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -159,6 +159,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -166,6 +171,11 @@ void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int mbedtls_md5_self_test( int verbose );
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -20,9 +20,9 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. We recommend considering stronger message
+ *            digests instead.
  *
  */
 #ifndef MBEDTLS_SHA1_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          SHA-1 context structure
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_sha1_context;
  * \param ctx      SHA-1 context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
  * \param ctx      SHA-1 context to be cleared
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
@@ -132,8 +132,8 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
@@ -161,8 +161,8 @@ extern "C" {
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
@@ -173,8 +173,8 @@ void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int mbedtls_sha1_self_test( int verbose );

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -19,6 +19,11 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef MBEDTLS_SHA1_H
 #define MBEDTLS_SHA1_H
@@ -42,6 +47,11 @@ extern "C" {
 
 /**
  * \brief          SHA-1 context structure
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -56,9 +56,9 @@ mbedtls_sha1_context;
  *
  * \param ctx      SHA-1 context to be initialized
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
@@ -68,9 +68,9 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
  *
  * \param ctx      SHA-1 context to be cleared
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
@@ -81,9 +81,9 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
  * \param dst      The destination context
  * \param src      The context to be cloned
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
@@ -94,9 +94,9 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  *
  * \param ctx      context to be initialized
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
@@ -108,9 +108,9 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
@@ -121,9 +121,9 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
  * \param ctx      SHA-1 context
  * \param output   SHA-1 checksum result
  *
- * \warning        SHA1 is considered a weak message digest and its use
+ * \warning        SHA-1 is considered a weak message digest and its use
  *                 constitutes a security risk. It is recommended
- *                 to use SHA-256 or SHA-512 instead.
+ *                 to use a strong message digest instead.
  *
  */
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -55,6 +55,11 @@ mbedtls_sha1_context;
  * \brief          Initialize SHA-1 context
  *
  * \param ctx      SHA-1 context to be initialized
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
 
@@ -62,6 +67,11 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
  * \brief          Clear SHA-1 context
  *
  * \param ctx      SHA-1 context to be cleared
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
 
@@ -70,6 +80,11 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
  *
  * \param dst      The destination context
  * \param src      The context to be cloned
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
                          const mbedtls_sha1_context *src );
@@ -78,6 +93,11 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \brief          SHA-1 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
 
@@ -87,6 +107,11 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
  * \param ctx      SHA-1 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -95,6 +120,11 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
  *
  * \param ctx      SHA-1 context
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use SHA-256 or SHA-512 instead.
+ *
  */
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -159,6 +159,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
 
@@ -166,6 +171,11 @@ void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int mbedtls_sha1_self_test( int verbose );
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -21,8 +21,8 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef MBEDTLS_SHA1_H
@@ -49,8 +49,8 @@ extern "C" {
  * \brief          SHA-1 context structure
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -67,8 +67,8 @@ mbedtls_sha1_context;
  * \param ctx      SHA-1 context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
@@ -79,8 +79,8 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
  * \param ctx      SHA-1 context to be cleared
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
@@ -92,8 +92,8 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
  * \param src      The context to be cloned
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
@@ -105,8 +105,8 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \param ctx      context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
@@ -119,8 +119,8 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
@@ -132,8 +132,8 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
@@ -161,8 +161,8 @@ extern "C" {
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
@@ -173,8 +173,8 @@ void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int mbedtls_sha1_self_test( int verbose );

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -155,7 +155,7 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
         my @res = $test_data =~ /^$mapping_regex/msg;
         foreach my $value (@res)
         {
-            next unless ($value !~ /^\d+$/);
+            next unless ($value !~ /^[+-]?\d*$/);
             if ( $mapping_values{$value} ) {
                 ${ $mapping_values{$value} }{$function_pre_code} = 1;
             } else {

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -152,14 +152,28 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
     # Find non-integer values we should map for this function
     if( $mapping_count)
     {
-        my @res = $test_data =~ /^$mapping_regex/msg;
+        my @res = $test_data =~ /^((?:depends_on:[\w:]+)?)\n?$mapping_regex/msg;
+        my $local_deps      = $function_deps;
+        my $local_pre_code  = $function_pre_code;
         foreach my $value (@res)
         {
+            # Check if we're at the beginning of a test case and
+            # need to update the local dependencies
+            if( $value =~ /^depends_on:/)
+            {
+                $local_pre_code  = $function_pre_code;
+                ( $local_deps ) = $value =~ /^depends_on:(.*)$/;
+                foreach my $req (split(/:/, $local_deps))
+                {
+                    $local_pre_code  .= "#ifdef $req\n";
+                }
+                next;
+            }
             next unless ($value !~ /^[+-]?\d*$/);
             if ( $mapping_values{$value} ) {
-                ${ $mapping_values{$value} }{$function_pre_code} = 1;
+                ${ $mapping_values{$value} }{$local_pre_code} = 1;
             } else {
-                $mapping_values{$value} = { $function_pre_code => 1 };
+                $mapping_values{$value} = { $local_pre_code => 1 };
             }
         }
     }

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -118,8 +118,8 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
 
     foreach my $req (split(/:/, $function_deps))
     {
-        $function_pre_code .= "#ifdef $req\n";
-        $function_post_code .= "#endif /* $req */\n";
+        $function_pre_code  .= "#ifdef $req\n";
+        $function_post_code = "#endif /* $req */\n" . $function_post_code;
     }
 
     foreach my $def (@var_def_arr)
@@ -228,13 +228,16 @@ while( my ($key, $value) = each(%mapping_values) )
     }
 END
 
-    # handle depenencies, unless used at least one without depends
+    # Unless the identifier is used at least once without
+    # dependencies, add a mapping for each occurrence, guarded
+    # by the respective dependency.
     if ($value->{""}) {
         $mapping_code .= $key_mapping_code;
         next;
     }
     for my $ifdef ( keys %$value ) {
         (my $endif = $ifdef) =~ s!ifdef!endif //!g;
+        $endif = join("", reverse(split(/^/m, $endif)));
         $mapping_code .= $ifdef . $key_mapping_code . $endif;
     }
 }

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -69,6 +69,11 @@ int verify_int( char *str, int *value )
             continue;
         }
 
+        if( i == 0 && str[i] == '+' )
+        {
+            continue;
+        }
+
         if( ( ( minus && i == 2 ) || ( !minus && i == 1 ) ) &&
             str[i - 1] == '0' && str[i] == 'x' )
         {


### PR DESCRIPTION
__Summary:__ This is the backport of #1100 to Mbed TLS 2.1.

__Internal Reference:__ IOTSSL-1754