### PR TITLE
Backport 2.1:Fix compilation error with Mingw32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,9 @@ Bugfix
    * Fix issue in RSA key generation program programs/x509/rsa_genkey
      where the failure of CTR DRBG initialization lead to freeing an
      RSA context without proper initialization beforehand.
+   * Fix compilation error on Mingw32 when `_TRUNCATE` is defined. Use `_TRUNCATE`
+     only if `__MINGW32__` not defined. Fix suggested by Thomas Glanzmann and
+     Nick Wilson on issue #355
 
 Changes
    * Extend cert_write example program by options to set the CRT version

--- a/ChangeLog
+++ b/ChangeLog
@@ -62,8 +62,8 @@ Bugfix
    * Fix issue in RSA key generation program programs/x509/rsa_genkey
      where the failure of CTR DRBG initialization lead to freeing an
      RSA context without proper initialization beforehand.
-   * Fix compilation error on Mingw32 when `_TRUNCATE` is defined. Use `_TRUNCATE`
-     only if `__MINGW32__` not defined. Fix suggested by Thomas Glanzmann and
+   * Fix compilation error on Mingw32 when _TRUNCATE is defined. Use _TRUNCATE
+     only if __MINGW32__ not defined. Fix suggested by Thomas Glanzmann and
      Nick Wilson on issue #355
 
 Changes

--- a/library/debug.c
+++ b/library/debug.c
@@ -90,7 +90,7 @@ void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
 
     va_start( argp, format );
 #if defined(_WIN32)
-#if defined(_TRUNCATE)
+#if defined(_TRUNCATE) && !defined(__MINGW32__)
     ret = _vsnprintf_s( str, DEBUG_BUF_SIZE, _TRUNCATE, format, argp );
 #else
     ret = _vsnprintf( str, DEBUG_BUF_SIZE, format, argp );

--- a/library/platform.c
+++ b/library/platform.c
@@ -74,7 +74,7 @@ int mbedtls_platform_win32_snprintf( char *s, size_t n, const char *fmt, ... )
         return( -1 );
 
     va_start( argp, fmt );
-#if defined(_TRUNCATE)
+#if defined(_TRUNCATE) && !defined(__MINGW32__)
     ret = _vsnprintf_s( s, n, _TRUNCATE, fmt, argp );
 #else
     ret = _vsnprintf( s, n, fmt, argp );


### PR DESCRIPTION
This is a backport of https://github.com/ARMmbed/mbedtls/pull/1079 to mbedtls-2.1
