### PR TITLE
Backport 1.3: Wrong identifier used to check Encrypt-then-MAC flag

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1963,7 +1963,7 @@ static void ssl_write_encrypt_then_mac_ext( ssl_context *ssl,
     const ssl_ciphersuite_t *suite = NULL;
     const cipher_info_t *cipher = NULL;
 
-    if( ssl->session_negotiate->encrypt_then_mac == SSL_EXTENDED_MS_DISABLED ||
+    if( ssl->session_negotiate->encrypt_then_mac == SSL_ETM_DISABLED ||
         ssl->minor_ver == SSL_MINOR_VERSION_0 )
     {
         *olen = 0;


### PR DESCRIPTION
This is the backport of #1150 to Mbed TLS 1.3.