### PR TITLE
Backport 2.1: Properly initialize and free entropy mixing hash contexts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,11 @@ Features
      heavily-loaded machine.
 
 Bugfix
+   * Properly initialize and free SHA-256 / SHA-512 context in entropy module
+     instead of performing zeroization only. This could lead to failure for
+     alternative implementations of SHA-256 / SHA-512 for which zeroization
+     of contexts is not a proper way of initialization.
+     Found and fix suggested by ccli8.
    * Fix ssl_parse_record_header() to silently discard invalid DTLS records
      as recommended in RFC 6347 Section 4.1.2.7.
    * Fix memory leak in mbedtls_ssl_set_hostname() when called multiple times.

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -68,8 +68,10 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
 #endif
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    mbedtls_sha512_init( &ctx->accumulator );
     mbedtls_sha512_starts( &ctx->accumulator, 0 );
 #else
+    mbedtls_sha256_init( &ctx->accumulator );
     mbedtls_sha256_starts( &ctx->accumulator, 0 );
 #endif
 #if defined(MBEDTLS_HAVEGE_C)
@@ -105,6 +107,13 @@ void mbedtls_entropy_free( mbedtls_entropy_context *ctx )
 #if defined(MBEDTLS_HAVEGE_C)
     mbedtls_havege_free( &ctx->havege_data );
 #endif
+
+#if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    mbedtls_sha512_free( &ctx->accumulator );
+#else
+    mbedtls_sha256_free( &ctx->accumulator );
+#endif
+
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &ctx->mutex );
 #endif

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -318,7 +318,8 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     /*
      * Reset accumulator and counters and recycle existing entropy
      */
-    memset( &ctx->accumulator, 0, sizeof( mbedtls_sha512_context ) );
+    mbedtls_sha512_free( &ctx->accumulator );
+    mbedtls_sha512_init( &ctx->accumulator );
     mbedtls_sha512_starts( &ctx->accumulator, 0 );
     mbedtls_sha512_update( &ctx->accumulator, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
@@ -332,7 +333,8 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     /*
      * Reset accumulator and counters and recycle existing entropy
      */
-    memset( &ctx->accumulator, 0, sizeof( mbedtls_sha256_context ) );
+    mbedtls_sha256_free( &ctx->accumulator );
+    mbedtls_sha256_init( &ctx->accumulator );
     mbedtls_sha256_starts( &ctx->accumulator, 0 );
     mbedtls_sha256_update( &ctx->accumulator, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
 


### PR DESCRIPTION
This is the backport of #1275 to Mbed TLS 2.1.

Found and fix suggested by @ccli8 in https://github.com/ARMmbed/mbed-os/issues/5853. 