### PR TITLE
Parse Signature Algorithm extension when renegotiating

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Bugfix
    * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.
      Found by projectgus and jethrogb, #836.
    * Fix usage help in ssl_server2 example. Found and fixed by Bei Lin.
+   * Parse signature algorithm extension when renegotiating.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,9 @@ Bugfix
    * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.
      Found by projectgus and jethrogb, #836.
    * Fix usage help in ssl_server2 example. Found and fixed by Bei Lin.
-   * Parse signature algorithm extension when renegotiating.
+   * Parse signature algorithm extension when renegotiating. Previously,
+     renegotiating handshakes would only accept signatures using SHA-1,
+     or fail if the latter was disabled.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1694,11 +1694,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
     defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
             case MBEDTLS_TLS_EXT_SIG_ALG:
-                    MBEDTLS_SSL_DEBUG_MSG( 3, ( "found signature_algorithms extension" ) );
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-                if( ssl->renego_status == MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS )
-                    break;
-#endif
+                MBEDTLS_SSL_DEBUG_MSG( 3, ( "found signature_algorithms extension" ) );
+
                 ret = ssl_parse_signature_algorithms_ext( ssl, ext + 4, ext_size );
                 if( ret != 0 )
                     return( ret );


### PR DESCRIPTION
## Description
signature algorithm extension was skipped when renegotiation was in progress,
Causing the signature algorithm not to be known when renegotiating, and
failing the handshake. Fix removes the renegotiation step check
before parsing the extension

## Status
**READY**

## Requires Backporting

Yes 
Which branch?
mbedtls-2.1
mbedtls-1.3


## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported
