### PR TITLE
Backport 1.3: Memory leak in example programs pk_encrypt and pk_decrypt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ Bugfix
    * Parse signature algorithm extension when renegotiating. Previously,
      renegotiated handshakes would only accept signatures using SHA-1
      regardless of the peer's preferences, or fail if SHA-1 was disabled.
+   * Fix memory leak and free without initialization in pk_encrypt
+     and pk_decrypt example programs. Reported by Brace Stout. Fixes #1128.
 
 = mbed TLS 1.3.21 branch released 2017-08-10
 

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -150,8 +150,8 @@ int main( int argc, char *argv[] )
 
 exit:
     pk_free( &pk );
-    ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
+    ctr_drbg_free( &ctr_drbg );
 
 #if defined(POLARSSL_ERROR_C)
     if( ret != 0 )

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -78,32 +78,35 @@ int main( int argc, char *argv[] )
         polarssl_printf( "usage: pk_decrypt <key_file>\n" );
 
 #if defined(_WIN32)
-        polarssl_printf( "\n" );
+        polarssl_printf( "\n  + Press Enter to exit this program.\n" );
+        fflush( stdout ); getchar();
 #endif
 
-        goto exit;
+        return( 1 );
     }
+
+    pk_init( &pk );
+    entropy_init( &entropy );
 
     polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
-    entropy_init( &entropy );
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n",
+                         ret );
         goto exit;
     }
 
     polarssl_printf( "\n  . Reading private key from '%s'", argv[1] );
     fflush( stdout );
 
-    pk_init( &pk );
-
     if( ( ret = pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! pk_parse_keyfile returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_parse_keyfile returned -0x%04x\n",
+                         -ret );
         goto exit;
     }
 
@@ -118,11 +121,11 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    i = 0;
-
-    while( fscanf( f, "%02X", &c ) > 0 &&
-           i < (int) sizeof( buf ) )
-        buf[i++] = (unsigned char) c;
+    for( i = 0; fscanf( f, "%02X", &c ) > 0 &&
+                i < (int) sizeof( buf ); i++ )
+    {
+        buf[i] = (unsigned char) c;
+    }
 
     fclose( f );
 
@@ -132,26 +135,30 @@ int main( int argc, char *argv[] )
     polarssl_printf( "\n  . Decrypting the encrypted data" );
     fflush( stdout );
 
-    if( ( ret = pk_decrypt( &pk, buf, i, result, &olen, sizeof(result),
+    if( ( ret = pk_decrypt( &pk, buf, i, result, &olen, sizeof( result ),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! pk_decrypt returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_decrypt returned -0x%04x\n",
+                         -ret );
         goto exit;
     }
 
     polarssl_printf( "\n  . OK\n\n" );
 
     polarssl_printf( "The decrypted result is: '%s'\n\n", result );
-
     ret = 0;
 
 exit:
+    pk_free( &pk );
     ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    polarssl_printf( "  !  Last error was: %s\n", buf );
+    if( ret != 0 )
+    {
+        polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
+        polarssl_printf( "  !  Last error was: %s\n", buf );
+    }
 #endif
 
 #if defined(_WIN32)

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -155,8 +155,8 @@ int main( int argc, char *argv[] )
 exit:
 
     pk_free( &pk );
-    ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
+    ctr_drbg_free( &ctr_drbg );
 
 #if defined(POLARSSL_ERROR_C)
     if( ret != 0 )

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -76,32 +76,35 @@ int main( int argc, char *argv[] )
         polarssl_printf( "usage: pk_encrypt <key_file> <string of max 100 characters>\n" );
 
 #if defined(_WIN32)
-        polarssl_printf( "\n" );
+        polarssl_printf( "\n  + Press Enter to exit this program.\n" );
+        fflush( stdout ); getchar();
 #endif
 
-        goto exit;
+        return( 1 );
     }
+
+    entropy_init( &entropy );
+    pk_init( &pk );
 
     polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
-    entropy_init( &entropy );
-    if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
-                               (const unsigned char *) pers,
+    if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func,
+                               &entropy, (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! ctr_drbg_init returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_seed returned -0x%04x\n",
+                        -ret );
         goto exit;
     }
 
     polarssl_printf( "\n  . Reading public key from '%s'", argv[1] );
     fflush( stdout );
 
-    pk_init( &pk );
-
     if( ( ret = pk_parse_public_keyfile( &pk, argv[1] ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! pk_parse_public_keyfile returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_parse_public_keyfile returned "
+                         "-0x%04x\n", -ret );
         goto exit;
     }
 
@@ -123,7 +126,8 @@ int main( int argc, char *argv[] )
                             buf, &olen, sizeof(buf),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        polarssl_printf( " failed\n  ! pk_encrypt returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_encrypt returned -0x%04x\n",
+                         -ret );
         goto exit;
     }
 
@@ -133,25 +137,33 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( "result-enc.txt", "wb+" ) ) == NULL )
     {
         ret = 1;
-        polarssl_printf( " failed\n  ! Could not create %s\n\n", "result-enc.txt" );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n",
+                         "result-enc.txt" );
         goto exit;
     }
 
     for( i = 0; i < olen; i++ )
+    {
         polarssl_fprintf( f, "%02X%s", buf[i],
-                 ( i + 1 ) % 16 == 0 ? "\r\n" : " " );
+                         ( i + 1 ) % 16 == 0 ? "\r\n" : " " );
+    }
 
     fclose( f );
 
     polarssl_printf( "\n  . Done (created \"%s\")\n\n", "result-enc.txt" );
 
 exit:
+
+    pk_free( &pk );
     ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
 
 #if defined(POLARSSL_ERROR_C)
-    polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    polarssl_printf( "  !  Last error was: %s\n", buf );
+    if( ret != 0 )
+    {
+        polarssl_strerror( ret, (char *) buf, sizeof( buf ) );
+        polarssl_printf( "  !  Last error was: %s\n", buf );
+    }
 #endif
 
 #if defined(_WIN32)


### PR DESCRIPTION
This is the backport of #1129 to Mbed TLS 1.3. It's slighly different from the head and the 2.1 backport because there is no separation of `ctr_drbg_init` and `ctr_drbg_seed` in 1.3.