### PR TITLE
Fix copy paste error in the error message of mbedtls_ecp_gen_key in gen_key.c

### DIFF
--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -339,7 +339,7 @@ int main( int argc, char *argv[] )
                           mbedtls_ctr_drbg_random, &ctr_drbg );
         if( ret != 0 )
         {
-            mbedtls_printf( " failed\n  !  mbedtls_rsa_gen_key returned -0x%04x", -ret );
+            mbedtls_printf( " failed\n  !  mbedtls_ecp_gen_key returned -0x%04x", -ret );
             goto exit;
         }
     }


### PR DESCRIPTION
## Description
Fix copy paste error in the error message of mbedtls_ecp_gen_key in gen_key.c

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO
