### PR TITLE
Backport 2.1: Wrong identifier used to check Encrypt-then-MAC flag

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1941,7 +1941,7 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
     const mbedtls_ssl_ciphersuite_t *suite = NULL;
     const mbedtls_cipher_info_t *cipher = NULL;
 
-    if( ssl->session_negotiate->encrypt_then_mac == MBEDTLS_SSL_EXTENDED_MS_DISABLED ||
+    if( ssl->session_negotiate->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED ||
         ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
     {
         *olen = 0;


### PR DESCRIPTION
This is the backport of #1150 to Mbed TLS 2.1.