### PR TITLE
Properly initialize and free entropy mixing hash contexts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,11 @@ API Changes
      implementations of the RSA interface declared in rsa.h.
 
 Bugfix
+   * Properly initialize and free SHA-256 / SHA-512 context in entropy module
+     instead of performing zeroization only. This could lead to failure for
+     alternative implementations of SHA-256 / SHA-512 for which zeroization
+     of contexts is not a proper way of initialization.
+     Found and fix suggested by ccli8.
    * Fix ssl_parse_record_header() to silently discard invalid DTLS records
      as recommended in RFC 6347 Section 4.1.2.7.
    * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -350,7 +350,8 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     /*
      * Reset accumulator and counters and recycle existing entropy
      */
-    memset( &ctx->accumulator, 0, sizeof( mbedtls_sha512_context ) );
+    mbedtls_sha512_free( &ctx->accumulator );
+    mbedtls_sha512_init( &ctx->accumulator );
     mbedtls_sha512_starts( &ctx->accumulator, 0 );
     mbedtls_sha512_update( &ctx->accumulator, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
@@ -364,7 +365,8 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     /*
      * Reset accumulator and counters and recycle existing entropy
      */
-    memset( &ctx->accumulator, 0, sizeof( mbedtls_sha256_context ) );
+    mbedtls_sha256_free( &ctx->accumulator );
+    mbedtls_sha256_init( &ctx->accumulator );
     mbedtls_sha256_starts( &ctx->accumulator, 0 );
     mbedtls_sha256_update( &ctx->accumulator, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
 

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -75,8 +75,10 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
 #endif
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    mbedtls_sha512_init( &ctx->accumulator );
     mbedtls_sha512_starts( &ctx->accumulator, 0 );
 #else
+    mbedtls_sha256_init( &ctx->accumulator );
     mbedtls_sha256_starts( &ctx->accumulator, 0 );
 #endif
 #if defined(MBEDTLS_HAVEGE_C)
@@ -125,6 +127,13 @@ void mbedtls_entropy_free( mbedtls_entropy_context *ctx )
 #if defined(MBEDTLS_HAVEGE_C)
     mbedtls_havege_free( &ctx->havege_data );
 #endif
+
+#if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    mbedtls_sha512_free( &ctx->accumulator );
+#else
+    mbedtls_sha256_free( &ctx->accumulator );
+#endif
+
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &ctx->mutex );
 #endif


### PR DESCRIPTION
__Summary:__ The entropy context contains a SHA-256 or SHA-512 context for entropy mixing, but doesn't initialize / free this context properly in the initialization and freeing functions `mbedtls_entropy_init` and `mbedtls_entropy_free` through a call to `mbedtls_sha{256/512}_init` resp. `mbedtls_sha{256/512}_free`. Instead, only a zeroization of the entire entropy structure is performed. This doesn't lead to problems for the current software implementations of SHA-256 and SHA-512 because zeroization is proper initialization for them, but it may (and does) cause problems for alternative implementations of SHA-256 and SHA-512 that use context structures that cannot be properly initialized through zeroization. 

This PR fixes this. 
 
Found and fix suggested by @ccli8 in https://github.com/ARMmbed/mbed-os/issues/5853. 

__Internal Reference:__ IOTSSL-2014