### PR TITLE
Backport 1.3: Fix build without MBEDTLS_FS_IO

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -61,12 +61,15 @@
 #define polarssl_free       free
 #endif
 
-#if defined(POLARSSL_FS_IO)
+#if defined(POLARSSL_FS_IO) || \
+    defined(POLARSSL_PKCS12_C) || defined(POLARSSL_PKCS5_C)
 /* Implementation that should never be optimized out by the compiler */
 static void polarssl_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
 }
+#endif
 
+#if defined(POLARSSL_FS_IO)
 /*
  * Load all data from a file into a given buffer.
  */


### PR DESCRIPTION
Fix build with `POLARSSL_PKCS12_C` or `POLARSSL_PKCS5_C` but without `POLARSSL_FS_IO` (missing definition of `polarssl_zeroize` in `library/pkparse.c`).

Issue introduced by #1113, caught by `all.sh`.

Backport of #1184