### PR TITLE
Changed mbedtls_entropy_func in tests to test_mbedtls_entropy_func

### DIFF
--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -2,7 +2,7 @@
 #include "mbedtls/ctr_drbg.h"
 
 int test_offset_idx;
-int mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
+int test_mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     const unsigned char *p = (unsigned char *) data;
     memcpy( buf, p + test_offset_idx, len );
@@ -72,7 +72,7 @@ void ctr_drbg_validate_pr( char *add_init_string, char *entropy_string,
     add2_len = unhexify( add2, add2_string );
 
     test_offset_idx = 0;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, test_mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
     mbedtls_ctr_drbg_set_prediction_resistance( &ctx, MBEDTLS_CTR_DRBG_PR_ON );
 
     TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, buf, 16, add1, add1_len ) == 0 );
@@ -110,7 +110,7 @@ void ctr_drbg_validate_nopr( char *add_init_string, char *entropy_string,
     add2_len = unhexify( add2, add2_string );
 
     test_offset_idx = 0;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, test_mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
 
     TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, buf, 16, add1, add1_len ) == 0 );
     TEST_ASSERT( mbedtls_ctr_drbg_reseed( &ctx, add_reseed, add_reseed_len ) == 0 );
@@ -141,7 +141,7 @@ void ctr_drbg_entropy_usage( )
 
     /* Init must use entropy */
     last_idx = test_offset_idx;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, mbedtls_entropy_func, entropy, NULL, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, test_mbedtls_entropy_func, entropy, NULL, 0 ) == 0 );
     TEST_ASSERT( last_idx < test_offset_idx );
 
     /* By default, PR is off and reseed_interval is large,

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -1,8 +1,8 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ctr_drbg.h"
 
-int test_offset_idx;
-int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
+static int test_offset_idx;
+static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     const unsigned char *p = (unsigned char *) data;
     memcpy( buf, p + test_offset_idx, len );

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -2,7 +2,7 @@
 #include "mbedtls/ctr_drbg.h"
 
 int test_offset_idx;
-int test_mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
+int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     const unsigned char *p = (unsigned char *) data;
     memcpy( buf, p + test_offset_idx, len );

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -72,7 +72,7 @@ void ctr_drbg_validate_pr( char *add_init_string, char *entropy_string,
     add2_len = unhexify( add2, add2_string );
 
     test_offset_idx = 0;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, test_mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, mbedtls_test_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
     mbedtls_ctr_drbg_set_prediction_resistance( &ctx, MBEDTLS_CTR_DRBG_PR_ON );
 
     TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, buf, 16, add1, add1_len ) == 0 );
@@ -110,7 +110,7 @@ void ctr_drbg_validate_nopr( char *add_init_string, char *entropy_string,
     add2_len = unhexify( add2, add2_string );
 
     test_offset_idx = 0;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, test_mbedtls_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed_entropy_len( &ctx, mbedtls_test_entropy_func, entropy, add_init, add_init_len, 32 ) == 0 );
 
     TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, buf, 16, add1, add1_len ) == 0 );
     TEST_ASSERT( mbedtls_ctr_drbg_reseed( &ctx, add_reseed, add_reseed_len ) == 0 );
@@ -141,7 +141,7 @@ void ctr_drbg_entropy_usage( )
 
     /* Init must use entropy */
     last_idx = test_offset_idx;
-    TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, test_mbedtls_entropy_func, entropy, NULL, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, mbedtls_test_entropy_func, entropy, NULL, 0 ) == 0 );
     TEST_ASSERT( last_idx < test_offset_idx );
 
     /* By default, PR is off and reseed_interval is large,

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -7,7 +7,7 @@ typedef struct
     size_t len;
 } entropy_ctx;
 
-int test_mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
+int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     entropy_ctx *ctx = (entropy_ctx *) data;
 
@@ -50,7 +50,7 @@ void hmac_drbg_entropy_usage( int md_alg )
 
     /* Init must use entropy */
     last_len = entropy.len;
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &entropy,
                                  NULL, 0 ) == 0 );
     TEST_ASSERT( entropy.len < last_len );
 
@@ -206,7 +206,7 @@ void hmac_drbg_no_reseed( int md_alg,
     TEST_ASSERT( memcmp( my_output, output, out_len ) == 0 );
 
     /* And now the normal entropy-based variant */
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,
                                             add1, add1_len ) == 0 );
@@ -251,7 +251,7 @@ void hmac_drbg_nopr( int md_alg,
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
 
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_reseed( &ctx, add1, add1_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,
@@ -296,7 +296,7 @@ void hmac_drbg_pr( int md_alg,
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
 
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     mbedtls_hmac_drbg_set_prediction_resistance( &ctx, MBEDTLS_HMAC_DRBG_PR_ON );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -7,7 +7,7 @@ typedef struct
     size_t len;
 } entropy_ctx;
 
-int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
+static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     entropy_ctx *ctx = (entropy_ctx *) data;
 

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -7,7 +7,7 @@ typedef struct
     size_t len;
 } entropy_ctx;
 
-int mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
+int test_mbedtls_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     entropy_ctx *ctx = (entropy_ctx *) data;
 
@@ -50,7 +50,7 @@ void hmac_drbg_entropy_usage( int md_alg )
 
     /* Init must use entropy */
     last_len = entropy.len;
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &entropy,
                                  NULL, 0 ) == 0 );
     TEST_ASSERT( entropy.len < last_len );
 
@@ -206,7 +206,7 @@ void hmac_drbg_no_reseed( int md_alg,
     TEST_ASSERT( memcmp( my_output, output, out_len ) == 0 );
 
     /* And now the normal entropy-based variant */
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,
                                             add1, add1_len ) == 0 );
@@ -251,7 +251,7 @@ void hmac_drbg_nopr( int md_alg,
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
 
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_reseed( &ctx, add1, add1_len ) == 0 );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,
@@ -296,7 +296,7 @@ void hmac_drbg_pr( int md_alg,
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
 
-    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_entropy_func, &p_entropy,
+    TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, test_mbedtls_entropy_func, &p_entropy,
                                  custom, custom_len ) == 0 );
     mbedtls_hmac_drbg_set_prediction_resistance( &ctx, MBEDTLS_HMAC_DRBG_PR_ON );
     TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, my_output, out_len,


### PR DESCRIPTION
## Description
Changed function in tests named mbedtls_entropy_func to
test_suite_mbedtls_entropy_func to avoid getting error from the linker
when calling the mbedtls_entropy_func elsewhere.

## Status
**READY/IN DEVELOPMENT/HOLD**

## Migrations
Avoid getting error from the linker when calling the mbedtls_entropy_func elsewhere.

YES

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


