### PR TITLE
all.sh --keep-going

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -65,10 +65,11 @@ General options:
   -f|--force            Force the tests to overwrite any modified files.
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
-     --no-yotta         Skip yotta build.
+     --no-yotta         Skip yotta module build.
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
   -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
   -s|--seed             Integer seed value to use for this test run.
+     --yotta            Build yotta module (on by default).
 
 Tool path options:
      --armc5-bin-dir=<ARMC5_bin_dir_path>       ARM Compiler 5 bin directory.
@@ -209,6 +210,9 @@ while [ $# -gt 0 ]; do
             shift
             SEED="$1"
             ;;
+        --yotta)
+            YOTTA=1
+            ;;
         *)
             echo >&2 "Unknown option: $1"
             echo >&2 "Run $0 --help for usage."
@@ -226,7 +230,7 @@ if [ $FORCE -eq 1 ]; then
     cleanup
 else
 
-    if [ $YOTTA -eq 1 ] && [ -d yotta/module ]; then
+    if [ $YOTTA -ne 0 ] && [ -d yotta/module ]; then
         err_msg "Warning - there is an existing yotta module in the directory 'yotta/module'"
         echo "You can either delete your work and retry, or force the test to overwrite the"
         echo "test by rerunning the script as: $0 --force"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -56,22 +56,28 @@ fi
 
 usage()
 {
-    printf "Usage: $0\n"
-    printf "  -h|--help\t\tPrint this help.\n"
-    printf "  -m|--memory\t\tAdditional optional memory tests.\n"
-    printf "  -f|--force\t\tForce the tests to overwrite any modified files.\n"
-    printf "  -s|--seed\t\tInteger seed value to use for this test run.\n"
-    printf "  -r|--release-test\t\tRun this script in release mode. This fixes the seed value to 1.\n"
-    printf "     --no-yotta\t\tSkip yotta build\n"
-    printf "     --out-of-source-dir=<path>\t\tDirectory used for CMake out-of-source build tests."
-    printf "     --openssl=<OpenSSL_path>\t\tPath to OpenSSL executable to use for most tests.\n"
-    printf "     --openssl-legacy=<OpenSSL_path>\t\tPath to OpenSSL executable to use for legacy tests e.g. SSLv3.\n"
-    printf "     --gnutls-cli=<GnuTLS_cli_path>\t\tPath to GnuTLS client executable to use for most tests.\n"
-    printf "     --gnutls-serv=<GnuTLS_serv_path>\t\tPath to GnuTLS server executable to use for most tests.\n"
-    printf "     --gnutls-legacy-cli=<GnuTLS_cli_path>\t\tPath to GnuTLS client executable to use for legacy tests.\n"
-    printf "     --gnutls-legacy-serv=<GnuTLS_serv_path>\t\tPath to GnuTLS server executable to use for legacy tests.\n"
-    printf "     --armc5-bin-dir=<ARMC5_bin_dir_path>\t\tPath to the ARM Compiler 5 bin directory.\n"
-    printf "     --armc6-bin-dir=<ARMC6_bin_dir_path>\t\tPath to the ARM Compiler 6 bin directory.\n"
+    cat <<EOF
+Usage: $0 [OPTION]...
+  -h|--help             Print this help.
+
+General options:
+  -f|--force            Force the tests to overwrite any modified files.
+  -m|--memory           Additional optional memory tests.
+     --no-yotta         Skip yotta build.
+     --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
+  -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
+  -s|--seed             Integer seed value to use for this test run.
+
+Tool path options:
+     --armc5-bin-dir=<ARMC5_bin_dir_path>       ARM Compiler 5 bin directory.
+     --armc6-bin-dir=<ARMC6_bin_dir_path>       ARM Compiler 6 bin directory.
+     --gnutls-cli=<GnuTLS_cli_path>             GnuTLS client executable to use for most tests.
+     --gnutls-serv=<GnuTLS_serv_path>           GnuTLS server executable to use for most tests.
+     --gnutls-legacy-cli=<GnuTLS_cli_path>      GnuTLS client executable to use for legacy tests.
+     --gnutls-legacy-serv=<GnuTLS_serv_path>    GnuTLS server executable to use for legacy tests.
+     --openssl=<OpenSSL_path>                   OpenSSL executable to use for most tests.
+     --openssl-legacy=<OpenSSL_path>            OpenSSL executable to use for legacy tests e.g. SSLv3.
+EOF
 }
 
 # remove built files as well as the cmake cache/config
@@ -127,41 +133,20 @@ check_tools()
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --memory|-m*)
-            MEMORY=${1#-m}
+        --armc5-bin-dir)
+            shift
+            ARMC5_BIN_DIR="$1"
+            ;;
+        --armc6-bin-dir)
+            shift
+            ARMC6_BIN_DIR="$1"
             ;;
         --force|-f)
             FORCE=1
             ;;
-        --seed|-s)
-            shift
-            SEED="$1"
-            ;;
-        --release-test|-r)
-            RELEASE=1
-            ;;
-          --no-yotta)
-            YOTTA=0
-            ;;
-        --out-of-source-dir)
-            shift
-            OUT_OF_SOURCE_DIR="$1"
-            ;;
-        --openssl)
-            shift
-            OPENSSL="$1"
-            ;;
-        --openssl-legacy)
-            shift
-            OPENSSL_LEGACY="$1"
-            ;;
         --gnutls-cli)
             shift
             GNUTLS_CLI="$1"
-            ;;
-        --gnutls-serv)
-            shift
-            GNUTLS_SERV="$1"
             ;;
         --gnutls-legacy-cli)
             shift
@@ -171,17 +156,43 @@ while [ $# -gt 0 ]; do
             shift
             GNUTLS_LEGACY_SERV="$1"
             ;;
-        --armc5-bin-dir)
+        --gnutls-serv)
             shift
-            ARMC5_BIN_DIR="$1"
+            GNUTLS_SERV="$1"
             ;;
-        --armc6-bin-dir)
-            shift
-            ARMC6_BIN_DIR="$1"
-            ;;
-        --help|-h|*)
+        --help|-h)
             usage
-            exit 1
+            exit
+            ;;
+        --memory|-m)
+            MEMORY=1
+            ;;
+        --no-yotta)
+            YOTTA=0
+            ;;
+        --openssl)
+            shift
+            OPENSSL="$1"
+            ;;
+        --openssl-legacy)
+            shift
+            OPENSSL_LEGACY="$1"
+            ;;
+        --out-of-source-dir)
+            shift
+            OUT_OF_SOURCE_DIR="$1"
+            ;;
+        --release-test|-r)
+            RELEASE=1
+            ;;
+        --seed|-s)
+            shift
+            SEED="$1"
+            ;;
+        *)
+            echo >&2 "Unknown option: $1"
+            echo >&2 "Run $0 --help for usage."
+            exit 120
             ;;
     esac
     shift

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -4,20 +4,78 @@
 #
 # This file is part of mbed TLS (https://tls.mbed.org)
 #
-# Copyright (c) 2014-2016, ARM Limited, All Rights Reserved
-#
+# Copyright (c) 2014-2017, ARM Limited, All Rights Reserved
+
+
+
+################################################################
+#### Documentation
+################################################################
+
 # Purpose
+# -------
 #
 # To run all tests possible or available on the platform.
 #
+# Notes for users
+# ---------------
+#
 # Warning: the test is destructive. It includes various build modes and
 # configurations, and can and will arbitrarily change the current CMake
-# configuration. After this script has been run, the CMake cache will be lost
-# and CMake will no longer be initialised.
+# configuration. The following files must be committed into git:
+#    * include/mbedtls/config.h
+#    * Makefile, library/Makefile, programs/Makefile, tests/Makefile
+# After running this script, the CMake cache will be lost and CMake
+# will no longer be initialised.
 #
-# The script assumes the presence of gcc and clang (recent enough for using
-# ASan with gcc and MemSan with clang, or valgrind) are available, as well as
-# cmake and a "good" find.
+# The script assumes the presence of a number of tools:
+#   * Basic Unix tools (Windows users note: a Unix-style find must be before
+#     the Windows find in the PATH)
+#   * Perl
+#   * GNU Make
+#   * CMake
+#   * GCC and Clang (recent enough for using ASan with gcc and MemSan with clang, or valgrind)
+#   * arm-gcc and mingw-gcc
+#   * ArmCC 5 and ArmCC 6, unless invoked with --no-armcc
+#   * Yotta build dependencies, unless invoked with --no-yotta
+#   * OpenSSL and GnuTLS command line tools, recent enough for the
+#     interoperability tests. If they don't support SSLv3 then a legacy
+#     version of these tools must be present as well (search for LEGACY
+#     below).
+# See the invocation of check_tools below for details.
+#
+# This script must be invoked from the toplevel directory of a git
+# working copy of Mbed TLS.
+#
+# Note that the output is not saved. You may want to run
+#   script -c tests/scripts/all.sh
+# or
+#   tests/scripts/all.sh >all.log 2>&1
+#
+# Notes for maintainers
+# ---------------------
+#
+# The tests are roughly in order from fastest to slowest. This doesn't
+# have to be exact, but in general you should add slower tests towards
+# the end and fast checks near the beginning.
+#
+# Sanity checks have the following form:
+#   1. msg "short description of what is about to be done"
+#   2. run sanity check (failure stops the script)
+#
+# Build or build-and-test steps have the following form:
+#   1. msg "short description of what is about to be done"
+#   2. cleanup
+#   3. preparation (config.pl, cmake, ...) (failure stops the script)
+#   4. make
+#   5. Run tests if relevant. All tests must be prefixed with
+#      if_build_successful for the sake of --keep-going.
+
+
+
+################################################################
+#### Initialization and command line parsing
+################################################################
 
 # Abort on errors (and uninitialised variables)
 set -eu
@@ -368,6 +426,12 @@ if [ $RUN_ARMCC -ne 0 ]; then
     check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
 fi
 
+
+
+################################################################
+#### Basic checks
+################################################################
+
 #
 # Test Suites to be executed
 #
@@ -401,6 +465,12 @@ tests/scripts/check-names.sh
 msg "test: doxygen warnings" # ~ 3s
 cleanup
 tests/scripts/doxygen.sh
+
+
+
+################################################################
+#### Build and test many configurations and targets
+################################################################
 
 if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
     # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
@@ -771,6 +841,12 @@ msg "test: cmake 'out-of-source' build"
 make test
 cd "$MBEDTLS_ROOT_DIR"
 rm -rf "$OUT_OF_SOURCE_DIR"
+
+
+
+################################################################
+#### Termination
+################################################################
 
 msg "Done, cleaning up"
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -252,9 +252,9 @@ export GNUTLS_SERV="$GNUTLS_SERV"
 
 # Make sure the tools we need are available.
 check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
-    "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-    "arm-none-eabi-gcc" "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR" \
-    "i686-w64-mingw32-gcc"
+            "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
+            "arm-none-eabi-gcc" "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR" \
+            "i686-w64-mingw32-gcc"
 
 #
 # Test Suites to be executed
@@ -461,42 +461,42 @@ msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)
 make test
 
 if uname -a | grep -F Linux >/dev/null; then
-msg "build/test: make shared" # ~ 40s
-cleanup
-make SHARED=1 all check
+    msg "build/test: make shared" # ~ 40s
+    cleanup
+    make SHARED=1 all check
 fi
 
 if uname -a | grep -F x86_64 >/dev/null; then
-msg "build: i386, make, gcc" # ~ 30s
-cleanup
-CC=gcc CFLAGS='-Werror -Wall -Wextra -m32' make
+    msg "build: i386, make, gcc" # ~ 30s
+    cleanup
+    CC=gcc CFLAGS='-Werror -Wall -Wextra -m32' make
 
-msg "build: gcc, force 32-bit compilation"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32' make
+    msg "build: gcc, force 32-bit compilation"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32' make
 
-msg "build: gcc, force 64-bit compilation"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
+    msg "build: gcc, force 64-bit compilation"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
 
-msg "test: gcc, force 64-bit compilation"
-make test
+    msg "test: gcc, force 64-bit compilation"
+    make test
 
-msg "build: gcc, force 64-bit compilation"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
+    msg "build: gcc, force 64-bit compilation"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64' make
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
@@ -599,49 +599,49 @@ WINDOWS_BUILD=1 make clean
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then
 
-msg "build: MSan (clang)" # ~ 1 min 20s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
-make
+    msg "build: MSan (clang)" # ~ 1 min 20s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
+    make
 
-msg "test: main suites (MSan)" # ~ 10s
-make test
+    msg "test: main suites (MSan)" # ~ 10s
+    make test
 
-msg "test: ssl-opt.sh (MSan)" # ~ 1 min
-tests/ssl-opt.sh
+    msg "test: ssl-opt.sh (MSan)" # ~ 1 min
+    tests/ssl-opt.sh
 
-# Optional part(s)
+    # Optional part(s)
 
-if [ "$MEMORY" -gt 0 ]; then
-    msg "test: compat.sh (MSan)" # ~ 6 min 20s
-    tests/compat.sh
-fi
+    if [ "$MEMORY" -gt 0 ]; then
+        msg "test: compat.sh (MSan)" # ~ 6 min 20s
+        tests/compat.sh
+    fi
 
 else # no MemSan
 
-msg "build: Release (clang)"
-cleanup
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
-make
+    msg "build: Release (clang)"
+    cleanup
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
+    make
 
-msg "test: main suites valgrind (Release)"
-make memcheck
+    msg "test: main suites valgrind (Release)"
+    make memcheck
 
-# Optional part(s)
-# Currently broken, programs don't seem to receive signals
-# under valgrind on OS X
+    # Optional part(s)
+    # Currently broken, programs don't seem to receive signals
+    # under valgrind on OS X
 
-if [ "$MEMORY" -gt 0 ]; then
-    msg "test: ssl-opt.sh --memcheck (Release)"
-    tests/ssl-opt.sh --memcheck
-fi
+    if [ "$MEMORY" -gt 0 ]; then
+        msg "test: ssl-opt.sh --memcheck (Release)"
+        tests/ssl-opt.sh --memcheck
+    fi
 
-if [ "$MEMORY" -gt 1 ]; then
-    msg "test: compat.sh --memcheck (Release)"
-    tests/compat.sh --memcheck
-fi
+    if [ "$MEMORY" -gt 1 ]; then
+        msg "test: compat.sh --memcheck (Release)"
+        tests/compat.sh --memcheck
+    fi
 
 fi # MemSan
 


### PR DESCRIPTION
Keep-going mode for `tests/scripts/all.sh` so that even if one of the tests fails, the other tests run. Print a report at the end and return a nonzero status code if anything failed.

The reason to have this mode is to get complete feedback so that this script can be used for regular testing and not as a last-minute check that we don't expect to fail.

Also added options to skip yotta and armcc usage.

Backports: #1221 #1222