### PR TITLE
Fix for returning correct error code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Bugfix
    * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
      dates on leap years with 100 and 400 intervals are handled correctly. Found
      by Nicholas Wilson. #694
+   * Fix overriding and ignoring return values when parsing and writing to
+     a file in pk_sign program. Found by kevlut in #1142.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -168,7 +168,7 @@ exit:
     fflush( stdout ); getchar();
 #endif
 
-    return( ret );
+    return( ret ? EXIT_FAILURE : EXIT_SUCCESS );
 }
 #endif /* MBEDTLS_BIGNUM_C && MBEDTLS_ENTROPY_C &&
           MBEDTLS_SHA256_C && MBEDTLS_PK_PARSE_C && MBEDTLS_FS_IO &&

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -29,6 +29,7 @@
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
+#include <stdlib.h>
 #define mbedtls_snprintf   snprintf
 #define mbedtls_printf     printf
 #endif

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -140,6 +140,7 @@ int main( int argc, char *argv[] )
 
     if( fwrite( buf, 1, olen, f ) != olen )
     {
+        ret = 1;
         mbedtls_printf( "failed\n  ! fwrite failed\n\n" );
         fclose( f );
         goto exit;

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -100,7 +100,7 @@ int main( int argc, char *argv[] )
 
     if( ( ret = mbedtls_pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! Could not open '%s'\n", argv[1] );
+        mbedtls_printf( " failed\n  ! Could not parse '%s'\n", argv[1] );
         goto exit;
     }
 
@@ -133,6 +133,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {
+        ret = 1;
         mbedtls_printf( " failed\n  ! Could not create %s\n\n", filename );
         goto exit;
     }

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -100,7 +100,6 @@ int main( int argc, char *argv[] )
 
     if( ( ret = mbedtls_pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
-        ret = 1;
         mbedtls_printf( " failed\n  ! Could not open '%s'\n", argv[1] );
         goto exit;
     }
@@ -134,7 +133,6 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {
-        ret = 1;
         mbedtls_printf( " failed\n  ! Could not create %s\n\n", filename );
         goto exit;
     }


### PR DESCRIPTION
## Description
I was receiving "!  Last error was: UNKNOWN ERROR CODE (0001)" during builds.  Looking into it, I found that the return value `ret` is being suppressed by writing 1 to it, causing it to be an unknown error code.  This is not helpful. 

By not overwriting the value of `ret`, the tool should now provide better feedback to developers running into issues.

## Status
READY/IN DEVELOPMENT/**HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Provide `mbedtls_pk_parse_keyfile` and invalid DER key file.