### PR TITLE
Backport 1.3: Generate error.h automatically

### DIFF
--- a/include/polarssl/error.h
+++ b/include/polarssl/error.h
@@ -48,48 +48,48 @@
  *
  * Low-level module errors (0x0002-0x007E, 0x0003-0x007F)
  *
- * Module   Nr  Codes assigned
- * MPI       7  0x0002-0x0010
- * GCM       2  0x0012-0x0014
- * BLOWFISH  2  0x0016-0x0018
- * THREADING 3  0x001A-0x001E
- * AES       2  0x0020-0x0022
- * CAMELLIA  2  0x0024-0x0026
- * XTEA      1  0x0028-0x0028
- * BASE64    2  0x002A-0x002C
- * OID       1  0x002E-0x002E   0x000B-0x000B
- * PADLOCK   1  0x0030-0x0030
- * DES       1  0x0032-0x0032
- * CTR_DBRG  4  0x0034-0x003A
- * ENTROPY   3  0x003C-0x0040
- * NET      11  0x0042-0x0056
- * ENTROPY   1  0x0058-0x0058
- * ASN1      7  0x0060-0x006C
- * MD2       1  0x0070-0x0070
- * MD4       1  0x0072-0x0072
- * MD5       1  0x0074-0x0074
- * SHA1      1  0x0076-0x0076
- * SHA256    1  0x0078-0x0078
- * SHA512    1  0x007A-0x007A
- * PBKDF2    1  0x007C-0x007C
- * RIPEMD160 1  0x007E-0x007E
- * HMAC_DRBG 4  0x0003-0x0009
- * CCM       2                  0x000D-0x000F
+ * Module    Nr  Codes assigned
+ * MPI        7  0x0002-0x0010
+ * GCM        2  0x0012-0x0014
+ * BLOWFISH   2  0x0016-0x0018
+ * THREADING  3  0x001A-0x001E
+ * AES        2  0x0020-0x0022
+ * CAMELLIA   2  0x0024-0x0026
+ * XTEA       1  0x0028-0x0028
+ * BASE64     2  0x002A-0x002C
+ * OID        1  0x002E-0x002E   0x000B-0x000B
+ * PADLOCK    1  0x0030-0x0030
+ * DES        1  0x0032-0x0032
+ * CTR_DBRG   4  0x0034-0x003A
+ * ENTROPY    3  0x003C-0x0040
+ * NET       11  0x0042-0x0056
+ * ENTROPY    1  0x0058-0x0058
+ * ASN1       7  0x0060-0x006C
+ * MD2        1  0x0070-0x0070
+ * MD4        1  0x0072-0x0072
+ * MD5        1  0x0074-0x0074
+ * SHA1       1  0x0076-0x0076
+ * SHA256     1  0x0078-0x0078
+ * SHA512     1  0x007A-0x007A
+ * PBKDF2     1  0x007C-0x007C
+ * RIPEMD160  1  0x007E-0x007E
+ * HMAC_DRBG  4  0x0003-0x0009
+ * CCM        2                  0x000D-0x000F
  *
  * High-level module nr (3 bits - 0x0...-0x7...)
  * Name      ID  Nr of Errors
- * PEM       1   9
- * PKCS#12   1   4 (Started from top)
- * X509      2   18
- * PK        2   14 (Started from top, plus 0x2000)
- * DHM       3   9
- * PKCS5     3   4 (Started from top)
- * RSA       4   9
- * ECP       4   8 (Started from top)
- * MD        5   4
- * CIPHER    6   6
- * SSL       6   11 (Started from top)
- * SSL       7   31
+ * PEM        1  9
+ * PKCS12     1  4 (Started from top)
+ * X509       2  18
+ * PK         2  14 (Started from top, plus 0x2000)
+ * DHM        3  9
+ * PKCS5      3  4 (Started from top)
+ * RSA        4  9
+ * ECP        4  8 (Started from top)
+ * MD         5  4
+ * CIPHER     6  6
+ * SSL        6  11 (Started from top)
+ * SSL        7  31
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/include/polarssl/error.h
+++ b/include/polarssl/error.h
@@ -49,7 +49,7 @@
  * Low-level module errors (0x0002-0x007E, 0x0003-0x007F)
  *
  * Module    Nr  Codes assigned
- * MPI        7  0x0002-0x0010
+ * BIGNUM     8  0x0002-0x0010
  * GCM        2  0x0012-0x0014
  * BLOWFISH   2  0x0016-0x0018
  * THREADING  3  0x001A-0x001E
@@ -57,10 +57,10 @@
  * CAMELLIA   2  0x0024-0x0026
  * XTEA       1  0x0028-0x0028
  * BASE64     2  0x002A-0x002C
- * OID        1  0x002E-0x002E   0x000B-0x000B
+ * OID        2  0x002E-0x002E   0x000B-0x000B
  * PADLOCK    1  0x0030-0x0030
  * DES        1  0x0032-0x0032
- * CTR_DBRG   4  0x0034-0x003A
+ * CTR_DRBG   4  0x0034-0x003A
  * ENTROPY    3  0x003C-0x0040
  * NET       11  0x0042-0x0056
  * ENTROPY    1  0x0058-0x0058
@@ -73,14 +73,14 @@
  * SHA512     1  0x007A-0x007A
  * PBKDF2     1  0x007C-0x007C
  * RIPEMD160  1  0x007E-0x007E
- * HMAC_DRBG  4  0x0003-0x0009
+ * HMAC_DRBG  4                  0x0003-0x0009
  * CCM        2                  0x000D-0x000F
  *
  * High-level module nr (3 bits - 0x0...-0x7...)
  * Name      ID  Nr of Errors
  * PEM        1  9
  * PKCS12     1  4 (Started from top)
- * X509       2  18
+ * X509       2  19 (plus 0x3000)
  * PK         2  14 (Started from top, plus 0x2000)
  * DHM        3  9
  * PKCS5      3  4 (Started from top)

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -11,14 +11,18 @@ fi
 
 check()
 {
-    FILE=$1
-    SCRIPT=$2
+    SCRIPT=$1
+    shift
 
-    cp $FILE $FILE.bak
-    $SCRIPT
-    diff $FILE $FILE.bak
-    mv $FILE.bak $FILE
+    for FILE; do
+        cp "$FILE" "$FILE.bak"
+    done
+    "$SCRIPT"
+    for FILE; do
+        diff "$FILE" "$FILE.bak"
+        mv "$FILE.bak" "$FILE"
+    done
 }
 
-check library/error.c scripts/generate_errors.pl
-check library/version_features.c scripts/generate_features.pl
+check scripts/generate_errors.pl library/error.c include/polarssl/error.h
+check scripts/generate_features.pl library/version_features.c


### PR DESCRIPTION
There is an overview of error codes in a comment in `include/polarssl/error.h`. This overview has been out of synch for a long time. This PR enhances `scripts/generate_errors.pl` to update `include/polarssl/error.h` in addition to `library/error.c`.

The script contains quirks to preserve the current format of `error.h`. It could be simplified if we decide to format the information differently.

Backport of #1204
