### PR TITLE
Backport 1.3 : Fix race condition in error printing in ssl_server2.c

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1620,8 +1620,13 @@ reset:
 #if !defined(_WIN32)
     if( received_sigterm )
     {
-        polarssl_printf( " interrupted by SIGTERM\n" );
-        ret = 0;
+        polarssl_printf( " interrupted by SIGTERM (not in net_accept())\n" );
+        if( ret == POLARSSL_ERR_NET_RECV_FAILED ||
+            ret == POLARSSL_ERR_NET_SEND_FAILED )
+        {
+            ret = 0;
+        }
+
         goto exit;
     }
 #endif
@@ -1653,8 +1658,10 @@ reset:
 #if !defined(_WIN32)
         if( received_sigterm )
         {
-            polarssl_printf( " interrupted by signal\n" );
-            ret = 0;
+            polarssl_printf( " interrupted by SIGTERM (in net_accept())\n" );
+            if( ret == POLARSSL_ERR_NET_ACCEPT_FAILED )
+                ret = 0;
+
             goto exit;
         }
 #endif


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/1287

Note: compared to 2.x, 1.3 didn't have any `ERR_NET_ACCEPT_INVALID_CONTEXT` error, but returned `NET_RECV_FAILED` when trying to read from a closed socket. This is less specific so could in principle hide errors, but:
- those errors were already hidden anyway, so this PR is an improvement,
- the errors that could in principle be hidden are not those that we are actually interested in, so this PR solves the problem it's trying to solve.
