### PR TITLE
Fix crash when calling `mbedtls_ssl_cache_free` twice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ Bugfix
    * Parse signature algorithm extension when renegotiating. Previously,
      renegotiated handshakes would only accept signatures using SHA-1
      regardless of the peer's preferences, or fail if SHA-1 was disabled.
+   * Fix crash when calling mbedtls_ssl_cache_free() twice. Found by
+     MilenkoMitrovic, #1104
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -43,6 +43,11 @@
 
 #include <string.h>
 
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
@@ -321,6 +326,8 @@ void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache )
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &cache->mutex );
 #endif
+
+    mbedtls_zeroize( cache, sizeof(mbedtls_ssl_cache_context) );
 }
 
 #endif /* MBEDTLS_SSL_CACHE_C */

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -43,11 +43,6 @@
 
 #include <string.h>
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
-
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
@@ -326,8 +321,7 @@ void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache )
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &cache->mutex );
 #endif
-
-    mbedtls_zeroize( cache, sizeof(mbedtls_ssl_cache_context) );
+    cache->chain = NULL;
 }
 
 #endif /* MBEDTLS_SSL_CACHE_C */


### PR DESCRIPTION
## Description
Set `cache` to zero at the end of `mbedtls_ssl_cache_free` 
fixes #1104


## Status
**READY**

## Requires Backporting

Yes 
Which branch?
mbedtls-2.1
mbedtls-1.3


## Steps to test or reproduce
call ``mbedtls_ssl_cache_free` when session has been set to the chain
