### PR TITLE
fix bug in get_one_and_zeros_padding()

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -516,14 +516,14 @@ static int get_one_and_zeros_padding( unsigned char *input, size_t input_len,
     if( NULL == input || NULL == data_len )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    bad = 0xFF;
+    bad = 0x80;
     *data_len = 0;
     for( i = input_len; i > 0; i-- )
     {
         prev_done = done;
-        done |= ( input[i-1] != 0 );
+        done |= ( input[i - 1] != 0 );
         *data_len |= ( i - 1 ) * ( done != prev_done );
-        bad &= ( input[i-1] ^ 0x80 ) | ( done == prev_done );
+        bad ^= input[i - 1] * ( done != prev_done );
     }
 
     return( MBEDTLS_ERR_CIPHER_INVALID_PADDING * ( bad != 0 ) );

--- a/tests/suites/test_suite_cipher.padding.data
+++ b/tests/suites/test_suite_cipher.padding.data
@@ -184,6 +184,10 @@ Check one and zeros padding #7 (overlong)
 depends_on:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 check_padding:MBEDTLS_PADDING_ONE_AND_ZEROS:"0000000000":MBEDTLS_ERR_CIPHER_INVALID_PADDING:4
 
+Check one and zeros padding #8 (last byte 0x80 | x)
+depends_on:MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+check_padding:MBEDTLS_PADDING_ONE_AND_ZEROS:"0000000082":MBEDTLS_ERR_CIPHER_INVALID_PADDING:4
+
 Check zeros and len padding #1 (correct)
 depends_on:MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
 check_padding:MBEDTLS_PADDING_ZEROS_AND_LEN:"DABBAD0001":0:4


### PR DESCRIPTION
## Description
The function get_one_and_zeros_padding() accepts invalid padded data.
This commit fixes the bug and adds a test case (“0000000082”) which fails with the old implementation.


## Status
**READY**

## Requires Backporting
Yes

## Migrations
NO