### PR TITLE
Fix race condition in error printing in ssl_server2.c

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2019,8 +2019,10 @@ reset:
 #if !defined(_WIN32)
     if( received_sigterm )
     {
-        mbedtls_printf( " interrupted by SIGTERM\n" );
-        ret = 0;
+        mbedtls_printf( " interrupted by SIGTERM (not in net_accept())\n" );
+        if( ret == MBEDTLS_ERR_NET_INVALID_CONTEXT )
+            ret = 0;
+
         goto exit;
     }
 #endif
@@ -2056,8 +2058,10 @@ reset:
 #if !defined(_WIN32)
         if( received_sigterm )
         {
-            mbedtls_printf( " interrupted by signal\n" );
-            ret = 0;
+            mbedtls_printf( " interrupted by SIGTERM (in net_accept())\n" );
+            if( ret == MBEDTLS_ERR_NET_ACCEPT_FAILED )
+                ret = 0;
+
             goto exit;
         }
 #endif


### PR DESCRIPTION
## Description
Fix a race condition in `ssl_server2.c` that caused spurious failures of `ssl-opt.sh` especially on hghly-loaded CI machines where it is likely for a process to not get a slice of CPU often enough.

This is part 2 of the replacement for https://github.com/ARMmbed/mbedtls/pull/1269 - addressing the "incomplete server logs" issue.

I believe this is not worth a ChangeLog entry as this is hardly visible / of importance to users other than us.

## Status
**READY**

## Requires Backporting
Yes
[x] Mbed TLS 2.1 https://github.com/ARMmbed/mbedtls/pull/1290
[x] Mbed TLS 1.3 https://github.com/ARMmbed/mbedtls/pull/1291

