### PR TITLE
Fixes to config.pl get

### DIFF
--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -205,7 +205,7 @@ for my $line (@config_lines) {
             $done = 1;
         }
     } elsif (!$done && $action eq "get") {
-        if ($line =~ /^\s*#define\s*$name\s*([^\s]+)\s*\b/) {
+        if ($line =~ /^\s*#define\s*$name(?:\s+(.*?))\s*(?:$|\/\*|\/\/)/) {
             $value = $1;
             $done = 1;
         }

--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -175,7 +175,10 @@ if ($action eq "realfull") {
     $no_exclude_re = join '|', @non_excluded;
 }
 
-open my $config_write, '>', $config_file or die "write $config_file: $!\n";
+my $config_write = undef;
+if ($action ne "get") {
+    open $config_write, '>', $config_file or die "write $config_file: $!\n";
+}
 
 my $done;
 for my $line (@config_lines) {
@@ -211,7 +214,9 @@ for my $line (@config_lines) {
         }
     }
 
-    print $config_write $line;
+    if (defined $config_write) {
+        print $config_write $line or die "write $config_file: $!\n";;
+    }
 }
 
 # Did the set command work?
@@ -223,10 +228,12 @@ if ($action eq "set"&& $force_option && !$done) {
     $line .= "\n";
     $done = 1;
 
-    print $config_write $line;
+    print $config_write $line or die "write $config_file: $!\n";
 }
 
-close $config_write;
+if (defined $config_write) {
+    close $config_write or die "close $config_file: $!\n";
+}
 
 if ($action eq "get") {
     if($done) {

--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -215,7 +215,7 @@ for my $line (@config_lines) {
     }
 
     if (defined $config_write) {
-        print $config_write $line or die "write $config_file: $!\n";;
+        print $config_write $line or die "write $config_file: $!\n";
     }
 }
 

--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -56,7 +56,7 @@ Commands
     unset <symbol>          - Comments out the #define for the given symbol if
                               present in the configuration file.
     get <symbol>            - Finds the #define for the given symbol, returning
-                              an exitcode of 0 if the symbol is found, and -1 if
+                              an exitcode of 0 if the symbol is found, and 1 if
                               not. The value of the symbol is output if one is
                               specified in the configuration file.
     full                    - Uncomments all #define's in the configuration file
@@ -220,7 +220,7 @@ for my $line (@config_lines) {
 }
 
 # Did the set command work?
-if ($action eq "set"&& $force_option && !$done) {
+if ($action eq "set" && $force_option && !$done) {
 
     # If the force option was set, append the symbol to the end of the file
     my $line = "#define $name";
@@ -236,14 +236,14 @@ if (defined $config_write) {
 }
 
 if ($action eq "get") {
-    if($done) {
+    if ($done) {
         if ($value ne '') {
-            print $value;
+            print "$value\n";
         }
         exit 0;
     } else {
         # If the symbol was not found, return an error
-        exit -1;
+        exit 1;
     }
 }
 


### PR DESCRIPTION
A few small fixes to `scripts/config.pl`, mostly for the `get` command.

* Fixed the case of `get` on a macro with an empty value, which broke between 2.5.0 and 2.6.0. With our scripts, the only consequence is that the warning for `MBEDTLS_TEST_NULL_ENTROPY` displayed at the end of `make all` would never be triggered.
* Don't rewrite `config.h` for the `get` command. (Having it modified every time I run `make all` was annoying me.)
* Be more mainstream: print a newline at the end of a line; return 1 for “not found” rather than -1.
* Die on write errors.
