### PR TITLE
remove additional zero byte when writing pub der

### DIFF
--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -128,7 +128,7 @@ static int write_public_key( mbedtls_pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof(output_buf) - len;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )


### PR DESCRIPTION
## Description
The key_app writer writes wrong public key, in der format.
The reason is a leading zero byte, which is not a valid ASN1 tag
Fixes #1257 

## Status
**READY**

## Requires Backporting
NO  
This is only in a sample application

## Steps to test or reproduce
- Generate a key pair
- use `key_app_writer` to write a public key in der format
- try parsing the public key
~~~
./gen_key type=rsa rsa_keysize=4096 filename=rsa_4096_private.der format=der
./key_app_writer mode=private filename=rsa_4096_private.der output_mode=public output_format=der output_file=rsa_4096_public.der
./key_app mode=public filename=rsa_4096_public.der
~~~
