### PR TITLE
Backport 1.3: Fix crash when calling `mbedtls_ssl_cache_free` twice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Bugfix
    * Fix leap year calculation in x509_date_is_valid() to ensure that invalid
      dates on leap years with 100 and 400 intervals are handled correctly. Found
      by Nicholas Wilson. #694
+   * Fix crash when calling mbedtls_ssl_cache_free() twice. Found by
+     MilenkoMitrovic, #1104
 
 = mbed TLS 1.3.21 branch released 2017-08-10
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -44,6 +44,12 @@
 #define polarssl_free       free
 #endif
 
+
+/* Implementation that should never be optimized out by the compiler */
+static void polarssl_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
 void ssl_cache_init( ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( ssl_cache_context ) );
@@ -324,6 +330,8 @@ void ssl_cache_free( ssl_cache_context *cache )
 #if defined(POLARSSL_THREADING_C)
     polarssl_mutex_free( &cache->mutex );
 #endif
+
+    polarssl_zeroize( cache, sizeof(ssl_cache_context) );
 }
 
 #endif /* POLARSSL_SSL_CACHE_C */

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -44,12 +44,6 @@
 #define polarssl_free       free
 #endif
 
-
-/* Implementation that should never be optimized out by the compiler */
-static void polarssl_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
-
 void ssl_cache_init( ssl_cache_context *cache )
 {
     memset( cache, 0, sizeof( ssl_cache_context ) );
@@ -331,7 +325,7 @@ void ssl_cache_free( ssl_cache_context *cache )
     polarssl_mutex_free( &cache->mutex );
 #endif
 
-    polarssl_zeroize( cache, sizeof(ssl_cache_context) );
+    cache->chain = NULL;
 }
 
 #endif /* POLARSSL_SSL_CACHE_C */


### PR DESCRIPTION
Backport of #1145 to 1.3 branch