### PR TITLE
2.1 only: Fix build error with gcc6 (misleading indentation)

### DIFF
--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -502,14 +502,14 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
     {
         mbedtls_pem_init( &pem );
 
-    /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
-    if( buflen == 0 || buf[buflen - 1] != '\0' )
-        ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
-    else
-        ret = mbedtls_pem_read_buffer( &pem,
-                               "-----BEGIN X509 CRL-----",
-                               "-----END X509 CRL-----",
-                               buf, NULL, 0, &use_len );
+        /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
+        if( buflen == 0 || buf[buflen - 1] != '\0' )
+            ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
+        else
+            ret = mbedtls_pem_read_buffer( &pem,
+                                           "-----BEGIN X509 CRL-----",
+                                           "-----END X509 CRL-----",
+                                           buf, NULL, 0, &use_len );
 
         if( ret == 0 )
         {
@@ -522,7 +522,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
             buf += use_len;
 
             if( ( ret = mbedtls_x509_crl_parse_der( chain,
-                                            pem.buf, pem.buflen ) ) != 0 )
+                                                    pem.buf, pem.buflen ) ) != 0 )
             {
                 mbedtls_pem_free( &pem );
                 return( ret );


### PR DESCRIPTION
Fix misleading indentation. This was just bad indentation, the behavior was correct.

This matters because it breaks the build with `gcc-6 -Werror`.

This issue is only present on the 2.1 branch, not in 1.3 or in development.

Tested locally with `all.sh` using gcc 6.4.0.