### PR TITLE
Update Doxygen file blocks to remove copyright and license information

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -78,6 +78,7 @@ Changes
      and the message digest. Further, allow enabling/disabling of authority
      identifier, subject identifier and basic constraints extensions.
    * Only run AES-192 self-test if AES-192 is available. Fixes #963.
+   * Remove copyright and license information from Doxygen documentation.
 
 = mbed TLS 2.6.0 branch released 2017-08-10
 

--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -1,6 +1,9 @@
-/*
- *  Minimal configuration for TLS 1.2 with PSK and AES-CCM ciphersuites
+/**
+ * \file config-ccm-psk-tls1_2.h
  *
+ * \brief Minimal configuration for TLS 1.2 with PSK and AES-CCM ciphersuites
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/configs/config-mini-tls1_1.h
+++ b/configs/config-mini-tls1_1.h
@@ -1,6 +1,9 @@
-/*
- *  Minimal configuration for TLS 1.1 (RFC 4346)
+/**
+ * \file config-mini-tls1_1.h
  *
+ * \brief Minimal configuration for TLS 1.1 (RFC 4346)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -1,6 +1,9 @@
 /**
- *  Minimal configuration of features that do not require an entropy source
+ * \file config-no-entropy.h
  *
+ * \brief Minimal configuration of features that do not require an entropy source
+ */
+/*
  *  Copyright (C) 2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/configs/config-picocoin.h
+++ b/configs/config-picocoin.h
@@ -1,6 +1,9 @@
-/*
- *  Reduced configuration used by Picocoin.
+/**
+ * \file config-picocoin.h
  *
+ * \brief Reduced configuration used by Picocoin.
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -1,6 +1,9 @@
-/*
- *  Minimal configuration for TLS NSA Suite B Profile (RFC 6460)
+/**
+ * \file config-suite-b.h
  *
+ * \brief Minimal configuration for TLS NSA Suite B Profile (RFC 6460)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -1,6 +1,9 @@
-/*
- *  Minimal configuration for using TLS as part of Thread
+/**
+ * \file config-thread.h
  *
+ * \brief Minimal configuration for using TLS as part of Thread
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -2,7 +2,8 @@
  * \file aes.h
  *
  * \brief AES block cipher
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -2,7 +2,8 @@
  * \file aesni.h
  *
  * \brief AES-NI for hardware AES acceleration on some Intel processors
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -2,7 +2,8 @@
  * \file arc4.h
  *
  * \brief The ARCFOUR stream cipher
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -2,7 +2,8 @@
  * \file asn1.h
  *
  * \brief Generic ASN.1 parsing
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -2,7 +2,8 @@
  * \file asn1write.h
  *
  * \brief ASN.1 buffer writing functionality
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/base64.h
+++ b/include/mbedtls/base64.h
@@ -2,7 +2,8 @@
  * \file base64.h
  *
  * \brief RFC 1521 base64 encoding/decoding
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -1,8 +1,9 @@
 /**
  * \file bignum.h
  *
- * \brief  Multi-precision integer library
- *
+ * \brief Multi-precision integer library
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/blowfish.h
+++ b/include/mbedtls/blowfish.h
@@ -2,7 +2,8 @@
  * \file blowfish.h
  *
  * \brief Blowfish block cipher
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -1,8 +1,9 @@
 /**
  * \file bn_mul.h
  *
- * \brief  Multi-precision integer library
- *
+ * \brief Multi-precision integer library
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -2,7 +2,8 @@
  * \file camellia.h
  *
  * \brief Camellia block cipher
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -2,7 +2,8 @@
  * \file ccm.h
  *
  * \brief Counter with CBC-MAC (CCM) for 128-bit block ciphers
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/certs.h
+++ b/include/mbedtls/certs.h
@@ -2,7 +2,8 @@
  * \file certs.h
  *
  * \brief Sample certificates and DHM parameters for testing
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -2,7 +2,8 @@
  * \file check_config.h
  *
  * \brief Consistency checks for configuration options
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -4,7 +4,8 @@
  * \brief Generic cipher wrapper.
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -4,7 +4,8 @@
  * \brief Cipher wrappers.
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -3,7 +3,8 @@
  *
  * \brief Cipher-based Message Authentication Code (CMAC) Mode for
  *        Authentication
- *
+ */
+/*
  *  Copyright (C) 2015-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/compat-1.3.h
+++ b/include/mbedtls/compat-1.3.h
@@ -5,7 +5,8 @@
  *  for the PolarSSL naming conventions.
  *
  * \deprecated Use the new names directly instead
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -6,7 +6,8 @@
  *  This set of compile-time options may be used to enable
  *  or disable features selectively, and reduce the global
  *  memory footprint.
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -2,7 +2,8 @@
  * \file ctr_drbg.h
  *
  * \brief CTR_DRBG based on AES-256 (NIST SP 800-90)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -2,7 +2,8 @@
  * \file debug.h
  *
  * \brief Functions for controlling and providing debug output from the library.
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -2,7 +2,8 @@
  * \file des.h
  *
  * \brief DES block cipher
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -2,7 +2,8 @@
  * \file dhm.h
  *
  * \brief Diffie-Hellman-Merkle key exchange
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -2,7 +2,8 @@
  * \file ecdh.h
  *
  * \brief Elliptic curve Diffie-Hellman
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ecdsa.h
+++ b/include/mbedtls/ecdsa.h
@@ -2,7 +2,8 @@
  * \file ecdsa.h
  *
  * \brief Elliptic curve DSA
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -2,7 +2,8 @@
  * \file ecjpake.h
  *
  * \brief Elliptic curve J-PAKE
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -2,7 +2,8 @@
  * \file ecp.h
  *
  * \brief Elliptic curves over GF(p)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ecp_internal.h
+++ b/include/mbedtls/ecp_internal.h
@@ -3,7 +3,8 @@
  *
  * \brief Function declarations for alternative implementation of elliptic curve
  * point arithmetic.
- *
+ */
+/*
  *  Copyright (C) 2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -2,7 +2,8 @@
  * \file entropy.h
  *
  * \brief Entropy accumulator implementation
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/entropy_poll.h
+++ b/include/mbedtls/entropy_poll.h
@@ -2,7 +2,8 @@
  * \file entropy_poll.h
  *
  * \brief Platform-specific and custom entropy polling functions
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -2,7 +2,8 @@
  * \file error.h
  *
  * \brief Error to string translation
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -2,7 +2,8 @@
  * \file gcm.h
  *
  * \brief Galois/Counter mode for 128-bit block ciphers
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/havege.h
+++ b/include/mbedtls/havege.h
@@ -2,7 +2,8 @@
  * \file havege.h
  *
  * \brief HAVEGE: HArdware Volatile Entropy Gathering and Expansion
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -2,7 +2,8 @@
  * \file hmac_drbg.h
  *
  * \brief HMAC_DRBG (NIST SP 800-90A)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -4,7 +4,8 @@
  * \brief Generic message digest wrapper
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -2,7 +2,8 @@
  * \file md2.h
  *
  * \brief MD2 message digest algorithm (hash function)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -2,7 +2,8 @@
  * \file md4.h
  *
  * \brief MD4 message digest algorithm (hash function)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -2,7 +2,8 @@
  * \file md5.h
  *
  * \brief MD5 message digest algorithm (hash function)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/md_internal.h
+++ b/include/mbedtls/md_internal.h
@@ -6,7 +6,8 @@
  * \warning This in an internal header. Do not include directly.
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/memory_buffer_alloc.h
+++ b/include/mbedtls/memory_buffer_alloc.h
@@ -2,7 +2,8 @@
  * \file memory_buffer_alloc.h
  *
  * \brief Buffer-based memory allocator
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/net.h
+++ b/include/mbedtls/net.h
@@ -3,6 +3,9 @@
  *
  * \brief Deprecated header file that includes mbedtls/net_sockets.h
  *
+ * \deprecated Superseded by mbedtls/net_sockets.h
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -19,8 +22,7 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
- *
- * \deprecated Superseded by mbedtls/net_sockets.h
+
  */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -2,7 +2,8 @@
  * \file net_sockets.h
  *
  * \brief Network communication functions
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -2,7 +2,8 @@
  * \file oid.h
  *
  * \brief Object Identifier (OID) database
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -3,7 +3,8 @@
  *
  * \brief VIA PadLock ACE for HW encryption/decryption supported by some
  *        processors
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pem.h
+++ b/include/mbedtls/pem.h
@@ -2,7 +2,8 @@
  * \file pem.h
  *
  * \brief Privacy Enhanced Mail (PEM) decoding
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -2,7 +2,8 @@
  * \file pk.h
  *
  * \brief Public Key abstraction layer
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -1,8 +1,9 @@
 /**
- * \file pk.h
+ * \file pk_internal.h
  *
  * \brief Public Key abstraction layer: wrapper functions
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -4,7 +4,8 @@
  * \brief Wrapper for PKCS#11 library libpkcs11-helper
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -2,7 +2,8 @@
  * \file pkcs12.h
  *
  * \brief PKCS#12 Personal Information Exchange Syntax
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/pkcs5.h
+++ b/include/mbedtls/pkcs5.h
@@ -4,7 +4,8 @@
  * \brief PKCS#5 functions
  *
  * \author Mathias Olsson <mathias@kompetensum.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -2,7 +2,8 @@
  * \file platform.h
  *
  * \brief mbed TLS Platform abstraction layer
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -2,7 +2,8 @@
  * \file platform_time.h
  *
  * \brief mbed TLS Platform time abstraction
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -2,7 +2,8 @@
  * \file ripemd160.h
  *
  * \brief RIPE MD-160 message digest
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -2,7 +2,8 @@
  * \file rsa.h
  *
  * \brief The RSA public-key cryptosystem
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -2,7 +2,8 @@
  * \file sha1.h
  *
  * \brief SHA-1 cryptographic hash function
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -2,7 +2,8 @@
  * \file sha256.h
  *
  * \brief SHA-224 and SHA-256 cryptographic hash function
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -2,7 +2,8 @@
  * \file sha512.h
  *
  * \brief SHA-384 and SHA-512 cryptographic hash function
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2,7 +2,8 @@
  * \file ssl.h
  *
  * \brief SSL/TLS functions.
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -2,7 +2,8 @@
  * \file ssl_cache.h
  *
  * \brief SSL session cache implementation
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -2,7 +2,8 @@
  * \file ssl_ciphersuites.h
  *
  * \brief SSL Ciphersuites for mbed TLS
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -2,7 +2,8 @@
  * \file ssl_cookie.h
  *
  * \brief DTLS cookie callbacks implementation
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1,8 +1,9 @@
 /**
- * \file ssl_ticket.h
+ * \file ssl_internal.h
  *
  * \brief Internal functions shared by the SSL modules
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -2,7 +2,8 @@
  * \file ssl_ticket.h
  *
  * \brief TLS server ticket callbacks implementation
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -2,7 +2,8 @@
  * \file threading.h
  *
  * \brief Threading abstraction layer
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -2,7 +2,8 @@
  * \file timing.h
  *
  * \brief Portable interface to timeouts and to the CPU cycle counter
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -2,7 +2,8 @@
  * \file version.h
  *
  * \brief Run-time version information
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -2,7 +2,8 @@
  * \file x509.h
  *
  * \brief X.509 generic defines and structures
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -2,7 +2,8 @@
  * \file x509_crl.h
  *
  * \brief X.509 certificate revocation list parsing
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -2,7 +2,8 @@
  * \file x509_crt.h
  *
  * \brief X.509 certificate parsing and writing
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -2,7 +2,8 @@
  * \file x509_csr.h
  *
  * \brief X.509 certificate signing request parsing and writing
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/include/mbedtls/xtea.h
+++ b/include/mbedtls/xtea.h
@@ -2,7 +2,8 @@
  * \file xtea.h
  *
  * \brief XTEA block cipher (32-bit)
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/aes.c
+++ b/library/aes.c
@@ -1,6 +1,9 @@
-/*
- *  FIPS-197 compliant AES implementation
+/**
+ * \file aes.c
  *
+ * \brief FIPS-197 compliant AES implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -1,6 +1,9 @@
-/*
- *  AES-NI support functions
+/**
+ * \file aesni.c
  *
+ * \brief AES-NI support functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -1,6 +1,9 @@
-/*
- *  An implementation of the ARCFOUR algorithm
+/**
+ * \file arc4.c
  *
+ * \brief An implementation of the ARCFOUR algorithm
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -1,6 +1,9 @@
-/*
- *  Generic ASN.1 parsing
+/**
+ * \file asn1parse.c
  *
+ * \brief Generic ASN.1 parsing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -1,6 +1,9 @@
-/*
- * ASN.1 buffer writing functionality
+/**
+ * \file asn1write.c
  *
+ * \brief ASN.1 buffer writing functionality
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/base64.c
+++ b/library/base64.c
@@ -1,6 +1,9 @@
-/*
- *  RFC 1521 base64 encoding/decoding
+/**
+ * \file base64.c
  *
+ * \brief RFC 1521 base64 encoding/decoding
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1,6 +1,9 @@
-/*
- *  Multi-precision integer library
+/**
+ * \file bignum.c
  *
+ * \brief Multi-precision integer library
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -1,6 +1,9 @@
-/*
- *  Blowfish implementation
+/**
+ * \file blowfish.c
  *
+ * \brief Blowfish implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -1,6 +1,9 @@
-/*
- *  Camellia implementation
+/**
+ * \file camellia.c
  *
+ * \brief Camellia implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -1,6 +1,9 @@
-/*
- *  NIST SP800-38C compliant CCM implementation
+/**
+ * \file ccm.c
  *
+ * \brief NIST SP800-38C compliant CCM implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/certs.c
+++ b/library/certs.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 test certificates
+/**
+ * \file certs.c
  *
+ * \brief X.509 test certificates
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -4,7 +4,8 @@
  * \brief Generic cipher wrapper for mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -4,7 +4,8 @@
  * \brief Generic cipher wrapper for mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -2,7 +2,8 @@
  * \file cmac.c
  *
  * \brief NIST SP800-38B compliant CMAC implementation for AES and 3DES
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -1,6 +1,9 @@
-/*
- *  CTR_DRBG implementation based on AES-256 (NIST SP 800-90)
+/**
+ * \file ctr_drbg.c
  *
+ * \brief CTR_DRBG implementation based on AES-256 (NIST SP 800-90)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/debug.c
+++ b/library/debug.c
@@ -1,6 +1,9 @@
-/*
- *  Debugging routines
+/**
+ * \file debug.c
  *
+ * \brief Debugging routines
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/des.c
+++ b/library/des.c
@@ -1,6 +1,9 @@
-/*
- *  FIPS-46-3 compliant Triple-DES implementation
+/**
+ * \file des.c
  *
+ * \brief FIPS-46-3 compliant Triple-DES implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -1,6 +1,9 @@
-/*
- *  Diffie-Hellman-Merkle key exchange
+/**
+ * \file dhm.c
  *
+ * \brief Diffie-Hellman-Merkle key exchange
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -1,6 +1,9 @@
-/*
- *  Elliptic curve Diffie-Hellman
+/**
+ * \file ecdh.c
  *
+ * \brief Elliptic curve Diffie-Hellman
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -1,6 +1,9 @@
-/*
- *  Elliptic curve DSA
+/**
+ * \file ecdsa.c
  *
+ * \brief Elliptic curve DSA
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -1,6 +1,9 @@
-/*
- *  Elliptic curve J-PAKE
+/**
+ * \file ecjpake.c
  *
+ * \brief Elliptic curve J-PAKE
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1,6 +1,9 @@
-/*
- *  Elliptic curves over GF(p): generic functions
+/**
+ * \file ecp.c
  *
+ * \brief Elliptic curves over GF(p): generic functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -1,6 +1,9 @@
-/*
- *  Elliptic curves over GF(p): curve-specific data and functions
+/**
+ * \file ecp_curves.c
  *
+ * \brief Elliptic curves over GF(p): curve-specific data and functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -1,6 +1,9 @@
-/*
- *  Entropy accumulator implementation
+/**
+ * \file entropy.c
  *
+ * \brief Entropy accumulator implementation
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -1,6 +1,9 @@
-/*
- *  Platform-specific and custom entropy polling functions
+/**
+ * \file entropy_poll.c
  *
+ * \brief Platform-specific and custom entropy polling functions
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/error.c
+++ b/library/error.c
@@ -1,6 +1,9 @@
-/*
- *  Error message information
+/**
+ * \file error.c
  *
+ * \brief Error message information
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -1,6 +1,9 @@
-/*
- *  NIST SP800-38D compliant GCM implementation
+/**
+ * \file gcm.c
  *
+ * \brief NIST SP800-38D compliant GCM implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/havege.c
+++ b/library/havege.c
@@ -1,6 +1,9 @@
 /**
- *  \brief HAVEGE: HArdware Volatile Entropy Gathering and Expansion
+ * \file havege.c
  *
+ * \brief HAVEGE: HArdware Volatile Entropy Gathering and Expansion
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -1,6 +1,9 @@
-/*
- *  HMAC_DRBG implementation (NIST SP 800-90)
+/**
+ * \file hmac_drbg.c
  *
+ * \brief HMAC_DRBG implementation (NIST SP 800-90)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/md.c
+++ b/library/md.c
@@ -1,10 +1,11 @@
 /**
- * \file mbedtls_md.c
+ * \file md.c
  *
  * \brief Generic message digest wrapper for mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/md2.c
+++ b/library/md2.c
@@ -1,6 +1,9 @@
-/*
- *  RFC 1115/1319 compliant MD2 implementation
+/**
+ * \file md2.c
  *
+ * \brief RFC 1115/1319 compliant MD2 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/md4.c
+++ b/library/md4.c
@@ -1,6 +1,9 @@
-/*
- *  RFC 1186/1320 compliant MD4 implementation
+/**
+ * \file md4.c
  *
+ * \brief RFC 1186/1320 compliant MD4 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/md5.c
+++ b/library/md5.c
@@ -1,6 +1,9 @@
-/*
- *  RFC 1321 compliant MD5 implementation
+/**
+ * \file md5.c
  *
+ * \brief RFC 1321 compliant MD5 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -4,7 +4,8 @@
  * \brief Generic message digest wrapper for mbed TLS
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -1,6 +1,9 @@
-/*
- *  Buffer-based memory allocator
+/**
+ * \file memory_buffer_alloc.c
  *
+ * \brief Buffer-based memory allocator
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -1,6 +1,9 @@
-/*
- *  TCP/IP or UDP/IP networking functions
+/**
+ * \file net_sockets.c
  *
+ * \brief TCP/IP or UDP/IP networking functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/oid.c
+++ b/library/oid.c
@@ -2,7 +2,8 @@
  * \file oid.c
  *
  * \brief Object Identifier (OID) database
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -1,6 +1,9 @@
-/*
- *  VIA PadLock support functions
+/**
+ * \file padlock.c
  *
+ * \brief VIA PadLock support functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pem.c
+++ b/library/pem.c
@@ -1,6 +1,9 @@
-/*
- *  Privacy Enhanced Mail (PEM) decoding
+/**
+ * \file pem.c
  *
+ * \brief Privacy Enhanced Mail (PEM) decoding
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pk.c
+++ b/library/pk.c
@@ -1,6 +1,9 @@
-/*
- *  Public Key abstraction layer
+/**
+ * \file pk.c
  *
+ * \brief Public Key abstraction layer
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1,6 +1,9 @@
-/*
- *  Public Key abstraction layer: wrapper functions
+/**
+ * \file pk_wrap.c
  *
+ * \brief Public Key abstraction layer: wrapper functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -4,7 +4,8 @@
  * \brief Wrapper for PKCS#11 library libpkcs11-helper
  *
  * \author Adriaan de Jong <dejong@fox-it.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -1,6 +1,9 @@
-/*
- *  PKCS#12 Personal Information Exchange Syntax
+/**
+ * \file pkcs12.c
  *
+ * \brief PKCS#12 Personal Information Exchange Syntax
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -4,7 +4,8 @@
  * \brief PKCS#5 functions
  *
  * \author Mathias Olsson <mathias@kompetensum.com>
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1,6 +1,9 @@
-/*
- *  Public Key layer for parsing key files and structures
+/**
+ * \file pkparse.c
  *
+ * \brief Public Key layer for parsing key files and structures
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -1,6 +1,9 @@
-/*
- *  Public Key layer for writing key files and structures
+/**
+ * \file pkwrite.c
  *
+ * \brief Public Key layer for writing key files and structures
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/platform.c
+++ b/library/platform.c
@@ -1,6 +1,9 @@
-/*
- *  Platform abstraction layer
+/**
+ * \file platform.c
  *
+ * \brief Platform abstraction layer
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -1,6 +1,9 @@
-/*
- *  RIPE MD-160 implementation
+/**
+ * \file ripemd160.c
  *
+ * \brief RIPE MD-160 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1,6 +1,9 @@
-/*
- *  The RSA public-key cryptosystem
+/**
+ * \file rsa.c
  *
+ * \brief The RSA public-key cryptosystem
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -1,6 +1,9 @@
-/*
- *  FIPS-180-1 compliant SHA-1 implementation
+/**
+ * \file sha1.c
  *
+ * \brief FIPS-180-1 compliant SHA-1 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -1,6 +1,9 @@
-/*
- *  FIPS-180-2 compliant SHA-256 implementation
+/**
+ * \file sha256.c
  *
+ * \brief FIPS-180-2 compliant SHA-256 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -1,6 +1,9 @@
-/*
- *  FIPS-180-2 compliant SHA-384/512 implementation
+/**
+ * \file sha512.c
  *
+ * \brief FIPS-180-2 compliant SHA-384/512 implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -1,6 +1,9 @@
-/*
- *  SSL session cache implementation
+/**
+ * \file ssl_cache.c
  *
+ * \brief SSL session cache implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -2,7 +2,8 @@
  * \file ssl_ciphersuites.c
  *
  * \brief SSL ciphersuites for mbed TLS
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1,6 +1,9 @@
-/*
- *  SSLv3/TLSv1 client-side functions
+/**
+ * \file ssl_cli.c
  *
+ * \brief SSLv3/TLSv1 client-side functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -1,6 +1,9 @@
-/*
- *  DTLS cookie callbacks implementation
+/**
+ * \file ssl_cookie.c
  *
+ * \brief DTLS cookie callbacks implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1,6 +1,9 @@
-/*
- *  SSLv3/TLSv1 server-side functions
+/**
+ * \file ssl_srv.c
  *
+ * \brief SSLv3/TLSv1 server-side functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -1,6 +1,9 @@
-/*
- *  TLS server tickets callbacks implementation
+/**
+ * \file ssl_ticket.c
  *
+ * \brief TLS server tickets callbacks implementation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1,6 +1,9 @@
-/*
- *  SSLv3/TLSv1 shared functions
+/**
+ * \file ssl_tls.c
  *
+ * \brief SSLv3/TLSv1 shared functions
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/threading.c
+++ b/library/threading.c
@@ -1,6 +1,9 @@
-/*
- *  Threading abstraction layer
+/**
+ * \file threading.c
  *
+ * \brief Threading abstraction layer
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/timing.c
+++ b/library/timing.c
@@ -1,6 +1,9 @@
-/*
- *  Portable interface to the CPU cycle counter
+/**
+ * \file timing.c
  *
+ * \brief Portable interface to the CPU cycle counter
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/version.c
+++ b/library/version.c
@@ -1,6 +1,9 @@
-/*
- *  Version information
+/**
+ * \file version.c
  *
+ * \brief Version information
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -1,6 +1,9 @@
-/*
- *  Version feature information
+/**
+ * \file version_features.c
  *
+ * \brief Version feature information
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509.c
+++ b/library/x509.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 common functions for parsing and verification
+/**
+ * \file x509.c
  *
+ * \brief X.509 common functions for parsing and verification
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 base functions for creating certificates / CSRs
+/**
+ * \file x509_create.c
  *
+ * \brief X.509 base functions for creating certificates / CSRs
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 Certidicate Revocation List (CRL) parsing
+/**
+ * \file x509_crl.c
  *
+ * \brief X.509 Certidicate Revocation List (CRL) parsing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 certificate parsing and verification
+/**
+ * \file x509_crt.c
  *
+ * \brief X.509 certificate parsing and verification
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 Certificate Signing Request (CSR) parsing
+/**
+ * \file x509_csr.c
  *
+ * \brief X.509 Certificate Signing Request (CSR) parsing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 certificate writing
+/**
+ * \file x509write_crt.c
  *
+ * \brief X.509 certificate writing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -1,6 +1,9 @@
-/*
- *  X.509 Certificate Signing Request writing
+/**
+ * \file x509write_csr.c
  *
+ * \brief X.509 Certificate Signing Request writing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -1,6 +1,9 @@
-/*
- *  An 32-bit implementation of the XTEA algorithm
+/**
+ * \file xtea.c
  *
+ * \brief An 32-bit implementation of the XTEA algorithm
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -1,6 +1,9 @@
-/*
- *  AES-256 file encryption program
+/**
+ * \file aescrypt2.c
  *
+ * \brief AES-256 file encryption program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -1,7 +1,10 @@
-/*
+/**
+ * \file crypt_and_hash.c
+ *
  *  \brief  Generic file encryption program using generic wrappers for configured
  *          security.
- *
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -1,6 +1,9 @@
-/*
- *  generic message digest layer demonstration program
+/**
+ * \file generic_sum.c
  *
+ * \brief generic message digest layer demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -1,6 +1,9 @@
-/*
- *  Classic "Hello, world" demonstration program
+/**
+ * \file hello.c
  *
+ * \brief Classic "Hello, world" demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -1,6 +1,9 @@
-/*
- *  Diffie-Hellman-Merkle key exchange (client side)
+/**
+ * \file dh_client.c
  *
+ * \brief Diffie-Hellman-Merkle key exchange (client side)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -1,6 +1,9 @@
-/*
- *  Diffie-Hellman-Merkle key exchange (prime generation)
+/**
+ * \file dh_genprime.c
  *
+ * \brief Diffie-Hellman-Merkle key exchange (prime generation)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -1,6 +1,9 @@
-/*
- *  Diffie-Hellman-Merkle key exchange (server side)
+/**
+ * \file dh_server.c
  *
+ * \brief Diffie-Hellman-Merkle key exchange (server side)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -1,6 +1,9 @@
-/*
- *  Example ECDHE with Curve25519 program
+/**
+ * \file ecdh_curve25519.c
  *
+ * \brief Example ECDHE with Curve25519 program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -1,6 +1,9 @@
-/*
- *  Example ECDSA program
+/**
+ * \file ecdsa.c
  *
+ * \brief Example ECDSA program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -1,6 +1,9 @@
-/*
- *  Key generation application
+/**
+ * \file gen_key.c
  *
+ * \brief Key generation application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -1,6 +1,9 @@
-/*
- *  Key reading application
+/**
+ * \file key_app.c
  *
+ * \brief Key reading application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -1,6 +1,9 @@
-/*
- *  Key writing application
+/**
+ * \file key_app_writer.c
  *
+ * \brief Key writing application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/mpi_demo.c
+++ b/programs/pkey/mpi_demo.c
@@ -1,6 +1,9 @@
-/*
- *  Simple MPI demonstration program
+/**
+ * \file mpi_demo.c
  *
+ * \brief Simple MPI demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -1,6 +1,9 @@
-/*
- *  Public key-based simple decryption program
+/**
+ * \file pk_decrypt.c
  *
+ * \brief Public key-based simple decryption program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -1,6 +1,9 @@
-/*
- *  RSA simple data encryption program
+/**
+ * \file pk_encrypt.c
  *
+ * \brief RSA simple data encryption program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -1,6 +1,9 @@
-/*
- *  Public key-based signature creation program
+/**
+ * \file pk_sign.c
  *
+ * \brief Public key-based signature creation program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -1,6 +1,9 @@
-/*
- *  Public key-based signature verification program
+/**
+ * \file pk_verify.c
  *
+ * \brief Public key-based signature verification program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -1,6 +1,9 @@
-/*
- *  RSA simple decryption program
+/**
+ * \file rsa_decrypt.c
  *
+ * \brief RSA simple decryption program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -1,6 +1,9 @@
-/*
- *  RSA simple data encryption program
+/**
+ * \file rsa_encrypt.c
  *
+ * \brief RSA simple data encryption program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -1,6 +1,9 @@
-/*
- *  Example RSA key generation program
+/**
+ * \file rsa_genkey.c
  *
+ * \brief Example RSA key generation program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -1,6 +1,9 @@
-/*
- *  RSA/SHA-256 signature creation program
+/**
+ * \file rsa_sign.c
  *
+ * \brief RSA/SHA-256 signature creation program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -1,6 +1,9 @@
-/*
- *  RSASSA-PSS/SHA-256 signature creation program
+/**
+ * \file rsa_sign_pss.c
  *
+ * \brief RSASSA-PSS/SHA-256 signature creation program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -1,6 +1,9 @@
-/*
- *  RSA/SHA-256 signature verification program
+/**
+ * \file rsa_verify.c
  *
+ * \brief RSA/SHA-256 signature verification program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -1,6 +1,9 @@
-/*
- *  RSASSA-PSS/SHA-256 signature verification program
+/**
+ * \file rsa_verify_pss.c
  *
+ * \brief RSASSA-PSS/SHA-256 signature verification program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -1,6 +1,9 @@
 /**
+ * \file gen_entropy.c
+ **
  *  \brief Use and generate multiple entropies calls into a file
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -1,6 +1,9 @@
 /**
+ * \file gen_random_ctr_drbg.c
+ **
  *  \brief Use and generate random data into a file via the CTR_DBRG based on AES
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/random/gen_random_havege.c
+++ b/programs/random/gen_random_havege.c
@@ -1,6 +1,9 @@
 /**
+ * \file gen_random_havege.c
+ **
  *  \brief Generate random data into a file
- *
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -1,6 +1,9 @@
-/*
- *  Simple DTLS client demonstration program
+/**
+ * \file dtls_client.c
  *
+ * \brief Simple DTLS client demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -1,6 +1,9 @@
-/*
- *  Simple DTLS server demonstration program
+/**
+ * \file dtls_server.c
  *
+ * \brief Simple DTLS server demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -1,7 +1,10 @@
-/*
- *  Minimal SSL client, used for memory measurements.
- *  (meant to be used with config-suite-b.h or config-ccm-psk-tls1_2.h)
+/**
+ * \file mini_client.c
  *
+ * \brief Minimal SSL client, used for memory measurements.
+ *        (meant to be used with config-suite-b.h or config-ccm-psk-tls1_2.h)
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -1,6 +1,9 @@
-/*
- *  SSL client demonstration program
+/**
+ * \file ssl_client1.c
  *
+ * \brief SSL client demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1,6 +1,9 @@
-/*
- *  SSL client with certificate authentication
+/**
+ * \file ssl_client2.c
  *
+ * \brief SSL client with certificate authentication
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -1,6 +1,9 @@
-/*
- *  SSL server demonstration program using fork() for handling multiple clients
+/**
+ * \file ssl_fork_server.c
  *
+ * \brief SSL server demonstration program using fork() for handling multiple clients
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -1,6 +1,9 @@
-/*
- *  SSL client for SMTP servers
+/**
+ * \file ssl_mail_client.c
  *
+ * \brief SSL client for SMTP servers
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -1,7 +1,10 @@
-/*
- *  SSL server demonstration program using pthread for handling multiple
- *  clients.
+/**
+ * \file ssl_pthread_server.c
  *
+ * \brief SSL server demonstration program using pthread for handling multiple
+ *        clients.
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -1,6 +1,9 @@
-/*
- *  SSL server demonstration program
+/**
+ * \file ssl_server.c
  *
+ * \brief SSL server demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1,6 +1,9 @@
-/*
- *  SSL client with options
+/**
+ * \file ssl_server2.c
  *
+ * \brief SSL client with options
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -1,6 +1,9 @@
-/*
- *  Benchmark demonstration program
+/**
+ * \file benchmark.c
  *
+ * \brief Benchmark demonstration program
+ */
+/*
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -1,6 +1,9 @@
-/*
- *  Self-test demonstration program
+/**
+ * \file selftest.c
  *
+ * \brief Self-test demonstration program
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/test/ssl_cert_test.c
+++ b/programs/test/ssl_cert_test.c
@@ -1,6 +1,9 @@
-/*
- *  SSL certificate functionality tests
+/**
+ * \file ssl_cert_test.c
  *
+ * \brief SSL certificate functionality tests
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -1,6 +1,9 @@
-/*
- *  UDP proxy: emulate an unreliable UDP connexion for DTLS testing
+/**
+ * \file udp_proxy.c
  *
+ * \brief UDP proxy: emulate an unreliable UDP connexion for DTLS testing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -1,6 +1,9 @@
-/*
- *  Convert PEM to DER
+/**
+ * \file pem2der.c
  *
+ * \brief Convert PEM to DER
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/util/strerror.c
+++ b/programs/util/strerror.c
@@ -1,6 +1,9 @@
-/*
- *  Translate error code to error string
+/**
+ * \file strerror.c
  *
+ * \brief Translate error code to error string
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/wince_main.c
+++ b/programs/wince_main.c
@@ -1,6 +1,9 @@
-/*
- *  Windows CE console application entry point
+/**
+ * \file wince_main.c
  *
+ * \brief Windows CE console application entry point
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -1,6 +1,9 @@
-/*
- *  Certificate reading application
+/**
+ * \file cert_app.c
  *
+ * \brief Certificate reading application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -1,6 +1,9 @@
-/*
- *  Certificate request generation
+/**
+ * \file cert_req.c
  *
+ * \brief Certificate request generation
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -1,6 +1,9 @@
-/*
- *  Certificate generation and signing
+/**
+ * \file cert_write.c
  *
+ * \brief Certificate generation and signing
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -1,6 +1,9 @@
-/*
- *  CRL reading application
+/**
+ * \file crl_app.c
  *
+ * \brief CRL reading application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -1,6 +1,9 @@
-/*
- *  Certificate request reading application
+/**
+ * \file req_app.c
  *
+ * \brief Certificate request reading application
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -1,6 +1,9 @@
-/*
- *  Error message information
+/**
+ * \file error.c
  *
+ * \brief Error message information
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/scripts/data_files/version_features.fmt
+++ b/scripts/data_files/version_features.fmt
@@ -1,6 +1,9 @@
-/*
- *  Version feature information
+/**
+ * \file version_features.c
  *
+ * \brief Version feature information
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/yotta/data/entropy_hardware_poll.c
+++ b/yotta/data/entropy_hardware_poll.c
@@ -1,6 +1,9 @@
-/*
- *  Hardware entropy collector for the K64F, using Freescale's RNGA
+/**
+ * \file entropy_hardware_poll.c
  *
+ * \brief Hardware entropy collector for the K64F, using Freescale's RNGA
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *

--- a/yotta/data/target_config.h
+++ b/yotta/data/target_config.h
@@ -1,6 +1,9 @@
-/*
- *  Temporary target-specific config.h for entropy collection
+/**
+ * \file target_config.h
  *
+ * \brief Temporary target-specific config.h for entropy collection
+ */
+/*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
This PR separates the copyright and license information from the Doxygen documentation blocks. The documentation was also updated to have file and brief blocks for all files.