### PR TITLE
return plaintext data faster on unpadded decryption

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,8 @@ Changes
    * Improve testing in configurations that omit certain hashes or
      public-key algorithms. Includes contributions by Gert van Dijk.
    * Improve negative testing of X.509 parsing.
+   * Return plaintext data sooner on unpadded decryption. Contributed by Andy
+     Leiserson. #1180
 
 = mbed TLS 2.8.0 branch released 2018-03-16
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ Bugfix
      Fixes #1040.
    * Fix C89 incompatibility in benchmark.c. Contributed by Brendan Shanks.
      #1353
+   * Return plaintext data sooner on unpadded decryption, as stated in
+     mbedtls_cipher_update documentation. Contributed by Andy Leiserson. #1180
 
 Changes
    * Remove some redundant code in bignum.c. Contributed by Alexey Skalozub.
@@ -26,8 +28,6 @@ Changes
    * Improve testing in configurations that omit certain hashes or
      public-key algorithms. Includes contributions by Gert van Dijk.
    * Improve negative testing of X.509 parsing.
-   * Return plaintext data sooner on unpadded decryption. Contributed by Andy
-     Leiserson. #1180
 
 = mbed TLS 2.8.0 branch released 2018-03-16
 

--- a/tests/suites/test_suite_cipher.aes.data
+++ b/tests/suites/test_suite_cipher.aes.data
@@ -2,765 +2,789 @@ Decrypt empty buffer
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 dec_empty_buf:
 
-AES Encrypt and decrypt 0 bytes
+AES-128 CBC - Encrypt and decrypt 0 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:0:-1
 
-AES Encrypt and decrypt 1 byte
+AES-128 CBC - Encrypt and decrypt 1 byte with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:1:-1
 
-AES Encrypt and decrypt 2 bytes
+AES-128 CBC - Encrypt and decrypt 2 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:2:-1
 
-AES Encrypt and decrypt 7 bytes
+AES-128 CBC - Encrypt and decrypt 7 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:7:-1
 
-AES Encrypt and decrypt 8 bytes
+AES-128 CBC - Encrypt and decrypt 8 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:8:-1
 
-AES Encrypt and decrypt 9 bytes
+AES-128 CBC - Encrypt and decrypt 9 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:9:-1
 
-AES Encrypt and decrypt 15 bytes
+AES-128 CBC - Encrypt and decrypt 15 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:15:-1
 
-AES Encrypt and decrypt 16 bytes
+AES-128 CBC - Encrypt and decrypt 16 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:16:-1
 
-AES Encrypt and decrypt 17 bytes
+AES-128 CBC - Encrypt and decrypt 17 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:17:-1
 
-AES Encrypt and decrypt 31 bytes
+AES-128 CBC - Encrypt and decrypt 31 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:31:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-128 CBC - Encrypt and decrypt 32 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:32:-1
 
-AES Encrypt and decrypt 33 bytes
+AES-128 CBC - Encrypt and decrypt 33 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:33:-1
 
-AES Encrypt and decrypt 47 bytes
+AES-128 CBC - Encrypt and decrypt 47 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:47:-1
 
-AES Encrypt and decrypt 48 bytes
+AES-128 CBC - Encrypt and decrypt 48 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:48:-1
 
-AES Encrypt and decrypt 49 bytes
+AES-128 CBC - Encrypt and decrypt 49 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:49:-1
 
-AES Encrypt and decrypt 0 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 0 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:0:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 1 byte with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 1 byte with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:1:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 2 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 2 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:2:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 7 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 7 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:7:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 8 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 8 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:8:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 9 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 9 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:9:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 15 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 15 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:15:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 16 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 16 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:16:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 17 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 17 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:17:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 31 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 31 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:31:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 32 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 32 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:32:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 33 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 33 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:33:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 47 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 47 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:47:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 48 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 48 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:48:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 49 bytes with one and zeros padding
+AES-128 CBC - Encrypt and decrypt 49 bytes with one and zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:49:MBEDTLS_PADDING_ONE_AND_ZEROS
 
-AES Encrypt and decrypt 0 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 0 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:0:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 1 byte with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 1 byte with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:1:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 2 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 2 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:2:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 7 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 7 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:7:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 8 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 8 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:8:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 9 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 9 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:9:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 15 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 15 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:15:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 16 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 16 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:16:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 17 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 17 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:17:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 31 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 31 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:31:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 32 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 32 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:32:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 33 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 33 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:33:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 47 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 47 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:47:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 48 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 48 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:48:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 49 bytes with zeros and len padding
+AES-128 CBC - Encrypt and decrypt 49 bytes with zeros and len padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:49:MBEDTLS_PADDING_ZEROS_AND_LEN
 
-AES Encrypt and decrypt 0 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 0 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:0:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 1 byte with zeros padding
+AES-128 CBC - Encrypt and decrypt 1 byte with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:1:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 2 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 2 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:2:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 7 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 7 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:7:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 8 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 8 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:8:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 9 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 9 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:9:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 15 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 15 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:15:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 16 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 16 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:16:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 17 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 17 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:17:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 31 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 31 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:31:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 32 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 32 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:32:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 33 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 33 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:33:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 47 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 47 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:47:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 48 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 48 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:48:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 49 bytes with zeros padding
+AES-128 CBC - Encrypt and decrypt 49 bytes with zeros padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_ZEROS
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:49:MBEDTLS_PADDING_ZEROS
 
-AES Encrypt and decrypt 0 bytes with no padding
+AES-128 CBC - Encrypt and decrypt 0 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:0:MBEDTLS_PADDING_NONE
 
-AES Encrypt and decrypt 16 bytes with no padding
+AES-128 CBC - Encrypt and decrypt 16 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:16:MBEDTLS_PADDING_NONE
 
-AES Encrypt and decrypt 32 bytes with no padding
+AES-128 CBC - Encrypt and decrypt 32 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:32:MBEDTLS_PADDING_NONE
 
-AES Encrypt and decrypt 48 bytes with no padding
+AES-128 CBC - Encrypt and decrypt 48 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CBC:"AES-128-CBC":128:48:MBEDTLS_PADDING_NONE
 
-AES Try encrypting 1 bytes with no padding
+AES-128 CBC - Try encrypting 1 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:1:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 2 bytes with no padding
+AES-128 CBC - Try encrypting 2 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:2:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 7 bytes with no padding
+AES-128 CBC - Try encrypting 7 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:7:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 8 bytes with no padding
+AES-128 CBC - Try encrypting 8 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:8:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 9 bytes with no padding
+AES-128 CBC - Try encrypting 9 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:9:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 15 bytes with no padding
+AES-128 CBC - Try encrypting 15 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:15:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 17 bytes with no padding
+AES-128 CBC - Try encrypting 17 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:17:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 31 bytes with no padding
+AES-128 CBC - Try encrypting 31 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:31:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 33 bytes with no padding
+AES-128 CBC - Try encrypting 33 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:33:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 47 bytes with no padding
+AES-128 CBC - Try encrypting 47 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:47:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Try encrypting 49 bytes with no padding
+AES-128 CBC - Try encrypting 49 bytes with no padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_fail:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_PADDING_NONE:128:49:MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED
 
-AES Encrypt and decrypt 0 bytes in multiple parts
+AES-128 CBC - Encrypt and decrypt 0 bytes in multiple parts with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:0:MBEDTLS_PADDING_PKCS7:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:1:0:MBEDTLS_PADDING_PKCS7:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 2
+AES-128 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:1:MBEDTLS_PADDING_PKCS7:0:0:0:0
 
-AES Encrypt and decrypt 16 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:0:MBEDTLS_PADDING_PKCS7:16:0:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 2
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:16:MBEDTLS_PADDING_PKCS7:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 3
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 3
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:1:15:MBEDTLS_PADDING_PKCS7:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 4
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 4
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:15:1:MBEDTLS_PADDING_PKCS7:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:15:7:MBEDTLS_PADDING_PKCS7:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:6:MBEDTLS_PADDING_PKCS7:16:0:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 23 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:17:6:MBEDTLS_PADDING_PKCS7:16:0:16:0
 
-AES Encrypt and decrypt 32 bytes in multiple parts 1
+AES-128 CBC - Encrypt and decrypt 32 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:16:MBEDTLS_PADDING_PKCS7:16:16:0:32
 
-AES Encrypt and decrypt 0 bytes
+AES-128 CBC - Encrypt and decrypt 0 bytes in multiple parts with no padding
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:0:MBEDTLS_PADDING_NONE:0:0:0:0
+
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with no padding 1
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:0:MBEDTLS_PADDING_NONE:16:0:16:0
+
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with no padding 2
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:0:16:MBEDTLS_PADDING_NONE:0:16:0:16
+
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with no padding 3
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:1:15:MBEDTLS_PADDING_NONE:0:16:0:16
+
+AES-128 CBC - Encrypt and decrypt 16 bytes in multiple parts with no padding 4
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:15:1:MBEDTLS_PADDING_NONE:0:16:0:16
+
+AES-128 CBC - Encrypt and decrypt 32 bytes in multiple parts with no padding 1
+depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CBC:128:16:16:MBEDTLS_PADDING_NONE:16:16:16:16
+
+AES-128 CFB - Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:0:-1
 
-AES Encrypt and decrypt 1 byte
+AES-128 CFB - Encrypt and decrypt 1 byte
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:1:-1
 
-AES Encrypt and decrypt 2 bytes
+AES-128 CFB - Encrypt and decrypt 2 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:2:-1
 
-AES Encrypt and decrypt 7 bytes
+AES-128 CFB - Encrypt and decrypt 7 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:7:-1
 
-AES Encrypt and decrypt 8 bytes
+AES-128 CFB - Encrypt and decrypt 8 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:8:-1
 
-AES Encrypt and decrypt 9 bytes
+AES-128 CFB - Encrypt and decrypt 9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:9:-1
 
-AES Encrypt and decrypt 15 bytes
+AES-128 CFB - Encrypt and decrypt 15 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:15:-1
 
-AES Encrypt and decrypt 16 bytes
+AES-128 CFB - Encrypt and decrypt 16 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:16:-1
 
-AES Encrypt and decrypt 17 bytes
+AES-128 CFB - Encrypt and decrypt 17 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:17:-1
 
-AES Encrypt and decrypt 31 bytes
+AES-128 CFB - Encrypt and decrypt 31 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:31:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-128 CFB - Encrypt and decrypt 32 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:32:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-128 CFB - Encrypt and decrypt 32 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:33:-1
 
-AES Encrypt and decrypt 47 bytes
+AES-128 CFB - Encrypt and decrypt 47 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:47:-1
 
-AES Encrypt and decrypt 48 bytes
+AES-128 CFB - Encrypt and decrypt 48 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:48:-1
 
-AES Encrypt and decrypt 49 bytes
+AES-128 CFB - Encrypt and decrypt 49 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CFB128:"AES-128-CFB128":128:49:-1
 
-AES Encrypt and decrypt 0 bytes in multiple parts
+AES-128 CFB - Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:1:0:-1:1:0:1:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 2
+AES-128 CFB - Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:1:-1:0:1:0:1
 
-AES Encrypt and decrypt 16 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:0:-1:16:0:16:0
 
-AES Encrypt and decrypt 16 bytes in multiple parts 2
+AES-128 CFB - Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:0:16:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 3
+AES-128 CFB - Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:1:15:-1:1:15:1:15
 
-AES Encrypt and decrypt 16 bytes in multiple parts 4
+AES-128 CFB - Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:15:1:-1:15:1:15:1
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:15:7:-1:15:7:15:7
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:6:-1:16:6:16:6
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 23 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:17:6:-1:17:6:17:6
 
-AES Encrypt and decrypt 32 bytes in multiple parts 1
+AES-128 CFB - Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CFB128:128:16:16:-1:16:16:16:16
 
-AES Encrypt and decrypt 0 bytes
+AES-128 CTR - Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:0:-1
 
-AES Encrypt and decrypt 1 byte
+AES-128 CTR - Encrypt and decrypt 1 byte
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:1:-1
 
-AES Encrypt and decrypt 2 bytes
+AES-128 CTR - Encrypt and decrypt 2 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:2:-1
 
-AES Encrypt and decrypt 7 bytes
+AES-128 CTR - Encrypt and decrypt 7 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:7:-1
 
-AES Encrypt and decrypt 8 bytes
+AES-128 CTR - Encrypt and decrypt 8 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:8:-1
 
-AES Encrypt and decrypt 9 bytes
+AES-128 CTR - Encrypt and decrypt 9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:9:-1
 
-AES Encrypt and decrypt 15 bytes
+AES-128 CTR - Encrypt and decrypt 15 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:15:-1
 
-AES Encrypt and decrypt 16 bytes
+AES-128 CTR - Encrypt and decrypt 16 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:16:-1
 
-AES Encrypt and decrypt 17 bytes
+AES-128 CTR - Encrypt and decrypt 17 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:17:-1
 
-AES Encrypt and decrypt 31 bytes
+AES-128 CTR - Encrypt and decrypt 31 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:31:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-128 CTR - Encrypt and decrypt 32 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:32:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-128 CTR - Encrypt and decrypt 32 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:33:-1
 
-AES Encrypt and decrypt 47 bytes
+AES-128 CTR - Encrypt and decrypt 47 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:47:-1
 
-AES Encrypt and decrypt 48 bytes
+AES-128 CTR - Encrypt and decrypt 48 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:48:-1
 
-AES Encrypt and decrypt 49 bytes
+AES-128 CTR - Encrypt and decrypt 49 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 enc_dec_buf:MBEDTLS_CIPHER_AES_128_CTR:"AES-128-CTR":128:49:-1
 
-AES Encrypt and decrypt 0 bytes in multiple parts
+AES-128 CTR - Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:1:0:-1:1:0:1:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 2
+AES-128 CTR - Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:1:-1:0:1:0:1
 
-AES Encrypt and decrypt 16 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:0:-1:16:0:16:0
 
-AES Encrypt and decrypt 16 bytes in multiple parts 2
+AES-128 CTR - Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:0:16:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 3
+AES-128 CTR - Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:1:15:-1:1:15:1:15
 
-AES Encrypt and decrypt 16 bytes in multiple parts 4
+AES-128 CTR - Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:15:1:-1:15:1:15:1
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:15:7:-1:15:7:15:7
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:6:-1:16:6:16:6
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 23 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:17:6:-1:17:6:17:6
 
-AES Encrypt and decrypt 32 bytes in multiple parts 1
+AES-128 CTR - Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_CTR:128:16:16:-1:16:16:16:16
 
-AES Encrypt and decrypt 0 bytes
+AES-192 CBC - Encrypt and decrypt 0 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:0:-1
 
-AES Encrypt and decrypt 1 byte
+AES-192 CBC - Encrypt and decrypt 1 byte with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:1:-1
 
-AES Encrypt and decrypt 2 bytes
+AES-192 CBC - Encrypt and decrypt 2 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:2:-1
 
-AES Encrypt and decrypt 7 bytes
+AES-192 CBC - Encrypt and decrypt 7 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:7:-1
 
-AES Encrypt and decrypt 8 bytes
+AES-192 CBC - Encrypt and decrypt 8 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:8:-1
 
-AES Encrypt and decrypt 9 bytes
+AES-192 CBC - Encrypt and decrypt 9 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:9:-1
 
-AES Encrypt and decrypt 15 bytes
+AES-192 CBC - Encrypt and decrypt 15 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:15:-1
 
-AES Encrypt and decrypt 16 bytes
+AES-192 CBC - Encrypt and decrypt 16 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:16:-1
 
-AES Encrypt and decrypt 17 bytes
+AES-192 CBC - Encrypt and decrypt 17 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:17:-1
 
-AES Encrypt and decrypt 31 bytes
+AES-192 CBC - Encrypt and decrypt 31 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:31:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-192 CBC - Encrypt and decrypt 32 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:32:-1
 
-AES Encrypt and decrypt 33 bytes
+AES-192 CBC - Encrypt and decrypt 33 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:33:-1
 
-AES Encrypt and decrypt 47 bytes
+AES-192 CBC - Encrypt and decrypt 47 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:47:-1
 
-AES Encrypt and decrypt 48 bytes
+AES-192 CBC - Encrypt and decrypt 48 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:48:-1
 
-AES Encrypt and decrypt 49 bytes
+AES-192 CBC - Encrypt and decrypt 49 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_192_CBC:"AES-192-CBC":192:49:-1
 
-AES Encrypt and decrypt 0 bytes in multiple parts
+AES-192 CBC - Encrypt and decrypt 0 bytes in multiple parts with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:1:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 2
+AES-192 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:1:-1:0:0:0:0
 
-AES Encrypt and decrypt 16 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:0:-1:16:0:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 2
+AES-192 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:0:16:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 3
+AES-192 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 3
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:1:15:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 4
+AES-192 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 4
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:15:1:-1:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:15:7:-1:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:6:-1:16:0:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 23 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:17:6:-1:16:0:16:0
 
-AES Encrypt and decrypt 32 bytes in multiple parts 1
+AES-192 CBC - Encrypt and decrypt 32 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_CBC:192:16:16:-1:16:16:0:32
 
-AES Encrypt and decrypt 0 bytes
+AES-256 CBC - Encrypt and decrypt 0 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:0:-1
 
-AES Encrypt and decrypt 1 byte
+AES-256 CBC - Encrypt and decrypt 1 byte with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:1:-1
 
-AES Encrypt and decrypt 2 bytes
+AES-256 CBC - Encrypt and decrypt 2 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:2:-1
 
-AES Encrypt and decrypt 7 bytes
+AES-256 CBC - Encrypt and decrypt 7 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:7:-1
 
-AES Encrypt and decrypt 8 bytes
+AES-256 CBC - Encrypt and decrypt 8 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:8:-1
 
-AES Encrypt and decrypt 9 bytes
+AES-256 CBC - Encrypt and decrypt 9 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:9:-1
 
-AES Encrypt and decrypt 15 bytes
+AES-256 CBC - Encrypt and decrypt 15 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:15:-1
 
-AES Encrypt and decrypt 16 bytes
+AES-256 CBC - Encrypt and decrypt 16 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:16:-1
 
-AES Encrypt and decrypt 17 bytes
+AES-256 CBC - Encrypt and decrypt 17 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:17:-1
 
-AES Encrypt and decrypt 31 bytes
+AES-256 CBC - Encrypt and decrypt 31 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:31:-1
 
-AES Encrypt and decrypt 32 bytes
+AES-256 CBC - Encrypt and decrypt 32 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:32:-1
 
-AES Encrypt and decrypt 33 bytes
+AES-256 CBC - Encrypt and decrypt 33 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:33:-1
 
-AES Encrypt and decrypt 47 bytes
+AES-256 CBC - Encrypt and decrypt 47 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:47:-1
 
-AES Encrypt and decrypt 48 bytes
+AES-256 CBC - Encrypt and decrypt 48 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:48:-1
 
-AES Encrypt and decrypt 49 bytes
+AES-256 CBC - Encrypt and decrypt 49 bytes with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
 enc_dec_buf:MBEDTLS_CIPHER_AES_256_CBC:"AES-256-CBC":256:49:-1
 
-AES Encrypt and decrypt 0 bytes in multiple parts
+AES-256 CBC - Encrypt and decrypt 0 bytes in multiple parts with PKCS7 padding
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:1:0:-1:0:0:0:0
 
-AES Encrypt and decrypt 1 bytes in multiple parts 2
+AES-256 CBC - Encrypt and decrypt 1 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:1:-1:0:0:0:0
 
-AES Encrypt and decrypt 16 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:0:-1:16:0:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 2
+AES-256 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:0:16:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 3
+AES-256 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 3
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:1:15:-1:0:16:0:16
 
-AES Encrypt and decrypt 16 bytes in multiple parts 4
+AES-256 CBC - Encrypt and decrypt 16 bytes in multiple parts with PKCS7 padding 4
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:15:1:-1:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:15:7:-1:0:16:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 22 bytes in multiple parts with PKCS7 padding 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:6:-1:16:0:0:16
 
-AES Encrypt and decrypt 22 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 23 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:17:6:-1:16:0:16:0
 
-AES Encrypt and decrypt 32 bytes in multiple parts 1
+AES-256 CBC - Encrypt and decrypt 32 bytes in multiple parts with PKCS7 padding 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_CBC:256:16:16:-1:16:16:0:32
 
 AES Decrypt test vector #0
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_PADDING_PKCS7:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7

--- a/tests/suites/test_suite_cipher.arc4.data
+++ b/tests/suites/test_suite_cipher.arc4.data
@@ -60,44 +60,44 @@ enc_dec_buf:MBEDTLS_CIPHER_ARC4_128:"ARC4-128":128:49:-1
 
 ARC4 Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:0:-1:0:0:0:0
 
 ARC4 Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:1:0:-1:1:0:1:0
 
 ARC4 Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:1:-1:0:1:0:1
 
 ARC4 Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:0:-1:16:0:16:0
 
 ARC4 Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:0:16:-1:0:16:0:16
 
 ARC4 Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:1:15:-1:1:15:1:15
 
 ARC4 Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:15:1:-1:15:1:15:1
 
 ARC4 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:15:7:-1:15:7:15:7
 
 ARC4 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:6:-1:16:6:16:6
 
 ARC4 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:17:6:-1:17:6:17:6
 
 ARC4 Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_ARC4_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_ARC4_128:128:16:16:-1:16:16:16:16

--- a/tests/suites/test_suite_cipher.blowfish.data
+++ b/tests/suites/test_suite_cipher.blowfish.data
@@ -300,47 +300,47 @@ enc_fail:MBEDTLS_CIPHER_BLOWFISH_CBC:MBEDTLS_PADDING_NONE:128:49:MBEDTLS_ERR_CIP
 
 BLOWFISH Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:0:-1:0:0:0:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:1:0:-1:0:0:0:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:1:-1:0:0:0:0
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:0:-1:16:0:8:8
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:0:16:-1:0:16:0:16
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:1:15:-1:0:16:0:16
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:15:1:-1:8:8:8:8
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:15:7:-1:8:8:8:8
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:6:-1:16:0:8:8
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:17:6:-1:16:0:16:0
 
 BLOWFISH Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CBC:128:16:16:-1:16:16:8:24
 
 BLOWFISH Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
@@ -404,47 +404,47 @@ enc_dec_buf:MBEDTLS_CIPHER_BLOWFISH_CFB64:"BLOWFISH-CFB64":128:49:-1
 
 BLOWFISH Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:0:-1:0:0:0:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:1:0:-1:1:0:1:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:1:-1:0:1:0:1
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:0:-1:16:0:16:0
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:0:16:-1:0:16:0:16
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:1:15:-1:1:15:1:15
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:15:1:-1:15:1:15:1
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:15:7:-1:15:7:15:7
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:6:-1:16:6:16:6
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:17:6:-1:17:6:17:6
 
 BLOWFISH Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CFB64:128:16:16:-1:16:16:16:16
 
 BLOWFISH Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
@@ -508,47 +508,47 @@ enc_dec_buf:MBEDTLS_CIPHER_BLOWFISH_CTR:"BLOWFISH-CTR":128:49:-1
 
 BLOWFISH Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:0:-1:0:0:0:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:1:0:-1:1:0:1:0
 
 BLOWFISH Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:1:-1:0:1:0:1
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:0:-1:16:0:16:0
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:0:16:-1:0:16:0:16
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:1:15:-1:1:15:1:15
 
 BLOWFISH Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:15:1:-1:15:1:15:1
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:15:7:-1:15:7:15:7
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:6:-1:16:6:16:6
 
 BLOWFISH Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:17:6:-1:17:6:17:6
 
 BLOWFISH Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_BLOWFISH_CTR:128:16:16:-1:16:16:16:16
 
 BLOWFISH CBC Encrypt and decrypt 7 bytes, 192-bits key
 depends_on:MBEDTLS_BLOWFISH_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7

--- a/tests/suites/test_suite_cipher.camellia.data
+++ b/tests/suites/test_suite_cipher.camellia.data
@@ -300,47 +300,47 @@ enc_fail:MBEDTLS_CIPHER_CAMELLIA_128_CBC:MBEDTLS_PADDING_NONE:128:49:MBEDTLS_ERR
 
 CAMELLIA Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:1:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:1:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:0:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:0:16:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:1:15:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:15:1:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:15:7:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:6:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:17:6:-1:16:0:16:0
 
 CAMELLIA Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CBC:128:16:16:-1:16:16:0:32
 
 CAMELLIA Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
@@ -404,47 +404,47 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:"CAMELLIA-128-CFB128":128:49:-1
 
 CAMELLIA Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:1:0:-1:1:0:1:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:1:-1:0:1:0:1
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:0:-1:16:0:16:0
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:0:16:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:1:15:-1:1:15:1:15
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:15:1:-1:15:1:15:1
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:15:7:-1:15:7:15:7
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:6:-1:16:6:16:6
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:17:6:-1:17:6:17:6
 
 CAMELLIA Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CFB
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CFB128:128:16:16:-1:16:16:16:16
 
 CAMELLIA Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
@@ -508,47 +508,47 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_128_CTR:"CAMELLIA-128-CTR":128:49:-1
 
 CAMELLIA Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:1:0:-1:1:0:1:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:1:-1:0:1:0:1
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:0:-1:16:0:16:0
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:0:16:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:1:15:-1:1:15:1:15
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:15:1:-1:15:1:15:1
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:15:7:-1:15:7:15:7
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:6:-1:16:6:16:6
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:17:6:-1:17:6:17:6
 
 CAMELLIA Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CTR
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_CTR:128:16:16:-1:16:16:16:16
 
 CAMELLIA Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -612,47 +612,47 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_192_CBC:"CAMELLIA-192-CBC":192:49:-1
 
 CAMELLIA Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:1:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:1:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:0:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:0:16:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:1:15:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:15:1:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:15:7:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:6:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:17:6:-1:16:0:16:0
 
 CAMELLIA Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_CBC:192:16:16:-1:16:16:0:32
 
 CAMELLIA Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -716,44 +716,44 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_256_CBC:"CAMELLIA-256-CBC":256:49:-1
 
 CAMELLIA Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:1:0:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:1:-1:0:0:0:0
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:0:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:0:16:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:1:15:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:15:1:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:15:7:-1:0:16:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:6:-1:16:0:0:16
 
 CAMELLIA Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:17:6:-1:16:0:16:0
 
 CAMELLIA Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_CBC:256:16:16:-1:16:16:0:32

--- a/tests/suites/test_suite_cipher.des.data
+++ b/tests/suites/test_suite_cipher.des.data
@@ -300,47 +300,47 @@ enc_fail:MBEDTLS_CIPHER_DES_CBC:MBEDTLS_PADDING_NONE:64:49:MBEDTLS_ERR_CIPHER_FU
 
 DES Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:0:-1:0:0:0:0
 
 DES Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:1:0:-1:0:0:0:0
 
 DES Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:1:-1:0:0:0:0
 
 DES Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:0:-1:16:0:8:8
 
 DES Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:0:16:-1:0:16:0:16
 
 DES Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:1:15:-1:0:16:0:16
 
 DES Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:15:1:-1:8:8:8:8
 
 DES Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:15:7:-1:8:8:8:8
 
 DES Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:6:-1:16:0:8:8
 
 DES Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:17:6:-1:16:0:16:0
 
 DES Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_CBC:64:16:16:-1:16:16:8:24
 
 DES Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -404,47 +404,47 @@ enc_dec_buf:MBEDTLS_CIPHER_DES_EDE_CBC:"DES-EDE-CBC":128:49:-1
 
 DES3 Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:0:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:1:0:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:1:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:0:-1:16:0:8:8
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:0:16:-1:0:16:0:16
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:1:15:-1:0:16:0:16
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:15:1:-1:8:8:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:15:7:-1:8:8:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:6:-1:16:0:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:17:6:-1:16:0:16:0
 
 DES3 Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE_CBC:128:16:16:-1:16:16:8:24
 
 DES3 Encrypt and decrypt 0 bytes
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
@@ -508,47 +508,47 @@ enc_dec_buf:MBEDTLS_CIPHER_DES_EDE3_CBC:"DES-EDE3-CBC":192:49:-1
 
 DES3 Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:0:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:1:0:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:1:-1:0:0:0:0
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:0:-1:16:0:8:8
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:0:16:-1:0:16:0:16
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:1:15:-1:0:16:0:16
 
 DES3 Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:15:1:-1:8:8:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:15:7:-1:8:8:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:6:-1:16:0:8:8
 
 DES3 Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:17:6:-1:16:0:16:0
 
 DES3 Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_PADDING_PKCS7
-enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_DES_EDE3_CBC:192:16:16:-1:16:16:8:24
 
 DES ECB Encrypt test vector (OpenSSL) #1
 depends_on:MBEDTLS_DES_C

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -358,7 +358,9 @@ exit:
 
 /* BEGIN_CASE */
 void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
-                            int second_length_val )
+                            int second_length_val, int pad_mode,
+                            int first_encrypt_output_len, int second_encrypt_output_len,
+                            int first_decrypt_output_len, int second_decrypt_output_len )
 {
     size_t first_length = first_length_val;
     size_t second_length = second_length_val;
@@ -398,6 +400,16 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx_dec, key, key_len, MBEDTLS_DECRYPT ) );
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx_enc, key, key_len, MBEDTLS_ENCRYPT ) );
 
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+    if( -1 != pad_mode )
+    {
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_dec, pad_mode ) );
+        TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx_enc, pad_mode ) );
+    }
+#else
+    (void) pad_mode;
+#endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
+
     TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx_dec, iv, 16 ) );
     TEST_ASSERT( 0 == mbedtls_cipher_set_iv( &ctx_enc, iv, 16 ) );
 
@@ -414,8 +426,10 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
 
     /* encode length number of bytes from inbuf */
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf, first_length, encbuf, &outlen ) );
+    TEST_ASSERT( (size_t)first_encrypt_output_len == outlen );
     totaloutlen = outlen;
     TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_enc, inbuf + first_length, second_length, encbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( (size_t)second_encrypt_output_len == outlen );
     totaloutlen += outlen;
     TEST_ASSERT( totaloutlen == length ||
                  ( totaloutlen % block_size == 0 &&
@@ -430,15 +444,20 @@ void enc_dec_buf_multipart( int cipher_id, int key_len, int first_length_val,
                    totaloutlen <= length + block_size ) );
 
     /* decode the previously encoded string */
-    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf, totaloutlen, decbuf, &outlen ) );
+    second_length = totaloutlen - first_length;
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf, first_length, decbuf, &outlen ) );
+    TEST_ASSERT( (size_t)first_decrypt_output_len == outlen );
     totaloutlen = outlen;
+    TEST_ASSERT( 0 == mbedtls_cipher_update( &ctx_dec, encbuf + first_length, second_length, decbuf + totaloutlen, &outlen ) );
+    TEST_ASSERT( (size_t)second_decrypt_output_len == outlen );
+    totaloutlen += outlen;
 
     TEST_ASSERT( totaloutlen == length ||
                  ( totaloutlen % block_size == 0 &&
                    totaloutlen < length &&
                    totaloutlen + block_size >= length ) );
 
-    TEST_ASSERT( 0 == mbedtls_cipher_finish( &ctx_dec, decbuf + outlen, &outlen ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_finish( &ctx_dec, decbuf + totaloutlen, &outlen ) );
     totaloutlen += outlen;
 
     TEST_ASSERT( totaloutlen == length );

--- a/tests/suites/test_suite_cipher.gcm.data
+++ b/tests/suites/test_suite_cipher.gcm.data
@@ -60,35 +60,35 @@ enc_dec_buf:MBEDTLS_CIPHER_AES_128_GCM:"AES-128-GCM":128:49:-1
 
 AES 128 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:0:-1:0:0:0:0
 
 AES 128 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:1:0:-1:1:0:1:0
 
 AES 128 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:1:-1:0:1:0:1
 
 AES 128 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:0:-1:16:0:16:0
 
 AES 128 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:16:-1:0:16:0:16
 
 AES 128 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:6:-1:16:6:16:6
 
 AES 128 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:0:22:-1:0:22:0:22
 
 AES 128 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_128_GCM:128:16:16:-1:16:16:16:16
 
 AES 128 GCM Decrypt test vector #1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -188,35 +188,35 @@ enc_dec_buf:MBEDTLS_CIPHER_AES_192_GCM:"AES-192-GCM":192:49:-1
 
 AES 192 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:0:-1:0:0:0:0
 
 AES 192 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:1:0:-1:1:0:1:0
 
 AES 192 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:1:-1:0:1:0:1
 
 AES 192 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:0:-1:16:0:16:0
 
 AES 192 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:16:-1:0:16:0:16
 
 AES 192 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:6:-1:16:6:16:6
 
 AES 192 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:0:22:-1:0:22:0:22
 
 AES 192 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_192_GCM:192:16:16:-1:16:16:16:16
 
 AES 192 GCM Decrypt test vector #1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -304,35 +304,35 @@ enc_dec_buf:MBEDTLS_CIPHER_AES_256_GCM:"AES-256-GCM":256:49:-1
 
 AES 256 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:0:-1:0:0:0:0
 
 AES 256 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:1:0:-1:1:0:1:0
 
 AES 256 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:1:-1:0:1:0:1
 
 AES 256 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:0:-1:16:0:16:0
 
 AES 256 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:16:-1:0:16:0:16
 
 AES 256 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:6:-1:16:6:16:6
 
 AES 256 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:0:22:-1:0:22:0:22
 
 AES 256 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_AES_256_GCM:256:16:16:-1:16:16:16:16
 
 AES 128 GCM Decrypt test vector #0
 depends_on:MBEDTLS_AES_C:MBEDTLS_GCM_C
@@ -428,35 +428,35 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_128_GCM:"CAMELLIA-128-GCM":128:49:-1
 
 CAMELLIA 128 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:0:-1:0:0:0:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:1:0:-1:1:0:1:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:1:-1:0:1:0:1
 
 CAMELLIA 128 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:0:-1:16:0:16:0
 
 CAMELLIA 128 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:16:-1:0:16:0:16
 
 CAMELLIA 128 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:6:-1:16:6:16:6
 
 CAMELLIA 128 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:0:22:-1:0:22:0:22
 
 CAMELLIA 128 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_128_GCM:128:16:16:-1:16:16:16:16
 
 CAMELLIA 128 GCM Decrypt test vector #1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -540,35 +540,35 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_192_GCM:"CAMELLIA-192-GCM":192:49:-1
 
 CAMELLIA 192 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:0:-1:0:0:0:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:1:0:-1:1:0:1:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:1:-1:0:1:0:1
 
 CAMELLIA 192 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:0:-1:16:0:16:0
 
 CAMELLIA 192 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:16:-1:0:16:0:16
 
 CAMELLIA 192 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:6:-1:16:6:16:6
 
 CAMELLIA 192 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:0:22:-1:0:22:0:22
 
 CAMELLIA 192 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_192_GCM:192:16:16:-1:16:16:16:16
 
 CAMELLIA 192 GCM Decrypt test vector #1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
@@ -652,35 +652,35 @@ enc_dec_buf:MBEDTLS_CIPHER_CAMELLIA_256_GCM:"CAMELLIA-256-GCM":256:49:-1
 
 CAMELLIA 256 GCM Encrypt and decrypt 0 bytes in multiple parts
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:0:-1:0:0:0:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:1:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:1:0:-1:1:0:1:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:1
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:1:-1:0:1:0:1
 
 CAMELLIA 256 GCM Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:0
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:0:-1:16:0:16:0
 
 CAMELLIA 256 GCM Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:16:-1:0:16:0:16
 
 CAMELLIA 256 GCM Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:6
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:6:-1:16:6:16:6
 
 CAMELLIA 256 GCM Encrypt and decrypt 22 bytes in multiple parts 2
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:22
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:0:22:-1:0:22:0:22
 
 CAMELLIA 256 GCM Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C
-enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:16
+enc_dec_buf_multipart:MBEDTLS_CIPHER_CAMELLIA_256_GCM:256:16:16:-1:16:16:16:16
 
 CAMELLIA 256 GCM Decrypt test vector #1
 depends_on:MBEDTLS_CAMELLIA_C:MBEDTLS_GCM_C

--- a/tests/suites/test_suite_cipher.null.data
+++ b/tests/suites/test_suite_cipher.null.data
@@ -56,40 +56,40 @@ enc_dec_buf:MBEDTLS_CIPHER_NULL:"NULL":0:49:-1
 
 NULL Encrypt and decrypt 1 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:1:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:1:0:-1:1:0:1:0
 
 NULL Encrypt and decrypt 1 bytes in multiple parts 2
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:0:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:0:1:-1:0:1:0:1
 
 NULL Encrypt and decrypt 16 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:0:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:0:-1:16:0:16:0
 
 NULL Encrypt and decrypt 16 bytes in multiple parts 2
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:0:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:0:16:-1:0:16:0:16
 
 NULL Encrypt and decrypt 16 bytes in multiple parts 3
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:1:15:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:1:15:-1:1:15:1:15
 
 NULL Encrypt and decrypt 16 bytes in multiple parts 4
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:15:1:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:15:1:-1:15:1:15:1
 
 NULL Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:15:7:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:15:7:-1:15:7:15:7
 
 NULL Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:6:-1:16:6:16:6
 
 NULL Encrypt and decrypt 22 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:17:6:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:17:6:-1:17:6:17:6
 
 NULL Encrypt and decrypt 32 bytes in multiple parts 1
 depends_on:MBEDTLS_CIPHER_NULL_CIPHER
-enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:16:
+enc_dec_buf_multipart:MBEDTLS_CIPHER_NULL:0:16:16:-1:16:16:16:16


### PR DESCRIPTION
## Description
When doing symmetric decryption, the code buffers some output data because it might need to strip the padding later. If there is no padding, this buffering is unnecessary. This patch changes the behavior of `mbedtls_cipher_update` so that as much decrypted data as possible is returned.

This change is submitted under CLA with Fortanix, Inc.

## Status
READY

## Requires Backporting
NO

## Migrations
NO

## Additional comments
Documentation for `mbedtls_cipher_update` says that “[`output`] should be able to hold at least ilen + block_size.” This patch does not change this requirement.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
