### PR TITLE
Backport 1.3: Add documentation warnings for weak algorithms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.xx branch released xxxx-xx-xx
+
+Changes
+   * Add explicit warnings for the use of MD2, MD4, MD5,
+     SHA-1 and ARC4 throughout the library.
+
 = mbed TLS 1.3.21 branch released 2017-08-10
 
 Security

--- a/include/polarssl/arc4.h
+++ b/include/polarssl/arc4.h
@@ -21,9 +21,8 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  *
  */
 #ifndef POLARSSL_ARC4_H
@@ -48,9 +47,9 @@ extern "C" {
 /**
  * \brief          ARC4 context structure
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 typedef struct
@@ -66,9 +65,9 @@ arc4_context;
  *
  * \param ctx      ARC4 context to be initialized
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void arc4_init( arc4_context *ctx );
@@ -78,9 +77,9 @@ void arc4_init( arc4_context *ctx );
  *
  * \param ctx      ARC4 context to be cleared
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void arc4_free( arc4_context *ctx );
@@ -92,9 +91,9 @@ void arc4_free( arc4_context *ctx );
  * \param key      the secret key
  * \param keylen   length of the key, in bytes
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 void arc4_setup( arc4_context *ctx, const unsigned char *key,
@@ -110,9 +109,9 @@ void arc4_setup( arc4_context *ctx, const unsigned char *key,
  *
  * \return         0 if successful
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 int arc4_crypt( arc4_context *ctx, size_t length, const unsigned char *input,
@@ -135,9 +134,9 @@ extern "C" {
  *
  * \return         0 if successful, or 1 if the test failed
  *
- * \warning        ARC4 is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  *
  */
 int arc4_self_test( int verbose );

--- a/include/polarssl/arc4.h
+++ b/include/polarssl/arc4.h
@@ -21,10 +21,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 #ifndef POLARSSL_ARC4_H
@@ -51,7 +50,7 @@ extern "C" {
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 typedef struct
@@ -69,7 +68,7 @@ arc4_context;
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void arc4_init( arc4_context *ctx );
@@ -81,7 +80,7 @@ void arc4_init( arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void arc4_free( arc4_context *ctx );
@@ -95,7 +94,7 @@ void arc4_free( arc4_context *ctx );
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 void arc4_setup( arc4_context *ctx, const unsigned char *key,
@@ -113,7 +112,7 @@ void arc4_setup( arc4_context *ctx, const unsigned char *key,
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 int arc4_crypt( arc4_context *ctx, size_t length, const unsigned char *input,
@@ -138,7 +137,7 @@ extern "C" {
  *
  * \warning        ARC4 is considered a weak cipher and its use
  *                 constitutes a security risk. It is recommended
- *                 to use a strong cipher instead.
+ *                 alternative ciphers should be considered instead.
  *
  */
 int arc4_self_test( int verbose );

--- a/include/polarssl/arc4.h
+++ b/include/polarssl/arc4.h
@@ -20,6 +20,12 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 #ifndef POLARSSL_ARC4_H
 #define POLARSSL_ARC4_H
@@ -42,6 +48,11 @@ extern "C" {
 
 /**
  * \brief          ARC4 context structure
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 typedef struct
 {
@@ -55,6 +66,11 @@ arc4_context;
  * \brief          Initialize ARC4 context
  *
  * \param ctx      ARC4 context to be initialized
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 void arc4_init( arc4_context *ctx );
 
@@ -62,6 +78,11 @@ void arc4_init( arc4_context *ctx );
  * \brief          Clear ARC4 context
  *
  * \param ctx      ARC4 context to be cleared
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 void arc4_free( arc4_context *ctx );
 
@@ -71,6 +92,11 @@ void arc4_free( arc4_context *ctx );
  * \param ctx      ARC4 context to be setup
  * \param key      the secret key
  * \param keylen   length of the key, in bytes
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 void arc4_setup( arc4_context *ctx, const unsigned char *key,
                  unsigned int keylen );
@@ -84,6 +110,11 @@ void arc4_setup( arc4_context *ctx, const unsigned char *key,
  * \param output   buffer for the output data
  *
  * \return         0 if successful
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 int arc4_crypt( arc4_context *ctx, size_t length, const unsigned char *input,
                 unsigned char *output );
@@ -104,6 +135,11 @@ extern "C" {
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        ARC4 is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong cipher instead.
+ *
  */
 int arc4_self_test( int verbose );
 

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -70,8 +70,8 @@ extern "C" {
  * \brief     Enumeration of supported ciphers
  *
  * \warning   ARC4 and DES are considered weak ciphers and their use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
  */
 typedef enum {
     POLARSSL_CIPHER_ID_NONE = 0,
@@ -88,8 +88,8 @@ typedef enum {
  * \brief     Enumeration of supported (cipher,mode) pairs
  *
  * \warning   ARC4 and DES are considered weak ciphers and their use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
  *
  */
 typedef enum {

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -66,6 +66,13 @@
 extern "C" {
 #endif
 
+/*
+ * \brief     Enumeration of supported ciphers
+ *
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            to use a strong cipher instead.
+ */
 typedef enum {
     POLARSSL_CIPHER_ID_NONE = 0,
     POLARSSL_CIPHER_ID_NULL,

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -84,6 +84,14 @@ typedef enum {
     POLARSSL_CIPHER_ID_ARC4,
 } cipher_id_t;
 
+/*
+ * \brief     Enumeration of supported (cipher,mode) pairs
+ *
+ * \warning   ARC4 is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
+ *
+ */
 typedef enum {
     POLARSSL_CIPHER_NONE = 0,
     POLARSSL_CIPHER_NULL,

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -71,7 +71,7 @@ extern "C" {
  *
  * \warning   ARC4 is considered a weak cipher and its use
  *            constitutes a security risk. It is recommended
- *            to use a strong cipher instead.
+ *            alternative ciphers should be considered instead.
  */
 typedef enum {
     POLARSSL_CIPHER_ID_NONE = 0,

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -69,7 +69,7 @@ extern "C" {
 /*
  * \brief     Enumeration of supported ciphers
  *
- * \warning   ARC4 is considered a weak cipher and its use
+ * \warning   ARC4 and DES are considered weak ciphers and their use
  *            constitutes a security risk. It is recommended
  *            alternative ciphers should be considered instead.
  */
@@ -87,7 +87,7 @@ typedef enum {
 /*
  * \brief     Enumeration of supported (cipher,mode) pairs
  *
- * \warning   ARC4 is considered a weak cipher and its use
+ * \warning   ARC4 and DES are considered weak ciphers and their use
  *            constitutes a security risk. It is recommended
  *            alternative ciphers should be considered instead.
  *

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -258,9 +258,9 @@
  * functions
  *
  * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
- *            use constitutes a security risk. If possible, it is recommended to
- *            avoid dependencies on them and alternative message digests resp.
- *            ciphers should be considered instead.
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
  *
  */
 //#define POLARSSL_AES_ALT
@@ -377,9 +377,8 @@
  *
  * Uncomment this macro to enable weak ciphersuites
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 //#define POLARSSL_ENABLE_WEAK_CIPHERSUITES
 
@@ -1360,10 +1359,9 @@
  *      TLS_RSA_PSK_WITH_RC4_128_SHA
  *      TLS_PSK_WITH_RC4_128_SHA
  *
- * \warning  ARC4 is considered a weak cipher and its use
- *           constitutes a security risk. If possible, it is
- *           recommended to avoid dependencies on it and
- *           alternative ciphers should be considered instead.
+ * \warning  ARC4 is considered a weak cipher and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger ciphers instead.
  *
  */
 #define POLARSSL_ARC4_C
@@ -1580,9 +1578,8 @@
  *
  * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 #define POLARSSL_DES_C
 
@@ -1743,10 +1740,9 @@
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
  *
- * \warning  MD2 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and alternative message digests
- *           should be considered instead.
+ * \warning  MD2 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
  *
  */
 //#define POLARSSL_MD2_C
@@ -1761,10 +1757,9 @@
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
  *
- * \warning  MD4 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and alternative message digests
- *           should be considered instead.
+ * \warning  MD4 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
  *
  */
 //#define POLARSSL_MD4_C
@@ -1784,10 +1779,9 @@
  * checking MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
  * encrypted keys.
  *
- * \warning  MD5 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and alternative message digests
- *           should be considered instead.
+ * \warning  MD5 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
  *
  */
 #define POLARSSL_MD5_C
@@ -2066,10 +2060,9 @@
  *
  * This module is required for SSL/TLS and SHA1-signed certificates.
  *
- * \warning  SHA-1 is considered a weak message digest and its use
- *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and alternative message digests
- *           should be considered instead.
+ * \warning  SHA-1 is considered a weak message digest and its use constitutes
+ *           a security risk. If possible, we recommend avoiding dependencies
+ *           on it, and considering stronger message digests instead.
  *
  */
 #define POLARSSL_SHA1_C

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -257,10 +257,10 @@
  * Uncomment a macro to enable alternate implementation for core algorithm
  * functions
  *
- * \warning  MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their
- *           use constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on them and to use strong message
- *           digests resp. ciphers instead.
+ * \warning   MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their use
+ *            constitutes a security risk. If possible, it is recommended to
+ *            avoid dependencies on them and alternative message digests resp.
+ *            ciphers should be considered instead.
  *
  */
 //#define POLARSSL_AES_ALT
@@ -1356,9 +1356,10 @@
  *      TLS_RSA_PSK_WITH_RC4_128_SHA
  *      TLS_PSK_WITH_RC4_128_SHA
  *
- * \warning  ARC4 is considered a weak cipher and its use constitutes
- *           a security risk. If possible, it is recommended to avoid dependencies
- *           on it and to use a strong cipher instead.
+ * \warning  ARC4 is considered a weak cipher and its use
+ *           constitutes a security risk. If possible, it is
+ *           recommended to avoid dependencies on it and
+ *           alternative ciphers should be considered instead.
  *
  */
 #define POLARSSL_ARC4_C
@@ -1736,8 +1737,8 @@
  *
  * \warning  MD2 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ *           to avoid dependencies on it and alternative message digests
+ *           should be considered instead.
  *
  */
 //#define POLARSSL_MD2_C
@@ -1754,8 +1755,8 @@
  *
  * \warning  MD4 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ *           to avoid dependencies on it and alternative message digests
+ *           should be considered instead.
  *
  */
 //#define POLARSSL_MD4_C
@@ -1777,8 +1778,8 @@
  *
  * \warning  MD5 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ *           to avoid dependencies on it and alternative message digests
+ *           should be considered instead.
  *
  */
 #define POLARSSL_MD5_C
@@ -2059,8 +2060,8 @@
  *
  * \warning  SHA-1 is considered a weak message digest and its use
  *           constitutes a security risk. If possible, it is recommended
- *           to avoid dependencies on it and to use a strong message
- *           digest instead.
+ *           to avoid dependencies on it and alternative message digests
+ *           should be considered instead.
  *
  */
 #define POLARSSL_SHA1_C

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -1779,9 +1779,9 @@
  *          library/pem.c
  *          library/ssl_tls.c
  *
- * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
- * depending on the handshake parameters. Further, it is used for checking
- * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * This module is required for SSL/TLS up to version 1.1, and it can be used in
+ * TLS 1.2 through the choice on handshake parameters. Further, it is used for
+ * checking MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
  * encrypted keys.
  *
  * \warning  MD5 is considered a weak message digest and its use

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -257,8 +257,8 @@
  * Uncomment a macro to enable alternate implementation for core algorithm
  * functions
  *
- * \warning   MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their use
- *            constitutes a security risk. If possible, it is recommended to
+ * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, it is recommended to
  *            avoid dependencies on them and alternative message digests resp.
  *            ciphers should be considered instead.
  *
@@ -376,6 +376,10 @@
  *      TLS_DHE_RSA_WITH_DES_CBC_SHA
  *
  * Uncomment this macro to enable weak ciphersuites
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  */
 //#define POLARSSL_ENABLE_WEAK_CIPHERSUITES
 
@@ -1575,6 +1579,10 @@
  *      TLS_PSK_WITH_3DES_EDE_CBC_SHA
  *
  * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
  */
 #define POLARSSL_DES_C
 

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -256,6 +256,12 @@
  *
  * Uncomment a macro to enable alternate implementation for core algorithm
  * functions
+ *
+ * \warning  MD2, MD4, MD5, ARC4 and SHA-1 are considered weak and their
+ *           use constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on them and to use strong message
+ *           digests resp. ciphers instead.
+ *
  */
 //#define POLARSSL_AES_ALT
 //#define POLARSSL_ARC4_ALT
@@ -1349,6 +1355,11 @@
  *      TLS_RSA_WITH_RC4_128_MD5
  *      TLS_RSA_PSK_WITH_RC4_128_SHA
  *      TLS_PSK_WITH_RC4_128_SHA
+ *
+ * \warning  ARC4 is considered a weak cipher and its use constitutes
+ *           a security risk. If possible, it is recommended to avoid dependencies
+ *           on it and to use a strong cipher instead.
+ *
  */
 #define POLARSSL_ARC4_C
 
@@ -1722,6 +1733,12 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
+ *
+ * \warning  MD2 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 //#define POLARSSL_MD2_C
 
@@ -1734,6 +1751,12 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
+ *
+ * \warning  MD4 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 //#define POLARSSL_MD4_C
 
@@ -1747,8 +1770,16 @@
  *          library/pem.c
  *          library/ssl_tls.c
  *
- * This module is required for SSL/TLS and X.509.
- * PEM_PARSE uses MD5 for decrypting encrypted keys.
+ * This module is required for SSL/TLS up to version 1.1, and for TLS 1.2
+ * depending on the handshake parameters. Further, it is used for checking
+ * MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * encrypted keys.
+ *
+ * \warning  MD5 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 #define POLARSSL_MD5_C
 
@@ -2025,6 +2056,12 @@
  *          library/x509write_crt.c
  *
  * This module is required for SSL/TLS and SHA1-signed certificates.
+ *
+ * \warning  SHA-1 is considered a weak message digest and its use
+ *           constitutes a security risk. If possible, it is recommended
+ *           to avoid dependencies on it and to use a strong message
+ *           digest instead.
+ *
  */
 #define POLARSSL_SHA1_C
 

--- a/include/polarssl/des.h
+++ b/include/polarssl/des.h
@@ -21,9 +21,8 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning   DES is considered a weak cipher and its use
- *            constitutes a security risk. It is recommended
- *            alternative ciphers should be considered instead.
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  *
  */
 #ifndef POLARSSL_DES_H
@@ -62,9 +61,9 @@ extern "C" {
 /**
  * \brief          DES context structure
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 typedef struct
 {
@@ -88,9 +87,9 @@ des3_context;
  *
  * \param ctx      DES context to be initialized
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_init( des_context *ctx );
 
@@ -99,9 +98,9 @@ void des_init( des_context *ctx );
  *
  * \param ctx      DES context to be cleared
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_free( des_context *ctx );
 
@@ -127,9 +126,9 @@ void des3_free( des3_context *ctx );
  *
  * \param key      8-byte secret key
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
 
@@ -143,9 +142,9 @@ void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
  *
  * \return         0 is parity was ok, 1 if parity was not correct.
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
 
@@ -156,9 +155,9 @@ int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
  *
  * \return         0 if no weak key was found, 1 if a weak key was identified.
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
 
@@ -170,9 +169,9 @@ int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
  *
  * \return         0
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -184,9 +183,9 @@ int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
  *
  * \return         0
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_setkey_dec( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -243,9 +242,9 @@ int des3_set3key_dec( des3_context *ctx,
  *
  * \return         0 if successful
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_crypt_ecb( des_context *ctx,
                     const unsigned char input[8],
@@ -270,9 +269,9 @@ int des_crypt_ecb( des_context *ctx,
  * \param input    buffer holding the input data
  * \param output   buffer holding the output data
  *
- * \warning        DES is considered a weak cipher and its use
- *                 constitutes a security risk. It is recommended
- *                 alternative ciphers should be considered instead.
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_crypt_cbc( des_context *ctx,
                     int mode,

--- a/include/polarssl/des.h
+++ b/include/polarssl/des.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   DES is considered a weak cipher and its use
+ *            constitutes a security risk. It is recommended
+ *            alternative ciphers should be considered instead.
+ *
  */
 #ifndef POLARSSL_DES_H
 #define POLARSSL_DES_H
@@ -56,6 +61,10 @@ extern "C" {
 
 /**
  * \brief          DES context structure
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 typedef struct
 {
@@ -78,6 +87,10 @@ des3_context;
  * \brief          Initialize DES context
  *
  * \param ctx      DES context to be initialized
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void des_init( des_context *ctx );
 
@@ -85,6 +98,10 @@ void des_init( des_context *ctx );
  * \brief          Clear DES context
  *
  * \param ctx      DES context to be cleared
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void des_free( des_context *ctx );
 
@@ -109,6 +126,10 @@ void des3_free( des3_context *ctx );
  *                 a parity bit to allow verification.
  *
  * \param key      8-byte secret key
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
 
@@ -121,6 +142,10 @@ void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0 is parity was ok, 1 if parity was not correct.
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
 
@@ -130,6 +155,10 @@ int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0 if no weak key was found, 1 if a weak key was identified.
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
 
@@ -140,6 +169,10 @@ int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -150,6 +183,10 @@ int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_setkey_dec( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -205,6 +242,10 @@ int des3_set3key_dec( des3_context *ctx,
  * \param output   64-bit output block
  *
  * \return         0 if successful
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_crypt_ecb( des_context *ctx,
                     const unsigned char input[8],
@@ -228,6 +269,10 @@ int des_crypt_ecb( des_context *ctx,
  * \param iv       initialization vector (updated after use)
  * \param input    buffer holding the input data
  * \param output   buffer holding the output data
+ *
+ * \warning        DES is considered a weak cipher and its use
+ *                 constitutes a security risk. It is recommended
+ *                 alternative ciphers should be considered instead.
  */
 int des_crypt_cbc( des_context *ctx,
                     int mode,

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -45,9 +45,9 @@ extern "C" {
 /*
  * \brief     Enumeration of supported message digests
  *
- * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
- *            and their use constitutes a security risk. It is recommended
- *            alternative message digests should be considered instead.
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests and
+ *            their use constitutes a security risk. We recommend considering
+ *            stronger message digests instead.
  */
 typedef enum {
     POLARSSL_MD_NONE=0,

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -47,7 +47,7 @@ extern "C" {
  *
  * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
  *            and their use constitutes a security risk. It is recommended
- *            to use strong message digests instead.
+ *            alternative message digests should be considered instead.
  */
 typedef enum {
     POLARSSL_MD_NONE=0,

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -42,6 +42,13 @@
 extern "C" {
 #endif
 
+/*
+ * \brief     Enumeration of supported message digests
+ *
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests
+ *            and their use constitutes a security risk. It is recommended
+ *            to use strong message digests instead.
+ */
 typedef enum {
     POLARSSL_MD_NONE=0,
     POLARSSL_MD_MD2,

--- a/include/polarssl/md2.h
+++ b/include/polarssl/md2.h
@@ -21,9 +21,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
  *
  */
 #ifndef POLARSSL_MD2_H
@@ -51,8 +51,8 @@ extern "C" {
  * \brief          MD2 context structure
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -73,8 +73,8 @@ md2_context;
  * \param ctx      MD2 context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_init( md2_context *ctx );
@@ -85,8 +85,8 @@ void md2_init( md2_context *ctx );
  * \param ctx      MD2 context to be cleared
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_free( md2_context *ctx );
@@ -97,8 +97,8 @@ void md2_free( md2_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_starts( md2_context *ctx );
@@ -111,8 +111,8 @@ void md2_starts( md2_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
@@ -124,8 +124,8 @@ void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_finish( md2_context *ctx, unsigned char output[16] );
@@ -150,8 +150,8 @@ extern "C" {
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -165,8 +165,8 @@ void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD2_FILE_IO_ERROR
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md2_file( const char *path, unsigned char output[16] );
@@ -179,8 +179,8 @@ int md2_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
@@ -194,8 +194,8 @@ void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_hmac_update( md2_context *ctx, const unsigned char *input,
@@ -208,8 +208,8 @@ void md2_hmac_update( md2_context *ctx, const unsigned char *input,
  * \param output   MD2 HMAC checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
@@ -220,8 +220,8 @@ void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_hmac_reset( md2_context *ctx );
@@ -236,8 +236,8 @@ void md2_hmac_reset( md2_context *ctx );
  * \param output   HMAC-MD2 result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md2_hmac( const unsigned char *key, size_t keylen,
@@ -250,8 +250,8 @@ void md2_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md2_self_test( int verbose );

--- a/include/polarssl/md2.h
+++ b/include/polarssl/md2.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef POLARSSL_MD2_H
 #define POLARSSL_MD2_H
@@ -44,6 +49,11 @@ extern "C" {
 
 /**
  * \brief          MD2 context structure
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {
@@ -61,6 +71,11 @@ md2_context;
  * \brief          Initialize MD2 context
  *
  * \param ctx      MD2 context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_init( md2_context *ctx );
 
@@ -68,6 +83,11 @@ void md2_init( md2_context *ctx );
  * \brief          Clear MD2 context
  *
  * \param ctx      MD2 context to be cleared
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_free( md2_context *ctx );
 
@@ -75,6 +95,11 @@ void md2_free( md2_context *ctx );
  * \brief          MD2 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_starts( md2_context *ctx );
 
@@ -84,6 +109,11 @@ void md2_starts( md2_context *ctx );
  * \param ctx      MD2 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -92,6 +122,11 @@ void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD2 context
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_finish( md2_context *ctx, unsigned char output[16] );
 
@@ -113,6 +148,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -123,6 +163,11 @@ void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD2 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD2_FILE_IO_ERROR
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md2_file( const char *path, unsigned char output[16] );
 
@@ -132,6 +177,11 @@ int md2_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
                       size_t keylen );
@@ -142,6 +192,11 @@ void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_hmac_update( md2_context *ctx, const unsigned char *input,
                       size_t ilen );
@@ -151,6 +206,11 @@ void md2_hmac_update( md2_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   MD2 HMAC checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
 
@@ -158,6 +218,11 @@ void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
  * \brief          MD2 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_hmac_reset( md2_context *ctx );
 
@@ -169,6 +234,11 @@ void md2_hmac_reset( md2_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD2 result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md2_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -178,6 +248,11 @@ void md2_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md2_self_test( int verbose );
 

--- a/include/polarssl/md2.h
+++ b/include/polarssl/md2.h
@@ -22,8 +22,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef POLARSSL_MD2_H
@@ -51,8 +51,8 @@ extern "C" {
  * \brief          MD2 context structure
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -73,8 +73,8 @@ md2_context;
  * \param ctx      MD2 context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_init( md2_context *ctx );
@@ -85,8 +85,8 @@ void md2_init( md2_context *ctx );
  * \param ctx      MD2 context to be cleared
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_free( md2_context *ctx );
@@ -97,8 +97,8 @@ void md2_free( md2_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_starts( md2_context *ctx );
@@ -111,8 +111,8 @@ void md2_starts( md2_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
@@ -124,8 +124,8 @@ void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_finish( md2_context *ctx, unsigned char output[16] );
@@ -150,8 +150,8 @@ extern "C" {
  * \param output   MD2 checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -165,8 +165,8 @@ void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD2_FILE_IO_ERROR
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md2_file( const char *path, unsigned char output[16] );
@@ -179,8 +179,8 @@ int md2_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
@@ -194,8 +194,8 @@ void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_hmac_update( md2_context *ctx, const unsigned char *input,
@@ -208,8 +208,8 @@ void md2_hmac_update( md2_context *ctx, const unsigned char *input,
  * \param output   MD2 HMAC checksum result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
@@ -220,8 +220,8 @@ void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_hmac_reset( md2_context *ctx );
@@ -236,8 +236,8 @@ void md2_hmac_reset( md2_context *ctx );
  * \param output   HMAC-MD2 result
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md2_hmac( const unsigned char *key, size_t keylen,
@@ -250,8 +250,8 @@ void md2_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md2_self_test( int verbose );

--- a/include/polarssl/md4.h
+++ b/include/polarssl/md4.h
@@ -21,9 +21,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
  *
  */
 #ifndef POLARSSL_MD4_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          MD4 context structure
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ md4_context;
  * \param ctx      MD4 context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_init( md4_context *ctx );
@@ -91,8 +91,8 @@ void md4_init( md4_context *ctx );
  * \param ctx      MD4 context to be cleared
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_free( md4_context *ctx );
@@ -103,8 +103,8 @@ void md4_free( md4_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_starts( md4_context *ctx );
@@ -117,8 +117,8 @@ void md4_starts( md4_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_finish( md4_context *ctx, unsigned char output[16] );
@@ -156,8 +156,8 @@ extern "C" {
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -171,8 +171,8 @@ void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD4_FILE_IO_ERROR
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md4_file( const char *path, unsigned char output[16] );
@@ -185,8 +185,8 @@ int md4_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
@@ -200,8 +200,8 @@ void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_hmac_update( md4_context *ctx, const unsigned char *input,
@@ -214,8 +214,8 @@ void md4_hmac_update( md4_context *ctx, const unsigned char *input,
  * \param output   MD4 HMAC checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
@@ -226,8 +226,8 @@ void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_hmac_reset( md4_context *ctx );
@@ -242,8 +242,8 @@ void md4_hmac_reset( md4_context *ctx );
  * \param output   HMAC-MD4 result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md4_hmac( const unsigned char *key, size_t keylen,
@@ -256,8 +256,8 @@ void md4_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md4_self_test( int verbose );

--- a/include/polarssl/md4.h
+++ b/include/polarssl/md4.h
@@ -22,8 +22,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef POLARSSL_MD4_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          MD4 context structure
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ md4_context;
  * \param ctx      MD4 context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_init( md4_context *ctx );
@@ -91,8 +91,8 @@ void md4_init( md4_context *ctx );
  * \param ctx      MD4 context to be cleared
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_free( md4_context *ctx );
@@ -103,8 +103,8 @@ void md4_free( md4_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_starts( md4_context *ctx );
@@ -117,8 +117,8 @@ void md4_starts( md4_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_finish( md4_context *ctx, unsigned char output[16] );
@@ -156,8 +156,8 @@ extern "C" {
  * \param output   MD4 checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -171,8 +171,8 @@ void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD4_FILE_IO_ERROR
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md4_file( const char *path, unsigned char output[16] );
@@ -185,8 +185,8 @@ int md4_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
@@ -200,8 +200,8 @@ void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_hmac_update( md4_context *ctx, const unsigned char *input,
@@ -214,8 +214,8 @@ void md4_hmac_update( md4_context *ctx, const unsigned char *input,
  * \param output   MD4 HMAC checksum result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
@@ -226,8 +226,8 @@ void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_hmac_reset( md4_context *ctx );
@@ -242,8 +242,8 @@ void md4_hmac_reset( md4_context *ctx );
  * \param output   HMAC-MD4 result
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md4_hmac( const unsigned char *key, size_t keylen,
@@ -256,8 +256,8 @@ void md4_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md4_self_test( int verbose );

--- a/include/polarssl/md4.h
+++ b/include/polarssl/md4.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef POLARSSL_MD4_H
 #define POLARSSL_MD4_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          MD4 context structure
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ md4_context;
  * \brief          Initialize MD4 context
  *
  * \param ctx      MD4 context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_init( md4_context *ctx );
 
@@ -74,6 +89,11 @@ void md4_init( md4_context *ctx );
  * \brief          Clear MD4 context
  *
  * \param ctx      MD4 context to be cleared
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_free( md4_context *ctx );
 
@@ -90,6 +110,11 @@ void md4_starts( md4_context *ctx );
  * \param ctx      MD4 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +123,11 @@ void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD4 context
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_finish( md4_context *ctx, unsigned char output[16] );
 
@@ -119,6 +149,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -129,6 +164,11 @@ void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD4 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD4_FILE_IO_ERROR
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md4_file( const char *path, unsigned char output[16] );
 
@@ -138,6 +178,11 @@ int md4_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
                       size_t keylen );
@@ -148,6 +193,11 @@ void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_hmac_update( md4_context *ctx, const unsigned char *input,
                       size_t ilen );
@@ -157,6 +207,11 @@ void md4_hmac_update( md4_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   MD4 HMAC checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
 
@@ -164,6 +219,11 @@ void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
  * \brief          MD4 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_hmac_reset( md4_context *ctx );
 
@@ -175,6 +235,11 @@ void md4_hmac_reset( md4_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD4 result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -184,6 +249,11 @@ void md4_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md4_self_test( int verbose );
 

--- a/include/polarssl/md4.h
+++ b/include/polarssl/md4.h
@@ -101,6 +101,11 @@ void md4_free( md4_context *ctx );
  * \brief          MD4 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md4_starts( md4_context *ctx );
 

--- a/include/polarssl/md5.h
+++ b/include/polarssl/md5.h
@@ -21,9 +21,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
  *
  */
 #ifndef POLARSSL_MD5_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          MD5 context structure
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ md5_context;
  * \param ctx      MD5 context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_init( md5_context *ctx );
@@ -91,8 +91,8 @@ void md5_init( md5_context *ctx );
  * \param ctx      MD5 context to be cleared
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_free( md5_context *ctx );
@@ -103,8 +103,8 @@ void md5_free( md5_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_starts( md5_context *ctx );
@@ -117,8 +117,8 @@ void md5_starts( md5_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_finish( md5_context *ctx, unsigned char output[16] );
@@ -159,8 +159,8 @@ extern "C" {
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -174,8 +174,8 @@ void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD5_FILE_IO_ERROR
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md5_file( const char *path, unsigned char output[16] );
@@ -188,8 +188,8 @@ int md5_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_hmac_starts( md5_context *ctx,
@@ -203,8 +203,8 @@ void md5_hmac_starts( md5_context *ctx,
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_hmac_update( md5_context *ctx,
@@ -217,8 +217,8 @@ void md5_hmac_update( md5_context *ctx,
  * \param output   MD5 HMAC checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
@@ -229,8 +229,8 @@ void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_hmac_reset( md5_context *ctx );
@@ -245,8 +245,8 @@ void md5_hmac_reset( md5_context *ctx );
  * \param output   HMAC-MD5 result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void md5_hmac( const unsigned char *key, size_t keylen,
@@ -259,8 +259,8 @@ void md5_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int md5_self_test( int verbose );

--- a/include/polarssl/md5.h
+++ b/include/polarssl/md5.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef POLARSSL_MD5_H
 #define POLARSSL_MD5_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          MD5 context structure
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ md5_context;
  * \brief          Initialize MD5 context
  *
  * \param ctx      MD5 context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_init( md5_context *ctx );
 
@@ -74,6 +89,11 @@ void md5_init( md5_context *ctx );
  * \brief          Clear MD5 context
  *
  * \param ctx      MD5 context to be cleared
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_free( md5_context *ctx );
 
@@ -81,6 +101,11 @@ void md5_free( md5_context *ctx );
  * \brief          MD5 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_starts( md5_context *ctx );
 
@@ -90,6 +115,11 @@ void md5_starts( md5_context *ctx );
  * \param ctx      MD5 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +128,11 @@ void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD5 context
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_finish( md5_context *ctx, unsigned char output[16] );
 
@@ -122,6 +157,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -132,6 +172,11 @@ void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD5 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD5_FILE_IO_ERROR
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md5_file( const char *path, unsigned char output[16] );
 
@@ -141,6 +186,11 @@ int md5_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_hmac_starts( md5_context *ctx,
                       const unsigned char *key, size_t keylen );
@@ -151,6 +201,11 @@ void md5_hmac_starts( md5_context *ctx,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_hmac_update( md5_context *ctx,
                       const unsigned char *input, size_t ilen );
@@ -160,6 +215,11 @@ void md5_hmac_update( md5_context *ctx,
  *
  * \param ctx      HMAC context
  * \param output   MD5 HMAC checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
 
@@ -178,6 +238,11 @@ void md5_hmac_reset( md5_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD5 result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -187,6 +252,11 @@ void md5_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int md5_self_test( int verbose );
 

--- a/include/polarssl/md5.h
+++ b/include/polarssl/md5.h
@@ -22,8 +22,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef POLARSSL_MD5_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          MD5 context structure
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ md5_context;
  * \param ctx      MD5 context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_init( md5_context *ctx );
@@ -91,8 +91,8 @@ void md5_init( md5_context *ctx );
  * \param ctx      MD5 context to be cleared
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_free( md5_context *ctx );
@@ -103,8 +103,8 @@ void md5_free( md5_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_starts( md5_context *ctx );
@@ -117,8 +117,8 @@ void md5_starts( md5_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_finish( md5_context *ctx, unsigned char output[16] );
@@ -159,8 +159,8 @@ extern "C" {
  * \param output   MD5 checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
@@ -174,8 +174,8 @@ void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \return         0 if successful, or POLARSSL_ERR_MD5_FILE_IO_ERROR
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md5_file( const char *path, unsigned char output[16] );
@@ -188,8 +188,8 @@ int md5_file( const char *path, unsigned char output[16] );
  * \param keylen   length of the HMAC key
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_hmac_starts( md5_context *ctx,
@@ -203,8 +203,8 @@ void md5_hmac_starts( md5_context *ctx,
  * \param ilen     length of the input data
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_hmac_update( md5_context *ctx,
@@ -217,8 +217,8 @@ void md5_hmac_update( md5_context *ctx,
  * \param output   MD5 HMAC checksum result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
@@ -229,8 +229,8 @@ void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_hmac_reset( md5_context *ctx );
@@ -245,8 +245,8 @@ void md5_hmac_reset( md5_context *ctx );
  * \param output   HMAC-MD5 result
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void md5_hmac( const unsigned char *key, size_t keylen,
@@ -259,8 +259,8 @@ void md5_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int md5_self_test( int verbose );

--- a/include/polarssl/md5.h
+++ b/include/polarssl/md5.h
@@ -227,6 +227,11 @@ void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
  * \brief          MD5 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void md5_hmac_reset( md5_context *ctx );
 

--- a/include/polarssl/sha1.h
+++ b/include/polarssl/sha1.h
@@ -21,9 +21,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. We recommend considering stronger message
+ *            digests instead.
  *
  */
 #ifndef POLARSSL_SHA1_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          SHA-1 context structure
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ sha1_context;
  * \param ctx      SHA-1 context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_init( sha1_context *ctx );
@@ -91,8 +91,8 @@ void sha1_init( sha1_context *ctx );
  * \param ctx      SHA-1 context to be cleared
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_free( sha1_context *ctx );
@@ -103,8 +103,8 @@ void sha1_free( sha1_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_starts( sha1_context *ctx );
@@ -117,8 +117,8 @@ void sha1_starts( sha1_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_finish( sha1_context *ctx, unsigned char output[20] );
@@ -159,8 +159,8 @@ extern "C" {
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
@@ -174,8 +174,8 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
  * \return         0 if successful, or POLARSSL_ERR_SHA1_FILE_IO_ERROR
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int sha1_file( const char *path, unsigned char output[20] );
@@ -188,8 +188,8 @@ int sha1_file( const char *path, unsigned char output[20] );
  * \param keylen   length of the HMAC key
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
@@ -203,8 +203,8 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
@@ -217,8 +217,8 @@ void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
  * \param output   SHA-1 HMAC checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
@@ -229,8 +229,8 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_hmac_reset( sha1_context *ctx );
@@ -245,8 +245,8 @@ void sha1_hmac_reset( sha1_context *ctx );
  * \param output   HMAC-SHA-1 result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 void sha1_hmac( const unsigned char *key, size_t keylen,
@@ -259,8 +259,8 @@ void sha1_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended alternative
- *                 message digests should be considered instead.
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
  *
  */
 int sha1_self_test( int verbose );

--- a/include/polarssl/sha1.h
+++ b/include/polarssl/sha1.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 #ifndef POLARSSL_SHA1_H
 #define POLARSSL_SHA1_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          SHA-1 context structure
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ sha1_context;
  * \brief          Initialize SHA-1 context
  *
  * \param ctx      SHA-1 context to be initialized
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_init( sha1_context *ctx );
 
@@ -74,6 +89,11 @@ void sha1_init( sha1_context *ctx );
  * \brief          Clear SHA-1 context
  *
  * \param ctx      SHA-1 context to be cleared
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_free( sha1_context *ctx );
 
@@ -81,6 +101,11 @@ void sha1_free( sha1_context *ctx );
  * \brief          SHA-1 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_starts( sha1_context *ctx );
 
@@ -90,6 +115,11 @@ void sha1_starts( sha1_context *ctx );
  * \param ctx      SHA-1 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +128,11 @@ void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      SHA-1 context
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_finish( sha1_context *ctx, unsigned char output[20] );
 
@@ -122,6 +157,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
 
@@ -132,6 +172,11 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
  * \param output   SHA-1 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_SHA1_FILE_IO_ERROR
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int sha1_file( const char *path, unsigned char output[20] );
 
@@ -141,6 +186,11 @@ int sha1_file( const char *path, unsigned char output[20] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
                        size_t keylen );
@@ -151,6 +201,11 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
                        size_t ilen );
@@ -160,6 +215,11 @@ void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   SHA-1 HMAC checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
 
@@ -167,6 +227,11 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
  * \brief          SHA-1 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_hmac_reset( sha1_context *ctx );
 
@@ -178,6 +243,11 @@ void sha1_hmac_reset( sha1_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-SHA-1 result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 void sha1_hmac( const unsigned char *key, size_t keylen,
                 const unsigned char *input, size_t ilen,
@@ -187,6 +257,11 @@ void sha1_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. It is recommended
+ *                 to use a strong message digest instead.
+ *
  */
 int sha1_self_test( int verbose );
 

--- a/include/polarssl/sha1.h
+++ b/include/polarssl/sha1.h
@@ -22,8 +22,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 #ifndef POLARSSL_SHA1_H
@@ -58,8 +58,8 @@ extern "C" {
  * \brief          SHA-1 context structure
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 typedef struct
@@ -79,8 +79,8 @@ sha1_context;
  * \param ctx      SHA-1 context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_init( sha1_context *ctx );
@@ -91,8 +91,8 @@ void sha1_init( sha1_context *ctx );
  * \param ctx      SHA-1 context to be cleared
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_free( sha1_context *ctx );
@@ -103,8 +103,8 @@ void sha1_free( sha1_context *ctx );
  * \param ctx      context to be initialized
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_starts( sha1_context *ctx );
@@ -117,8 +117,8 @@ void sha1_starts( sha1_context *ctx );
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
@@ -130,8 +130,8 @@ void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_finish( sha1_context *ctx, unsigned char output[20] );
@@ -159,8 +159,8 @@ extern "C" {
  * \param output   SHA-1 checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
@@ -174,8 +174,8 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
  * \return         0 if successful, or POLARSSL_ERR_SHA1_FILE_IO_ERROR
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int sha1_file( const char *path, unsigned char output[20] );
@@ -188,8 +188,8 @@ int sha1_file( const char *path, unsigned char output[20] );
  * \param keylen   length of the HMAC key
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
@@ -203,8 +203,8 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
  * \param ilen     length of the input data
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
@@ -217,8 +217,8 @@ void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
  * \param output   SHA-1 HMAC checksum result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
@@ -229,8 +229,8 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
  * \param ctx      HMAC context to be reset
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_hmac_reset( sha1_context *ctx );
@@ -245,8 +245,8 @@ void sha1_hmac_reset( sha1_context *ctx );
  * \param output   HMAC-SHA-1 result
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 void sha1_hmac( const unsigned char *key, size_t keylen,
@@ -259,8 +259,8 @@ void sha1_hmac( const unsigned char *key, size_t keylen,
  * \return         0 if successful, or 1 if the test failed
  *
  * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. It is recommended
- *                 to use a strong message digest instead.
+ *                 constitutes a security risk. It is recommended alternative
+ *                 message digests should be considered instead.
  *
  */
 int sha1_self_test( int verbose );

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -155,7 +155,7 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
         my @res = $test_data =~ /^$mapping_regex/msg;
         foreach my $value (@res)
         {
-            next unless ($value !~ /^\d+$/);
+            next unless ($value !~ /^[+-]?\d*$/);
             if ( $mapping_values{$value} ) {
                 ${ $mapping_values{$value} }{$function_pre_code} = 1;
             } else {

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -152,14 +152,28 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
     # Find non-integer values we should map for this function
     if( $mapping_count)
     {
-        my @res = $test_data =~ /^$mapping_regex/msg;
+        my @res = $test_data =~ /^((?:depends_on:[\w:]+)?)\n?$mapping_regex/msg;
+        my $local_deps      = $function_deps;
+        my $local_pre_code  = $function_pre_code;
         foreach my $value (@res)
         {
+            # Check if we're at the beginning of a test case and
+            # need to update the local dependencies
+            if( $value =~ /^depends_on:/)
+            {
+                $local_pre_code  = $function_pre_code;
+                ( $local_deps ) = $value =~ /^depends_on:(.*)$/;
+                foreach my $req (split(/:/, $local_deps))
+                {
+                    $local_pre_code  .= "#ifdef $req\n";
+                }
+                next;
+            }
             next unless ($value !~ /^[+-]?\d*$/);
             if ( $mapping_values{$value} ) {
-                ${ $mapping_values{$value} }{$function_pre_code} = 1;
+                ${ $mapping_values{$value} }{$local_pre_code} = 1;
             } else {
-                $mapping_values{$value} = { $function_pre_code => 1 };
+                $mapping_values{$value} = { $local_pre_code => 1 };
             }
         }
     }

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -118,8 +118,8 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
 
     foreach my $req (split(/:/, $function_deps))
     {
-        $function_pre_code .= "#ifdef $req\n";
-        $function_post_code .= "#endif /* $req */\n";
+        $function_pre_code  .= "#ifdef $req\n";
+        $function_post_code = "#endif /* $req */\n" . $function_post_code;
     }
 
     foreach my $def (@var_def_arr)
@@ -228,13 +228,16 @@ while( my ($key, $value) = each(%mapping_values) )
     }
 END
 
-    # handle depenencies, unless used at least one without depends
+    # Unless the identifier is used at least once without
+    # dependencies, add a mapping for each occurrence, guarded
+    # by the respective dependency.
     if ($value->{""}) {
         $mapping_code .= $key_mapping_code;
         next;
     }
     for my $ifdef ( keys %$value ) {
         (my $endif = $ifdef) =~ s!ifdef!endif //!g;
+        $endif = join("", reverse(split(/^/m, $endif)));
         $mapping_code .= $ifdef . $key_mapping_code . $endif;
     }
 }

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -68,6 +68,11 @@ int verify_int( char *str, int *value )
             continue;
         }
 
+        if( i == 0 && str[i] == '+' )
+        {
+            continue;
+        }
+
         if( ( ( minus && i == 2 ) || ( !minus && i == 1 ) ) &&
             str[i - 1] == '0' && str[i] == 'x' )
         {


### PR DESCRIPTION
__Summary:__ This is the backport of #1100 to Mbed TLS 1.3.

__Internal Reference:__ IOTSSL-1754