### PR TITLE
Iotssl 2005 slow start

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -888,7 +888,7 @@ if type lsof >/dev/null 2>/dev/null; then
     }
 else
     wait_server_start() {
-        sleep 1
+        sleep 2
     }
 fi
 

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -887,6 +887,7 @@ if type lsof >/dev/null 2>/dev/null; then
         done
     }
 else
+    echo "Warning: lsof not available, wait_server_start = sleep"
     wait_server_start() {
         sleep 2
     }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -656,14 +656,28 @@ fi
 # used by watchdog
 MAIN_PID="$$"
 
-# be more patient with valgrind
+# We use somewhat arbitrary delays for tests:
+# - how long do we wait for the server to start (when lsof not available)?
+# - how long do we allow for the client to finish?
+#   (not to check performance, just to avoid waiting indefinitely)
+# Things are slower with valgrind, so give extra time here.
+#
+# Note: without lsof, there is a trade-off between the running time of this
+# script and the risk of spurious errors because we didn't wait long enough.
+# The watchdog delay on the other hand doesn't affect normal running time of
+# the script, only the case where a client or server gets stuck.
 if [ "$MEMCHECK" -gt 0 ]; then
-    START_DELAY=3
-    DOG_DELAY=30
+    START_DELAY=6
+    DOG_DELAY=60
 else
-    START_DELAY=1
-    DOG_DELAY=10
+    START_DELAY=2
+    DOG_DELAY=20
 fi
+
+# some particular tests need more time:
+# - for the client, we multiply the usual watchdog limit by a factor
+# - for the server, we sleep for a number of seconds after the client exits
+# see client_need_more_time() and server_needs_more_time()
 CLI_DELAY_FACTOR=1
 SRV_DELAY_SECONDS=0
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -308,6 +308,7 @@ if type lsof >/dev/null 2>/dev/null; then
         done
     }
 else
+    echo "Warning: lsof not available, wait_server_start = sleep $START_DELAY"
     wait_server_start() {
         sleep "$START_DELAY"
     }


### PR DESCRIPTION
## Description

This tries to address the slow start issues we're seeing with compat.sh and ssl-opt.sh on CI machines that don't have lsof yet.

It is a replacement for https://github.com/ARMmbed/mbedtls/pull/1269 addressing only the slow start issue (the issue with incomplete server logs will be addressed in a separate PR).

I believe this is not worth a ChangeLog entry as this is hardly visible / of importance to users other than us.

## Status
**READY**

## Requires Backporting
Yes

[x] Mbed TLS 2.1 https://github.com/ARMmbed/mbedtls/pull/1288
[x] Mbed TLS 1.3 https://github.com/ARMmbed/mbedtls/pull/1289
