### PR TITLE
Add support for alternative ECJPAKE implementation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,14 +28,14 @@ Features
      The following functions from the ECDSA module can be replaced
      with alternative implementation:
      mbedtls_ecdsa_sign(), mbedtls_ecdsa_verify() and mbedtls_ecdsa_genkey().
-   * Add support for alternative implementation for ECDH, controlled by new
-     configuration flags MBEDTLS_ECDH_COMPUTE_SHARED_ALT and
+   * Add support for alternative implementation of ECDH, controlled by the
+     new configuration flags MBEDTLS_ECDH_COMPUTE_SHARED_ALT and
      MBEDTLS_ECDH_GEN_PUBLIC_ALT in config.h.
      The following functions from the ECDH module can be replaced
      with an alternative implementation:
      mbedtls_ecdh_gen_public() and mbedtls_ecdh_compute_shared().
-   * Add support for alternative implementation for ECJPAKE, controlled by
-     new configuration flag MBEDTLS_ECJPAKE_ALT.
+   * Add support for alternative implementation of ECJPAKE, controlled by
+     the new configuration flag MBEDTLS_ECJPAKE_ALT.
 
 API Changes
    * Extend RSA interface by multiple functions allowing structure-

--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,8 @@ Features
      The following functions from the ECDH module can be replaced
      with an alternative implementation:
      mbedtls_ecdh_gen_public() and mbedtls_ecdh_compute_shared().
+   * Add support for alternative implementation for ECJPAKE, controlled by
+     new configuration flag MBEDTLS_ECJPAKE_ALT.
 
 API Changes
    * Extend RSA interface by multiple functions allowing structure-

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -271,6 +271,7 @@
 //#define MBEDTLS_CMAC_ALT
 //#define MBEDTLS_DES_ALT
 //#define MBEDTLS_DHM_ALT
+//#define MBEDTLS_ECJPAKE_ALT
 //#define MBEDTLS_GCM_ALT
 //#define MBEDTLS_MD2_ALT
 //#define MBEDTLS_MD4_ALT

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -44,6 +44,8 @@
 #include "ecp.h"
 #include "md.h"
 
+#if !defined(MBEDTLS_ECJPAKE_ALT)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -223,17 +225,31 @@ int mbedtls_ecjpake_derive_secret( mbedtls_ecjpake_context *ctx,
  */
 void mbedtls_ecjpake_free( mbedtls_ecjpake_context *ctx );
 
+#ifdef __cplusplus
+}
+#endif
+
+#else  /* MBEDTLS_ECJPAKE_ALT */
+#include "ecjpake_alt.h"
+#endif /* MBEDTLS_ECJPAKE_ALT */
+
 #if defined(MBEDTLS_SELF_TEST)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if a test failed
  */
 int mbedtls_ecjpake_self_test( int verbose );
-#endif
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* MBEDTLS_SELF_TEST */
 
 #endif /* ecjpake.h */

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -36,6 +36,8 @@
 
 #include <string.h>
 
+#if !defined(MBEDTLS_ECJPAKE_ALT)
+
 /*
  * Convert a mbedtls_ecjpake_role to identifier string
  */
@@ -764,6 +766,7 @@ cleanup:
 #undef ID_MINE
 #undef ID_PEER
 
+#endif /* ! MBEDTLS_ECJPAKE_ALT */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -108,6 +108,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DHM_ALT)
     "MBEDTLS_DHM_ALT",
 #endif /* MBEDTLS_DHM_ALT */
+#if defined(MBEDTLS_ECJPAKE_ALT)
+    "MBEDTLS_ECJPAKE_ALT",
+#endif /* MBEDTLS_ECJPAKE_ALT */
 #if defined(MBEDTLS_GCM_ALT)
     "MBEDTLS_GCM_ALT",
 #endif /* MBEDTLS_GCM_ALT */


### PR DESCRIPTION
__Summary:__ This PR adds support for alternative implementation of the entire ECJPAKE module, controlled as usual by a configuration flag `MBEDTLS_ECJPAKE_ALT`. 

__Internal Reference:__ IOTSSL-2042

@Patater @yanesca Please review.