### PR TITLE
corrected a typo in a comment

### DIFF
--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -937,7 +937,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
 #endif
 
     /*
-     * We don't support compression with DTLS right now: is many records come
+     * We don't support compression with DTLS right now: if many records come
      * in the same datagram, uncompressing one could overwrite the next one.
      * We don't want to add complexity for handling that case unless there is
      * an actual need for it.


### PR DESCRIPTION
## Description
This is only the fix of a typo in a comment (which is saying that compression is not supported with DTLS)

## Status
**READY/IN DEVELOPMENT/HOLD**