### PR TITLE
Backport 1.3: wait_server_start: warn if lsof is not available

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -780,6 +780,7 @@ if type lsof >/dev/null 2>/dev/null; then
         done
     }
 else
+    echo "Warning: lsof not available, wait_server_start = sleep 1"
     wait_server_start() {
         sleep 1
     }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -187,6 +187,7 @@ if type lsof >/dev/null 2>/dev/null; then
         done
     }
 else
+    echo "Warning: lsof not available, wait_server_start = sleep 1"
     wait_server_start() {
         sleep "$START_DELAY"
     }


### PR DESCRIPTION
In `ssl-opt.sh` and `compat.sh`, emit a warning if `lsof` is not available, so that we know about the potential race condition from the test logs.

Follow-up to #1217 which fixes the race condition, but only if `lsof` is available.

Backport of #1260