### PR TITLE
Backport 1.3: Correctly handle handshake messages in ssl_read if renegotiation is disabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Bugfix
    * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
      dates on leap years with 100 and 400 intervals are handled correctly. Found
      by Nicholas Wilson. #694
+   * Fix handling of handshake messages in ssl_read in case
+     POLARSSL_SSL_DISABLE_RENEGOTIATION is set. Found by erja-gp.
 
 = mbed TLS 1.3.21 branch released 2017-08-10
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4755,7 +4755,6 @@ int ssl_read( ssl_context *ssl, unsigned char *buf, size_t len )
             }
         }
 
-#if defined(POLARSSL_SSL_RENEGOTIATION)
         if( ssl->in_msgtype == SSL_MSG_HANDSHAKE )
         {
             SSL_DEBUG_MSG( 1, ( "received handshake message" ) );
@@ -4770,6 +4769,7 @@ int ssl_read( ssl_context *ssl, unsigned char *buf, size_t len )
             }
 #endif
 
+#if defined(POLARSSL_SSL_RENEGOTIATION)
             if( ! ( ssl->disable_renegotiation == SSL_RENEGOTIATION_DISABLED ||
                     ( ssl->secure_renegotiation == SSL_LEGACY_RENEGOTIATION &&
                       ssl->allow_legacy_renegotiation ==
@@ -4784,6 +4784,7 @@ int ssl_read( ssl_context *ssl, unsigned char *buf, size_t len )
                 }
             }
             else
+#endif /* POLARSSL_SSL_RENEGOTIATION */
             {
                 SSL_DEBUG_MSG( 3, ( "ignoring renegotiation, sending alert" ) );
 
@@ -4820,6 +4821,7 @@ int ssl_read( ssl_context *ssl, unsigned char *buf, size_t len )
 
             return( POLARSSL_ERR_NET_WANT_READ );
         }
+#if defined(POLARSSL_SSL_RENEGOTIATION)
         else if( ssl->renegotiation == SSL_RENEGOTIATION_PENDING )
         {
             ssl->renego_records_seen++;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -259,6 +259,19 @@ OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
 msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
 tests/ssl-opt.sh
 
+msg "build: Default + POLARSSL_SSL_DISABLE_RENEGOTIATION (ASan build)" # ~ 6 min
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set POLARSSL_SSL_DISABLE_RENEGOTIATION
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: POLARSSL_SSL_DISABLE_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
+make test
+
+msg "test: POLARSSL_SSL_DISABLE_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
+tests/ssl-opt.sh
+
 msg "build: cmake, full config, clang" # ~ 50s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -75,6 +75,13 @@ requires_config_enabled() {
     fi
 }
 
+# skip next test if the flag is enabled in config.h
+requires_config_disabled() {
+    if grep "^#define $1" $CONFIG_H > /dev/null; then
+        SKIP_NEXT="YES"
+    fi
+}
+
 # skip next test if OpenSSL can't send SSLv2 ClientHello
 requires_openssl_with_sslv2() {
     if [ -z "${OPENSSL_HAS_SSL2:-}" ]; then
@@ -1073,6 +1080,7 @@ run_test    "Renegotiation: none, for reference" \
             -S "=> renegotiate" \
             -S "write hello request"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: client-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
@@ -1086,6 +1094,7 @@ run_test    "Renegotiation: client-initiated" \
             -s "=> renegotiate" \
             -S "write hello request"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1" \
@@ -1102,6 +1111,7 @@ run_test    "Renegotiation: server-initiated" \
 # Checks that no Signature Algorithm with SHA-1 gets negotiated. Negotiating SHA-1 would mean that
 # the server did not parse the Signature Algorithm extension. This test is valid only if an MD
 # algorithm stronger than SHA-1 is enabled in config.h
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: Signature Algorithms parsing, client-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 auth_mode=optional" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
@@ -1119,6 +1129,7 @@ run_test    "Renegotiation: Signature Algorithms parsing, client-initiated" \
 # Checks that no Signature Algorithm with SHA-1 gets negotiated. Negotiating SHA-1 would mean that
 # the server did not parse the Signature Algorithm extension. This test is valid only if an MD
 # algorithm stronger than SHA-1 is enabled in config.h
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: Signature Algorithms parsing, server-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 auth_mode=optional renegotiate=1" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1" \
@@ -1133,6 +1144,7 @@ run_test    "Renegotiation: Signature Algorithms parsing, server-initiated" \
             -s "write hello request" \
             -S "client hello v3, signature_algorithm ext: 2" # Is SHA-1 negotiated?
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: double" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
@@ -1146,6 +1158,7 @@ run_test    "Renegotiation: double" \
             -s "=> renegotiate" \
             -s "write hello request"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: client-initiated, server-rejected" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=0" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
@@ -1161,6 +1174,7 @@ run_test    "Renegotiation: client-initiated, server-rejected" \
             -c "SSL - Unexpected message at ServerHello in renegotiation" \
             -c "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated, client-rejected, default" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=0" \
@@ -1176,6 +1190,7 @@ run_test    "Renegotiation: server-initiated, client-rejected, default" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated, client-rejected, not enforced" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1 \
              renego_delay=-1" \
@@ -1193,6 +1208,7 @@ run_test    "Renegotiation: server-initiated, client-rejected, not enforced" \
             -S "failed"
 
 # delay 2 for 1 alert record + 1 application data record
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated, client-rejected, delay 2" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1 \
              renego_delay=2" \
@@ -1209,6 +1225,7 @@ run_test    "Renegotiation: server-initiated, client-rejected, delay 2" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated, client-rejected, delay 0" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1 \
              renego_delay=0" \
@@ -1224,6 +1241,7 @@ run_test    "Renegotiation: server-initiated, client-rejected, delay 0" \
             -s "write hello request" \
             -s "SSL - An unexpected message was received from our peer"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: server-initiated, client-accepted, delay 0" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 renegotiate=1 \
              renego_delay=0" \
@@ -1240,6 +1258,7 @@ run_test    "Renegotiation: server-initiated, client-accepted, delay 0" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: periodic, just below period" \
             "$P_SRV debug_level=3 exchanges=9 renegotiation=1 renego_period=3" \
             "$P_CLI debug_level=3 exchanges=2 renegotiation=1" \
@@ -1257,6 +1276,7 @@ run_test    "Renegotiation: periodic, just below period" \
             -S "failed"
 
 # one extra exchange to be able to complete renego
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: periodic, just above period" \
             "$P_SRV debug_level=3 exchanges=9 renegotiation=1 renego_period=3" \
             "$P_CLI debug_level=3 exchanges=4 renegotiation=1" \
@@ -1273,6 +1293,7 @@ run_test    "Renegotiation: periodic, just above period" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: periodic, two times period" \
             "$P_SRV debug_level=3 exchanges=9 renegotiation=1 renego_period=3" \
             "$P_CLI debug_level=3 exchanges=7 renegotiation=1" \
@@ -1289,6 +1310,7 @@ run_test    "Renegotiation: periodic, two times period" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: periodic, above period, disabled" \
             "$P_SRV debug_level=3 exchanges=9 renegotiation=0 renego_period=3" \
             "$P_CLI debug_level=3 exchanges=4 renegotiation=1" \
@@ -1305,6 +1327,7 @@ run_test    "Renegotiation: periodic, above period, disabled" \
             -S "SSL - An unexpected message was received from our peer" \
             -S "failed"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: nbio, client-initiated" \
             "$P_SRV debug_level=3 nbio=2 exchanges=2 renegotiation=1" \
             "$P_CLI debug_level=3 nbio=2 exchanges=2 renegotiation=1 renegotiate=1" \
@@ -1318,6 +1341,7 @@ run_test    "Renegotiation: nbio, client-initiated" \
             -s "=> renegotiate" \
             -S "write hello request"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: nbio, server-initiated" \
             "$P_SRV debug_level=3 nbio=2 exchanges=2 renegotiation=1 renegotiate=1" \
             "$P_CLI debug_level=3 nbio=2 exchanges=2 renegotiation=1" \
@@ -1331,6 +1355,7 @@ run_test    "Renegotiation: nbio, server-initiated" \
             -s "=> renegotiate" \
             -s "write hello request"
 
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: openssl server, client-initiated" \
             "$O_SRV" \
             "$P_CLI debug_level=3 exchanges=1 renegotiation=1 renegotiate=1" \
@@ -1343,6 +1368,7 @@ run_test    "Renegotiation: openssl server, client-initiated" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
 requires_gnutls
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: gnutls server strict, client-initiated" \
             "$G_SRV --priority=NORMAL:%SAFE_RENEGOTIATION" \
             "$P_CLI debug_level=3 exchanges=1 renegotiation=1 renegotiate=1" \
@@ -1355,6 +1381,7 @@ run_test    "Renegotiation: gnutls server strict, client-initiated" \
             -c "HTTP/1.0 200 [Oo][Kk]"
 
 requires_gnutls
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: gnutls server unsafe, client-initiated default" \
             "$G_SRV --priority=NORMAL:%DISABLE_SAFE_RENEGOTIATION" \
             "$P_CLI debug_level=3 exchanges=1 renegotiation=1 renegotiate=1" \
@@ -1367,6 +1394,7 @@ run_test    "Renegotiation: gnutls server unsafe, client-initiated default" \
             -C "HTTP/1.0 200 [Oo][Kk]"
 
 requires_gnutls
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: gnutls server unsafe, client-inititated no legacy" \
             "$G_SRV --priority=NORMAL:%DISABLE_SAFE_RENEGOTIATION" \
             "$P_CLI debug_level=3 exchanges=1 renegotiation=1 renegotiate=1 \
@@ -1380,6 +1408,7 @@ run_test    "Renegotiation: gnutls server unsafe, client-inititated no legacy" \
             -C "HTTP/1.0 200 [Oo][Kk]"
 
 requires_gnutls
+requires_config_disabled POLARSSL_SSL_DISABLE_RENEGOTIATION
 run_test    "Renegotiation: gnutls server unsafe, client-inititated legacy" \
             "$G_SRV --priority=NORMAL:%DISABLE_SAFE_RENEGOTIATION" \
             "$P_CLI debug_level=3 exchanges=1 renegotiation=1 renegotiate=1 \


### PR DESCRIPTION
__Summary:__ This is the backport of #1141 to Mbed TLS 1.3, obtained manually. There is a slight difference to the head and 2.1 PR's in that in Mbed TLS 1.3 the config used `SSL_DISABLE_RENEGOTIATION` instead of the later `SSL_RENEGOTIATION`. As `ssl.h` adds `SSL_RENEGOTIATION` as `! SSL_DISABLE_RENEGOTIATION`, the changes in `ssl_read` read the same as for the head and 2.1 PR's, but the test changes to `ssl-opt.sh` and `all.sh` use `SSL_DISABLE_RENEGOTIATION`.

__Internal Reference:__ IOTSSL-1707.