### PR TITLE
ARMv8 crypto extensions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 Features
    * Allow comments in test data files.
+   * ARMv8 Crypto Extensions: Faster AES and GCM
 
 Bugfix
    * Fix ssl_parse_record_header() to silently discard invalid DTLS records

--- a/include/mbedtls/armv8ce_aes.h
+++ b/include/mbedtls/armv8ce_aes.h
@@ -1,0 +1,60 @@
+/**
+ * \file armv8ce_aes.h
+ *
+ * \brief ARMv8 Cryptography Extensions -- Optimized code for AES and GCM
+ *
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_ARMV8CE_AES_H
+#define MBEDTLS_ARMV8CE_AES_H
+
+#include "aes.h"
+
+/**
+ * \brief          [ARMv8 Crypto Extensions] AES-ECB block en(de)cryption
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    16-byte input block
+ * \param output   16-byte output block
+ *
+ * \return         0 on success (cannot fail)
+ */
+
+int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                                   int mode,
+                                   const unsigned char input[16],
+                                   unsigned char output[16] );
+
+/**
+ * \brief          [ARMv8 Crypto Extensions]  Multiply in GF(2^128) for GCM
+ *
+ * \param c        Result
+ * \param a        First operand
+ * \param b        Second operand
+ *
+ * \note           Both operands and result are bit strings interpreted as
+ *                 elements of GF(2^128) as per the GCM spec.
+ */
+
+void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
+                               const unsigned char a[16],
+                               const unsigned char b[16] );
+
+#endif /* MBEDTLS_ARMV8CE_AES_H */

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -69,6 +69,10 @@
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_ARMV8CE_AES_C) && !defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_ARMV8CE_AES_C defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)
 #error "MBEDTLS_CTR_DRBG_C defined, but not all prerequisites"
 #endif
@@ -667,3 +671,4 @@
 typedef int mbedtls_iso_c_forbids_empty_translation_units;
 
 #endif /* MBEDTLS_CHECK_CONFIG_H */
+

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -50,6 +50,7 @@
  *      library/timing.c
  *      library/padlock.c
  *      include/mbedtls/bn_mul.h
+ *		library/armv8ce_aes.c
  *
  * Comment to disable the use of assembly code.
  */
@@ -1500,6 +1501,21 @@
  * This modules adds support for the AES-NI instructions on x86-64
  */
 #define MBEDTLS_AESNI_C
+
+/**
+ * \def MBEDTLS_ARMV8CE_AES_C
+ *
+ * Enable ARMv8 Crypto Extensions for AES and GCM
+ *
+ * Module:  library/aesni.c
+ * Caller:  library/aes.c
+ *          library/gcm.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This module utilizes ARMv8 Crypto Extensions for AES and GCM
+ */
+//#define MBEDTLS_ARMV8CE_AES_C
 
 /**
  * \def MBEDTLS_AES_C

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -6,6 +6,7 @@ set(src_crypto
     aes.c
     aesni.c
     arc4.c
+	armv8ce_aes.c
     asn1parse.c
     asn1write.c
     base64.c

--- a/library/Makefile
+++ b/library/Makefile
@@ -44,7 +44,8 @@ ifdef WINDOWS_BUILD
 DLEXT=dll
 endif
 
-OBJS_CRYPTO=	aes.o		aesni.o		arc4.o		\
+OBJS_CRYPTO=	aes.o		aesni.o		armv8ce_aes.o 	\
+		arc4.o		\
 		asn1parse.o	asn1write.o	base64.o	\
 		bignum.o	blowfish.o	camellia.o	\
 		ccm.o		cipher.o	cipher_wrap.o	\

--- a/library/aes.c
+++ b/library/aes.c
@@ -42,7 +42,9 @@
 #if defined(MBEDTLS_AESNI_C)
 #include "mbedtls/aesni.h"
 #endif
-
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+#include "mbedtls/armv8ce_aes.h"
+#endif
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -849,6 +851,11 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
         return( mbedtls_aesni_crypt_ecb( ctx, mode, input, output ) );
+#endif
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+	// We don't do runtime checking for ARMv8 Crypto Extensions
+	return mbedtls_armv8ce_aes_crypt_ecb( ctx, mode, input, output );
 #endif
 
 #if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)

--- a/library/armv8ce_aes.c
+++ b/library/armv8ce_aes.c
@@ -1,0 +1,143 @@
+/*
+ *  ARMv8 Cryptography Extensions -- Optimized code for AES and GCM
+ *
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+
+#include <arm_neon.h>
+#include "mbedtls/armv8ce_aes.h"
+
+#ifndef asm
+#define asm __asm
+#endif
+
+/*
+ *  [ARMv8 Crypto Extensions]  AES-ECB block en(de)cryption
+ */
+
+#if defined(MBEDTLS_AES_C)
+
+int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                                   int mode,
+                                   const unsigned char input[16],
+                                   unsigned char output[16] )
+{
+    unsigned int i;
+    const uint8_t *rk;
+    uint8x16_t x, k;
+
+    x = vld1q_u8( input );                          // input block
+    rk = (const uint8_t *) ctx->rk;                 // round keys
+
+    if( mode == MBEDTLS_AES_ENCRYPT )
+    {
+        for( i = ctx->nr - 1; i ; i-- )             // encryption loop
+        {
+            k = vld1q_u8( rk );
+            rk += 16;
+            x = vaeseq_u8( x, k );
+            x = vaesmcq_u8( x );
+        }
+        k = vld1q_u8( rk );
+        rk += 16;
+        x = vaeseq_u8( x, k );
+    }
+    else
+    {
+        for( i = ctx->nr - 1; i ; i-- )             // decryption loop
+        {
+            k = vld1q_u8( rk );
+            rk += 16;
+            x = vaesdq_u8( x, k );
+            x = vaesimcq_u8( x );
+        }
+        k = vld1q_u8( rk );
+        rk += 16;
+        x = vaesdq_u8( x, k );
+    }
+
+    k = vld1q_u8( rk );                             // final key just XORed
+    x = veorq_u8( x, k );
+    vst1q_u8( output, x );                          // write out
+
+    return ( 0 );
+}
+
+#endif /* MBEDTLS_AES_C */
+
+
+/*
+ *  [ARMv8 Crypto Extensions]  Multiply in GF(2^128) for GCM
+ */
+
+#if defined(MBEDTLS_GCM_C)
+
+void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
+                               const unsigned char a[16],
+                               const unsigned char b[16] )
+{
+    // GCM's GF(2^128) polynomial basis is x^128 + x^7 + x^2 + x + 1
+    const uint64x2_t base = { 0, 0x86 };            // note missing LS bit
+
+    register uint8x16_t vc asm( "v0" );             // named registers
+    register uint8x16_t va asm( "v1" );             // (to avoid conflict)
+    register uint8x16_t vb asm( "v2" );
+    register uint64x2_t vp asm( "v3" );
+
+    va = vld1q_u8( a );                             // load inputs
+    vb = vld1q_u8( b );
+    vp = base;
+
+    asm (
+        "rbit    %1.16b, %1.16b             \n\t"   // reverse bit order
+        "rbit    %2.16b, %2.16b             \n\t"
+        "pmull2  %0.1q,  %1.2d,  %2.2d      \n\t"   // v0 = a.hi * b.hi
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "ext     v5.16b, %2.16b, %2.16b, #8 \n\t"   // (swap hi and lo in b)
+        "pmull   v4.1q,  %1.1d,  v5.1d      \n\t"   // v0 ^= a.lo * b.hi
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull2  v4.1q,  %1.2d,  v5.2d      \n\t"   // v0 ^= a.hi * b.lo
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull   v4.1q,  %1.1d,  %2.1d      \n\t"   // v0 ^= a.lo * b.lo
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "rbit    %0.16b, %0.16b             \n\t"   // reverse bits for output
+        : "=w" (vc)                                 // q0:      output
+        : "w" (va), "w" (vb), "w" (vp)              // q1, q2:  input
+        : "v4", "v5"                                // q4, q5:  clobbered
+    );
+
+    vst1q_u8( c, vc );                              // write out
+}
+
+#endif /* MBEDTLS_GCM_C */
+
+#endif /* MBEDTLS_ARMV8CE_AES_C */
+

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -45,6 +45,10 @@
 #include "mbedtls/aesni.h"
 #endif
 
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+#include "mbedtls/armv8ce_aes.h"
+#endif
+
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -109,6 +113,12 @@ static int gcm_gen_table( mbedtls_gcm_context *ctx )
     memset( h, 0, 16 );
     if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, h, 16, h, &olen ) ) != 0 )
         return( ret );
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+	// we don't do feature testing with ARMv8 cryptography extensions
+    memcpy( ctx ->HL, h, 16 );          // put H at the beginning of buffer
+    return( 0 );                        // that's all we need
+#endif
 
     /* pack h as two 64-bits ints, big-endian */
     GET_UINT32_BE( hi, h,  0  );
@@ -213,6 +223,11 @@ static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
     int i = 0;
     unsigned char lo, hi, rem;
     uint64_t zh, zl;
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+	mbedtls_armv8ce_gcm_mult( output, x, (const unsigned char *) ctx->HL );
+	return;
+#endif
 
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_CLMUL ) ) {

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -465,6 +465,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_AESNI_C)
     "MBEDTLS_AESNI_C",
 #endif /* MBEDTLS_AESNI_C */
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+    "MBEDTLS_ARMV8CE_AES_C",
+#endif /* MBEDTLS_ARMV8CE_AES_C */
 #if defined(MBEDTLS_AES_C)
     "MBEDTLS_AES_C",
 #endif /* MBEDTLS_AES_C */

--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -35,6 +35,7 @@
 #       - this could be enabled if the respective tests were adapted
 #   MBEDTLS_ZLIB_SUPPORT
 #   MBEDTLS_PKCS11_C
+#   MBEDTLS_ARMV8CE_AES_C
 #   and any symbol beginning _ALT
 #
 
@@ -91,6 +92,7 @@ MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
 MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
 MBEDTLS_ZLIB_SUPPORT
 MBEDTLS_PKCS11_C
+MBEDTLS_ARMV8CE_AES_C
 _ALT\s*$
 );
 


### PR DESCRIPTION
A compact patch that provides AES and GCM implementations that utilize the **ARMv8 Crypto Extensions**. The config flag is MBEDTLS_ARMV8CE_AES_C, which is disabled by default as we don't do runtime checking for the feature. The new implementation lives in `armv8ce_aes.c`.

Provides similar functionality to https://github.com/ARMmbed/mbedtls/pull/432
Thanks to Barry O'Rourke and others for that contribtion.

Tested on a Cortex A53 device and QEMU. On a midrange phone the real AES-GCM throughput increases about 4x, while raw AES speed is up to 10x faster.

When cross-compiling, you want to set something like:

```
export CC='aarch64-linux-gnu-gcc'
export CFLAGS='-Ofast -march=armv8-a+crypto'
scripts/config.pl set MBEDTLS_ARMV8CE_AES_C
```

QEMU seems to also need 

```
export LDFLAGS='-static'
```
Then run normal `make` or` cmake` etc.
