### PR TITLE
add nc_off tests in AES self tests for CTR mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -378,6 +378,9 @@ Changes
    * Add explicit warnings for the use of MD2, MD4, MD5, SHA-1, DES and ARC4
      throughout the library.
 
+Changes
+   * Add tests for different nc_off in AES CTR mode, in the AES selftests
+
 = mbed TLS 2.6.0 branch released 2017-08-10
 
 Security

--- a/library/aes.c
+++ b/library/aes.c
@@ -1534,22 +1534,21 @@ int mbedtls_aes_self_test( int verbose )
         {
             len = aes_test_ctr_len[u];
             tst_offset = 0;
-            while ( tst_offset < ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) )
+            while ( tst_offset < 16 )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx,  ( ( len / 16 ) * 16 ) + tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx,  tst_offset, &offset, nonce_counter, stream_block,
                                        buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-
-                ret = mbedtls_aes_crypt_ctr( &ctx, ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) - tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + ( ( len / 16 ) * 16 )  + tst_offset, buf  + ( ( len / 16 ) * 16 ) + tst_offset );
+                ret = mbedtls_aes_crypt_ctr( &ctx, len - tst_offset, &offset, nonce_counter, stream_block,
+                                       buf + tst_offset, buf  + tst_offset );
                 if( ret != 0 )
                     goto exit;
 
@@ -1568,21 +1567,21 @@ int mbedtls_aes_self_test( int verbose )
         {
             len = aes_test_ctr_len[u];
             tst_offset = 0;
-            while ( tst_offset <  ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) )
+            while ( tst_offset < 16 )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx,  ( ( len / 16 ) * 16 ) + tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx, tst_offset, &offset, nonce_counter, stream_block,
                                         buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) - tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + ( ( len / 16 ) * 16 ) + tst_offset, buf + ( ( len / 16 ) * 16 ) + tst_offset );
+                ret = mbedtls_aes_crypt_ctr( &ctx, len- tst_offset, &offset, nonce_counter, stream_block,
+                                       buf + tst_offset, buf + tst_offset );
                 if( ret != 0 )
                     goto exit;
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1533,8 +1533,8 @@ int mbedtls_aes_self_test( int verbose )
         if( mode == MBEDTLS_AES_DECRYPT )
         {
             len = aes_test_ctr_len[u];
-            size_to_cipher = 0;
-            while ( size_to_cipher < len )
+
+            for(size_to_cipher = 0; size_to_cipher < len; size_to_cipher++ )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
@@ -1545,6 +1545,14 @@ int mbedtls_aes_self_test( int verbose )
                                        buf, buf );
                 if( ret != 0 )
                     goto exit;
+
+                if( offset != ( size_to_cipher % 16 ) )
+                {
+                    if( verbose != 0 )
+                        mbedtls_printf( "failed: calculated offset is not as expected\n" );
+                    ret = 1;
+                    goto exit;
+                }
 
                 /* cipher the last block, from offset*/
                 ret = mbedtls_aes_crypt_ctr( &ctx, len - size_to_cipher, &offset, nonce_counter, stream_block,
@@ -1560,14 +1568,12 @@ int mbedtls_aes_self_test( int verbose )
                     ret = 1;
                     goto exit;
                 }
-                size_to_cipher++;
             }
         }
         else
         {
             len = aes_test_ctr_len[u];
-            size_to_cipher = 0;
-            while ( size_to_cipher < len )
+            for( size_to_cipher = 0; size_to_cipher < len; size_to_cipher++ )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
@@ -1578,6 +1584,14 @@ int mbedtls_aes_self_test( int verbose )
                                         buf, buf );
                 if( ret != 0 )
                     goto exit;
+
+                if( offset != ( size_to_cipher % 16 ) )
+                {
+                    if( verbose != 0 )
+                        mbedtls_printf( "failed: calculated offset is not as expected\n" );
+                    ret = 1;
+                    goto exit;
+                }
 
                 /* cipher the last block, from offset*/
                 ret = mbedtls_aes_crypt_ctr( &ctx, len- size_to_cipher, &offset, nonce_counter, stream_block,
@@ -1592,7 +1606,6 @@ int mbedtls_aes_self_test( int verbose )
                     ret = 1;
                     goto exit;
                 }
-                size_to_cipher++;
             }
         }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1534,21 +1534,22 @@ int mbedtls_aes_self_test( int verbose )
         {
             len = aes_test_ctr_len[u];
             tst_offset = 0;
-            while ( tst_offset < 16 )
+            while ( tst_offset < ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, len - 16 + tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx,  ( ( len / 16 ) * 16 ) + tst_offset, &offset, nonce_counter, stream_block,
                                        buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, 16 - tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + len - 16 + tst_offset, buf  + len - 16 + tst_offset );
+
+                ret = mbedtls_aes_crypt_ctr( &ctx, ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) - tst_offset, &offset, nonce_counter, stream_block,
+                                       buf + ( ( len / 16 ) * 16 )  + tst_offset, buf  + ( ( len / 16 ) * 16 ) + tst_offset );
                 if( ret != 0 )
                     goto exit;
 
@@ -1567,23 +1568,24 @@ int mbedtls_aes_self_test( int verbose )
         {
             len = aes_test_ctr_len[u];
             tst_offset = 0;
-            while ( tst_offset < 16 )
+            while ( tst_offset <  ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, len - 16 + tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx,  ( ( len / 16 ) * 16 ) + tst_offset, &offset, nonce_counter, stream_block,
                                         buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, 16 - tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + len - 16 + tst_offset, buf + len - 16 + tst_offset );
+                ret = mbedtls_aes_crypt_ctr( &ctx, ( ( len % 16 ) > 0 ? ( len % 16 ) : 16 ) - tst_offset, &offset, nonce_counter, stream_block,
+                                       buf + ( ( len / 16 ) * 16 ) + tst_offset, buf + ( ( len / 16 ) * 16 ) + tst_offset );
                 if( ret != 0 )
                     goto exit;
+
                 if( memcmp( buf, aes_test_ctr_pt[u], len ) != 0 )
                 {
                     if( verbose != 0 )

--- a/library/aes.c
+++ b/library/aes.c
@@ -1299,7 +1299,7 @@ int mbedtls_aes_self_test( int verbose )
     unsigned char prv[16];
 #endif
 #if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_CFB)
-    size_t offset, tst_offset;
+    size_t offset, size_to_cipher;
 #endif
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
     size_t len;
@@ -1533,67 +1533,66 @@ int mbedtls_aes_self_test( int verbose )
         if( mode == MBEDTLS_AES_DECRYPT )
         {
             len = aes_test_ctr_len[u];
-            tst_offset = 0;
-            while ( tst_offset < 16 )
+            size_to_cipher = 0;
+            while ( size_to_cipher < len )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx,  tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx,  size_to_cipher, &offset, nonce_counter, stream_block,
                                        buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, len - tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + tst_offset, buf  + tst_offset );
+                ret = mbedtls_aes_crypt_ctr( &ctx, len - size_to_cipher, &offset, nonce_counter, stream_block,
+                                       buf + size_to_cipher, buf  + size_to_cipher );
                 if( ret != 0 )
                     goto exit;
 
                 if( memcmp( buf, aes_test_ctr_pt[u], len ) != 0 )
                 {
                     if( verbose != 0 )
-                        mbedtls_printf( "failed with offset %zu\n", tst_offset );
+                        mbedtls_printf( "failed with cipher size %zu\n", size_to_cipher );
 
                     ret = 1;
                     goto exit;
                 }
-                tst_offset++;
+                size_to_cipher++;
             }
         }
         else
         {
             len = aes_test_ctr_len[u];
-            tst_offset = 0;
-            while ( tst_offset < 16 )
+            size_to_cipher = 0;
+            while ( size_to_cipher < len )
             {
                 memcpy( buf, aes_test_ctr_ct[u], len );
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
                 /* cipher all the blocks until the last one, and add the offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, tst_offset, &offset, nonce_counter, stream_block,
+                ret = mbedtls_aes_crypt_ctr( &ctx, size_to_cipher, &offset, nonce_counter, stream_block,
                                         buf, buf );
                 if( ret != 0 )
                     goto exit;
 
                 /* cipher the last block, from offset*/
-                ret = mbedtls_aes_crypt_ctr( &ctx, len- tst_offset, &offset, nonce_counter, stream_block,
-                                       buf + tst_offset, buf + tst_offset );
+                ret = mbedtls_aes_crypt_ctr( &ctx, len- size_to_cipher, &offset, nonce_counter, stream_block,
+                                       buf + size_to_cipher, buf + size_to_cipher );
                 if( ret != 0 )
                     goto exit;
-
                 if( memcmp( buf, aes_test_ctr_pt[u], len ) != 0 )
                 {
                     if( verbose != 0 )
-                        mbedtls_printf( "failed with offset %zu\n", tst_offset );
+                        mbedtls_printf( "failed with cipher size %zu\n", size_to_cipher );
 
                     ret = 1;
                     goto exit;
                 }
-                    tst_offset++;
+                size_to_cipher++;
             }
         }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1540,7 +1540,7 @@ int mbedtls_aes_self_test( int verbose )
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
-                /* cipher all the blocks until the last one, and add the offset*/
+                /* cipher the first bytes with length size_to_cipher */
                 ret = mbedtls_aes_crypt_ctr( &ctx,  size_to_cipher, &offset, nonce_counter, stream_block,
                                        buf, buf );
                 if( ret != 0 )
@@ -1554,7 +1554,7 @@ int mbedtls_aes_self_test( int verbose )
                     goto exit;
                 }
 
-                /* cipher the last block, from offset*/
+                /* resume the cipher, from offset */
                 ret = mbedtls_aes_crypt_ctr( &ctx, len - size_to_cipher, &offset, nonce_counter, stream_block,
                                        buf + size_to_cipher, buf  + size_to_cipher );
                 if( ret != 0 )
@@ -1579,7 +1579,7 @@ int mbedtls_aes_self_test( int verbose )
                 memcpy( nonce_counter, aes_test_ctr_nonce_counter[u], 16 );
                 offset = 0;
 
-                /* cipher all the blocks until the last one, and add the offset*/
+                /*  cipher the first bytes with length size_to_cipher */
                 ret = mbedtls_aes_crypt_ctr( &ctx, size_to_cipher, &offset, nonce_counter, stream_block,
                                         buf, buf );
                 if( ret != 0 )
@@ -1593,7 +1593,7 @@ int mbedtls_aes_self_test( int verbose )
                     goto exit;
                 }
 
-                /* cipher the last block, from offset*/
+                /* resume the cipher, from offset */
                 ret = mbedtls_aes_crypt_ctr( &ctx, len- size_to_cipher, &offset, nonce_counter, stream_block,
                                        buf + size_to_cipher, buf + size_to_cipher );
                 if( ret != 0 )


### PR DESCRIPTION
## Description
Add in the AES selftest tests for different `nc_off`


## Status
**READY**

## Requires Backporting
NO  

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
run the `./test_suite_aes.rest` test suite

Note: should be merged together with #1178
