### PR TITLE
Backport 1.3: all.sh --keep-going

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -45,19 +45,25 @@ RELEASE=0
 
 usage()
 {
-    printf "Usage: $0\n"
-    printf "  -h|--help\t\tPrint this help.\n"
-    printf "  -m|--memory\t\tAdditional optional memory tests.\n"
-    printf "  -f|--force\t\tForce the tests to overwrite any modified files.\n"
-    printf "  -s|--seed\t\tInteger seed value to use for this test run.\n"
-    printf "  -r|--release-test\t\tRun this script in release mode. This fixes the seed value to 1.\n"
-    printf "     --out-of-source-dir=<path>\t\tDirectory used for CMake out-of-source build tests."
-    printf "     --openssl=<OpenSSL_path>\t\tPath to OpenSSL executable to use for most tests.\n"
-    printf "     --openssl-legacy=<OpenSSL_path>\t\tPath to OpenSSL executable to use for legacy tests e.g. SSLv3.\n"
-    printf "     --gnutls-cli=<GnuTLS_cli_path>\t\tPath to GnuTLS client executable to use for most tests.\n"
-    printf "     --gnutls-serv=<GnuTLS_serv_path>\t\tPath to GnuTLS server executable to use for most tests.\n"
-    printf "     --gnutls-legacy-cli=<GnuTLS_cli_path>\t\tPath to GnuTLS client executable to use for legacy tests.\n"
-    printf "     --gnutls-legacy-serv=<GnuTLS_serv_path>\t\tPath to GnuTLS server executable to use for legacy tests.\n"
+    cat <<EOF
+Usage: $0 [OPTION]...
+  -h|--help             Print this help.
+
+General options:
+  -f|--force            Force the tests to overwrite any modified files.
+  -m|--memory           Additional optional memory tests.
+     --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
+  -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
+  -s|--seed             Integer seed value to use for this test run.
+
+Tool path options:
+     --gnutls-cli=<GnuTLS_cli_path>             GnuTLS client executable to use for most tests.
+     --gnutls-serv=<GnuTLS_serv_path>           GnuTLS server executable to use for most tests.
+     --gnutls-legacy-cli=<GnuTLS_cli_path>      GnuTLS client executable to use for legacy tests.
+     --gnutls-legacy-serv=<GnuTLS_serv_path>    GnuTLS server executable to use for legacy tests.
+     --openssl=<OpenSSL_path>                   OpenSSL executable to use for most tests.
+     --openssl-legacy=<OpenSSL_path>            OpenSSL executable to use for legacy tests e.g. SSLv3.
+EOF
 }
 
 # remove built files as well as the cmake cache/config
@@ -103,38 +109,12 @@ check_tools()
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --memory|-m*)
-            MEMORY=${1#-m}
-            ;;
         --force|-f)
             FORCE=1
-            ;;
-        --seed|-s)
-            shift
-            SEED="$1"
-            ;;
-        --release-test|-r)
-            RELEASE=1
-            ;;
-        --out-of-source-dir)
-            shift
-            OUT_OF_SOURCE_DIR="$1"
-            ;;
-        --openssl)
-            shift
-            OPENSSL="$1"
-            ;;
-        --openssl-legacy)
-            shift
-            OPENSSL_LEGACY="$1"
             ;;
         --gnutls-cli)
             shift
             GNUTLS_CLI="$1"
-            ;;
-        --gnutls-serv)
-            shift
-            GNUTLS_SERV="$1"
             ;;
         --gnutls-legacy-cli)
             shift
@@ -144,9 +124,40 @@ while [ $# -gt 0 ]; do
             shift
             GNUTLS_LEGACY_SERV="$1"
             ;;
-        --help|-h|*)
+        --gnutls-serv)
+            shift
+            GNUTLS_SERV="$1"
+            ;;
+        --help|-h)
             usage
-            exit 1
+            exit
+            ;;
+        --memory|-m)
+            MEMORY=1
+            ;;
+        --openssl)
+            shift
+            OPENSSL="$1"
+            ;;
+        --openssl-legacy)
+            shift
+            OPENSSL_LEGACY="$1"
+            ;;
+        --out-of-source-dir)
+            shift
+            OUT_OF_SOURCE_DIR="$1"
+            ;;
+        --release-test|-r)
+            RELEASE=1
+            ;;
+        --seed|-s)
+            shift
+            SEED="$1"
+            ;;
+        *)
+            echo >&2 "Unknown option: $1"
+            echo >&2 "Run $0 --help for usage."
+            exit 120
             ;;
     esac
     shift

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -200,8 +200,8 @@ export GNUTLS_SERV="$GNUTLS_SERV"
 
 # Make sure the tools we need are available.
 check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
-    "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-    "arm-none-eabi-gcc" "armcc"
+            "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
+            "arm-none-eabi-gcc" "armcc"
 
 #
 # Test Suites to be executed
@@ -349,15 +349,15 @@ scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
 CC=gcc CFLAGS='-Werror -O0' make
 
 if uname -a | grep -F Linux >/dev/null; then
-msg "build/test: make shared" # ~ 40s
-cleanup
-make SHARED=1 all check
+    msg "build/test: make shared" # ~ 40s
+    cleanup
+    make SHARED=1 all check
 fi
 
 if uname -a | grep -F x86_64 >/dev/null; then
-msg "build: i386, make, gcc" # ~ 30s
-cleanup
-CC=gcc CFLAGS='-Werror -m32' make
+    msg "build: i386, make, gcc" # ~ 30s
+    cleanup
+    CC=gcc CFLAGS='-Werror -m32' make
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
@@ -399,61 +399,61 @@ scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
 CC=armcc AR=armar WARNING_CFLAGS= make lib
 
 if which i686-w64-mingw32-gcc >/dev/null; then
-msg "build: cross-mingw64, make" # ~ 30s
-cleanup
-CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 make
-WINDOWS_BUILD=1 make clean
-CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 SHARED=1 make
-WINDOWS_BUILD=1 make clean
+    msg "build: cross-mingw64, make" # ~ 30s
+    cleanup
+    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 make
+    WINDOWS_BUILD=1 make clean
+    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 SHARED=1 make
+    WINDOWS_BUILD=1 make clean
 fi
 
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then
 
-msg "build: MSan (clang)" # ~ 1 min 20s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset POLARSSL_AESNI_C # memsan doesn't grok asm
-scripts/config.pl set POLARSSL_NO_PLATFORM_ENTROPY # memsan vs getrandom()
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
-make
+    msg "build: MSan (clang)" # ~ 1 min 20s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset POLARSSL_AESNI_C # memsan doesn't grok asm
+    scripts/config.pl set POLARSSL_NO_PLATFORM_ENTROPY # memsan vs getrandom()
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
+    make
 
-msg "test: main suites (MSan)" # ~ 10s
-make test
+    msg "test: main suites (MSan)" # ~ 10s
+    make test
 
-msg "test: ssl-opt.sh (MSan)" # ~ 1 min
-tests/ssl-opt.sh
+    msg "test: ssl-opt.sh (MSan)" # ~ 1 min
+    tests/ssl-opt.sh
 
-# Optional part(s)
+    # Optional part(s)
 
-if [ "$MEMORY" -gt 0 ]; then
-    msg "test: compat.sh (MSan)" # ~ 6 min 20s
-    tests/compat.sh
-fi
+    if [ "$MEMORY" -gt 0 ]; then
+        msg "test: compat.sh (MSan)" # ~ 6 min 20s
+        tests/compat.sh
+    fi
 
 else # no MemSan
 
-msg "build: Release (clang)"
-cleanup
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
-make
+    msg "build: Release (clang)"
+    cleanup
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
+    make
 
-msg "test: main suites valgrind (Release)"
-make test
+    msg "test: main suites valgrind (Release)"
+    make test
 
-# Optional part(s)
-# Currently broken, programs don't seem to receive signals
-# under valgrind on OS X
+    # Optional part(s)
+    # Currently broken, programs don't seem to receive signals
+    # under valgrind on OS X
 
-if [ "$MEMORY" -gt 0 ]; then
-    msg "test: ssl-opt.sh --memcheck (Release)"
-    tests/ssl-opt.sh --memcheck
-fi
+    if [ "$MEMORY" -gt 0 ]; then
+        msg "test: ssl-opt.sh --memcheck (Release)"
+        tests/ssl-opt.sh --memcheck
+    fi
 
-if [ "$MEMORY" -gt 1 ]; then
-    msg "test: compat.sh --memcheck (Release)"
-    tests/compat.sh --memcheck
-fi
+    if [ "$MEMORY" -gt 1 ]; then
+        msg "test: compat.sh --memcheck (Release)"
+        tests/compat.sh --memcheck
+    fi
 
 fi # MemSan
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -32,6 +32,7 @@ CONFIG_BAK="$CONFIG_H.bak"
 
 MEMORY=0
 FORCE=0
+KEEP_GOING=0
 RELEASE=0
 
 # Default commands, can be overriden by the environment
@@ -51,6 +52,7 @@ Usage: $0 [OPTION]...
 
 General options:
   -f|--force            Force the tests to overwrite any modified files.
+  -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
   -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
@@ -69,7 +71,7 @@ EOF
 # remove built files as well as the cmake cache/config
 cleanup()
 {
-    make clean
+    command make clean
 
     find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
     rm -f include/Makefile include/polarssl/Makefile programs/*/Makefile
@@ -81,7 +83,21 @@ cleanup()
     fi
 }
 
-trap cleanup INT TERM HUP
+# Executed on exit. May be redefined depending on command line options.
+final_report () {
+    :
+}
+
+fatal_signal () {
+    cleanup
+    final_report $1
+    trap - $1
+    kill -$1 $$
+}
+
+trap 'fatal_signal HUP' HUP
+trap 'fatal_signal INT' INT
+trap 'fatal_signal TERM' TERM
 
 msg()
 {
@@ -90,6 +106,7 @@ msg()
     echo "* $1 "
     printf "* "; date
     echo "******************************************************************"
+    current_section=$1
 }
 
 err_msg()
@@ -131,6 +148,9 @@ while [ $# -gt 0 ]; do
         --help|-h)
             usage
             exit
+            ;;
+        --keep-going|-k)
+            KEEP_GOING=1
             ;;
         --memory|-m)
             MEMORY=1
@@ -176,13 +196,77 @@ else
     fi
 
     if ! git diff-files --quiet include/polarssl/config.h; then
-        echo $?
         err_msg "Warning - the configuration file 'include/polarssl/config.h' has been edited. "
         echo "You can either delete or preserve your work, or force the test by rerunning the"
         echo "script as: $0 --force"
         exit 1
     fi
 fi
+
+build_status=0
+if [ $KEEP_GOING -eq 1 ]; then
+    failure_summary=
+    failure_count=0
+    start_red=
+    end_color=
+    if [ -t 1 ]; then
+        case "$TERM" in
+            *color*|cygwin|linux|rxvt*|screen|[Eex]term*)
+                start_red=$(printf '\033[31m')
+                end_color=$(printf '\033[0m')
+                ;;
+        esac
+    fi
+    record_status () {
+        if "$@"; then
+            last_status=0
+        else
+            last_status=$?
+            text="$current_section: $* -> $last_status"
+            failure_summary="$failure_summary
+$text"
+            failure_count=$((failure_count + 1))
+            echo "${start_red}^^^^$text^^^^${end_color}"
+        fi
+    }
+    make () {
+        case "$*" in
+            *test|*check)
+                if [ $build_status -eq 0 ]; then
+                    record_status command make "$@"
+                else
+                    echo "(skipped because the build failed)"
+                fi
+                ;;
+            *)
+                record_status command make "$@"
+                build_status=$last_status
+                ;;
+        esac
+    }
+    final_report () {
+        if [ $failure_count -gt 0 ]; then
+            echo
+            echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+            echo "${start_red}FAILED: $failure_count${end_color}$failure_summary"
+            echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        elif [ -z "${1-}" ]; then
+            echo "SUCCESS :)"
+        fi
+        if [ -n "${1-}" ]; then
+            echo "Killed by SIG$1."
+        fi
+    }
+else
+    record_status () {
+        "$@"
+    }
+fi
+if_build_succeeded () {
+    if [ $build_status -eq 0 ]; then
+        record_status "$@"
+    fi
+}
 
 if [ $RELEASE -eq 1 ]; then
     # Fix the seed value to 1 to ensure that the tests are deterministic.
@@ -241,16 +325,16 @@ make test
 programs/test/selftest
 
 msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
-tests/ssl-opt.sh
+if_build_succeeded tests/ssl-opt.sh
 
 msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-tests/scripts/test-ref-configs.pl
+if_build_succeeded tests/scripts/test-ref-configs.pl
 
 msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
 make
 
 msg "test: compat.sh (ASan build)" # ~ 6 min
-tests/compat.sh
+if_build_succeeded tests/compat.sh
 
 msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
 cleanup
@@ -264,11 +348,11 @@ make test
 programs/test/selftest
 
 msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
-tests/compat.sh -m 'tls1 tls1_1 tls1_2'
-OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
+if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2'
+if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
 
 msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
-tests/ssl-opt.sh
+if_build_succeeded tests/ssl-opt.sh
 
 msg "build: Default + POLARSSL_SSL_DISABLE_RENEGOTIATION (ASan build)" # ~ 6 min
 cleanup
@@ -281,7 +365,7 @@ msg "test: POLARSSL_SSL_DISABLE_RENEGOTIATION - main suites (inc. selftests) (AS
 make test
 
 msg "test: POLARSSL_SSL_DISABLE_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-tests/ssl-opt.sh
+if_build_succeeded tests/ssl-opt.sh
 
 msg "build: cmake, full config, clang" # ~ 50s
 cleanup
@@ -297,20 +381,19 @@ msg "test: main suites (full config)" # ~ 5s
 make test
 
 msg "test: ssl-opt.sh default (full config)" # ~ 1s
-tests/ssl-opt.sh -f Default
+if_build_succeeded tests/ssl-opt.sh -f Default
 
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
-OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '^$' -f 'NULL\|3DES-EDE-CBC\|DES-CBC3'
-
+if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '^$' -f 'NULL\|3DES-EDE-CBC\|DES-CBC3'
 
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup
 cmake -D CMAKE_BUILD_TYPE:String=Debug .
-tests/scripts/curves.pl
+if_build_succeeded tests/scripts/curves.pl
 
 msg "build: Unix make, -Os (gcc)" # ~ 30s
 cleanup
-CC=gcc CFLAGS='-Werror -Os' make
+make CC=gcc CFLAGS='-Werror -Os'
 
 # this is meant to cath missing #define polarssl_printf etc
 # disable fsio to catch some more missing #include <stdio.h>
@@ -329,7 +412,7 @@ scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C
 scripts/config.pl unset POLARSSL_FS_IO
 scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
 scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
-CC=gcc CFLAGS='-Werror -O0' make
+make CC=gcc CFLAGS='-Werror -O0'
 
 # catch compile bugs in _uninit functions
 msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
@@ -339,7 +422,7 @@ scripts/config.pl full
 scripts/config.pl set POLARSSL_PLATFORM_NO_STD_FUNCTIONS
 scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
 scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
-CC=gcc CFLAGS='-Werror -O0' make
+make CC=gcc CFLAGS='-Werror -O0'
 
 msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
 cleanup
@@ -348,7 +431,7 @@ scripts/config.pl full
 scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
 scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
 scripts/config.pl unset POLARSSL_SSL_SRV_C
-CC=gcc CFLAGS='-Werror -O0' make
+make CC=gcc CFLAGS='-Werror -O0'
 
 msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
 cleanup
@@ -357,7 +440,7 @@ scripts/config.pl full
 scripts/config.pl unset POLARSSL_SSL_CLI_C
 scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
 scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
-CC=gcc CFLAGS='-Werror -O0' make
+make CC=gcc CFLAGS='-Werror -O0'
 
 if uname -a | grep -F Linux >/dev/null; then
     msg "build/test: make shared" # ~ 40s
@@ -368,7 +451,7 @@ fi
 if uname -a | grep -F x86_64 >/dev/null; then
     msg "build: i386, make, gcc" # ~ 30s
     cleanup
-    CC=gcc CFLAGS='-Werror -m32' make
+    make CC=gcc CFLAGS='-Werror -m32'
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
@@ -387,7 +470,7 @@ scripts/config.pl unset POLARSSL_THREADING_PTHREAD
 scripts/config.pl unset POLARSSL_THREADING_C
 scripts/config.pl unset POLARSSL_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
-CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS=-Werror make lib
+make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS=-Werror lib
 
 msg "build: armcc, make"
 cleanup
@@ -407,15 +490,15 @@ scripts/config.pl unset POLARSSL_THREADING_PTHREAD
 scripts/config.pl unset POLARSSL_THREADING_C
 scripts/config.pl unset POLARSSL_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
-CC=armcc AR=armar WARNING_CFLAGS= make lib
+make CC=armcc AR=armar WARNING_CFLAGS= lib
 
 if which i686-w64-mingw32-gcc >/dev/null; then
     msg "build: cross-mingw64, make" # ~ 30s
     cleanup
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 make
-    WINDOWS_BUILD=1 make clean
-    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 SHARED=1 make
-    WINDOWS_BUILD=1 make clean
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1
+    make WINDOWS_BUILD=1 clean
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 SHARED=1
+    make WINDOWS_BUILD=1 clean
 fi
 
 # MemSan currently only available on Linux 64 bits
@@ -433,13 +516,13 @@ if uname -a | grep 'Linux.*x86_64' >/dev/null; then
     make test
 
     msg "test: ssl-opt.sh (MSan)" # ~ 1 min
-    tests/ssl-opt.sh
+    if_build_succeeded tests/ssl-opt.sh
 
     # Optional part(s)
 
     if [ "$MEMORY" -gt 0 ]; then
         msg "test: compat.sh (MSan)" # ~ 6 min 20s
-        tests/compat.sh
+        if_build_succeeded tests/compat.sh
     fi
 
 else # no MemSan
@@ -458,12 +541,12 @@ else # no MemSan
 
     if [ "$MEMORY" -gt 0 ]; then
         msg "test: ssl-opt.sh --memcheck (Release)"
-        tests/ssl-opt.sh --memcheck
+        if_build_succeeded tests/ssl-opt.sh --memcheck
     fi
 
     if [ "$MEMORY" -gt 1 ]; then
         msg "test: compat.sh --memcheck (Release)"
-        tests/compat.sh --memcheck
+        if_build_succeeded tests/compat.sh --memcheck
     fi
 
 fi # MemSan
@@ -484,3 +567,4 @@ rm -rf "$OUT_OF_SOURCE_DIR"
 msg "Done, cleaning up"
 cleanup
 
+final_report

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -34,6 +34,7 @@ MEMORY=0
 FORCE=0
 KEEP_GOING=0
 RELEASE=0
+RUN_ARMCC=1
 
 # Default commands, can be overriden by the environment
 : ${OPENSSL:="openssl"}
@@ -54,6 +55,8 @@ General options:
   -f|--force            Force the tests to overwrite any modified files.
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
+     --armcc            Run ARM Compiler builds (on by default).
+     --no-armcc         Skip ARM Compiler builds.
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
   -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
   -s|--seed             Integer seed value to use for this test run.
@@ -126,6 +129,9 @@ check_tools()
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --armcc)
+            RUN_ARMCC=1
+            ;;
         --force|-f)
             FORCE=1
             ;;
@@ -154,6 +160,9 @@ while [ $# -gt 0 ]; do
             ;;
         --memory|-m)
             MEMORY=1
+            ;;
+        --no-armcc)
+            RUN_ARMCC=0
             ;;
         --openssl)
             shift
@@ -296,7 +305,10 @@ export GNUTLS_SERV="$GNUTLS_SERV"
 # Make sure the tools we need are available.
 check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
             "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-            "arm-none-eabi-gcc" "armcc"
+            "arm-none-eabi-gcc"
+if [ $RUN_ARMCC -ne 0 ]; then
+    check_tools "armcc"
+fi
 
 #
 # Test Suites to be executed
@@ -472,25 +484,27 @@ scripts/config.pl unset POLARSSL_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS=-Werror lib
 
-msg "build: armcc, make"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset POLARSSL_NET_C
-scripts/config.pl unset POLARSSL_TIMING_C
-scripts/config.pl unset POLARSSL_FS_IO
-scripts/config.pl unset POLARSSL_HAVE_TIME
-scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
-scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
-scripts/config.pl set POLARSSL_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset POLARSSL_DEPRECATED_WARNING
-scripts/config.pl unset POLARSSL_HAVEGE_C # depends on timing.c
-scripts/config.pl unset POLARSSL_THREADING_PTHREAD
-scripts/config.pl unset POLARSSL_THREADING_C
-scripts/config.pl unset POLARSSL_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
-make CC=armcc AR=armar WARNING_CFLAGS= lib
+if [ $RUN_ARMCC -ne 0 ]; then
+    msg "build: armcc, make"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset POLARSSL_NET_C
+    scripts/config.pl unset POLARSSL_TIMING_C
+    scripts/config.pl unset POLARSSL_FS_IO
+    scripts/config.pl unset POLARSSL_HAVE_TIME
+    scripts/config.pl unset POLARSSL_ERROR_STRERROR_BC # deprecated
+    scripts/config.pl unset POLARSSL_PBKDF2_C # deprecated
+    scripts/config.pl set POLARSSL_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset POLARSSL_DEPRECATED_WARNING
+    scripts/config.pl unset POLARSSL_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset POLARSSL_THREADING_PTHREAD
+    scripts/config.pl unset POLARSSL_THREADING_C
+    scripts/config.pl unset POLARSSL_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset POLARSSL_MEMORY_BUFFER_ALLOC_C # calls exit
+    make CC=armcc AR=armar WARNING_CFLAGS= lib
+fi
 
 if which i686-w64-mingw32-gcc >/dev/null; then
     msg "build: cross-mingw64, make" # ~ 30s


### PR DESCRIPTION
Keep-going mode for `tests/scripts/all.sh` so that even if one of the tests fails, the other tests run. Print a report at the end and return a nonzero status code if anything failed.

The reason to have this mode is to get complete feedback so that this script can be used for regular testing and not as a last-minute check that we don't expect to fail.

Also added an option to skip armcc usage (this version doesn't run yotta).

Backport of #1207 