### PR TITLE
Backport 2.1: Fix crash when calling `mbedtls_ssl_cache_free` twice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ Bugfix
    * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
      dates on leap years with 100 and 400 intervals are handled correctly. Found
      by Nicholas Wilson. #694
+   * Fix crash when calling mbedtls_ssl_cache_free() twice. Found by
+     MilenkoMitrovic, #1104
 
 = mbed TLS 2.1.9 branch released 2017-08-10
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -43,15 +43,6 @@
 #define mbedtls_free       free
 #endif
 
-#include "mbedtls/ssl_cache.h"
-
-#include <string.h>
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
-
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
@@ -330,8 +321,7 @@ void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache )
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &cache->mutex );
 #endif
-
-    mbedtls_zeroize( cache, sizeof(mbedtls_ssl_cache_context) );
+    cache->chain = NULL;
 }
 
 #endif /* MBEDTLS_SSL_CACHE_C */

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -43,6 +43,15 @@
 #define mbedtls_free       free
 #endif
 
+#include "mbedtls/ssl_cache.h"
+
+#include <string.h>
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
@@ -321,6 +330,8 @@ void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache )
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &cache->mutex );
 #endif
+
+    mbedtls_zeroize( cache, sizeof(mbedtls_ssl_cache_context) );
 }
 
 #endif /* MBEDTLS_SSL_CACHE_C */


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/1145 to 2.1 branch