### PR TITLE
Separate psk and psk_identity buffers free

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7652,10 +7652,14 @@ void mbedtls_ssl_config_free( mbedtls_ssl_config *conf )
     if( conf->psk != NULL )
     {
         mbedtls_zeroize( conf->psk, conf->psk_len );
-        mbedtls_zeroize( conf->psk_identity, conf->psk_identity_len );
         mbedtls_free( conf->psk );
-        mbedtls_free( conf->psk_identity );
         conf->psk_len = 0;
+    }
+
+    if( conf->psk_identity != NULL )
+    {
+        mbedtls_zeroize( conf->psk_identity, conf->psk_identity_len );
+        mbedtls_free( conf->psk_identity );
         conf->psk_identity_len = 0;
     }
 #endif


### PR DESCRIPTION
User can handle the psk with f_psk callback function and only set the psk_identity
in mbedtls_ssl_config context. In this case, psk_identity can not be freed even though
user called mbedtls_ssl_config_free function.

So, i propose to separate this two release routines.
Thanks.