### PR TITLE
Change generate_errors.pl to call perl grep

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -50,7 +50,7 @@ my @files = <$include_dir/*.h>;
 my @matches;
 foreach my $file (@files) {
     open(FILE, "$file");
-    my @grep_res = grep(/define MBEDTLS_ERR_/, <FILE>);
+    my @grep_res = grep(/^\s*#define\s+MBEDTLS_ERR_\w+\s+\-0x[0-9A-Fa-f]+/, <FILE>);
     push(@matches, @grep_res);
     close FILE;
 }

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -46,7 +46,7 @@ close(FORMAT_FILE);
 
 $/ = $line_separator;
 
-my @files = <$include_dir/*>;
+my @files = <$include_dir/*.h>;
 my @matches;
 foreach my $file (@files) {
     open(FILE, "$file");

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -46,7 +46,14 @@ close(FORMAT_FILE);
 
 $/ = $line_separator;
 
-open(GREP, "grep \"define MBEDTLS_ERR_\" $include_dir/* |") || die("Failure when calling grep: $!");
+my @files = <$include_dir/*>;
+my @matches;
+foreach my $file (@files) {
+    open(FILE, "$file");
+    my @grep_res = grep(/define MBEDTLS_ERR_/, <FILE>);
+    push(@matches, @grep_res);
+    close FILE;
+}
 
 my $ll_old_define = "";
 my $hl_old_define = "";
@@ -58,7 +65,8 @@ my $headers = "";
 
 my %error_codes_seen;
 
-while (my $line = <GREP>)
+
+foreach my $line (@matches)
 {
     next if ($line =~ /compat-1.2.h/);
     my ($error_name, $error_code) = $line =~ /(MBEDTLS_ERR_\w+)\s+\-(0x\w+)/;


### PR DESCRIPTION
Change the script generate_errors.pl to call the grep function in Perl
instead of calling the external tool grep directly as this causes
problems when ANSI escape sequences are included in the grep output
string.

This PR fixes https://github.com/ARMmbed/mbedtls/issues/504 and #1057

## Status
READY

## Requires Backporting
The problem is also present in mbedtls-2.1 (see https://github.com/armmbed/mbedtls/blob/mbedtls-2.1/scripts/generate_errors.pl#L49), but this is only a change in one of the tool scripts, so I do not think we should backport it. However, I am happy to do so if necessary.

## Todos
- [n/a] Tests
- [n/a] Documentation
- [n/a] Changelog updated
- [?] Backported (maybe)

## Steps to test or reproduce
Refer to original issue https://github.com/ARMmbed/mbedtls/issues/504
