### PR TITLE
Backport 2.1: Fix for dh_server example program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -159,6 +159,8 @@ Bugfix
      Vranken.
    * Fix a numerical underflow leading to stack overflow in mpi_read_file()
      that was triggered uppon reading an empty line. Found by Guido Vranken.
+   * Fix programs/pkey/dh_server.c so that it actually works with dh_client.c.
+     Found and fixed by Martijn de Milliano.
 
 Changes
    * Clarify ECDSA documentation and improve the sample code to avoid

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -229,6 +229,7 @@ int main( void )
 
     memset( buf, 0, sizeof( buf ) );
 
+    n = dhm.len;
     if( ( ret = mbedtls_net_recv( &client_fd, buf, n ) ) != (int) n )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_recv returned %d\n\n", ret );


### PR DESCRIPTION
The example programs `dh_server` and `dh_client` do not work out of the box. The client sends 256 bytes, the length of the public key, but the server (wrongly) expects 519 bytes, which is the total length of the DH parameters structure.

This fixes initialises the value of `n` in `dh_server.c` in a similar fashion as is done in `dh_client.c`.

Straightforward backport of #1000 by @mjdemilliano . We don't usually care about sample programs in maintenance branches, but this bug completely breaks the example.
