### PR TITLE
Have doxygen run in the doxygen directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,8 @@ if(ENABLE_PROGRAMS)
 endif()
 
 ADD_CUSTOM_TARGET(apidoc
-    COMMAND doxygen doxygen/mbedtls.doxyfile
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    COMMAND doxygen mbedtls.doxyfile
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen)
 
 if(ENABLE_TESTING)
     enable_testing()

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ lcov:
 
 apidoc:
 	mkdir -p apidoc
-	doxygen doxygen/mbedtls.doxyfile
+	cd doxygen; doxygen mbedtls.doxyfile
 
 apidoc_clean:
 	rm -rf apidoc

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ lcov:
 
 apidoc:
 	mkdir -p apidoc
-	cd doxygen; doxygen mbedtls.doxyfile
+	cd doxygen && doxygen mbedtls.doxyfile
 
 apidoc_clean:
 	rm -rf apidoc

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -54,7 +54,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = apidoc/
+OUTPUT_DIRECTORY       = ../apidoc/
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -664,7 +664,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = .
+INPUT                  = ..
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -696,7 +696,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = configs yotta/module
+EXCLUDE                = ../configs ../yotta/module
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
## Description
When the Doxywizzard GUI is used and the doxyfile is loaded, the
workind directory for doxygen is set to the location of the doxyfile.
However the Make and CMake build systems expect doxygen to be ran
from the top level directory.
This commit unifies the build system and the Doxywizzard GUI so that
all of them expect doxygen to be executed in the doxygen directory.

## Status
**READY**

## Requires Backporting
This change may be considered backporting, but it's impact is limited to the user experience while generating documentation.

## Migrations
NO

## Additional comments
NONE

## Todos
NONE

## Steps to test or reproduce
Perform all of the following, deleting the apidoc directory in the top level directory after each step:

1. Create the documentation using `make apidoc` command in the top level directory; verify the documentation in the apidoc directory.
2. Create the documentation using CMake; verify the result as above.
3. Create the documentation by loading the doxygen/mbedtls.doxyfile into the Doxywizzard and hitting the "Run doxygen" button; again - verify the result.

The results should be identical in all the above steps.
