### PR TITLE
Fix race condition in compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -866,6 +866,33 @@ has_mem_err() {
     fi
 }
 
+# Wait for process $2 to be listening on port $1
+if type lsof >/dev/null 2>/dev/null; then
+    wait_server_start() {
+        START_TIME=$(date +%s)
+        if is_dtls "$MODE"; then
+            proto=UDP
+        else
+            proto=TCP
+        fi
+        while ! lsof -a -n -b -i "$proto:$1" -p "$2" >/dev/null 2>/dev/null; do
+              if [ $(( $(date +%s) - $START_TIME )) -gt $DOG_DELAY ]; then
+                  echo "SERVERSTART TIMEOUT"
+                  echo "SERVERSTART TIMEOUT" >> $SRV_OUT
+                  break
+              fi
+              # Linux and *BSD support decimal arguments to sleep. On other
+              # OSes this may be a tight loop.
+              sleep 0.1 2>/dev/null || true
+        done
+    }
+else
+    wait_server_start() {
+        sleep 1
+    }
+fi
+
+
 # start_server <name>
 # also saves name and command
 start_server() {
@@ -895,7 +922,7 @@ start_server() {
     while :; do echo bla; sleep 1; done | $SERVER_CMD >> $SRV_OUT 2>&1 &
     PROCESS_ID=$!
 
-    sleep 1
+    wait_server_start "$PORT" "$PROCESS_ID"
 }
 
 # terminate the running server


### PR DESCRIPTION
Fix a race condition in `compat.sh`: instead of using `sleep 1` to detect whether the server has started, call `lsof` if available, as was already done in `ssl-opt.sh`. In addition to fixing this race condition, which causes CI runs to fail when the machine is heavily loaded, this makes the script faster on a lightly-loaded machine (I observed -25% on a fast PC).

I also made some minor improvements to the way `lsof` is called so that on the platforms we care about, there is no tight loop and the detection tends to be a little faster.

Internal ref: IOTSSL-1831

Backports: #1216 #1217 