### PR TITLE
Fix braces in mbedtls_memory_buffer_alloc_status()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ API Changes
 Bugfix
    * Fix an issue with MicroBlaze support in bn_mul.h which was causing the
      build to fail. Found by zv-io. Fixes #1651.
+   * Fix braces in mbedtls_memory_buffer_alloc_status(). Found by sbranden, #552.
 
 Changes
    * Support TLS testing in out-of-source builds using cmake. Fixes #1193.

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -518,7 +518,9 @@ void mbedtls_memory_buffer_alloc_status( void )
                       heap.alloc_count, heap.free_count );
 
     if( heap.first->next == NULL )
+    {
         mbedtls_fprintf( stderr, "All memory de-allocated in stack buffer\n" );
+    }
     else
     {
         mbedtls_fprintf( stderr, "Memory currently allocated:\n" );


### PR DESCRIPTION
IOTSSL-960: This is a code style fix for braces in mbedtls_memory_buffer_alloc_status.