### PR TITLE
Script to merge ChangeLog automatically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ChangeLog merge=mbedtls-changelog

--- a/scripts/merge-changelog
+++ b/scripts/merge-changelog
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+"""Git merge driver for the PolarSSL/Mbed TLS ChangeLog file.
+
+ Run with --help for setup and usage instructions."""
+
+import optparse, os, re, subprocess, sys
+
+def next_version_xxx(match):
+    """Return the conventional placeholder for the next version number.
+
+    This is e.g. 2.1.x for a backport and x.x.x for the development branch.
+    """
+    if match.group(1) in ['1.3', '2.1']:
+        return match.group(1) + '.' + str(int(match.group(2)) + 1)
+    else:
+        return 'x.x.x'
+
+class ChangeLogParseError(Exception):
+    def __init__(self, side, message):
+        self.message = side + ': ' + message
+
+class ChangeLogHead:
+    """ChangeLog content with partly-parsed top version."""
+
+    def __init__(self, side, content):
+        """Parse ChangeLog content. Use the name side in logs."""
+        m = re.search('\n= (.*)\n+(?=\w)((?:(?:[^\n=].*)?\n)*)\n= (.*)\n',
+                      content)
+        if m is None:
+            raise ChangeLogParseError, (side, 'version headers not found')
+        self.content = content
+        self.v0_start = m.start(1) - 2
+        self.v0_title = m.group(1)
+        self.v1_start = m.start(3) - 2
+        self.v1_title = m.group(3)
+        self.init_v0_sections()
+        for section in re.split(r'(?:\A|\n)(?=\w)', m.group(2)):
+            section = section.strip() + '\n'
+            eol = section.find('\n')
+            self.extend_section(section[:eol], section[eol+1:].lstrip('\n'))
+
+    def init_v0_sections(self):
+        """Declare the common section names in their standard order."""
+        self.v0_titles = ['Security',
+                          'Features',
+                          'API changes',
+                          'Removals',
+                          'New deprecations',
+                          'Bugfix',
+                          'Changes']
+        self.v0_contents = {}
+        for title in self.v0_titles:
+            self.v0_contents[title] = ''
+
+    def extend_section(self, title, content):
+        """Extend the section called title with content."""
+        if title in self.v0_titles:
+            self.v0_contents[title] += content
+        else:
+            self.v0_titles.append(title)
+            self.v0_contents[title] = content
+
+    def extends_new(self, ancestor):
+        """Test if self is ancestor plus a new version at the top."""
+        if self.content[:self.v0_start] != ancestor.content[:ancestor.v0_start]:
+            return False
+        if self.content[self.v1_start:] != ancestor.content[ancestor.v0_start:]:
+            return False
+        return True
+
+    def extends_latest(self, ancestor):
+        """Test if self is ancestor plus new items in the top version."""
+        if self.content[:self.v0_start] != ancestor.content[:ancestor.v0_start]:
+            return False
+        if self.content[self.v1_start:] != ancestor.content[ancestor.v1_start:]:
+            return False
+        for title, content in ancestor.v0_contents.iteritems():
+            if title not in self.v0_contents:
+                return False
+            if not self.v0_contents[title].startswith(content):
+                return False
+        return True
+
+    def create_version(self):
+        """Create a new version at the top of self."""
+        self.v1_title = self.v0_title
+        self.v1_start = self.v0_start
+        self.v0_title = re.sub(r'([0-9][0-9.]+)\.([0-9]+)', next_version_xxx,
+                               re.sub(r' [0-9]+(?:-[0-9]{2}){2}', r' xxxx-xx-xx',
+                                      self.v0_title))
+        self.init_v0_sections()
+
+    def extension_of(self, ancestor):
+        """Test if self is a simple extension of ancestor.
+
+        A simple extension is one that either creates a single new version at
+        the top, or adds entries at the end of the top version.
+
+        If this is an extension, return a representation of the additions in
+        a form suitable for merging with merge_extensions. Otherwise return
+        None.
+        """
+        if self.content[:self.v0_start] != ancestor.content[:ancestor.v0_start]:
+            return None
+        if self.content[self.v1_start:] == ancestor.content[ancestor.v0_start:]:
+            return self.v0_titles, self.v0_contents
+        if not self.content.endswith(ancestor.content[ancestor.v1_start:]):
+            return None
+        contents = self.v0_contents.copy()
+        for title, old in ancestor.v0_contents.iteritems():
+            if title not in contents:
+                return None
+            if not contents[title].startswith(old):
+                return None
+            contents[title] = contents[title][len(old):]
+        return self.v0_titles, contents
+
+    def merge_extension(self, new):
+        """Merge the additions of new into self.
+
+        new should have been returned by extension_of."""
+        (new_titles, new_contents) = new
+        for title in new_titles:
+            if title in self.v0_contents:
+                self.v0_contents[title] += new_contents[title]
+            else:
+                self.v0_contents[title] = new_contents[title]
+                self.v0_titles.append(title)
+
+    def section_text(self, title):
+        """Return the text of the section with the given title.
+
+        If the section is empty, return an empty string."""
+        if title in self.v0_contents and self.v0_contents[title] != '':
+            return title + '\n' + self.v0_contents[title] + '\n'
+        else:
+            return ''
+
+    def text(self):
+        """Reassemble the top version and return the whole ChangeLog."""
+        head = self.content[:self.v0_start] + '= ' + self.v0_title + '\n\n'
+        sections = map(self.section_text, self.v0_titles)
+        return head + ''.join(sections) + self.content[self.v1_start:]
+
+def merge_changelog_extension(into, new, options):
+    """Merge the additions new into the ChangeLog object into."""
+    if not re.search(r'-xx', into.v0_title):
+        into.create_version()
+        if options.verbose:
+            sys.stderr.write('Creating version %s\n' % (into.v0_title,))
+    into.merge_extension(new)
+    return into.text()
+
+def merge_changelog_content(ancestor_content, current_content, other_content,
+                            options):
+    """Do a 3-way merge of ChangeLog contents.
+
+    Return the resulting content as a string.
+    """
+    ancestor = ChangeLogHead('ancestor', ancestor_content)
+    current = ChangeLogHead('current', current_content)
+    other = ChangeLogHead('other', other_content)
+    new = other.extension_of(ancestor)
+    if new is not None:
+        if options.verbose:
+            sys.stderr.write('Merging %s from %%A\n' %
+                             ('all' if new[1] is other.v0_contents else
+                              '%d sections' % (len([1 for k in new[1]
+                                                    if new[1][k] != '']),)))
+        return merge_changelog_extension(current, new, options)
+    new = current.extension_of(ancestor)
+    if new is not None:
+        if options.verbose:
+            sys.stderr.write('Merging %s from %%B\n' %
+                             ('all' if new[1] is current.v0_contents else
+                              '%d sections' % (len([1 for k in new[1]
+                                                    if new[1][k] != '']),)))
+        return merge_changelog_extension(other, new, options)
+
+def merge_changelog_file(ancestor_file, current_file, other_file, options):
+    """Do a 3-way merge of ChangeLog files.
+
+    Either print the result to standard output or overwrite current_file,
+    depending on options.stdout.
+    """
+    ancestor_content = open(ancestor_file).read()
+    current_content = open(current_file).read()
+    other_content = open(other_file).read()
+    new_content = merge_changelog_content(ancestor_content, current_content,
+                                          other_content, options)
+    if new_content is None:
+        return False
+    if options.stdout:
+        sys.stdout.write(new_content)
+    else:
+        with open(current_file, 'w') as new_file:
+            new_file.write(new_content)
+    return True
+
+def merge_changelog_revisions(commit1, commit2, filename, options):
+    """Do a 3-way merge of ChangeLog files checked out with git.
+
+    Merge filename from commit1 and commit2, using their merge-base as the
+    common ancestor. Print the result to standard output.
+    """
+    commit0 = subprocess.check_output(['git', 'merge-base', commit1, commit2]).strip()
+    if options.verbose:
+        sys.stderr.write('Common ancestor: ' + commit0 + '\n')
+    content0 = subprocess.check_output(['git', 'show', commit0 + ':' + filename])
+    content1 = subprocess.check_output(['git', 'show', commit1 + ':' + filename])
+    content2 = subprocess.check_output(['git', 'show', commit2 + ':' + filename])
+    new_content = merge_changelog_content(content0, content1, content2, options)
+    if new_content is None:
+        return False
+    else:
+        sys.stdout.write(new_content)
+        return True
+
+def set_git_options(option, opt_str, value, parser):
+    """Set preferred options for use as a git merge driver."""
+    parser.values.revisions = False
+    parser.values.stdout = False
+
+def exec_git_merge(options):
+    """Run git merge-file because we failed."""
+    cmd = ['git-merge-file', '-q']
+    if options.marker_size is not None:
+        cmd.append(['--marker-size=' + str(options.marker_size)])
+    cmd.append([current_file, ancestor_file, other_file])
+    # TODO: figure out -L options.
+    # https://stackoverflow.com/questions/24302644/how-to-retrieve-branch-names-in-a-custom-git-merge-driver
+    # Useful environment variables:
+    # GITHEAD_a6ed9c54299102e2d20fca70998f05e72916e1c4=upstream-public/pr/895
+    # GIT_DIR=.git
+    # GIT_PREFIX=
+    # GIT_REFLOG_ACTION=merge upstream-public/pr/895
+    if options.exec_fallback:
+        os.execlp(cmd[0], *cmd)
+    else:
+        return subprocess.call(cmd)
+
+if __name__ == '__main__':
+    parser = optparse.OptionParser(usage="""Usage: %prog [OPTION]... %O %A %B
+       %prog -r [OPTION]... COMMIT1 COMMIT2 [FILENAME]
+Merge two versions of the Mbed TLS ChangeLog file.
+
+Without -r, pass 3 arguments:
+    %O  file containing the common ancestor
+    %A  file containing version A
+        %a will be overwritten by the merge results if successful.
+    %B  file containing version B
+This mode is meant to be used as a git merge driver. Put the following line
+in .gitattributes or .git/info/attributes:
+    ChangeLog merge=mbedtls-changelog
+And put the following stanza in .gitconfig:
+    [merge "mbedtls-changelog"]
+        name = Mbed TLS ChangeLog merge driver
+        driver = %prog --driver --marker-size=%L %O %A %B
+See gitattributes(5) for more information.
+
+With -g, pass 2 or 3 arguments: COMMIT1 COMMIT2 [FILENAME]. This script will
+run git to determine the common ancestor and obtain the file contents. If
+FILENAME is omitted, it defaults to ChangeLog.
+The result is always printed to stdout (implicit -p).
+
+This script only handles the common case where one of the revisions has only
+added entries to the top version in the ChangeLog or created a new top
+version.""")
+    parser.add_option('--driver',
+                      action='callback', callback=set_git_options,
+                      help='Set correct options for a git merge driver')
+    parser.add_option('-f', '--git-fallback',
+                      action='store_true', dest='git_fallback',
+                      help='Run git-merge-file as a fallback if unsuccessful')
+    parser.add_option('--git-dir', default=os.getenv('GIT_DIR', '.git'),
+                      action='store', dest='git_dir',
+                      help='Directory for --log file (default: $GIT_DIR)')
+    parser.add_option('-l', '--log',
+                      action='store_true', dest='log',
+                      help='Log to .git/%prog.log instead of stderr')
+    parser.add_option('--marker-size',
+                      action='store', type='int', dest='marker_size',
+                      help='Marker size (%L)')
+    parser.add_option('--no-exec-fallback', default=False,
+                      action='store_false', dest='exec_fallback',
+                      help='Run fallback as subprocess (default: use exec)')
+    parser.add_option('-p', '--print',
+                      action='store_true', dest='stdout',
+                      help='output to stdout instead of changing %A')
+    parser.add_option('-r', '--revisions',
+                      action='store_true', dest='revisions',
+                      help='Run on git revisions instead of files; implies -p')
+    parser.add_option('-v', '--verbose',
+                      action='store_true', dest='verbose',
+                      help='print diagnostic messages')
+    (options, args) = parser.parse_args()
+    if options.log:
+        log_file = os.path.join(git_dir, 'mbedtls-merge-changelog.log')
+        sys.stderr = open(log_file, 'w')
+    if options.revisions:
+        if len(args) not in [2, 3]:
+            sys.stderr.write('Usage: %s -r COMMIT COMMIT [FILENAME]\n' % (sys.argv[0],))
+            sys.exit(3)
+        ok = merge_changelog_revisions(args[0], args[1],
+                                       args[2] if len(args) > 2 else 'ChangeLog',
+                                       options)
+    else:
+        if len(args) != 3:
+            sys.stderr.write('Usage: %s %%O %%A %%B\n' % (sys.argv[0],))
+            sys.exit(3)
+        ok = merge_changelog_file(args[0], args[1], args[2], options)
+        if not ok:
+            exec_git_merge(args[0], args[1], args[2], options)
+    sys.exit(not ok)
+


### PR DESCRIPTION
If you set up git to use this script, git merges will do the right
thing for ChangeLog files in simple cases. Simple cases are those
where one side only adds one or more entries to the latest version, or
only adds a new version.

This script has not been extensively tested, so you should always
review its output.

Note that you need an entry to your git configuration to make use of
this feature. Run the script with --help for instructions.

This script is mostly of interest to Mbed TLS team members, but I see no reason to keep it out of the repository.
