### PR TITLE
Backport 2.1: Fix race condition in compat.sh

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -857,6 +857,33 @@ has_mem_err() {
     fi
 }
 
+# Wait for process $2 to be listening on port $1
+if type lsof >/dev/null 2>/dev/null; then
+    wait_server_start() {
+        START_TIME=$(date +%s)
+        if is_dtls "$MODE"; then
+            proto=UDP
+        else
+            proto=TCP
+        fi
+        while ! lsof -a -n -b -i "$proto:$1" -p "$2" >/dev/null 2>/dev/null; do
+              if [ $(( $(date +%s) - $START_TIME )) -gt $DOG_DELAY ]; then
+                  echo "SERVERSTART TIMEOUT"
+                  echo "SERVERSTART TIMEOUT" >> $SRV_OUT
+                  break
+              fi
+              # Linux and *BSD support decimal arguments to sleep. On other
+              # OSes this may be a tight loop.
+              sleep 0.1 2>/dev/null || true
+        done
+    }
+else
+    wait_server_start() {
+        sleep 1
+    }
+fi
+
+
 # start_server <name>
 # also saves name and command
 start_server() {
@@ -886,7 +913,7 @@ start_server() {
     while :; do echo bla; sleep 1; done | $SERVER_CMD >> $SRV_OUT 2>&1 &
     PROCESS_ID=$!
 
-    sleep 1
+    wait_server_start "$PORT" "$PROCESS_ID"
 }
 
 # terminate the running server

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -232,40 +232,32 @@ has_mem_err() {
     fi
 }
 
-# wait for server to start: two versions depending on lsof availability
-wait_server_start() {
-    if which lsof >/dev/null 2>&1; then
-        START_TIME=$( date +%s )
-        DONE=0
-
-        # make a tight loop, server usually takes less than 1 sec to start
+# Wait for process $2 to be listening on port $1
+if type lsof >/dev/null 2>/dev/null; then
+    wait_server_start() {
+        START_TIME=$(date +%s)
         if [ "$DTLS" -eq 1 ]; then
-            while [ $DONE -eq 0 ]; do
-                if lsof -nbi UDP:"$SRV_PORT" 2>/dev/null | grep UDP >/dev/null
-                then
-                    DONE=1
-                elif [ $(( $( date +%s ) - $START_TIME )) -gt $DOG_DELAY ]; then
-                    echo "SERVERSTART TIMEOUT"
-                    echo "SERVERSTART TIMEOUT" >> $SRV_OUT
-                    DONE=1
-                fi
-            done
+            proto=UDP
         else
-            while [ $DONE -eq 0 ]; do
-                if lsof -nbi TCP:"$SRV_PORT" 2>/dev/null | grep LISTEN >/dev/null
-                then
-                    DONE=1
-                elif [ $(( $( date +%s ) - $START_TIME )) -gt $DOG_DELAY ]; then
-                    echo "SERVERSTART TIMEOUT"
-                    echo "SERVERSTART TIMEOUT" >> $SRV_OUT
-                    DONE=1
-                fi
-            done
+            proto=TCP
         fi
-    else
+        # Make a tight loop, server normally takes less than 1s to start.
+        while ! lsof -a -n -b -i "$proto:$1" -p "$2" >/dev/null 2>/dev/null; do
+              if [ $(( $(date +%s) - $START_TIME )) -gt $DOG_DELAY ]; then
+                  echo "SERVERSTART TIMEOUT"
+                  echo "SERVERSTART TIMEOUT" >> $SRV_OUT
+                  break
+              fi
+              # Linux and *BSD support decimal arguments to sleep. On other
+              # OSes this may be a tight loop.
+              sleep 0.1 2>/dev/null || true
+        done
+    }
+else
+    wait_server_start() {
         sleep "$START_DELAY"
-    fi
-}
+    }
+fi
 
 # wait for client to terminate and set CLI_EXIT
 # must be called right after starting the client
@@ -373,7 +365,7 @@ run_test() {
         echo "$SRV_CMD" > $SRV_OUT
         provide_input | $SRV_CMD >> $SRV_OUT 2>&1 &
         SRV_PID=$!
-        wait_server_start
+        wait_server_start "$SRV_PORT" "$SRV_PID"
 
         echo "$CLI_CMD" > $CLI_OUT
         eval "$CLI_CMD" >> $CLI_OUT 2>&1 &


### PR DESCRIPTION
Fix a race condition in `compat.sh`: instead of using `sleep 1` to detect whether the server has started, call `lsof` if available, as was already done in `ssl-opt.sh`. In addition to fixing this race condition, which causes CI runs to fail when the machine is heavily loaded, this makes the script faster on a lightly-loaded machine.

I also made some minor improvements to the way `lsof` is called so that on the platforms we care about, there is no tight loop and the detection tends to be a little faster.

Internal ref: IOTSSL-1831

Straight backport of #1210
