### PR TITLE
Asynchronous private key operations in SSL: signature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,10 @@ Features
      MBEDTLS_CMAC_ALT). Submitted by Steve Cooreman, Silicon Labs.
    * Add support for alternative implementations of GCM, selected by the
      configuration flag MBEDTLS_GCM_ALT.
+   * In TLS, support offloading private key operations to an external
+     cryptoprocessor. Private key operations can be asynchronous to allow
+     non-blocking operation of the TLS stack.
+     Currently restricted to signature only, server-side only.
 
 New deprecations
    * Deprecate usage of RSA primitives with non-matching key-type

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2342,7 +2342,7 @@
  * operation inside the library.
  *
  */
-#define MBEDTLS_SSL_ASYNC_PRIVATE_C
+//#define MBEDTLS_SSL_ASYNC_PRIVATE_C
 
 /**
  * \def MBEDTLS_SSL_CACHE_C

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2334,6 +2334,17 @@
 #define MBEDTLS_SHA512_C
 
 /**
+ * \def MBEDTLS_SSL_ASYNC_PRIVATE_C
+ *
+ * Enable asynchronous external private key operations in SSL. This allows
+ * you to configure an SSL connection to call an external cryptographic
+ * module to perform private key operations instead of performing the
+ * operation inside the library.
+ *
+ */
+#define MBEDTLS_SSL_ASYNC_PRIVATE_C
+
+/**
  * \def MBEDTLS_SSL_CACHE_C
  *
  * Enable simple SSL cache implementation.

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -79,7 +79,7 @@
  * ECP       4   8 (Started from top)
  * MD        5   4
  * CIPHER    6   6
- * SSL       6   17 (Started from top)
+ * SSL       6   21 (Started from top)
  * SSL       7   31
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -551,28 +551,29 @@ typedef int mbedtls_ssl_get_timer_t( void * ctx );
  *
  * \param connection_ctx  Pointer to the connection context set in the
  *                        SSL configuration
- * \param p_operation_ctx On output, pointer to the operation context.
- *                        This pointer will be passed later to the resume
- *                        or detach function. The value is only used if
- *                        an operation is started, i.e. if this callback
- *                        returns 0 or \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
+ * \param p_operation_ctx On success, pointer to the operation context.
+ *                        This must be a non-null pointer. Success means
+ *                        that an operation was started, and the return
+ *                        status is 0 or \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
+ *                        This pointer will be passed to later calls to the
+ *                        resume or cancel function. If the callback fails,
+ *                        the value is ignored.
  * \param cert            Certificate containing the public key
  * \param md_alg          Hash algorithm
  * \param hash            Buffer containing the hash. This buffer is
  *                        no longer valid when the function returns.
  * \param hash_len        Size of the \c hash buffer in bytes
  *
- * \return          - 0 if the SSL stack should call the resume callback
- *                    immediately. The resume function may provide the
- *                    or may itself return
- *                    \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
- *                  - \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS if the SSL stack
- *                    should return immediately without calling the resume
- *                    callback.
+ * \return          - 0 if the operation was started successfully and the SSL
+ *                    stack should call the resume callback immediately.
+ *                  - \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS if the operation
+ *                    was started successfully and the SSL stack should return
+ *                    immediately without calling the resume callback yet.
  *                  - \c MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH if the external
  *                    processor does not support this key. The SSL stack will
- *                    use the associated private key object instead.
- *                  - Any other error is propagated up the call chain.
+ *                    use the private key object instead.
+ *                  - Any other error indicates a fatal failure and is
+ *                    propagated up the call chain.
  */
 typedef int mbedtls_ssl_async_sign_t( void *connection_ctx,
                                       void **p_operation_ctx,
@@ -604,27 +605,28 @@ typedef int mbedtls_ssl_async_sign_t( void *connection_ctx,
  *
  * \param connection_ctx  Pointer to the connection context set in the
  *                        SSL configuration
- * \param p_operation_ctx On output, pointer to the operation context.
- *                        This pointer will be passed later to the resume
- *                        or detach function. The value is only used if
- *                        an operation is started, i.e. if this callback
- *                        returns 0 or \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
+ * \param p_operation_ctx On success, pointer to the operation context.
+ *                        This must be a non-null pointer. Success means
+ *                        that an operation was started, and the return
+ *                        status is 0 or \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
+ *                        This pointer will be passed to later calls to the
+ *                        resume or cancel function. If the callback fails,
+ *                        the value is ignored.
  * \param cert            Certificate containing the public key
  * \param input           Buffer containing the input ciphertext. This buffer
  *                        is no longer valid when the function returns.
  * \param input_len       Size of the \c input buffer in bytes
  *
- * \return          - 0 if the SSL stack should call the resume callback
- *                    immediately. The resume function may provide the
- *                    or may itself return
- *                    \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS.
- *                  - \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS if the SSL stack
- *                    should return immediately without calling the resume
- *                    callback.
+ * \return          - 0 if the operation was started successfully and the SSL
+ *                    stack should call the resume callback immediately.
+ *                  - \c MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS if the operation
+ *                    was started successfully and the SSL stack should return
+ *                    immediately without calling the resume callback yet.
  *                  - \c MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH if the external
  *                    processor does not support this key. The SSL stack will
- *                    use the associated private key object instead.
- *                  - Any other error is propagated up the call chain.
+ *                    use the private key object instead.
+ *                  - Any other error indicates a fatal failure and is
+ *                    propagated up the call chain.
  */
 typedef int mbedtls_ssl_async_decrypt_t( void *connection_ctx,
                                          void **p_operation_ctx,

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -220,7 +220,6 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
     void *p_async_operation_ctx;        /*!< asynchronous operation context */
-    unsigned char *out_async_start;     /*!< pointer where the asynchronous operation must write in the output buffer */
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -385,9 +385,11 @@ void mbedtls_ssl_transform_free( mbedtls_ssl_transform *transform );
  * \brief           Free referenced items in an SSL handshake context and clear
  *                  memory
  *
+ * \param conf      SSL configuration
  * \param handshake SSL handshake context
  */
-void mbedtls_ssl_handshake_free( mbedtls_ssl_handshake_params *handshake );
+void mbedtls_ssl_handshake_free( const mbedtls_ssl_config *conf,
+                                 mbedtls_ssl_handshake_params *handshake );
 
 int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl );

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -218,6 +218,10 @@ struct mbedtls_ssl_handshake_params
     mbedtls_x509_crl *sni_ca_crl;       /*!< trusted CAs CRLs from SNI      */
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+    void *p_async_operation_ctx;        /*!< asynchronous operation context */
+#endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
+
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     unsigned int out_msg_seq;           /*!<  Outgoing handshake sequence number */
     unsigned int in_msg_seq;            /*!<  Incoming handshake sequence number */

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -220,6 +220,7 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
     void *p_async_operation_ctx;        /*!< asynchronous operation context */
+    unsigned char *out_async_start;     /*!< pointer where the asynchronous operation must write in the output buffer */
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/library/error.c
+++ b/library/error.c
@@ -441,6 +441,8 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
             mbedtls_snprintf( buf, buflen, "SSL - The alert message received indicates a non-fatal error" );
         if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH) )
             mbedtls_snprintf( buf, buflen, "SSL - Couldn't set the hash for verifying CertificateVerify" );
+        if( use_ret == -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) )
+            mbedtls_snprintf( buf, buflen, "SSL - Asynchronous operation is not completed yet" );
 #endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -731,7 +731,7 @@ static int ssl_pick_cert( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_ECDSA_C)
         if( pk_alg == MBEDTLS_PK_ECDSA &&
-            ssl_check_key_curve( cur->key, ssl->handshake->curves ) != 0 )
+            ssl_check_key_curve( &cur->cert->pk, ssl->handshake->curves ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "certificate mismatch: elliptic curve" ) );
             continue;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2836,8 +2836,7 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME_PFS__ENABLED)
     size_t len;
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
-    unsigned char *dig_signed = p;
-    size_t dig_signed_len = 0;
+    unsigned char *dig_signed = NULL;
 #endif /* MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED */
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME_PFS__ENABLED */
 
@@ -2961,7 +2960,6 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)        
         dig_signed = p;
-        dig_signed_len = len;
 #endif
 
         p += len;
@@ -3022,8 +3020,7 @@ curve_matching_done:
         }
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
-        dig_signed     = p;
-        dig_signed_len = len;
+        dig_signed = p;
 #endif
 
         p += len;
@@ -3041,6 +3038,7 @@ curve_matching_done:
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
     if( mbedtls_ssl_ciphersuite_uses_server_signature( ciphersuite_info ) )
     {
+        size_t dig_signed_len = p - dig_signed;
         size_t signature_len = 0;
         unsigned int hashlen = 0;
         unsigned char hash[MBEDTLS_MD_MAX_SIZE];

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2846,10 +2846,9 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED) && \
     defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
-    if( ssl->handshake->out_async_start != NULL )
+    if( ssl->handshake->p_async_operation_ctx != NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "resuming signature operation" ) );
-        p = ssl->handshake->out_async_start;
         goto async_resume;
     }
 #endif /* defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED) &&
@@ -3215,7 +3214,6 @@ curve_matching_done:
                 }
                 /* FALLTHROUGH */
             case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
-                ssl->handshake->out_async_start = ssl->out_msg + ssl->out_msglen;
                 MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write server key exchange (pending)" ) );
                 return( MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS );
             default:

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3032,7 +3032,7 @@ curve_matching_done:
     {
         size_t signature_len = 0;
         unsigned int hashlen = 0;
-        unsigned char hash[64];
+        unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
         /*
          * 3.1: Choose hash algorithm:

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -707,7 +707,7 @@ static int ssl_pick_cert( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_CRT( 3, "candidate certificate chain, certificate",
                           cur->cert );
 
-        if( ! mbedtls_pk_can_do( cur->key, pk_alg ) )
+        if( ! mbedtls_pk_can_do( &cur->cert->pk, pk_alg ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "certificate mismatch: key type" ) );
             continue;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3135,8 +3135,7 @@ curve_matching_done:
 
             mbedtls_md_init( &ctx );
 
-            /* Info from md_alg will be used instead */
-            hashlen = 0;
+            hashlen = mbedtls_md_get_size( md_info );
 
             /*
              * digitally-signed struct {
@@ -3165,18 +3164,11 @@ curve_matching_done:
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 
-        MBEDTLS_SSL_DEBUG_BUF( 3, "parameters hash", hash, hashlen != 0 ? hashlen :
-            (unsigned int) ( mbedtls_md_get_size( mbedtls_md_info_from_type( md_alg ) ) ) );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "parameters hash", hash, hashlen );
 
         /*
          * 3.3: Compute and add the signature
          */
-        if( mbedtls_ssl_own_key( ssl ) == NULL )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no private key" ) );
-            return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
-        }
-
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
         {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2843,6 +2843,17 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write server key exchange" ) );
 
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED) && \
+    defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+    if( ssl->handshake->out_async_start != NULL )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "resuming signature operation" ) );
+        p = ssl->handshake->out_async_start;
+        goto async_resume;
+    }
+#endif /* defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED) &&
+          defined(MBEDTLS_SSL_ASYNC_PRIVATE_C) */
+
     /*
      *
      * Part 1: Extract static ECDH parameters and abort
@@ -3193,6 +3204,55 @@ curve_matching_done:
         }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+        if( ssl->conf->f_async_sign_start != NULL )
+        {
+            size_t sig_max_len = ( ssl->out_buf + MBEDTLS_SSL_MAX_CONTENT_LEN
+                                   - ( p + 2 ) );
+            ret = ssl->conf->f_async_sign_start(
+                ssl->conf->p_async_connection_ctx,
+                &ssl->handshake->p_async_operation_ctx,
+                mbedtls_ssl_own_cert( ssl ),
+                md_alg, hash, hashlen );
+            switch( ret )
+            {
+            case MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH:
+                /* act as if f_async_sign was null */
+                break;
+            case 0:
+            async_resume:
+                ret = ssl->conf->f_async_resume(
+                    ssl->conf->p_async_connection_ctx,
+                    ssl->handshake->p_async_operation_ctx,
+                    p + 2, &signature_len, sig_max_len );
+                if( ret != MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS )
+                {
+                    ssl->handshake->p_async_operation_ctx = NULL;
+                    if( ret != 0 )
+                    {
+                        MBEDTLS_SSL_DEBUG_RET( 1, "f_async_resume", ret );
+                        return( ret );
+                    }
+                    goto have_signature;
+                }
+                /* FALLTHROUGH */
+            case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
+                ssl->handshake->out_async_start = p;
+                MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= write server key exchange (pending)" ) );
+                return( MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS );
+            default:
+                MBEDTLS_SSL_DEBUG_RET( 1, "f_async_sign", ret );
+                return( ret );
+            }
+        }
+#endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
+
+        if( mbedtls_ssl_own_key( ssl ) == NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "got no private key" ) );
+            return( MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED );
+        }
+
         if( ( ret = mbedtls_pk_sign( mbedtls_ssl_own_key( ssl ), md_alg, hash, hashlen,
                         p + 2 , &signature_len, ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
         {
@@ -3200,6 +3260,7 @@ curve_matching_done:
             return( ret );
         }
 
+    have_signature:
         *(p++) = (unsigned char)( signature_len >> 8 );
         *(p++) = (unsigned char)( signature_len      );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5153,7 +5153,7 @@ static void ssl_handshake_wrapup_free_hs_transform( mbedtls_ssl_context *ssl )
     /*
      * Free our handshake params
      */
-    mbedtls_ssl_handshake_free( ssl->handshake );
+    mbedtls_ssl_handshake_free( ssl->conf, ssl->handshake );
     mbedtls_free( ssl->handshake );
     ssl->handshake = NULL;
 
@@ -5508,7 +5508,7 @@ static int ssl_handshake_init( mbedtls_ssl_context *ssl )
     if( ssl->session_negotiate )
         mbedtls_ssl_session_free( ssl->session_negotiate );
     if( ssl->handshake )
-        mbedtls_ssl_handshake_free( ssl->handshake );
+        mbedtls_ssl_handshake_free( ssl->conf, ssl->handshake );
 
     /*
      * Either the pointers are now NULL or cleared properly and can be freed.
@@ -7263,10 +7263,12 @@ static void ssl_key_cert_free( mbedtls_ssl_key_cert *key_cert )
 }
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-void mbedtls_ssl_handshake_free( mbedtls_ssl_handshake_params *handshake )
+void mbedtls_ssl_handshake_free( const mbedtls_ssl_config *conf,
+                                 mbedtls_ssl_handshake_params *handshake )
 {
     if( handshake == NULL )
         return;
+    (void) conf; /*unused in some compile-time configurations*/
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
@@ -7397,7 +7399,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
 
     if( ssl->handshake )
     {
-        mbedtls_ssl_handshake_free( ssl->handshake );
+        mbedtls_ssl_handshake_free( ssl->conf, ssl->handshake );
         mbedtls_ssl_transform_free( ssl->transform_negotiate );
         mbedtls_ssl_session_free( ssl->session_negotiate );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6399,6 +6399,23 @@ void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
 }
 #endif
 
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+void mbedtls_ssl_conf_async_private_cb(
+    mbedtls_ssl_config *conf,
+    mbedtls_ssl_async_sign_t *f_async_sign,
+    mbedtls_ssl_async_decrypt_t *f_async_decrypt,
+    mbedtls_ssl_async_resume_t *f_async_resume,
+    mbedtls_ssl_async_cancel_t *f_async_cancel,
+    void *connection_ctx )
+{
+    conf->f_async_sign_start = f_async_sign;
+    conf->f_async_decrypt_start = f_async_decrypt;
+    conf->f_async_resume = f_async_resume;
+    conf->f_async_cancel = f_async_cancel;
+    conf->p_async_connection_ctx = connection_ctx;
+}
+#endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
+
 /*
  * SSL get accessors
  */
@@ -7331,6 +7348,15 @@ void mbedtls_ssl_handshake_free( const mbedtls_ssl_config *conf,
         }
     }
 #endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_SERVER_NAME_INDICATION */
+
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+    if( conf->f_async_cancel != NULL &&
+        handshake->p_async_operation_ctx != NULL )
+    {
+        conf->f_async_cancel( conf->p_async_connection_ctx,
+                              handshake->p_async_operation_ctx );
+    }
+#endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     mbedtls_free( handshake->verify_cookie );

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -615,6 +615,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_SHA512_C)
     "MBEDTLS_SHA512_C",
 #endif /* MBEDTLS_SHA512_C */
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE_C)
+    "MBEDTLS_SSL_ASYNC_PRIVATE_C",
+#endif /* MBEDTLS_SSL_ASYNC_PRIVATE_C */
 #if defined(MBEDTLS_SSL_CACHE_C)
     "MBEDTLS_SSL_CACHE_C",
 #endif /* MBEDTLS_SSL_CACHE_C */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -110,7 +110,7 @@ int main( void )
 #define DFL_KEY_FILE2           ""
 #define DFL_ASYNC_PRIVATE_DELAY1 ( -1 )
 #define DFL_ASYNC_PRIVATE_DELAY2 ( -1 )
-#define DFL_ASYNC_PRIVATE_ERROR  ( -1 )
+#define DFL_ASYNC_PRIVATE_ERROR  ( 0 )
 #define DFL_PSK                 ""
 #define DFL_PSK_IDENTITY        "Client_identity"
 #define DFL_ECJPAKE_PW          NULL

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -541,8 +541,8 @@ make CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic'
 msg "test: main suites (full config)" # ~ 5s
 make CFLAGS='-Werror -Wall -Wextra' test
 
-msg "test: ssl-opt.sh default (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f Default
+msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -3790,7 +3790,7 @@ run_test    "SSL async private: error in resume then fall back to transparent ke
 requires_config_enabled MBEDTLS_SSL_ASYNC_PRIVATE_C
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "SSL async private: renegotiation: client-initiated" \
-            "$P_SRV async_private_delay1=1 async_private_delay2=1
+            "$P_SRV async_private_delay1=1 async_private_delay2=1 \
              exchanges=2 renegotiation=1" \
             "$P_CLI exchanges=2 renegotiation=1 renegotiate=1" \
             0 \
@@ -3800,7 +3800,7 @@ run_test    "SSL async private: renegotiation: client-initiated" \
 requires_config_enabled MBEDTLS_SSL_ASYNC_PRIVATE_C
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "SSL async private: renegotiation: server-initiated" \
-            "$P_SRV async_private_delay1=1 async_private_delay2=1
+            "$P_SRV async_private_delay1=1 async_private_delay2=1 \
              exchanges=2 renegotiation=1 renegotiate=1" \
             "$P_CLI exchanges=2 renegotiation=1" \
             0 \


### PR DESCRIPTION
In TLS, support offloading private key operations to an external cryptoprocessor. Private key operations can be asynchronous to allow non-blocking operation of the TLS stack.

Currently restricted to signature only, server-side only.

Tested in a single-connection server.

This is a new feature, so no backport.

Internal reference: IOTSSL-1764, IOTSSL-1765
