### PR TITLE
make MBEDTLS_MD_MAX_SIZE define the right value

### DIFF
--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -25,6 +25,12 @@
 #ifndef MBEDTLS_MD_H
 #define MBEDTLS_MD_H
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #include <stddef.h>
 
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */


### PR DESCRIPTION
When enable MBEDTLS_SHA512_C, if the source code only
include the md.h, the MBEDTLS_MD_MAX_SIZE value is not
correct.



