### PR TITLE
Dynamic ssl buffers

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -221,12 +221,9 @@
  * Maxium fragment length in bytes,
  * determines the size of each of the two internal I/O buffers.
  *
- * Note: the RFC defines the default size of SSL / TLS messages. If you
- * change the value here, other clients / servers may not be able to
- * communicate with you anymore. Only change this value if you control
- * both sides of the connection and have it reduced at both sides, or
- * if you're using the Max Fragment Length extension and you know all your
- * peers are using it too!
+ * If you set this to less than 16384, mbedTLS will initially size the
+ * buffers to the value given, and if it finds something larger is
+ * necessary, it will reallocate the buffer.  This involves a memcpy.
  */
 #if !defined(MBEDTLS_SSL_MAX_CONTENT_LEN)
 #define MBEDTLS_SSL_MAX_CONTENT_LEN         16384   /**< Size of the input / output buffer */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -599,7 +599,9 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_alloc_record_buf( mbedtls_ssl_context *ssl,
                                   mbedtls_ssl_record *rec,
                                   size_t max_content_len );
-
+int mbedtls_ssl_confirm_content_len( mbedtls_ssl_context *ssl,
+                                     mbedtls_ssl_record *rec,
+                                     size_t content_len );
 /* constant-time buffer comparison */
 static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
 {

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -138,13 +138,13 @@
 #define MBEDTLS_SSL_PADDING_ADD              0
 #endif
 
-#define MBEDTLS_SSL_BUFFER_LEN  ( MBEDTLS_SSL_MAX_CONTENT_LEN               \
-                        + MBEDTLS_SSL_COMPRESSION_ADD               \
-                        + 29 /* counter + header + IV */    \
-                        + MBEDTLS_SSL_MAC_ADD                       \
-                        + MBEDTLS_SSL_PADDING_ADD                   \
-                        )
+#define MBEDTLS_SSL_BUFFER_OVERHEAD  (                         \
+                        + MBEDTLS_SSL_COMPRESSION_ADD          \
+                        + 29 /* counter + header + IV */       \
+                        + MBEDTLS_SSL_MAC_ADD                  \
+                        + MBEDTLS_SSL_PADDING_ADD )
 
+#define MBEDTLS_SSL_BUFFER_LEN  ( MBEDTLS_SSL_MAX_CONTENT_LEN + MBEDTLS_SSL_BUFFER_OVERHEAD )
 /*
  * TLS extension flags (for extensions with outgoing ServerHello content
  * that need it (e.g. for RENEGOTIATION_INFO the server already knows because
@@ -595,6 +595,10 @@ int mbedtls_ssl_resend( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_dtls_replay_check( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 #endif
+
+int mbedtls_ssl_alloc_record_buf( mbedtls_ssl_context *ssl,
+                                  mbedtls_ssl_record *rec,
+                                  size_t max_content_len );
 
 /* constant-time buffer comparison */
 static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -60,7 +60,7 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
                                     size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     size_t hostname_len;
 
     *olen = 0;
@@ -130,7 +130,7 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
                                          size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
 
     *olen = 0;
 
@@ -174,7 +174,7 @@ static void ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
                                                 size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     size_t sig_alg_len = 0;
     const int *md;
 #if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_ECDSA_C)
@@ -259,7 +259,7 @@ static void ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
                                                      size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     unsigned char *elliptic_curve_list = p + 6;
     size_t elliptic_curve_len = 0;
     const mbedtls_ecp_curve_info *info;
@@ -332,7 +332,7 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
                                                    size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
 
     *olen = 0;
 
@@ -365,7 +365,7 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 {
     int ret;
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     size_t kkpp_len;
 
     *olen = 0;
@@ -475,7 +475,7 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
                                           unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
 
     *olen = 0;
 
@@ -507,7 +507,7 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
                                        unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
 
     *olen = 0;
 
@@ -541,7 +541,7 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
                                        unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
 
     *olen = 0;
 
@@ -575,7 +575,7 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
                                           unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     size_t tlen = ssl->session_negotiate->ticket_len;
 
     *olen = 0;
@@ -619,7 +619,7 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
                                 unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + ssl->out.max_content_len;
     size_t alpnlen = 0;
     const char **cur;
 
@@ -2092,7 +2092,7 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
     size_t len_bytes = ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 ? 0 : 2;
     unsigned char *p = ssl->handshake->premaster + pms_offset;
 
-    if( offset + len_bytes > MBEDTLS_SSL_MAX_CONTENT_LEN )
+    if( offset + len_bytes > ssl->out.max_content_len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "buffer too small for encrypted pms" ) );
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
@@ -2135,7 +2135,7 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
     if( ( ret = mbedtls_pk_encrypt( &ssl->session_negotiate->peer_cert->pk,
                             p, ssl->handshake->pmslen,
                             ssl->out.msg + offset + len_bytes, olen,
-                            MBEDTLS_SSL_MAX_CONTENT_LEN - offset - len_bytes,
+                            ssl->out.max_content_len - offset - len_bytes,
                             ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_rsa_pkcs1_encrypt", ret );
@@ -2913,7 +2913,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         i = 4;
         n = ssl->conf->psk_identity_len;
 
-        if( i + 2 + n > MBEDTLS_SSL_MAX_CONTENT_LEN )
+        if( i + 2 + n > ssl->out.max_content_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "psk identity too long or "
                                         "SSL buffer too short" ) );
@@ -2949,7 +2949,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
              */
             n = ssl->handshake->dhm_ctx.len;
 
-            if( i + 2 + n > MBEDTLS_SSL_MAX_CONTENT_LEN )
+            if( i + 2 + n > ssl->out.max_content_len )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "psk identity or DHM size too long"
                                             " or SSL buffer too short" ) );
@@ -2978,7 +2978,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
              * ClientECDiffieHellmanPublic public;
              */
             ret = mbedtls_ecdh_make_public( &ssl->handshake->ecdh_ctx, &n,
-                    &ssl->out.msg[i], MBEDTLS_SSL_MAX_CONTENT_LEN - i,
+                    &ssl->out.msg[i], ssl->out.max_content_len - i,
                     ssl->conf->f_rng, ssl->conf->p_rng );
             if( ret != 0 )
             {
@@ -3019,7 +3019,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         i = 4;
 
         ret = mbedtls_ecjpake_write_round_two( &ssl->handshake->ecjpake_ctx,
-                ssl->out.msg + i, MBEDTLS_SSL_MAX_CONTENT_LEN - i, &n,
+                ssl->out.msg + i, ssl->out.max_content_len - i, &n,
                 ssl->conf->f_rng, ssl->conf->p_rng );
         if( ret != 0 )
         {

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -60,7 +60,7 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
                                     size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t hostname_len;
 
     *olen = 0;
@@ -130,7 +130,7 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
                                          size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -174,7 +174,7 @@ static void ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
                                                 size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t sig_alg_len = 0;
     const int *md;
 #if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_ECDSA_C)
@@ -259,7 +259,7 @@ static void ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
                                                      size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     unsigned char *elliptic_curve_list = p + 6;
     size_t elliptic_curve_len = 0;
     const mbedtls_ecp_curve_info *info;
@@ -332,7 +332,7 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
                                                    size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -365,7 +365,7 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 {
     int ret;
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t kkpp_len;
 
     *olen = 0;
@@ -442,7 +442,7 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
                                                size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -475,7 +475,7 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
                                           unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -507,7 +507,7 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
                                        unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -541,7 +541,7 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
                                        unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
 
     *olen = 0;
 
@@ -575,7 +575,7 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
                                           unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t tlen = ssl->session_negotiate->ticket_len;
 
     *olen = 0;
@@ -619,7 +619,7 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
                                 unsigned char *buf, size_t *olen )
 {
     unsigned char *p = buf;
-    const unsigned char *end = ssl->out_msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
+    const unsigned char *end = ssl->out.msg + MBEDTLS_SSL_MAX_CONTENT_LEN;
     size_t alpnlen = 0;
     const char **cur;
 
@@ -757,7 +757,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
      *     6  .   9   current UNIX time
      *    10  .  37   random bytes
      */
-    buf = ssl->out_msg;
+    buf = ssl->out.msg;
     p = buf + 4;
 
     mbedtls_ssl_write_version( ssl->conf->max_major_ver, ssl->conf->max_minor_ver,
@@ -1044,9 +1044,9 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         p += ext_len;
     }
 
-    ssl->out_msglen  = p - buf;
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0]  = MBEDTLS_SSL_HS_CLIENT_HELLO;
+    ssl->out.msglen  = p - buf;
+    ssl->out.msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+    ssl->out.msg[0]  = MBEDTLS_SSL_HS_CLIENT_HELLO;
 
     ssl->state++;
 
@@ -1369,7 +1369,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 static int ssl_parse_hello_verify_request( mbedtls_ssl_context *ssl )
 {
-    const unsigned char *p = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
+    const unsigned char *p = ssl->in.msg + mbedtls_ssl_hs_hdr_len( ssl );
     int major_ver, minor_ver;
     unsigned char cookie_len;
 
@@ -1405,7 +1405,7 @@ static int ssl_parse_hello_verify_request( mbedtls_ssl_context *ssl )
     cookie_len = *p++;
     MBEDTLS_SSL_DEBUG_BUF( 3, "cookie", p, cookie_len );
 
-    if( ( ssl->in_msg + ssl->in_msglen ) - p < cookie_len )
+    if( ( ssl->in.msg + ssl->in.msglen ) - p < cookie_len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1,
             ( "cookie length does not match incoming message size" ) );
@@ -1456,7 +1456,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse server hello" ) );
 
-    buf = ssl->in_msg;
+    buf = ssl->in.msg;
 
     if( ( ret = mbedtls_ssl_read_record( ssl ) ) != 0 )
     {
@@ -1465,7 +1465,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
+    if( ssl->in.msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
         if( ssl->renego_status == MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS )
@@ -2134,7 +2134,7 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
 
     if( ( ret = mbedtls_pk_encrypt( &ssl->session_negotiate->peer_cert->pk,
                             p, ssl->handshake->pmslen,
-                            ssl->out_msg + offset + len_bytes, olen,
+                            ssl->out.msg + offset + len_bytes, olen,
                             MBEDTLS_SSL_MAX_CONTENT_LEN - offset - len_bytes,
                             ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
     {
@@ -2146,8 +2146,8 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( len_bytes == 2 )
     {
-        ssl->out_msg[offset+0] = (unsigned char)( *olen >> 8 );
-        ssl->out_msg[offset+1] = (unsigned char)( *olen      );
+        ssl->out.msg[offset+0] = (unsigned char)( *olen >> 8 );
+        ssl->out.msg[offset+1] = (unsigned char)( *olen      );
         *olen += 2;
     }
 #endif
@@ -2309,7 +2309,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
+    if( ssl->in.msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
@@ -2321,7 +2321,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
      * ServerKeyExchange may be skipped with PSK and RSA-PSK when the server
      * doesn't use a psk_identity_hint
      */
-    if( ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE )
+    if( ssl->in.msg[0] != MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE )
     {
         if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK ||
             ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_RSA_PSK )
@@ -2340,8 +2340,8 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
     }
 
-    p   = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
-    end = ssl->in_msg + ssl->in_hslen;
+    p   = ssl->in.msg + mbedtls_ssl_hs_hdr_len( ssl );
+    end = ssl->in.msg + ssl->in_hslen;
     MBEDTLS_SSL_DEBUG_BUF( 3,   "server key exchange", p, end - p );
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
@@ -2430,7 +2430,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         unsigned char hash[64];
         mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
         mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
-        unsigned char *params = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
+        unsigned char *params = ssl->in.msg + mbedtls_ssl_hs_hdr_len( ssl );
         size_t params_len = p - params;
 
         /*
@@ -2660,7 +2660,7 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
+    if( ssl->in.msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
@@ -2669,7 +2669,7 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
     }
 
     ssl->state++;
-    ssl->client_auth = ( ssl->in_msg[0] == MBEDTLS_SSL_HS_CERTIFICATE_REQUEST );
+    ssl->client_auth = ( ssl->in.msg[0] == MBEDTLS_SSL_HS_CERTIFICATE_REQUEST );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "got %s certificate request",
                         ssl->client_auth ? "a" : "no" ) );
@@ -2705,7 +2705,7 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
      *  However, we still minimally parse the message to check it is at least
      *  superficially sane.
      */
-    buf = ssl->in_msg;
+    buf = ssl->in.msg;
 
     /* certificate_types */
     cert_type_len = buf[mbedtls_ssl_hs_hdr_len( ssl )];
@@ -2780,14 +2780,14 @@ static int ssl_parse_server_hello_done( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
+    if( ssl->in.msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server hello done message" ) );
         return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
     }
 
     if( ssl->in_hslen  != mbedtls_ssl_hs_hdr_len( ssl ) ||
-        ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO_DONE )
+        ssl->in.msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO_DONE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server hello done message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
@@ -2824,13 +2824,13 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
          */
         n = ssl->handshake->dhm_ctx.len;
 
-        ssl->out_msg[4] = (unsigned char)( n >> 8 );
-        ssl->out_msg[5] = (unsigned char)( n      );
+        ssl->out.msg[4] = (unsigned char)( n >> 8 );
+        ssl->out.msg[5] = (unsigned char)( n      );
         i = 6;
 
         ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
                                 (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
-                               &ssl->out_msg[i], n,
+                               &ssl->out.msg[i], n,
                                 ssl->conf->f_rng, ssl->conf->p_rng );
         if( ret != 0 )
         {
@@ -2871,7 +2871,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
 
         ret = mbedtls_ecdh_make_public( &ssl->handshake->ecdh_ctx,
                                 &n,
-                                &ssl->out_msg[i], 1000,
+                                &ssl->out.msg[i], 1000,
                                 ssl->conf->f_rng, ssl->conf->p_rng );
         if( ret != 0 )
         {
@@ -2920,10 +2920,10 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
         }
 
-        ssl->out_msg[i++] = (unsigned char)( n >> 8 );
-        ssl->out_msg[i++] = (unsigned char)( n      );
+        ssl->out.msg[i++] = (unsigned char)( n >> 8 );
+        ssl->out.msg[i++] = (unsigned char)( n      );
 
-        memcpy( ssl->out_msg + i, ssl->conf->psk_identity, ssl->conf->psk_identity_len );
+        memcpy( ssl->out.msg + i, ssl->conf->psk_identity, ssl->conf->psk_identity_len );
         i += ssl->conf->psk_identity_len;
 
 #if defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
@@ -2956,12 +2956,12 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
                 return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
             }
 
-            ssl->out_msg[i++] = (unsigned char)( n >> 8 );
-            ssl->out_msg[i++] = (unsigned char)( n      );
+            ssl->out.msg[i++] = (unsigned char)( n >> 8 );
+            ssl->out.msg[i++] = (unsigned char)( n      );
 
             ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
                     (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
-                    &ssl->out_msg[i], n,
+                    &ssl->out.msg[i], n,
                     ssl->conf->f_rng, ssl->conf->p_rng );
             if( ret != 0 )
             {
@@ -2978,7 +2978,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
              * ClientECDiffieHellmanPublic public;
              */
             ret = mbedtls_ecdh_make_public( &ssl->handshake->ecdh_ctx, &n,
-                    &ssl->out_msg[i], MBEDTLS_SSL_MAX_CONTENT_LEN - i,
+                    &ssl->out.msg[i], MBEDTLS_SSL_MAX_CONTENT_LEN - i,
                     ssl->conf->f_rng, ssl->conf->p_rng );
             if( ret != 0 )
             {
@@ -3019,7 +3019,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         i = 4;
 
         ret = mbedtls_ecjpake_write_round_two( &ssl->handshake->ecjpake_ctx,
-                ssl->out_msg + i, MBEDTLS_SSL_MAX_CONTENT_LEN - i, &n,
+                ssl->out.msg + i, MBEDTLS_SSL_MAX_CONTENT_LEN - i, &n,
                 ssl->conf->f_rng, ssl->conf->p_rng );
         if( ret != 0 )
         {
@@ -3044,9 +3044,9 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    ssl->out_msglen  = i + n;
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0]  = MBEDTLS_SSL_HS_CLIENT_KEY_EXCHANGE;
+    ssl->out.msglen  = i + n;
+    ssl->out.msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+    ssl->out.msg[0]  = MBEDTLS_SSL_HS_CLIENT_KEY_EXCHANGE;
 
     ssl->state++;
 
@@ -3198,14 +3198,14 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
             MBEDTLS_MD_SHA384 )
         {
             md_alg = MBEDTLS_MD_SHA384;
-            ssl->out_msg[4] = MBEDTLS_SSL_HASH_SHA384;
+            ssl->out.msg[4] = MBEDTLS_SSL_HASH_SHA384;
         }
         else
         {
             md_alg = MBEDTLS_MD_SHA256;
-            ssl->out_msg[4] = MBEDTLS_SSL_HASH_SHA256;
+            ssl->out.msg[4] = MBEDTLS_SSL_HASH_SHA256;
         }
-        ssl->out_msg[5] = mbedtls_ssl_sig_from_pk( mbedtls_ssl_own_key( ssl ) );
+        ssl->out.msg[5] = mbedtls_ssl_sig_from_pk( mbedtls_ssl_own_key( ssl ) );
 
         /* Info from md_alg will be used instead */
         hashlen = 0;
@@ -3219,19 +3219,19 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
     }
 
     if( ( ret = mbedtls_pk_sign( mbedtls_ssl_own_key( ssl ), md_alg, hash_start, hashlen,
-                         ssl->out_msg + 6 + offset, &n,
+                         ssl->out.msg + 6 + offset, &n,
                          ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_pk_sign", ret );
         return( ret );
     }
 
-    ssl->out_msg[4 + offset] = (unsigned char)( n >> 8 );
-    ssl->out_msg[5 + offset] = (unsigned char)( n      );
+    ssl->out.msg[4 + offset] = (unsigned char)( n >> 8 );
+    ssl->out.msg[5 + offset] = (unsigned char)( n      );
 
-    ssl->out_msglen  = 6 + n + offset;
-    ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
-    ssl->out_msg[0]  = MBEDTLS_SSL_HS_CERTIFICATE_VERIFY;
+    ssl->out.msglen  = 6 + n + offset;
+    ssl->out.msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+    ssl->out.msg[0]  = MBEDTLS_SSL_HS_CERTIFICATE_VERIFY;
 
     ssl->state++;
 
@@ -3269,7 +3269,7 @@ static int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
+    if( ssl->in.msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
@@ -3287,7 +3287,7 @@ static int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
      * 4  .  5   ticket_len (n)
      * 6  .  5+n ticket content
      */
-    if( ssl->in_msg[0] != MBEDTLS_SSL_HS_NEW_SESSION_TICKET ||
+    if( ssl->in.msg[0] != MBEDTLS_SSL_HS_NEW_SESSION_TICKET ||
         ssl->in_hslen < 6 + mbedtls_ssl_hs_hdr_len( ssl ) )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad new session ticket message" ) );
@@ -3296,7 +3296,7 @@ static int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET );
     }
 
-    msg = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
+    msg = ssl->in.msg + mbedtls_ssl_hs_hdr_len( ssl );
 
     lifetime = ( msg[0] << 24 ) | ( msg[1] << 16 ) |
                ( msg[2] <<  8 ) | ( msg[3]       );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2063,17 +2063,16 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
  */
 static int ssl_compress_buf( mbedtls_ssl_context *ssl )
 {
-    int ret;
-    unsigned char *msg_post = ssl->out.msg;
-    size_t len_pre = ssl->out.msglen;
-    unsigned char *msg_pre = ssl->compress_buf;
+    unsigned int pending;
+    size_t avail_out;
+    int ret, bits;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> compress buf" ) );
 
-    if( len_pre == 0 )
+    if( ssl->out.msglen == 0 )
         return( 0 );
 
-    memcpy( msg_pre, ssl->out.msg, len_pre );
+    memcpy( ssl->compress_buf, ssl->out.msg, ssl->out.msglen );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "before compression: msglen = %d, ",
                    ssl->out.msglen ) );
@@ -2081,21 +2080,41 @@ static int ssl_compress_buf( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_BUF( 4, "before compression: output payload",
                    ssl->out.msg, ssl->out.msglen );
 
-    ssl->transform_out->ctx_deflate.next_in = msg_pre;
-    ssl->transform_out->ctx_deflate.avail_in = len_pre;
-    ssl->transform_out->ctx_deflate.next_out = msg_post;
-    ssl->transform_out->ctx_deflate.avail_out = ssl->out.max_content_len + MBEDTLS_SSL_BUFFER_OVERHEAD -
-                                                  (ssl->out.msg - ssl->out.buf);
+    ssl->transform_out->ctx_deflate.next_in = ssl->compress_buf;
+    ssl->transform_out->ctx_deflate.avail_in = ssl->out.msglen;
+    ssl->out.msglen = 0;
 
-    ret = deflate( &ssl->transform_out->ctx_deflate, Z_SYNC_FLUSH );
-    if( ret != Z_OK )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "failed to perform compression (%d)", ret ) );
-        return( MBEDTLS_ERR_SSL_COMPRESSION_FAILED );
-    }
+    /*
+     * "compression" isn't guaranteed to result in something smaller...
+     * it's possible we have to increase the out buf size to write all
+     * the deflated data for the payload
+     */
+    do {
+        ssl->transform_out->ctx_deflate.next_out = ssl->out.msg + ssl->out.msglen;
+        ssl->transform_out->ctx_deflate.avail_out = ssl->out.max_content_len + MBEDTLS_SSL_BUFFER_OVERHEAD -
+                                                  (ssl->out.msg - ssl->out.buf) - ssl->out.msglen;
+	avail_out = ssl->transform_out->ctx_deflate.avail_out;
 
-    ssl->out.msglen = ssl->out.max_content_len + MBEDTLS_SSL_BUFFER_OVERHEAD -
-                      ssl->transform_out->ctx_deflate.avail_out;
+        ret = deflate( &ssl->transform_out->ctx_deflate, Z_SYNC_FLUSH );
+        if( ret != Z_OK && ret != Z_BUF_ERROR )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "failed to perform compression (%d)", ret ) );
+            return( MBEDTLS_ERR_SSL_COMPRESSION_FAILED );
+        }
+
+	ssl->out.msglen += avail_out - ssl->transform_out->ctx_deflate.avail_out;
+
+	/* check if we still have more compresssed to write */
+	deflatePending(&ssl->transform_out->ctx_deflate, &pending, &bits);
+        if( ssl->transform_out->ctx_deflate.avail_in ||
+            ( !ssl->transform_out->ctx_deflate.avail_out && ( pending || bits ) ) ) {
+		/* we have to increase the out buf and continue */
+	    ret = mbedtls_ssl_confirm_content_len( ssl, &ssl->out, ssl->out.max_content_len + 1024);
+            if( ret )
+	         return( ret );
+	    continue;
+        }
+    } while( 0 );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "after compression: msglen = %d, ",
                    ssl->out.msglen ) );
@@ -2111,16 +2130,14 @@ static int ssl_compress_buf( mbedtls_ssl_context *ssl )
 static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
 {
     int ret;
-    unsigned char *msg_post = ssl->in.msg;
-    size_t len_pre = ssl->in.msglen;
-    unsigned char *msg_pre = ssl->compress_buf;
+    size_t avail_out;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> decompress buf" ) );
 
-    if( len_pre == 0 )
+    if( ssl->in.msglen == 0 )
         return( 0 );
 
-    memcpy( msg_pre, ssl->in.msg, len_pre );
+    memcpy( ssl->compress_buf, ssl->in.msg, ssl->in.msglen );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "before decompression: msglen = %d, ",
                    ssl->in.msglen ) );
@@ -2128,22 +2145,39 @@ static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_BUF( 4, "before decompression: input payload",
                    ssl->in.msg, ssl->in.msglen );
 
-    ssl->transform_in->ctx_inflate.next_in = msg_pre;
-    ssl->transform_in->ctx_inflate.avail_in = len_pre;
-    ssl->transform_in->ctx_inflate.next_out = msg_post;
-    ssl->transform_in->ctx_inflate.avail_out = ssl->in.max_content_len +
-                                                MBEDTLS_SSL_BUFFER_OVERHEAD -
-						 (ssl->in.msg - ssl->in.buf);
+    ssl->transform_in->ctx_inflate.next_in = ssl->compress_buf;
+    ssl->transform_in->ctx_inflate.avail_in = ssl->in.msglen;
+    ssl->in.msglen = 0;
 
-    ret = inflate( &ssl->transform_in->ctx_inflate, Z_SYNC_FLUSH );
-    if( ret != Z_OK )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "failed to perform decompression (%d)", ret ) );
-        return( MBEDTLS_ERR_SSL_COMPRESSION_FAILED );
-    }
+    do {
+        ssl->transform_in->ctx_inflate.next_out = ssl->in.msg + ssl->in.msglen;
+        ssl->transform_in->ctx_inflate.avail_out = ssl->in.max_content_len +
+                                                   MBEDTLS_SSL_BUFFER_OVERHEAD -
+                                                   (ssl->in.msg - ssl->in.buf) - ssl->in.msglen;
+	avail_out = ssl->transform_in->ctx_inflate.avail_out;
 
-    ssl->in.msglen = MBEDTLS_SSL_MAX_CONTENT_LEN -
-                     ssl->transform_in->ctx_inflate.avail_out;
+        ret = inflate( &ssl->transform_in->ctx_inflate, Z_SYNC_FLUSH );
+        if( ret != Z_OK && ret != Z_BUF_ERROR )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "failed to perform decompression (%d)", ret ) );
+            return( MBEDTLS_ERR_SSL_COMPRESSION_FAILED );
+        }
+
+	if( avail_out == ssl->transform_in->ctx_inflate.avail_out )
+		/* we explicitly completed the inflate action */
+		break;
+
+        ssl->in.msglen += avail_out - ssl->transform_in->ctx_inflate.avail_out;
+	/* check if we still have more decompressed to write */
+        if( ssl->transform_in->ctx_deflate.avail_in ||
+            !ssl->transform_in->ctx_deflate.avail_out ) {
+		/* we have to increase the out buf and continue */
+	    ret = mbedtls_ssl_confirm_content_len( ssl, &ssl->in, ssl->in.max_content_len + 1024);
+            if( ret )
+	         return( ret );
+        }
+	/* we go around anyway, so inflate() can confirm nothing left and exit */
+    } while( 1 );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "after decompression: msglen = %d, ",
                    ssl->in.msglen ) );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -28,12 +28,12 @@ void ssl_dtls_replay( char *prevs, char *new, int ret )
     for( ; end_prevs - prevs >= 13; prevs += 13 )
     {
         prevs[12] = '\0';
-        unhexify( ssl.in_ctr + 2, prevs );
+        unhexify( ssl.in.ctr + 2, prevs );
         mbedtls_ssl_dtls_replay_update( &ssl );
     }
 
     /* Check new number */
-    unhexify( ssl.in_ctr + 2, new );
+    unhexify( ssl.in.ctr + 2, new );
     TEST_ASSERT( mbedtls_ssl_dtls_replay_check( &ssl ) == ret );
 
     mbedtls_ssl_free( &ssl );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -24,6 +24,12 @@ void ssl_dtls_replay( char *prevs, char *new, int ret )
                  MBEDTLS_SSL_PRESET_DEFAULT ) == 0 );
     TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
+    /* allocation for the ssl buffers is normally deferred until
+     * first use.  For the test, force an allocation of the in
+     * buffer.
+     */
+    TEST_ASSERT( mbedtls_ssl_confirm_content_len( &ssl, &ssl.in, 1024) == 0 );
+
     /* Read previous record numbers */
     for( ; end_prevs - prevs >= 13; prevs += 13 )
     {


### PR DESCRIPTION
This series makes ssl record buffer (ssl->in_buf, ssl->out_buf) allocation dynamic.

Today the buffers are allocated one-time and because the default is so expensive (32KB per connection), there is a hack added to silently restrict the allocation, MBEDTLS_MAX_CONTENT_LEN.  However this is both a very blunt instrument, since it operates on all connections in the build, and illegal, since there is no way for a server to inform a client that it has applied the restriction, unless by accident the client asked for the same restriction.  Therefore connections using non-default MBEDTLS_MAX_CONTENT_LEN are fragile against something bigger than was expected being received: the connection terminates.

This series:

 - defers any ssl buffer allocation until needed
 - allocates only what is needed, reallocating as necessary
 - has a settable allocation minimum in MBEDTLS_SSL_BUFFER_MIN (default 512) which can be used to tune minimizing reallocations at the cost of some overallocation
 - removes MBEDTLS_MAX_CONTENT_LEN, since it will adapt to whatever comes

For the mbedtls test server talking to the test client on x86_64, the client allocation for the connection is reduced from 32KB + overhead to 6625 bytes including overhead (1933 for out and 4692 for in).

## CLA
Signed by me

## Status
Development; tested against test client + server, with and without compression, and on ESP32 esp-idf, but it needs comment and further testing

## Style
Tries to conform already, happy to fix problems

## Backporting
No

## API changes
1) mbedtls_ssl_context gets the current 21 members related to ssl record buffering for in and out simplified into 2 x composed instances of the same 11-member record struct, one for in and one for out.  This allows later patches in the series to manage buffer size of in and out separately without in- or out- specific members that exist today.

2) MBEDTLS_SSL_MAX_CONTENT_LEN is eliminated, the series makes it meaningless

## Reproduce
Apply patches and should operate normally, but with reduced memory allocation