### PR TITLE
Adding the capability of parsing negative integers (configurable option) to the ASN.1 parser

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1630,6 +1630,22 @@
 #define MBEDTLS_ASN1_PARSE_C
 
 /**
+ * \def MBEDTLS_ASN1_PARSE_NEGINT
+ *
+ * Enable negative integer parsing in the generic ASN1 parser.
+ *
+ * Module:  library/asn1parse.c
+ * Caller:  library/pkcs12.c
+ *          library/pkcs5.c
+ *          library/pkparse.c
+ *          library/x509.c
+ *          library/x509_crl.c
+ *          library/x509_crt.c
+ *          library/x509_csr.c
+ */
+#define MBEDTLS_ASN1_PARSE_NEGINT
+
+/**
  * \def MBEDTLS_ASN1_WRITE_C
  *
  * Enable the generic ASN1 writer.

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -151,7 +151,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
     size_t len;
 
 #if defined(MBEDTLS_ASN1_PARSE_NEGINT)
-    unsigned char *neg = 0;
+    int neg = 0;
 #endif /* MBEDTLS_ASN1_PARSE_NEGINT */
 
     if( ( ret = mbedtls_asn1_get_tag( p, end, &len, MBEDTLS_ASN1_INTEGER ) ) != 0 )
@@ -160,10 +160,10 @@ int mbedtls_asn1_get_int( unsigned char **p,
     if( len == 0 || len > sizeof( int ) )
         return( MBEDTLS_ERR_ASN1_INVALID_LENGTH );
 
-    if ((**p & 0x80) != 0)
+    if( ( **p & 0x80 ) != 0 )
 #if defined(MBEDTLS_ASN1_PARSE_NEGINT)
     {
-        neg = *p;
+        neg = -1 << ( ( 8 * len ) - 1 );
         **p &= ~(0x80);
     }
 #else
@@ -181,8 +181,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
     }
 
 #if defined(MBEDTLS_ASN1_PARSE_NEGINT)
-    if (neg)
-        *val = ( ~(0) << ((*p - neg) * 8 - 1) ) | *val;
+    *val += neg;
 #endif /* MBEDTLS_ASN1_PARSE_NEGINT */
 
     return( 0 );


### PR DESCRIPTION
## Description
To help make the ASN.1 parser in mbedTLS generic (as suggested by `config.h`), I propose to add the capability of parsing negative integers to the said parser (the inability to handle negative integers is also not mentioned clearly in the [API doc](https://tls.mbed.org/api/asn1_8h.html#a7f8a8b447c11f2200cc5aa8033801b72)).

From a modular design perspective, a parser should be more about dealing with input at a syntactic level (e.g. handling ASN.1 data type INTEGER) and not enforcing semantic correctness (e.g rejecting negative integers).

At the cost of an extra pointer, 2 `if`s and some maths, this implements a simple 2's compliment. `MBEDTLS_ASN1_PARSE_NEGINT` is the option that can be used in `config.h` to turn on/off the negative integer parsing. 

Also changed the return value for the case when `MBEDTLS_ASN1_PARSE_NEGINT` is off but negative integers are encountered. Instead of `MBEDTLS_ERR_ASN1_INVALID_LENGTH`, the parser returns `MBEDTLS_ERR_ASN1_INVALID_DATA` to better match the semantic meaning of the error codes.

## Status
**READY**/IN DEVELOPMENT/HOLD

## Requires Backporting
**NO**  
(This PR is a new feature\enhancement)

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | **NO**

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

## Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things