### PR TITLE
Improve documentation of aes.h

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -86,7 +86,7 @@ mbedtls_aes_context;
 /**
  * \brief          This function initializes the specified AES context.
  *
- *                 It  must be the first API called before using
+ *                 It must be the first API called before using
  *                 the context.
  *
  * \param ctx      The AES context to initialize.

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -107,9 +107,9 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  * \param ctx      The AES context to which the key should be bound.
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:
- *                 <ul><li>128bits</li>
- *                 <li>192bits</li>
- *                 <li>256bits</li></ul>
+ *                 <ul><li>128 bits</li>
+ *                 <li>192 bits</li>
+ *                 <li>256 bits</li></ul>
  *
  * \return         \c 0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
  *                 on failure.
@@ -123,9 +123,9 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  * \param ctx      The AES context to which the key should be bound.
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:
- *                 <ul><li>128bits</li>
- *                 <li>192bits</li>
- *                 <li>256bits</li></ul>
+ *                 <ul><li>128 bits</li>
+ *                 <li>192 bits</li>
+ *                 <li>256 bits</li></ul>
  *
  * \return         \c 0 on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -1,11 +1,10 @@
 /**
  * \file aes.h
  *
- * \brief   AES is a family of block ciphers that processes data in multiples 
+ * \brief   AES is a family of block ciphers that processes data in multiples
  *          of block sizes (16 Bytes).
- * 
+ *
  */
- 
 /*  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -23,7 +22,7 @@
  *
  *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
- 
+
 #ifndef MBEDTLS_AES_H
 #define MBEDTLS_AES_H
 
@@ -61,14 +60,14 @@ extern "C" {
 #endif
 
 /**
- * \brief The AES context-type definition. 
+ * \brief The AES context-type definition.
  *
  * The AES context is passed to the APIs called.
  *
- * \note           This buffer can hold 32 extra Bytes, which can be used for 
+ * \note           This buffer can hold 32 extra Bytes, which can be used for
  *                 one of the following purposes:
  *                 <ul><li>Alignment if VIA padlock is used.</li>
- *                 <li>Simplifying key expansion in the 256-bit case by 
+ *                 <li>Simplifying key expansion in the 256-bit case by
  *                 generating an extra round key.</li></ul>
  */
 typedef struct
@@ -80,9 +79,9 @@ typedef struct
 mbedtls_aes_context;
 
 /**
- * \brief          This function initializes the specified AES context. 
- * 
- *                 It  must be the first API called before using 
+ * \brief          This function initializes the specified AES context.
+ *
+ *                 It  must be the first API called before using
  *                 the context.
  *
  * \param ctx      The AES context to initialize.
@@ -106,7 +105,7 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  *                 <li>192bits</li>
  *                 <li>256bits</li></ul>
  *
- * \return         \c 0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH 
+ * \return         \c 0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
  *                 on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
@@ -128,23 +127,23 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs an AES single-block encryption or 
+ * \brief          This function performs an AES single-block encryption or
  *                 decryption operation.
  *
- *                 It performs the operation defined in the \p mode parameter 
- *                 (encrypt or decrypt), on the input data buffer defined in 
- *                 the \p input parameter. 
+ *                 It performs the operation defined in the \p mode parameter
+ *                 (encrypt or decrypt), on the input data buffer defined in
+ *                 the \p input parameter.
  *
- *                 mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or  
- *                 mbedtls_aes_setkey_dec() must be called before the first 
+ *                 mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or 
+ *                 mbedtls_aes_setkey_dec() must be called before the first
  *                 call to this API with the same context.
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
  *                 #MBEDTLS_AES_DECRYPT.
- * \param input    The 16Byte buffer holding the input data.
- * \param output   The 16Byte buffer holding the output data.
- 
+ * \param input    The 16-Byte buffer holding the input data.
+ * \param output   The 16-Byte buffer holding the output data.
+
  * \return         \c 0 on success.
  */
 int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
@@ -154,39 +153,39 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief  This function performs an AES-CBC encryption or decryption operation 
+ * \brief  This function performs an AES-CBC encryption or decryption operation
  *         on full blocks.
- *         
- *         It performs the operation defined in the \p mode 
- *         parameter (encrypt/decrypt), on the input data buffer defined in 
- *         the \p input parameter. 
+ *        
+ *         It performs the operation defined in the \p mode
+ *         parameter (encrypt/decrypt), on the input data buffer defined in
+ *         the \p input parameter.
  *
- *         It can be called as many times as needed, until all the input 
- *         data is processed. mbedtls_aes_init(), and either 
- *         mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called 
+ *         It can be called as many times as needed, until all the input
+ *         data is processed. mbedtls_aes_init(), and either
+ *         mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called
  *         before the first call to this API with the same context.
  *
- * \note   This function operates on aligned blocks, that is, the input size 
+ * \note   This function operates on aligned blocks, that is, the input size
  *         must be a multiple of the AES block size of 16 Bytes.
  *
  * \note   Upon exit, the content of the IV is updated so that you can
  *         call the same function again on the next
  *         block(s) of data and get the same result as if it was
  *         encrypted in one call. This allows a "streaming" usage.
- *         If you need to retain the contents of the IV, you should 
+ *         If you need to retain the contents of the IV, you should
  *         either save it manually or use the cipher module instead.
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
  *                 #MBEDTLS_AES_DECRYPT.
- * \param length   The length of the input data in Bytes. This must be a 
+ * \param length   The length of the input data in Bytes. This must be a
  *                 multiple of the block size (16 Bytes).
  * \param iv       Initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         \c 0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH 
+ * \return         \c 0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH
  *                 on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
@@ -199,17 +198,17 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs an AES-CFB128 encryption or decryption 
+ * \brief This function performs an AES-CFB128 encryption or decryption
  *        operation.
- * 
- *        It performs the operation defined in the \p mode 
- *        parameter (encrypt or decrypt), on the input data buffer 
+ *
+ *        It performs the operation defined in the \p mode
+ *        parameter (encrypt or decrypt), on the input data buffer
  *        defined in the \p input parameter.
  *
  *        For CFB, you must set up the context with mbedtls_aes_setkey_enc(),
  *        regardless of whether you are performing an encryption or decryption
- *        operation, that is, regardless of the \p mode parameter. This is 
- *        because CFB mode uses the same key schedule for encryption and 
+ *        operation, that is, regardless of the \p mode parameter. This is
+ *        because CFB mode uses the same key schedule for encryption and
  *        decryption.
  *
  * \note  Upon exit, the content of the IV is updated so that you can
@@ -222,8 +221,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
- *                 #MBEDTLS_AES_DECRYPT. 
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
+ *                 #MBEDTLS_AES_DECRYPT.
  * \param length   The length of the input data.
  * \param iv_off   The offset in IV (updated after use).
  * \param iv       The initialization vector (updated after use).
@@ -241,16 +240,16 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs an AES-CFB8 encryption or decryption 
+ * \brief This function performs an AES-CFB8 encryption or decryption
  *        operation.
  *
- *        It performs the operation defined in the \p mode 
- *        parameter (encrypt/decrypt), on the input data buffer defined 
+ *        It performs the operation defined in the \p mode
+ *        parameter (encrypt/decrypt), on the input data buffer defined
  *        in the \p input parameter.
  *
  *        Due to the nature of CFB, you must use the same key schedule for
- *        both encryption and decryption operations. Therefore, you must  
- *        use the context initialized with mbedtls_aes_setkey_enc() for 
+ *        both encryption and decryption operations. Therefore, you must 
+ *        use the context initialized with mbedtls_aes_setkey_enc() for
  *        both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \note  Upon exit, the content of the IV is updated so that you can
@@ -263,7 +262,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or
  *                 #MBEDTLS_AES_DECRYPT
  * \param length   The length of the input data.
  * \param iv       The initialization vector (updated after use).
@@ -282,27 +281,27 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief      This function performs an AES-CTR encryption or decryption 
+ * \brief      This function performs an AES-CTR encryption or decryption
  *             operation.
- * 
- *             This function performs the operation defined in the \p mode  
- *             parameter (encrypt/decrypt), on the input data buffer  
+ *
+ *             This function performs the operation defined in the \p mode 
+ *             parameter (encrypt/decrypt), on the input data buffer 
  *             defined in the \p input parameter.
  *
- *             Due to the nature of CTR, you must use the same key schedule 
- *             for both encryption and decryption operations. Therefore, you  
- *             must use the context initialized with mbedtls_aes_setkey_enc() 
+ *             Due to the nature of CTR, you must use the same key schedule
+ *             for both encryption and decryption operations. Therefore, you 
+ *             must use the context initialized with mbedtls_aes_setkey_enc()
  *             for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \warning    You must keep the maximum use of your counter in mind.
  *
  * \param ctx              The AES context to use for encryption or decryption.
  * \param length           The length of the input data.
- * \param nc_off           The offset in the current \p stream_block, for 
- *                         resuming within the current cipher stream. The 
+ * \param nc_off           The offset in the current \p stream_block, for
+ *                         resuming within the current cipher stream. The
  *                         offset pointer should be 0 at the start of a stream.
  * \param nonce_counter    The 128-bit nonce and counter.
- * \param stream_block     The saved stream block for resuming. This is 
+ * \param stream_block     The saved stream block for resuming. This is
  *                         overwritten by the function.
  * \param input            The buffer holding the input data.
  * \param output           The buffer holding the output data.
@@ -319,8 +318,8 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /**
- * \brief           Internal AES block encryption function. This is only 
- *                  exposed to allow overriding it using 
+ * \brief           Internal AES block encryption function. This is only
+ *                  exposed to allow overriding it using
  *                  #MBEDTLS_AES_ENCRYPT_ALT.
  *
  * \param ctx       The AES context to use for encryption.
@@ -334,8 +333,8 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   unsigned char output[16] );
 
 /**
- * \brief           Internal AES block decryption function. This is only 
- *                  exposed to allow overriding it using see 
+ * \brief           Internal AES block decryption function. This is only
+ *                  exposed to allow overriding it using see
  *                  #MBEDTLS_AES_DECRYPT_ALT.
  *
  * \param ctx       The AES context to use for decryption.

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -119,7 +119,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 /**
  * \brief          This function sets the decryption key.
  *
- * \param ctx      The AES context to initialize.
+ * \param ctx      The AES context to which the key should be bound.
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:
  *                 <ul><li>128bits</li>

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -74,13 +74,13 @@ typedef struct
     int nr;                     /*!< The number of rounds. */
     uint32_t *rk;               /*!< AES round keys. */
     uint32_t buf[68];           /*!< Unaligned data buffer. This buffer can
-	                                 hold 32 extra Bytes, which can be used for
-									 one of the following purposes:
+                                     hold 32 extra Bytes, which can be used for
+                                     one of the following purposes:
                                      <ul><li>Alignment if VIA padlock is 
-									         used.</li>
-									 <li>Simplifying key expansion in the 256-bit
-									     case by generating an extra round key.
-										 </li></ul> */
+                                             used.</li>
+                                     <li>Simplifying key expansion in the 256-bit
+                                         case by generating an extra round key.
+                                         </li></ul> */
 }
 mbedtls_aes_context;
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -1,9 +1,16 @@
 /**
  * \file aes.h
  *
- * \brief   AES is a family of block ciphers that processes data in multiples
- *          of block sizes (16 Bytes).
+ * \brief   The Advanced Encryption Standard (AES) specifies a FIPS-approved
+ *          cryptographic algorithm that can be used to protect electronic
+ *          data.
  *
+ *          The AES algorithm is a symmetric block cipher that can
+ *          encrypt and decrypt information. For more information, see
+ *          <em>FIPS Publication 197: Advanced Encryption Standard</em> and
+ *          <em>•	ISO/IEC 18033-2:2006: Information technology -- Security
+ *          techniques -- Encryption algorithms -- Part 2: Asymmetric
+ *          ciphers</em>.
  */
 /*  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
@@ -62,8 +69,6 @@ extern "C" {
 /**
  * \brief The AES context-type definition.
  *
- * The AES context is passed to the APIs called.
- *
  * \note           This buffer can hold 32 extra Bytes, which can be used for
  *                 one of the following purposes:
  *                 <ul><li>Alignment if VIA padlock is used.</li>
@@ -98,7 +103,7 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
 /**
  * \brief          This function sets the encryption key.
  *
- * \param ctx      The AES context to initialize.
+ * \param ctx      The AES context to which the key should be bound.
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:
  *                 <ul><li>128bits</li>

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -77,9 +77,9 @@ extern "C" {
  */
 typedef struct
 {
-    int nr;                     /*!< The number of rounds.*/
-    uint32_t *rk;               /*!< AES round keys.*/
-    uint32_t buf[68];           /*!< Unaligned data buffer.*/
+    int nr;                     /*!< The number of rounds. */
+    uint32_t *rk;               /*!< AES round keys. */
+    uint32_t buf[68];           /*!< Unaligned data buffer. */
 }
 mbedtls_aes_context;
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -8,7 +8,7 @@
  *          The AES algorithm is a symmetric block cipher that can
  *          encrypt and decrypt information. For more information, see
  *          <em>FIPS Publication 197: Advanced Encryption Standard</em> and
- *          <em>•	ISO/IEC 18033-2:2006: Information technology -- Security
+ *          <em>ISO/IEC 18033-2:2006: Information technology -- Security
  *          techniques -- Encryption algorithms -- Part 2: Asymmetric
  *          ciphers</em>.
  */
@@ -68,18 +68,19 @@ extern "C" {
 
 /**
  * \brief The AES context-type definition.
- *
- * \note           This buffer can hold 32 extra Bytes, which can be used for
- *                 one of the following purposes:
- *                 <ul><li>Alignment if VIA padlock is used.</li>
- *                 <li>Simplifying key expansion in the 256-bit case by
- *                 generating an extra round key.</li></ul>
  */
 typedef struct
 {
     int nr;                     /*!< The number of rounds. */
     uint32_t *rk;               /*!< AES round keys. */
-    uint32_t buf[68];           /*!< Unaligned data buffer. */
+    uint32_t buf[68];           /*!< Unaligned data buffer. This buffer can
+	                                 hold 32 extra Bytes, which can be used for
+									 one of the following purposes:
+                                     <ul><li>Alignment if VIA padlock is 
+									         used.</li>
+									 <li>Simplifying key expansion in the 256-bit
+									     case by generating an extra round key.
+										 </li></ul> */
 }
 mbedtls_aes_context;
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -1,9 +1,4 @@
-/**
- * \file aes.h
- *
- * \brief AES block cipher
- *
- *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+/*  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -18,8 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of Mbed TLS (https://tls.mbed.org)
  */
+ 
+/**
+ * \file aes.h
+ *
+ * \brief AES is a family of block ciphers that processes data in multiples of block sizes (16 Bytes).
+ * 
+ */
+ 
 #ifndef MBEDTLS_AES_H
 #define MBEDTLS_AES_H
 
@@ -33,15 +36,15 @@
 #include <stdint.h>
 
 /* padlock.c and aesni.c rely on these values! */
-#define MBEDTLS_AES_ENCRYPT     1
-#define MBEDTLS_AES_DECRYPT     0
+#define MBEDTLS_AES_ENCRYPT     1 /**< AES encryption mode. */
+#define MBEDTLS_AES_DECRYPT     0 /**< AES decryption mode. */
 
 /* Error codes in range 0x0020-0x0022 */
 #define MBEDTLS_ERR_AES_INVALID_KEY_LENGTH                -0x0020  /**< Invalid key length. */
 #define MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH              -0x0022  /**< Invalid data input length. */
 
 /* Error codes in range 0x0023-0x0023 */
-#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available, e.g. unsupported AES key size. */
+#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example, unsupported AES key size. */
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)
@@ -57,68 +60,68 @@ extern "C" {
 #endif
 
 /**
- * \brief          AES context structure
- *
- * \note           buf is able to hold 32 extra bytes, which can be used:
- *                 - for alignment purposes if VIA padlock is used, and/or
- *                 - to simplify key expansion in the 256-bit case by
- *                 generating an extra round key
+ * The AES context-type definition. The AES context is passed to the APIs called.
+ * \note           This buffer can hold 32 extra Bytes, which can be used for one of the following purposes:
+ *                 <ul><li>Alignment if VIA padlock is used.</li>
+ *                 <li>Simplifying key expansion in the 256-bit case by generating an extra round key.</li></ul>
  */
 typedef struct
 {
-    int nr;                     /*!<  number of rounds  */
-    uint32_t *rk;               /*!<  AES round keys    */
-    uint32_t buf[68];           /*!<  unaligned data    */
+    int nr;                     /*!< The number of rounds.*/
+    uint32_t *rk;               /*!< AES round keys.*/
+    uint32_t buf[68];           /*!< Unaligned data buffer.*/
 }
 mbedtls_aes_context;
 
 /**
- * \brief          Initialize AES context
+ * \brief          This function initializes the specified AES context. To operate the AES machine, this must be the first API called.
  *
- * \param ctx      AES context to be initialized
+ * \param ctx      The AES context to be initialized.
  */
 void mbedtls_aes_init( mbedtls_aes_context *ctx );
 
 /**
- * \brief          Clear AES context
+ * \brief          This function releases and clears the specified AES context.
  *
- * \param ctx      AES context to be cleared
+ * \param ctx      The AES context to be cleared.
  */
 void mbedtls_aes_free( mbedtls_aes_context *ctx );
 
 /**
- * \brief          AES key schedule (encryption)
+ * \brief          This function initializes the context set in the \p ctx parameter and sets the encryption key schedule for the AES operation.
  *
- * \param ctx      AES context to be initialized
- * \param key      encryption key
- * \param keybits  must be 128, 192 or 256
+ * \param ctx      The AES context to be initialized.
+ * \param key      The encryption key.
+ * \param keybits  The size of data passed in bits. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *
- * \return         0 if successful, or MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
+* \return         Zero if successful or error.h for the specific error code on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          AES key schedule (decryption)
+ * \brief          This function initializes the context set in the \p ctx parameter and sets the decryption key schedule for the AES operation.
  *
- * \param ctx      AES context to be initialized
- * \param key      decryption key
- * \param keybits  must be 128, 192 or 256
+ * \param ctx      The AES context to be initialized.
+ * \param key      The decryption key.
+ * \param keybits  The size of data passed. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *
- * \return         0 if successful, or MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
+ * \return         Zero if successful or error.h for the specific error code on failure.
  */
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          AES-ECB block encryption/decryption
+ * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-ECB input data buffer defined in the \p ctx parameter.
+ * mbedtls_aes_init(),  mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
+ * the first call to this API with the same context.
  *
- * \param ctx      AES context
- * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
- * \param input    16-byte input block
- * \param output   16-byte output block
- *
- * \return         0 if successful
+ * \param ctx      The AES context to encrypt or decrypt.
+ * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
+ * \param input    The 16Byte buffer holding the input data.
+ * \param output   The 16Byte buffer holding the output data.
+ 
+ * \return         Zero if successful.
  */
 int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                     int mode,
@@ -127,26 +130,30 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief          AES-CBC buffer encryption/decryption
- *                 Length should be a multiple of the block
- *                 size (16 bytes)
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CBC input data buffer defined in the \p ctx parameter. 
+ * It can be called as many times as needed, until all the input data is processed.\par
+ * mbedtls_aes_init(),  mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
+ * the first call to this API with the same context.
+ * The function processes the last data block if needed, finalizes the AES-CBC operation, 
+ * and produces operation results for MAC operations. 
  *
- * \note           Upon exit, the content of the IV is updated so that you can
- *                 call the function same function again on the following
- *                 block(s) of data and get the same result as if it was
- *                 encrypted in one call. This allows a "streaming" usage.
- *                 If on the other hand you need to retain the contents of the
- *                 IV, you should either save it manually or use the cipher
- *                 module instead.
+ * \note Upon exit, the content of the IV is updated so that you can
+ *       call the same function again on the next
+ *       block(s) of data and get the same result as if it was
+ *       encrypted in one call. This allows a "streaming" usage.
+ *       If you need to retain the contents of the IV, you should 
+ *       either save it manually or use the cipher module instead.
  *
- * \param ctx      AES context
- * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
- * \param length   length of the input data
- * \param iv       initialization vector (updated after use)
- * \param input    buffer holding the input data
- * \param output   buffer holding the output data
+ * \note The output buffer may be NULL for MAC operations.
  *
- * \return         0 if successful, or MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH
+ * \param ctx      The AES context to encrypt/decrypt.
+ * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes. AES-CBC buffer encryption/decryption length must be a multiple of the block size (16 Bytes).
+ * \param iv       Initialization vector (updated after use).
+ * \param input    The buffer holding the input data.
+ * \param output   The buffer holding the output data.
+ *
+ * \return         Zero if successful or error.h for the specific error code on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -158,29 +165,30 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief          AES-CFB128 buffer encryption/decryption.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-CFB128 input data buffer defined in the \p ctx parameter.
  *
- * Note: Due to the nature of CFB you should use the same key schedule for
- * both encryption and decryption. So a context initialized with
- * mbedtls_aes_setkey_enc() for both MBEDTLS_AES_ENCRYPT and MBEDTLS_AES_DECRYPT.
+ * Due to the nature of CFB, you must use the same key schedule for
+ * both encryption and decryption operations. Therefore, you must use the context initialized with
+ * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
- * \note           Upon exit, the content of the IV is updated so that you can
- *                 call the function same function again on the following
- *                 block(s) of data and get the same result as if it was
- *                 encrypted in one call. This allows a "streaming" usage.
- *                 If on the other hand you need to retain the contents of the
- *                 IV, you should either save it manually or use the cipher
- *                 module instead.
+ * \note Upon exit, the content of the IV is updated so that you can
+ *       call the same function again on the next
+ *       block(s) of data and get the same result as if it was
+ *       encrypted in one call. This allows a "streaming" usage.
+ *       If you need to retain the contents of the
+ *       IV, you must either save it manually or use the cipher
+ *       module instead.
  *
- * \param ctx      AES context
- * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
- * \param length   length of the input data
- * \param iv_off   offset in IV (updated after use)
- * \param iv       initialization vector (updated after use)
- * \param input    buffer holding the input data
- * \param output   buffer holding the output data
  *
- * \return         0 if successful
+ * \param ctx      The AES context to encrypt/decrypt.
+ * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
+ * \param length   The length of the input data.
+ * \param iv_off   The offset in IV (updated after use).
+ * \param iv       The initialization vector (updated after use).
+ * \param input    The buffer holding the input data.
+ * \param output   The buffer holding the output data.
+ *
+ * \return         Zero if successful.
  */
 int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        int mode,
@@ -191,28 +199,29 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief          AES-CFB8 buffer encryption/decryption.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CFB8 input data buffer defined in the \p ctx parameter.
  *
- * Note: Due to the nature of CFB you should use the same key schedule for
- * both encryption and decryption. So a context initialized with
- * mbedtls_aes_setkey_enc() for both MBEDTLS_AES_ENCRYPT and MBEDTLS_AES_DECRYPT.
+ * Due to the nature of CFB, you must use the same key schedule for
+ * both encryption and decryption operations. Therefore, you must use the context initialized with
+ * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
- * \note           Upon exit, the content of the IV is updated so that you can
- *                 call the function same function again on the following
- *                 block(s) of data and get the same result as if it was
- *                 encrypted in one call. This allows a "streaming" usage.
- *                 If on the other hand you need to retain the contents of the
- *                 IV, you should either save it manually or use the cipher
- *                 module instead.
+ * \note Upon exit, the content of the IV is updated so that you can
+ *       call the same function again on the next
+ *       block(s) of data and get the same result as if it was
+ *       encrypted in one call. This allows a "streaming" usage.
+ *       If you need to retain the contents of the
+ *       IV, you should either save it manually or use the cipher
+ *       module instead.
  *
- * \param ctx      AES context
- * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
- * \param length   length of the input data
- * \param iv       initialization vector (updated after use)
- * \param input    buffer holding the input data
- * \param output   buffer holding the output data
  *
- * \return         0 if successful
+ * \param ctx      The AES context to encrypt/decrypt.
+ * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
+ * \param length   The length of the input data.
+ * \param iv       The initialization vector (updated after use).
+ * \param input    The buffer holding the input data.
+ * \param output   The buffer holding the output data.
+ *
+ * \return         Zero if successful.
  */
 int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
                     int mode,
@@ -224,26 +233,26 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief               AES-CTR buffer encryption/decryption
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CTR input data buffer defined in the \p ctx parameter.
  *
- * Warning: You have to keep the maximum use of your counter in mind!
+ * Due to the nature of CTR, you must use the same key schedule for
+ * both encryption and decryption operations. Therefore, you must use the context initialized with
+ * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
- * Note: Due to the nature of CTR you should use the same key schedule for
- * both encryption and decryption. So a context initialized with
- * mbedtls_aes_setkey_enc() for both MBEDTLS_AES_ENCRYPT and MBEDTLS_AES_DECRYPT.
+ * \warning You must keep the maximum use of your counter in mind.
  *
- * \param ctx           AES context
- * \param length        The length of the data
- * \param nc_off        The offset in the current stream_block (for resuming
- *                      within current cipher stream). The offset pointer to
- *                      should be 0 at the start of a stream.
+ * \param ctx      		The AES context to encrypt or decrypt.
+ * \param length   		The length of the input data.
+ * \param nc_off   		The offset in the current \p stream_block, for resuming
+ *                 		within current cipher stream. The offset pointer to
+ *                 		should be 0 at the start of a stream.
  * \param nonce_counter The 128-bit nonce and counter.
- * \param stream_block  The saved stream-block for resuming. Is overwritten
+ * \param stream_block  The saved stream block for resuming. This is overwritten
  *                      by the function.
- * \param input         The input data stream
- * \param output        The output data stream
+ * \param input    		The buffer holding the input data.
+ * \param output   		The buffer holding the output data.
  *
- * \return         0 if successful
+ * \return         Zero if successful.
  */
 int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
                        size_t length,
@@ -255,30 +264,30 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /**
- * \brief           Internal AES block encryption function
- *                  (Only exposed to allow overriding it,
- *                  see MBEDTLS_AES_ENCRYPT_ALT)
+ * \brief Internal AES block encryption function. This is 
+ *        only exposed to allow overriding it,
+ *        see MBEDTLS_AES_ENCRYPT_ALT.
  *
- * \param ctx       AES context
- * \param input     Plaintext block
- * \param output    Output (ciphertext) block
+ * \param ctx       The AES context to encrypt.
+ * \param input     The plaintext block.
+ * \param output    The output (ciphertext) block.
  *
- * \return          0 if successful
+ * \return          Zero if successful.
  */
 int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
                                   unsigned char output[16] );
 
 /**
- * \brief           Internal AES block decryption function
- *                  (Only exposed to allow overriding it,
- *                  see MBEDTLS_AES_DECRYPT_ALT)
+ * \brief Internal AES block decryption function. This is
+ *        only exposed to allow overriding it,
+ *        see MBEDTLS_AES_DECRYPT_ALT.
  *
- * \param ctx       AES context
- * \param input     Ciphertext block
- * \param output    Output (plaintext) block
+ * \param ctx       The AES context to decrypt.
+ * \param input     The ciphertext block
+ * \param output    The output (plaintext) block
  *
- * \return          0 if successful
+ * \return          Zero if successful.
  */
 int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -294,11 +303,11 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
  * \brief           Deprecated internal AES block encryption function
  *                  without return value.
  *
- * \deprecated      Superseded by mbedtls_aes_encrypt_ext() in 2.5.0
+ * \deprecated      Superseded by mbedtls_aes_encrypt_ext() in 2.5.0.
  *
- * \param ctx       AES context
- * \param input     Plaintext block
- * \param output    Output (ciphertext) block
+ * \param ctx       The AES context to encrypt.
+ * \param input     Plaintext block.
+ * \param output    Output (ciphertext) block.
  */
 MBEDTLS_DEPRECATED void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
                                              const unsigned char input[16],
@@ -308,11 +317,11 @@ MBEDTLS_DEPRECATED void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
  * \brief           Deprecated internal AES block decryption function
  *                  without return value.
  *
- * \deprecated      Superseded by mbedtls_aes_decrypt_ext() in 2.5.0
+ * \deprecated      Superseded by mbedtls_aes_decrypt_ext() in 2.5.0.
  *
- * \param ctx       AES context
- * \param input     Ciphertext block
- * \param output    Output (plaintext) block
+ * \param ctx       The AES context to decrypt.
+ * \param input     Ciphertext block.
+ * \param output    Output (plaintext) block.
  */
 MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
                                              const unsigned char input[16],
@@ -334,9 +343,9 @@ extern "C" {
 #endif
 
 /**
- * \brief          Checkup routine
+ * \brief          Checkup routine.
  *
- * \return         0 if successful, or 1 if the test failed
+ * \return         Zero if successful, or 1 if the test failed.
  */
 int mbedtls_aes_self_test( int verbose );
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -63,7 +63,8 @@ extern "C" {
  * The AES context-type definition. The AES context is passed to the APIs called.
  *
  * \note           This buffer can hold 32 extra Bytes, which can be used for one of the following 
- *                 purposes:<ul><li>Alignment if VIA padlock is used.</li>
+ *                 purposes:
+ *                 <ul><li>Alignment if VIA padlock is used.</li>
  *                 <li>Simplifying key expansion in the 256-bit case by generating an 
  *                 extra round key.</li></ul>
  */
@@ -97,7 +98,9 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  * \param ctx      The AES context to initialize.
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:
- *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
+ *                 <ul><li>128bits</li>
+ *                 <li>192bits</li>
+ *                 <li>256bits</li></ul>
  *
 * \return         0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
@@ -110,7 +113,9 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  * \param ctx      The AES context to initialize.
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:
- *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
+ *                 <ul><li>128bits</li>
+ *                 <li>192bits</li>
+ *                 <li>256bits</li></ul>
  *
  * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -1,8 +1,8 @@
 /**
  * \file aes.h
  *
- * \brief AES is a family of block ciphers that processes data in multiples 
- *		  of block sizes (16 Bytes).
+ * \brief   AES is a family of block ciphers that processes data in multiples 
+ *          of block sizes (16 Bytes).
  * 
  */
  
@@ -80,9 +80,10 @@ typedef struct
 mbedtls_aes_context;
 
 /**
- * \brief    This function initializes the specified AES context. 
+ * \brief          This function initializes the specified AES context. 
  * 
- *           It  must be the first API called before using the context.
+ *                 It  must be the first API called before using 
+ *                 the context.
  *
  * \param ctx      The AES context to initialize.
  */
@@ -105,13 +106,14 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  *                 <li>192bits</li>
  *                 <li>256bits</li></ul>
  *
-* \return         0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ * \return         \c 0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH 
+ *                 on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function initializes sets the decryption key.
+ * \brief          This function sets the decryption key.
  *
  * \param ctx      The AES context to initialize.
  * \param key      The decryption key.
@@ -120,14 +122,14 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  *                 <li>192bits</li>
  *                 <li>256bits</li></ul>
  *
- * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ * \return         \c 0 on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
  * \brief          This function performs an AES single-block encryption or 
- *				   decryption operation.
+ *                 decryption operation.
  *
  *                 It performs the operation defined in the \p mode parameter 
  *                 (encrypt or decrypt), on the input data buffer defined in 
@@ -139,11 +141,11 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
  *
  * \param ctx      The AES context to use for encryption or decryption.
  * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
- *				   #MBEDTLS_AES_DECRYPT.
+ *                 #MBEDTLS_AES_DECRYPT.
  * \param input    The 16Byte buffer holding the input data.
  * \param output   The 16Byte buffer holding the output data.
  
- * \return         0 on success.
+ * \return         \c 0 on success.
  */
 int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                     int mode,
@@ -153,9 +155,9 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief  This function performs an AES-CBC encryption or decryption operation 
- *		   on full blocks.
+ *         on full blocks.
  *         
- *         This function performs the operation defined in the \p mode 
+ *         It performs the operation defined in the \p mode 
  *         parameter (encrypt/decrypt), on the input data buffer defined in 
  *         the \p input parameter. 
  *
@@ -164,29 +166,28 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *         mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called 
  *         before the first call to this API with the same context.
  *
- * \note  This function operates on aligned blocks, that is the input size must 
- *		  be a multiple of the AES block size of 16 Bytes.
+ * \note   This function operates on aligned blocks, that is, the input size 
+ *         must be a multiple of the AES block size of 16 Bytes.
  *
- * \note Upon exit, the content of the IV is updated so that you can
- *       call the same function again on the next
- *       block(s) of data and get the same result as if it was
- *       encrypted in one call. This allows a "streaming" usage.
- *       If you need to retain the contents of the IV, you should 
- *       either save it manually or use the cipher module instead.
+ * \note   Upon exit, the content of the IV is updated so that you can
+ *         call the same function again on the next
+ *         block(s) of data and get the same result as if it was
+ *         encrypted in one call. This allows a "streaming" usage.
+ *         If you need to retain the contents of the IV, you should 
+ *         either save it manually or use the cipher module instead.
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
  * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
- *				   #MBEDTLS_AES_DECRYPT.
- * \param length   The length of the input data in Bytes. The buffer encryption
- *		 		   or decryption length must be a multiple of the block 
- *                 size (16 Bytes).
+ *                 #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes. This must be a 
+ *                 multiple of the block size (16 Bytes).
  * \param iv       Initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH 
- *				   on failure.
+ * \return         \c 0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH 
+ *                 on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -198,34 +199,38 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs the operation defined in the \p mode 
+ * \brief This function performs an AES-CFB128 encryption or decryption 
+ *        operation.
+ * 
+ *        It performs the operation defined in the \p mode 
  *        parameter (encrypt or decrypt), on the input data buffer 
  *        defined in the \p input parameter.
  *
- *        Due to the nature of CFB, you must use the same key schedule for
- *        both encryption and decryption operations. Therefore, you must use 
- *        the context initialized with mbedtls_aes_setkey_enc() for both 
- *        #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *        For CFB, you must set up the context with mbedtls_aes_setkey_enc(),
+ *        regardless of whether you are performing an encryption or decryption
+ *        operation, that is, regardless of the \p mode parameter. This is 
+ *        because CFB mode uses the same key schedule for encryption and 
+ *        decryption.
  *
- * \note Upon exit, the content of the IV is updated so that you can
- *       call the same function again on the next
- *       block(s) of data and get the same result as if it was
- *       encrypted in one call. This allows a "streaming" usage.
- *       If you need to retain the contents of the
- *       IV, you must either save it manually or use the cipher
- *       module instead.
+ * \note  Upon exit, the content of the IV is updated so that you can
+ *        call the same function again on the next
+ *        block(s) of data and get the same result as if it was
+ *        encrypted in one call. This allows a "streaming" usage.
+ *        If you need to retain the contents of the
+ *        IV, you must either save it manually or use the cipher
+ *        module instead.
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
  * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
- *				   #MBEDTLS_AES_DECRYPT. 
+ *                 #MBEDTLS_AES_DECRYPT. 
  * \param length   The length of the input data.
  * \param iv_off   The offset in IV (updated after use).
  * \param iv       The initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         0 on success.
+ * \return         \c 0 on success.
  */
 int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        int mode,
@@ -236,7 +241,10 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs the operation defined in the \p mode 
+ * \brief This function performs an AES-CFB8 encryption or decryption 
+ *        operation.
+ *
+ *        It performs the operation defined in the \p mode 
  *        parameter (encrypt/decrypt), on the input data buffer defined 
  *        in the \p input parameter.
  *
@@ -245,13 +253,13 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  *        use the context initialized with mbedtls_aes_setkey_enc() for 
  *        both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
- * \note Upon exit, the content of the IV is updated so that you can
- *       call the same function again on the next
- *       block(s) of data and get the same result as if it was
- *       encrypted in one call. This allows a "streaming" usage.
- *       If you need to retain the contents of the
- *       IV, you should either save it manually or use the cipher
- *       module instead.
+ * \note  Upon exit, the content of the IV is updated so that you can
+ *        call the same function again on the next
+ *        block(s) of data and get the same result as if it was
+ *        encrypted in one call. This allows a "streaming" usage.
+ *        If you need to retain the contents of the
+ *        IV, you should either save it manually or use the cipher
+ *        module instead.
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
@@ -262,7 +270,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         0 on success.
+ * \return         \c 0 on success.
  */
 int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
                     int mode,
@@ -274,29 +282,32 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief This function performs the operation defined in the \p mode  
- *        parameter (encrypt/decrypt), on the input data buffer  
- *        defined in the \p input parameter.
+ * \brief      This function performs an AES-CTR encryption or decryption 
+ *             operation.
+ * 
+ *             This function performs the operation defined in the \p mode  
+ *             parameter (encrypt/decrypt), on the input data buffer  
+ *             defined in the \p input parameter.
  *
- *        Due to the nature of CTR, you must use the same key schedule 
- *        for both encryption and decryption operations. Therefore, you  
- *        must use the context initialized with mbedtls_aes_setkey_enc() 
- *        for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *             Due to the nature of CTR, you must use the same key schedule 
+ *             for both encryption and decryption operations. Therefore, you  
+ *             must use the context initialized with mbedtls_aes_setkey_enc() 
+ *             for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
- * \warning You must keep the maximum use of your counter in mind.
+ * \warning    You must keep the maximum use of your counter in mind.
  *
- * \param ctx      		The AES context to use for encryption or decryption.
- * \param length   		The length of the input data.
- * \param nc_off   		The offset in the current \p stream_block, for resuming
- *                 		within current cipher stream. The offset pointer to
- *                 		should be 0 at the start of a stream.
- * \param nonce_counter The 128-bit nonce and counter.
- * \param stream_block  The saved stream block for resuming. This is 
- *                      overwritten by the function.
- * \param input    		The buffer holding the input data.
- * \param output   		The buffer holding the output data.
+ * \param ctx              The AES context to use for encryption or decryption.
+ * \param length           The length of the input data.
+ * \param nc_off           The offset in the current \p stream_block, for 
+ *                         resuming within the current cipher stream. The 
+ *                         offset pointer should be 0 at the start of a stream.
+ * \param nonce_counter    The 128-bit nonce and counter.
+ * \param stream_block     The saved stream block for resuming. This is 
+ *                         overwritten by the function.
+ * \param input            The buffer holding the input data.
+ * \param output           The buffer holding the output data.
  *
- * \return         0 on success.
+ * \return     \c 0 on success.
  */
 int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
                        size_t length,
@@ -308,28 +319,30 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /**
- * \brief Internal AES block encryption function. This is only exposed 
- *        to allow overriding it using #MBEDTLS_AES_ENCRYPT_ALT.
+ * \brief           Internal AES block encryption function. This is only 
+ *                  exposed to allow overriding it using 
+ *                  #MBEDTLS_AES_ENCRYPT_ALT.
  *
  * \param ctx       The AES context to use for encryption.
  * \param input     The plaintext block.
  * \param output    The output (ciphertext) block.
  *
- * \return          0 on success.
+ * \return          \c 0 on success.
  */
 int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
                                   unsigned char output[16] );
 
 /**
- * \brief Internal AES block decryption function. This is only exposed 
- *        to allow overriding it using see #MBEDTLS_AES_DECRYPT_ALT.
+ * \brief           Internal AES block decryption function. This is only 
+ *                  exposed to allow overriding it using see 
+ *                  #MBEDTLS_AES_DECRYPT_ALT.
  *
  * \param ctx       The AES context to use for decryption.
- * \param input     The ciphertext block
- * \param output    The output (plaintext) block
+ * \param input     The ciphertext block.
+ * \param output    The output (plaintext) block.
  *
- * \return          0 on success.
+ * \return          \c 0 on success.
  */
 int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -387,7 +400,7 @@ extern "C" {
 /**
  * \brief          Checkup routine.
  *
- * \return         0 on success, or 1 on failure.
+ * \return         \c 0 on success, or \c 1 on failure.
  */
 int mbedtls_aes_self_test( int verbose );
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -102,7 +102,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 /**
  * \brief          This function initializes the context set in the \p ctx parameter and sets the decryption key schedule for the AES operation.
  *
- * \param ctx      The AES context to initializebbbbbbbbbb.
+ * \param ctx      The AES context to initialize.
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -36,15 +36,15 @@
 #include <stdint.h>
 
 /* padlock.c and aesni.c rely on these values! */
-#define MBEDTLS_AES_ENCRYPT     1 /**< AES encryption mode. */
-#define MBEDTLS_AES_DECRYPT     0 /**< AES decryption mode. */
+#define MBEDTLS_AES_ENCRYPT     1 /**< AES encryption. */
+#define MBEDTLS_AES_DECRYPT     0 /**< AES decryption. */
 
 /* Error codes in range 0x0020-0x0022 */
 #define MBEDTLS_ERR_AES_INVALID_KEY_LENGTH                -0x0020  /**< Invalid key length. */
 #define MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH              -0x0022  /**< Invalid data input length. */
 
 /* Error codes in range 0x0023-0x0023 */
-#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example, unsupported AES key size. */
+#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example,unsupported AES key size. */
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)
@@ -61,9 +61,11 @@ extern "C" {
 
 /**
  * The AES context-type definition. The AES context is passed to the APIs called.
- * \note           This buffer can hold 32 extra Bytes, which can be used for one of the following purposes:
- *                 <ul><li>Alignment if VIA padlock is used.</li>
- *                 <li>Simplifying key expansion in the 256-bit case by generating an extra round key.</li></ul>
+ *
+ * \note           This buffer can hold 32 extra Bytes, which can be used for one of the following 
+ *                 purposes:<ul><li>Alignment if VIA padlock is used.</li>
+ *                 <li>Simplifying key expansion in the 256-bit case by generating an 
+ *                 extra round key.</li></ul>
  */
 typedef struct
 {
@@ -74,7 +76,9 @@ typedef struct
 mbedtls_aes_context;
 
 /**
- * \brief          This function initializes the specified AES context. To operate the AES machine, this must be the first API called.
+ * \brief    This function initializes the specified AES context. 
+ * 
+ *           It  must be the first API called before using the context.
  *
  * \param ctx      The AES context to initialize.
  */
@@ -88,40 +92,47 @@ void mbedtls_aes_init( mbedtls_aes_context *ctx );
 void mbedtls_aes_free( mbedtls_aes_context *ctx );
 
 /**
- * \brief          This function initializes the context set in the \p ctx parameter and sets the encryption key schedule for the AES operation.
+ * \brief          This function sets the encryption key.
+
  *
  * \param ctx      The AES context to initialize.
  * \param key      The encryption key.
- * \param keybits  The size of data passed in bits. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
+ * \param keybits  The size of data passed in bits. Valid options are:
+ *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
  *
-* \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+* \return         Zero on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function initializes the context set in the \p ctx parameter and sets the decryption key schedule for the AES operation.
+ * \brief          This function initializes sets the decryption key.
  *
  * \param ctx      The AES context to initialize.
  * \param key      The decryption key.
- * \param keybits  The size of data passed. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
+ * \param keybits  The size of data passed. Valid options are:
+ *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
  *
- * \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ * \return         Zero on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the input data buffer defined in the \p input parameter.
- * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
- * the first call to this API with the same context.
+ * \brief          This function performs the operation defined in the \p mode parameter 
+ *                 (encrypt or decrypt), on the input data buffer defined in the \p input 
+ *                 parameter. 
  *
- * \param ctx      The AES context to encrypt or decrypt.
- * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
+ *                 mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or  
+ *                 mbedtls_aes_setkey_dec() must be called before the first call to this 
+ *                 API with the same context.
+ *
+ * \param ctx      The AES context to use for encryption or decryption.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
  * \param input    The 16Byte buffer holding the input data.
  * \param output   The 16Byte buffer holding the output data.
  
- * \return         Zero if successful.
+ * \return         Zero on success.
  */
 int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                     int mode,
@@ -130,10 +141,14 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter. 
- * It can be called as many times as needed, until all the input data is processed.
- * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
- * the first call to this API with the same context.
+ * \brief   This function performs the operation defined in the \p mode parameter 
+ *          (encrypt/decrypt), on the input data buffer defined in the \p input 
+ *          parameter. 
+ *
+ *          It can be called as many times as needed, until all the input 
+ *          data is processed. mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() 
+ *          or mbedtls_aes_setkey_dec() must be called before the first call to this 
+ *          API with the same context.
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -143,14 +158,15 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *       either save it manually or use the cipher module instead.
  *
  *
- * \param ctx      The AES context to encrypt/decrypt.
- * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
- * \param length   The length of the input data in Bytes. The buffer encryption/decryption length must be a multiple of the block size (16 Bytes).
+ * \param ctx      The AES context to use for encryption or decryption.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes. The buffer encryption or decryption 
+ *                 length must be a multiple of the block size (16 Bytes).
  * \param iv       Initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
+ * \return         Zero on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -162,11 +178,14 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode parameter 
+ *        (encrypt or decrypt), on the input data buffer defined in the \p input
+ *        parameter.
  *
- * Due to the nature of CFB, you must use the same key schedule for
- * both encryption and decryption operations. Therefore, you must use the context initialized with
- * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *        Due to the nature of CFB, you must use the same key schedule for
+ *        both encryption and decryption operations. Therefore, you must use the 
+ *        context initialized with mbedtls_aes_setkey_enc() for both 
+ *        #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -177,15 +196,15 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
  *       module instead.
  *
  *
- * \param ctx      The AES context to encrypt/decrypt.
- * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
+ * \param ctx      The AES context to use for encryption or decryption.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
  * \param length   The length of the input data.
  * \param iv_off   The offset in IV (updated after use).
  * \param iv       The initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero if successful.
+ * \return         Zero on success.
  */
 int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        int mode,
@@ -196,11 +215,14 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode parameter 
+ *        (encrypt/decrypt), on the input data buffer defined in the \p input 
+ *        parameter.
  *
- * Due to the nature of CFB, you must use the same key schedule for
- * both encryption and decryption operations. Therefore, you must use the context initialized with
- * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *        Due to the nature of CFB, you must use the same key schedule for
+ *        both encryption and decryption operations. Therefore, you must  
+ *        use the context initialized with mbedtls_aes_setkey_enc() for 
+ *        both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -211,14 +233,15 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  *       module instead.
  *
  *
- * \param ctx      The AES context to encrypt/decrypt.
- * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
+ * \param ctx      The AES context to use for encryption or decryption.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ *                 #MBEDTLS_AES_DECRYPT
  * \param length   The length of the input data.
  * \param iv       The initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero if successful.
+ * \return         Zero on success.
  */
 int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
                     int mode,
@@ -230,15 +253,18 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode  
+ *        parameter (encrypt/decrypt), on the input data buffer  
+ *        defined in the \p input parameter.
  *
- * Due to the nature of CTR, you must use the same key schedule for
- * both encryption and decryption operations. Therefore, you must use the context initialized with
- * mbedtls_aes_setkey_enc() for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
+ *        Due to the nature of CTR, you must use the same key schedule 
+ *        for both encryption and decryption operations. Therefore, you  
+ *        must use the context initialized with mbedtls_aes_setkey_enc() 
+ *        for both #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \warning You must keep the maximum use of your counter in mind.
  *
- * \param ctx      		The AES context to encrypt or decrypt.
+ * \param ctx      		The AES context to use for encryption or decryption.
  * \param length   		The length of the input data.
  * \param nc_off   		The offset in the current \p stream_block, for resuming
  *                 		within current cipher stream. The offset pointer to
@@ -249,7 +275,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
  * \param input    		The buffer holding the input data.
  * \param output   		The buffer holding the output data.
  *
- * \return         Zero if successful.
+ * \return         Zero on success.
  */
 int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
                        size_t length,
@@ -264,11 +290,11 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
  * \brief Internal AES block encryption function. This is 
  *        only exposed to allow overriding it using #MBEDTLS_AES_ENCRYPT_ALT.
  *
- * \param ctx       The AES context to encrypt.
+ * \param ctx       The AES context to use for encryption.
  * \param input     The plaintext block.
  * \param output    The output (ciphertext) block.
  *
- * \return          Zero if successful.
+ * \return          Zero on success.
  */
 int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -278,11 +304,11 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
  * \brief Internal AES block decryption function. This is
  *        only exposed to allow overriding it using see #MBEDTLS_AES_DECRYPT_ALT.
  *
- * \param ctx       The AES context to decrypt.
+ * \param ctx       The AES context to use for decryption.
  * \param input     The ciphertext block
  * \param output    The output (plaintext) block
  *
- * \return          Zero if successful.
+ * \return          Zero on success.
  */
 int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -300,7 +326,7 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
  *
  * \deprecated      Superseded by mbedtls_aes_encrypt_ext() in 2.5.0.
  *
- * \param ctx       The AES context to encrypt.
+ * \param ctx       The AES context to use for encryption.
  * \param input     Plaintext block.
  * \param output    Output (ciphertext) block.
  */
@@ -314,7 +340,7 @@ MBEDTLS_DEPRECATED void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
  *
  * \deprecated      Superseded by mbedtls_aes_decrypt_ext() in 2.5.0.
  *
- * \param ctx       The AES context to decrypt.
+ * \param ctx       The AES context to use for decryption.
  * \param input     Ciphertext block.
  * \param output    Output (plaintext) block.
  */
@@ -340,7 +366,7 @@ extern "C" {
 /**
  * \brief          Checkup routine.
  *
- * \return         Zero if successful, or 1 if the test failed.
+ * \return         Zero on success, or one on failure.
  */
 int mbedtls_aes_self_test( int verbose );
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -76,21 +76,21 @@ mbedtls_aes_context;
 /**
  * \brief          This function initializes the specified AES context. To operate the AES machine, this must be the first API called.
  *
- * \param ctx      The AES context to be initialized.
+ * \param ctx      The AES context to initialize.
  */
 void mbedtls_aes_init( mbedtls_aes_context *ctx );
 
 /**
  * \brief          This function releases and clears the specified AES context.
  *
- * \param ctx      The AES context to be cleared.
+ * \param ctx      The AES context to clear.
  */
 void mbedtls_aes_free( mbedtls_aes_context *ctx );
 
 /**
  * \brief          This function initializes the context set in the \p ctx parameter and sets the encryption key schedule for the AES operation.
  *
- * \param ctx      The AES context to be initialized.
+ * \param ctx      The AES context to initialize.
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *
@@ -102,7 +102,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 /**
  * \brief          This function initializes the context set in the \p ctx parameter and sets the decryption key schedule for the AES operation.
  *
- * \param ctx      The AES context to be initialized.
+ * \param ctx      The AES context to initializebbbbbbbbbb.
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -19,7 +19,8 @@
 /**
  * \file aes.h
  *
- * \brief AES is a family of block ciphers that processes data in multiples of block sizes (16 Bytes).
+ * \brief AES is a family of block ciphers that processes data in multiples 
+ *		  of block sizes (16 Bytes).
  * 
  */
  
@@ -44,7 +45,7 @@
 #define MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH              -0x0022  /**< Invalid data input length. */
 
 /* Error codes in range 0x0023-0x0023 */
-#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example,unsupported AES key size. */
+#define MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE               -0x0023  /**< Feature not available. For example, an unsupported AES key size. */
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)
@@ -60,13 +61,15 @@ extern "C" {
 #endif
 
 /**
- * The AES context-type definition. The AES context is passed to the APIs called.
+ * \brief The AES context-type definition. 
  *
- * \note           This buffer can hold 32 extra Bytes, which can be used for one of the following 
- *                 purposes:
+ * The AES context is passed to the APIs called.
+ *
+ * \note           This buffer can hold 32 extra Bytes, which can be used for 
+ *                 one of the following purposes:
  *                 <ul><li>Alignment if VIA padlock is used.</li>
- *                 <li>Simplifying key expansion in the 256-bit case by generating an 
- *                 extra round key.</li></ul>
+ *                 <li>Simplifying key expansion in the 256-bit case by 
+ *                 generating an extra round key.</li></ul>
  */
 typedef struct
 {
@@ -123,18 +126,20 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs an AES single-block encryption or decryption operation.
+ * \brief          This function performs an AES single-block encryption or 
+ *				   decryption operation.
  *
  *                 It performs the operation defined in the \p mode parameter 
- *                 (encrypt or decrypt), on the input data buffer defined in the \p input 
- *                 parameter. 
+ *                 (encrypt or decrypt), on the input data buffer defined in 
+ *                 the \p input parameter. 
  *
  *                 mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or  
- *                 mbedtls_aes_setkey_dec() must be called before the first call to this 
- *                 API with the same context.
+ *                 mbedtls_aes_setkey_dec() must be called before the first 
+ *                 call to this API with the same context.
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ *				   #MBEDTLS_AES_DECRYPT.
  * \param input    The 16Byte buffer holding the input data.
  * \param output   The 16Byte buffer holding the output data.
  
@@ -147,18 +152,20 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief  This function performs an AES-CBC encryption or decryption operation on full blocks.
+ * \brief  This function performs an AES-CBC encryption or decryption operation 
+ *		   on full blocks.
  *         
- *          This function performs the operation defined in the \p mode parameter 
- *          (encrypt/decrypt), on the input data buffer defined in the \p input 
- *          parameter. 
+ *         This function performs the operation defined in the \p mode 
+ *         parameter (encrypt/decrypt), on the input data buffer defined in 
+ *         the \p input parameter. 
  *
- *          It can be called as many times as needed, until all the input 
- *          data is processed. mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() 
- *          or mbedtls_aes_setkey_dec() must be called before the first call to this 
- *          API with the same context.
+ *         It can be called as many times as needed, until all the input 
+ *         data is processed. mbedtls_aes_init(), and either 
+ *         mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called 
+ *         before the first call to this API with the same context.
  *
- * \note  This function operates on aligned blocks, that is the input size must be a multiple of the AES block size of 16 Bytes.
+ * \note  This function operates on aligned blocks, that is the input size must 
+ *		  be a multiple of the AES block size of 16 Bytes.
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -169,14 +176,17 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
- * \param length   The length of the input data in Bytes. The buffer encryption or decryption 
- *                 length must be a multiple of the block size (16 Bytes).
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ *				   #MBEDTLS_AES_DECRYPT.
+ * \param length   The length of the input data in Bytes. The buffer encryption
+ *		 		   or decryption length must be a multiple of the block 
+ *                 size (16 Bytes).
  * \param iv       Initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
+ * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH 
+ *				   on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -188,13 +198,13 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs the operation defined in the \p mode parameter 
- *        (encrypt or decrypt), on the input data buffer defined in the \p input
- *        parameter.
+ * \brief This function performs the operation defined in the \p mode 
+ *        parameter (encrypt or decrypt), on the input data buffer 
+ *        defined in the \p input parameter.
  *
  *        Due to the nature of CFB, you must use the same key schedule for
- *        both encryption and decryption operations. Therefore, you must use the 
- *        context initialized with mbedtls_aes_setkey_enc() for both 
+ *        both encryption and decryption operations. Therefore, you must use 
+ *        the context initialized with mbedtls_aes_setkey_enc() for both 
  *        #MBEDTLS_AES_ENCRYPT and #MBEDTLS_AES_DECRYPT.
  *
  * \note Upon exit, the content of the IV is updated so that you can
@@ -207,7 +217,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
  *
  *
  * \param ctx      The AES context to use for encryption or decryption.
- * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT
+ * \param mode     The AES operation: #MBEDTLS_AES_ENCRYPT or 
+ *				   #MBEDTLS_AES_DECRYPT. 
  * \param length   The length of the input data.
  * \param iv_off   The offset in IV (updated after use).
  * \param iv       The initialization vector (updated after use).
@@ -225,9 +236,9 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs the operation defined in the \p mode parameter 
- *        (encrypt/decrypt), on the input data buffer defined in the \p input 
- *        parameter.
+ * \brief This function performs the operation defined in the \p mode 
+ *        parameter (encrypt/decrypt), on the input data buffer defined 
+ *        in the \p input parameter.
  *
  *        Due to the nature of CFB, you must use the same key schedule for
  *        both encryption and decryption operations. Therefore, you must  
@@ -280,8 +291,8 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
  *                 		within current cipher stream. The offset pointer to
  *                 		should be 0 at the start of a stream.
  * \param nonce_counter The 128-bit nonce and counter.
- * \param stream_block  The saved stream block for resuming. This is overwritten
- *                      by the function.
+ * \param stream_block  The saved stream block for resuming. This is 
+ *                      overwritten by the function.
  * \param input    		The buffer holding the input data.
  * \param output   		The buffer holding the output data.
  *
@@ -297,8 +308,8 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /**
- * \brief Internal AES block encryption function. This is 
- *        only exposed to allow overriding it using #MBEDTLS_AES_ENCRYPT_ALT.
+ * \brief Internal AES block encryption function. This is only exposed 
+ *        to allow overriding it using #MBEDTLS_AES_ENCRYPT_ALT.
  *
  * \param ctx       The AES context to use for encryption.
  * \param input     The plaintext block.
@@ -311,8 +322,8 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   unsigned char output[16] );
 
 /**
- * \brief Internal AES block decryption function. This is
- *        only exposed to allow overriding it using see #MBEDTLS_AES_DECRYPT_ALT.
+ * \brief Internal AES block decryption function. This is only exposed 
+ *        to allow overriding it using see #MBEDTLS_AES_DECRYPT_ALT.
  *
  * \param ctx       The AES context to use for decryption.
  * \param input     The ciphertext block

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -1,3 +1,11 @@
+/**
+ * \file aes.h
+ *
+ * \brief AES is a family of block ciphers that processes data in multiples 
+ *		  of block sizes (16 Bytes).
+ * 
+ */
+ 
 /*  Copyright (C) 2006-2018, Arm Limited (or its affiliates), All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -14,14 +22,6 @@
  *  limitations under the License.
  *
  *  This file is part of Mbed TLS (https://tls.mbed.org)
- */
- 
-/**
- * \file aes.h
- *
- * \brief AES is a family of block ciphers that processes data in multiples 
- *		  of block sizes (16 Bytes).
- * 
  */
  
 #ifndef MBEDTLS_AES_H

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -94,7 +94,7 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *
-* \return         Zero if successful or error.h for the specific error code on failure.
+* \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
@@ -106,14 +106,14 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  * \param key      The decryption key.
  * \param keybits  The size of data passed. Valid options are:<ul><li>128bits</li><li>192bits</li><li>256bits</li></il>
  *
- * \return         Zero if successful or error.h for the specific error code on failure.
+ * \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-ECB input data buffer defined in the \p ctx parameter.
- * mbedtls_aes_init(),  mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
+ * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-ECB input data buffer defined in the \p input parameter.
+ * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
  * the first call to this API with the same context.
  *
  * \param ctx      The AES context to encrypt or decrypt.
@@ -130,12 +130,10 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CBC input data buffer defined in the \p ctx parameter. 
- * It can be called as many times as needed, until all the input data is processed.\par
- * mbedtls_aes_init(),  mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CBC input data buffer defined in the \p input parameter. 
+ * It can be called as many times as needed, until all the input data is processed.
+ * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
  * the first call to this API with the same context.
- * The function processes the last data block if needed, finalizes the AES-CBC operation, 
- * and produces operation results for MAC operations. 
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -144,7 +142,6 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *       If you need to retain the contents of the IV, you should 
  *       either save it manually or use the cipher module instead.
  *
- * \note The output buffer may be NULL for MAC operations.
  *
  * \param ctx      The AES context to encrypt/decrypt.
  * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
@@ -153,7 +150,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero if successful or error.h for the specific error code on failure.
+ * \return         Zero if successful or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -165,7 +162,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-CFB128 input data buffer defined in the \p ctx parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-CFB128 input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CFB, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with
@@ -199,7 +196,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CFB8 input data buffer defined in the \p ctx parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CFB8 input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CFB, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with
@@ -233,7 +230,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CTR input data buffer defined in the \p ctx parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CTR input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CTR, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with
@@ -265,8 +262,7 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
 
 /**
  * \brief Internal AES block encryption function. This is 
- *        only exposed to allow overriding it,
- *        see MBEDTLS_AES_ENCRYPT_ALT.
+ *        only exposed to allow overriding it using #MBEDTLS_AES_ENCRYPT_ALT.
  *
  * \param ctx       The AES context to encrypt.
  * \param input     The plaintext block.
@@ -280,8 +276,7 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
 
 /**
  * \brief Internal AES block decryption function. This is
- *        only exposed to allow overriding it,
- *        see MBEDTLS_AES_DECRYPT_ALT.
+ *        only exposed to allow overriding it using see #MBEDTLS_AES_DECRYPT_ALT.
  *
  * \param ctx       The AES context to decrypt.
  * \param input     The ciphertext block

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -93,14 +93,13 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
 
 /**
  * \brief          This function sets the encryption key.
-
  *
  * \param ctx      The AES context to initialize.
  * \param key      The encryption key.
  * \param keybits  The size of data passed in bits. Valid options are:
  *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
  *
-* \return         Zero on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+* \return         0 on success or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
@@ -113,13 +112,15 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  * \param keybits  The size of data passed. Valid options are:
  *                 <ul><li>128bits</li><li>192bits</li><li>256bits</li></ul>
  *
- * \return         Zero on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
+ * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
 int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs the operation defined in the \p mode parameter 
+ * \brief          This function performs an AES single-block encryption or decryption operation.
+ *
+ *                 It performs the operation defined in the \p mode parameter 
  *                 (encrypt or decrypt), on the input data buffer defined in the \p input 
  *                 parameter. 
  *
@@ -132,7 +133,7 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
  * \param input    The 16Byte buffer holding the input data.
  * \param output   The 16Byte buffer holding the output data.
  
- * \return         Zero on success.
+ * \return         0 on success.
  */
 int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                     int mode,
@@ -141,7 +142,9 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief   This function performs the operation defined in the \p mode parameter 
+ * \brief  This function performs an AES-CBC encryption or decryption operation on full blocks.
+ *         
+ *          This function performs the operation defined in the \p mode parameter 
  *          (encrypt/decrypt), on the input data buffer defined in the \p input 
  *          parameter. 
  *
@@ -149,6 +152,8 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *          data is processed. mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() 
  *          or mbedtls_aes_setkey_dec() must be called before the first call to this 
  *          API with the same context.
+ *
+ * \note  This function operates on aligned blocks, that is the input size must be a multiple of the AES block size of 16 Bytes.
  *
  * \note Upon exit, the content of the IV is updated so that you can
  *       call the same function again on the next
@@ -166,7 +171,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
+ * \return         0 on success, or #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH on failure.
  */
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -204,7 +209,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero on success.
+ * \return         0 on success.
  */
 int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        int mode,
@@ -241,7 +246,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
  *
- * \return         Zero on success.
+ * \return         0 on success.
  */
 int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
                     int mode,
@@ -275,7 +280,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
  * \param input    		The buffer holding the input data.
  * \param output   		The buffer holding the output data.
  *
- * \return         Zero on success.
+ * \return         0 on success.
  */
 int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
                        size_t length,
@@ -294,7 +299,7 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
  * \param input     The plaintext block.
  * \param output    The output (ciphertext) block.
  *
- * \return          Zero on success.
+ * \return          0 on success.
  */
 int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -308,7 +313,7 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
  * \param input     The ciphertext block
  * \param output    The output (plaintext) block
  *
- * \return          Zero on success.
+ * \return          0 on success.
  */
 int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
@@ -366,7 +371,7 @@ extern "C" {
 /**
  * \brief          Checkup routine.
  *
- * \return         Zero on success, or one on failure.
+ * \return         0 on success, or 1 on failure.
  */
 int mbedtls_aes_self_test( int verbose );
 

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -112,7 +112,7 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
- * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-ECB input data buffer defined in the \p input parameter.
+ * \brief          This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the input data buffer defined in the \p input parameter.
  * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
  * the first call to this API with the same context.
  *
@@ -130,7 +130,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CBC input data buffer defined in the \p input parameter. 
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter. 
  * It can be called as many times as needed, until all the input data is processed.
  * mbedtls_aes_init(), and either mbedtls_aes_setkey_enc() or mbedtls_aes_setkey_dec() must be called before 
  * the first call to this API with the same context.
@@ -145,7 +145,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  *
  * \param ctx      The AES context to encrypt/decrypt.
  * \param mode     The AES mode: #MBEDTLS_AES_ENCRYPT or #MBEDTLS_AES_DECRYPT.
- * \param length   The length of the input data in Bytes. AES-CBC buffer encryption/decryption length must be a multiple of the block size (16 Bytes).
+ * \param length   The length of the input data in Bytes. The buffer encryption/decryption length must be a multiple of the block size (16 Bytes).
  * \param iv       Initialization vector (updated after use).
  * \param input    The buffer holding the input data.
  * \param output   The buffer holding the output data.
@@ -162,7 +162,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the AES-CFB128 input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt or decrypt), on the input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CFB, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with
@@ -196,7 +196,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        unsigned char *output );
 
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CFB8 input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CFB, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with
@@ -230,7 +230,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the AES-CTR input data buffer defined in the \p input parameter.
+ * \brief This function performs the operation defined in the \p mode parameter (encrypt/decrypt), on the input data buffer defined in the \p input parameter.
  *
  * Due to the nature of CTR, you must use the same key schedule for
  * both encryption and decryption operations. Therefore, you must use the context initialized with


### PR DESCRIPTION
- separate "\file" blocks from copyright, so that Doxygen doesn't repeat the copyright information in all the Detailed Descriptions.
- Improved phrasing and clarity of functions, parameters, defines and enums.