### PR TITLE
all.sh --keep-going: work if TERM is unset

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -328,7 +328,7 @@ if [ $KEEP_GOING -eq 1 ]; then
     start_red=
     end_color=
     if [ -t 1 ]; then
-        case "$TERM" in
+        case "${TERM:-}" in
             *color*|cygwin|linux|rxvt*|screen|[Eex]term*)
                 start_red=$(printf '\033[31m')
                 end_color=$(printf '\033[0m')


### PR DESCRIPTION
Fix `all.sh --keep-going` not working if TERM is unset (e.g. in Docker).

Follow-up to https://github.com/ARMmbed/mbedtls/pull/1207

Backports: #1250 #1251 
