### PR TITLE
Fix build without MBEDTLS_FS_IO

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -60,12 +60,15 @@
 #define mbedtls_free       free
 #endif
 
-#if defined(MBEDTLS_FS_IO)
+#if defined(MBEDTLS_FS_IO) || \
+    defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
+#endif
 
+#if defined(MBEDTLS_FS_IO)
 /*
  * Load all data from a file into a given buffer.
  *


### PR DESCRIPTION
Fix build with `MBEDTLS_PKCS12_C` or `MBEDTLS_PKCS5_C` but without `MBEDTLS_FS_IO` (missing definition of `mbedtls_zeroize` in `library/pkparse.c`).

Issue introduced by #1062, caught by `all.sh`. This commit passes `all.sh` on my machine.

Backports: #1185 #1186