### PR TITLE
Smaller mbedtls_ctr_drbg_context

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,8 @@ Changes
    * Extend cert_write example program by options to set the CRT version
      and the message digest. Further, allow enabling/disabling of authority
      identifier, subject identifier and basic constraints extensions.
+   * Introducing flag MBEDTLS_CTR_DRBG_ABI_COMPAT. Disabling this shrinks
+     the size of mbedtls_ctr_drbg_context by ~248 bytes.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1785,6 +1785,14 @@
 #define MBEDTLS_CTR_DRBG_C
 
 /**
+ * \def MBEDTLS_CTR_DRBG_ABI_COMPAT
+ *
+ * Enables compatible ABI for DRBG. 
+ * Disabling this shrinks the size of mbedtls_ctr_drbg_context by ~248 bytes.
+ */
+#define MBEDTLS_CTR_DRBG_ABI_COMPAT
+
+/**
  * \def MBEDTLS_DEBUG_C
  *
  * Enable the debug functions.

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -35,7 +35,11 @@
 #define MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR                -0x003A  /**< Read/write error in file. */
 
 #define MBEDTLS_CTR_DRBG_BLOCKSIZE          16      /**< Block size used by the cipher                  */
+
+#if !defined(MBEDTLS_CTR_DRBG_KEYSIZE)
 #define MBEDTLS_CTR_DRBG_KEYSIZE            32      /**< Key size used by the cipher                    */
+#endif
+
 #define MBEDTLS_CTR_DRBG_KEYBITS            ( MBEDTLS_CTR_DRBG_KEYSIZE * 8 )
 #define MBEDTLS_CTR_DRBG_SEEDLEN            ( MBEDTLS_CTR_DRBG_KEYSIZE + MBEDTLS_CTR_DRBG_BLOCKSIZE )
                                             /**< The seed length (counter + AES key)            */
@@ -94,8 +98,11 @@ typedef struct
                                       (re)seed          */
     int reseed_interval;        /*!<  reseed interval   */
 
-    mbedtls_aes_context aes_ctx;        /*!<  AES context       */
-
+#if defined(MBEDTLS_CTR_DRBG_ABI_COMPAT)
+    mbedtls_aes_context aes_ctx;  /*!<  AES context       */
+#else
+    unsigned char aes_key[MBEDTLS_CTR_DRBG_KEYSIZE]; /*! secret AES KEY */
+#endif
     /*
      * Callbacks (Entropy)
      */

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -101,7 +101,7 @@ typedef struct
 #if defined(MBEDTLS_CTR_DRBG_ABI_COMPAT)
     mbedtls_aes_context aes_ctx;  /*!<  AES context       */
 #else
-    unsigned char aes_key[MBEDTLS_CTR_DRBG_KEYSIZE]; /*! secret AES KEY */
+    unsigned char aes_key[MBEDTLS_CTR_DRBG_KEYSIZE]; /*!< secret AES key */
 #endif
     /*
      * Callbacks (Entropy)

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -445,7 +445,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
                 break;
         mbedtls_aes_crypt_ecb( &aes_ctx, MBEDTLS_AES_ENCRYPT, ctx->counter, tmp );
 
-        for (i = 0; i < MBEDTLS_CTR_DRBG_BLOCKSIZE; i++)
+        for( i = 0; i < MBEDTLS_CTR_DRBG_BLOCKSIZE; i++ )
             add_input[j + i] ^= tmp[i];
     }
 

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -289,6 +289,9 @@ static int ctr_drbg_update_internal( mbedtls_ctr_drbg_context *ctx,
 
     memcpy( ctx->counter, tmp + MBEDTLS_CTR_DRBG_KEYSIZE, MBEDTLS_CTR_DRBG_BLOCKSIZE );
 
+#if !defined(MBEDTLS_CTR_DRBG_ABI_COMPAT)
+    mbedtls_aes_free( &aes_ctx );
+#endif
     return( 0 );
 }
 
@@ -434,7 +437,6 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
     ctr_drbg_update_internal( ctx, add_input );
 #else
     // avoid double initialization of key for each call
-
     for( j = 0; j < MBEDTLS_CTR_DRBG_SEEDLEN; j += MBEDTLS_CTR_DRBG_BLOCKSIZE )
     {
         // counter mode
@@ -453,6 +455,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
     memcpy( ctx->aes_key, add_input, MBEDTLS_CTR_DRBG_KEYSIZE );
     memcpy( ctx->counter, add_input + MBEDTLS_CTR_DRBG_KEYSIZE, MBEDTLS_CTR_DRBG_BLOCKSIZE );
 
+    mbedtls_aes_free( &aes_ctx );
 #endif
 
     ctx->reseed_counter++;

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -504,6 +504,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_CTR_DRBG_C)
     "MBEDTLS_CTR_DRBG_C",
 #endif /* MBEDTLS_CTR_DRBG_C */
+#if defined(MBEDTLS_CTR_DRBG_ABI_COMPAT)
+    "MBEDTLS_CTR_DRBG_ABI_COMPAT",
+#endif /* MBEDTLS_CTR_DRBG_ABI_COMPAT */
 #if defined(MBEDTLS_DEBUG_C)
     "MBEDTLS_DEBUG_C",
 #endif /* MBEDTLS_DEBUG_C */


### PR DESCRIPTION
Introducing *MBEDTLS_CTR_DRBG_ABI_COMPAT* flag. 

Since AES is rekeyed whenever random bytes are generated, we can equivalently have the expanded key in stack and store only the secret key in the DRBG context. This saves about 248 bytes in the context size, but breaks ABI compatibility. 
