### PR TITLE
Tolerate failures from unsupported operations in RSA test suites

### DIFF
--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -257,6 +257,14 @@ int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
  *                 the RSA context can be used for RSA operations without
  *                 the risk of failure or crash.
  *
+ *                 Alternative implementations need not support all of the
+ *                 above private key derivations; further, they might put
+ *                 constraints on acceptable sizes and values of the imported
+ *                 parameters. In case a failure originating from these
+ *                 implementation-specific restrictions, alternative
+ *                 implementations should return the error code
+ *                 \c MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION.
+ *
  * \warning        This function need not perform consistency checks
  *                 for the imported parameters. In particular, parameters that
  *                 are not needed by the implementation might be silently
@@ -266,8 +274,10 @@ int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
  * \param ctx      The initialized RSA context holding imported parameters.
  *
  * \return         \c 0 on success.
- * \return         #MBEDTLS_ERR_RSA_BAD_INPUT_DATA if the attempted derivations
- *                 failed.
+ * \return         \c MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION if the imported
+ *                 parameters are not suitable for the implementation to set
+ *                 up the public / private RSA context.
+ * \return         Another non-zero error code otherwise.
  *
  */
 int mbedtls_rsa_complete( mbedtls_rsa_context *ctx );

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -78,6 +78,15 @@ typedef struct data_tag
         }                                           \
     } while( 0 )
 
+#define TEST_ASSUME( TEST )                         \
+    do {                                            \
+        if( ! (TEST) )                              \
+        {                                           \
+            test_skip( #TEST, __LINE__, __FILE__ ); \
+            goto exit;                              \
+        }                                           \
+    } while( 0 )
+
 #define assert(a) if( !( a ) )                                      \
 {                                                                   \
     mbedtls_fprintf( stderr, "Assertion Failed at %s:%d - %s\n",   \
@@ -115,7 +124,7 @@ typedef struct data_tag
 
 static struct
 {
-    int failed;
+    int result; /* 0 on success, 1 on failure, 2 on skip */
     const char *test;
     const char *filename;
     int line_no;
@@ -449,7 +458,15 @@ static int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
 
 static void test_fail( const char *test, int line_no, const char* filename )
 {
-    test_info.failed = 1;
+    test_info.result = 1;
+    test_info.test = test;
+    test_info.line_no = line_no;
+    test_info.filename = filename;
+}
+
+static void test_skip( const char *test, int line_no, const char* filename )
+{
+    test_info.result = 2;
     test_info.test = test;
     test_info.line_no = line_no;
     test_info.filename = filename;
@@ -473,4 +490,3 @@ int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
     }
     return ret;
 }
-

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -498,7 +498,7 @@ int execute_tests( int argc , const char ** argv )
 
             if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
                 break;
-            mbedtls_fprintf( stdout, "%s%.66s", test_info.failed ? "\n" : "", buf );
+            mbedtls_fprintf( stdout, "%s%.66s", test_info.result ? "\n" : "", buf );
             mbedtls_fprintf( stdout, " " );
             for( i = strlen( buf ) + 1; i < 67; i++ )
                 mbedtls_fprintf( stdout, "." );
@@ -545,7 +545,7 @@ int execute_tests( int argc , const char ** argv )
             // If there are no unmet dependencies execute the test
             if( unmet_dep_count == 0 )
             {
-                test_info.failed = 0;
+                test_info.result = 0;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
                 /* Suppress all output from the library unless we're verbose
@@ -609,9 +609,17 @@ int execute_tests( int argc , const char ** argv )
             }
             else if( ret == DISPATCH_TEST_SUCCESS )
             {
-                if( test_info.failed == 0 )
+                if( test_info.result == 0 )
                 {
                     mbedtls_fprintf( stdout, "PASS\n" );
+                }
+                else if( test_info.result == 2 )
+                {
+                    total_skipped++;
+                    mbedtls_fprintf( stdout, "SKIP\n" );
+                    mbedtls_fprintf( stdout, "  Unmet assumption: %s\n  at line %d, %s\n",
+                                     test_info.test, test_info.line_no,
+                                     test_info.filename );
                 }
                 else
                 {

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -24,6 +24,7 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
                              char * input_N, int radix_E, char * input_E,
                              data_t * result_hex_str, int result )
 {
+    int res;
     unsigned char hash_result[1000];
     unsigned char output[1000];
     mbedtls_rsa_context ctx;
@@ -45,7 +46,14 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
 
     TEST_ASSERT( mbedtls_rsa_import( &ctx, &N, &P, &Q, NULL, &E ) == 0 );
     TEST_ASSERT( mbedtls_rsa_get_len( &ctx ) == (size_t) ( mod / 8 ) );
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
+
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
 
 
@@ -109,6 +117,7 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
                          int radix_N, char * input_N, int radix_E,
                          char * input_E, data_t * result_hex_str )
 {
+    int res;
     unsigned char output[1000];
     mbedtls_rsa_context ctx;
     mbedtls_mpi N, P, Q, E;
@@ -128,7 +137,14 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
 
     TEST_ASSERT( mbedtls_rsa_import( &ctx, &N, &P, &Q, NULL, &E ) == 0 );
     TEST_ASSERT( mbedtls_rsa_get_len( &ctx ) == (size_t) ( mod / 8 ) );
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
+
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
 
 
@@ -144,7 +160,6 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
     /* For PKCS#1 v1.5, there is an alternative way to generate signatures */
     if( padding_mode == MBEDTLS_RSA_PKCS_V15 )
     {
-        int res;
         memset( output, 0x00, 1000 );
 
         res = mbedtls_rsa_rsaes_pkcs1_v15_encrypt( &ctx,
@@ -321,6 +336,7 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
                                 int max_output, data_t * result_hex_str,
                                 int result )
 {
+    int res;
     unsigned char output[1000];
     mbedtls_rsa_context ctx;
     size_t output_len;
@@ -343,7 +359,14 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
 
     TEST_ASSERT( mbedtls_rsa_import( &ctx, &N, &P, &Q, NULL, &E ) == 0 );
     TEST_ASSERT( mbedtls_rsa_get_len( &ctx ) == (size_t) ( mod / 8 ) );
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
+
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
 
     output_len = 0;
@@ -421,6 +444,7 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
                           char * input_E, data_t * result_hex_str,
                           int result )
 {
+    int res;
     unsigned char output[1000];
     mbedtls_rsa_context ctx, ctx2; /* Also test mbedtls_rsa_copy() while at it */
     mbedtls_mpi N, P, Q, E;
@@ -441,7 +465,13 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
 
     TEST_ASSERT( mbedtls_rsa_import( &ctx, &N, &P, &Q, NULL, &E ) == 0 );
     TEST_ASSERT( mbedtls_rsa_get_len( &ctx ) == (size_t) ( mod / 8 ) );
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
 
 
@@ -796,6 +826,7 @@ void mbedtls_rsa_import( int radix_N, char *input_N,
                          int res_check,
                          int res_complete )
 {
+    int res;
     mbedtls_mpi N, P, Q, D, E;
     mbedtls_rsa_context ctx;
 
@@ -878,7 +909,12 @@ void mbedtls_rsa_import( int radix_N, char *input_N,
                                have_E ? &E : NULL ) == 0 );
     }
 
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == res_complete );
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == res_complete );
 
     /* On expected success, perform some public and private
      * key operations to check if the key is working properly. */
@@ -943,6 +979,8 @@ void mbedtls_rsa_export( int radix_N, char *input_N,
                          int is_priv,
                          int successive )
 {
+    int res;
+
     /* Original MPI's with which we set up the RSA context */
     mbedtls_mpi N, P, Q, D, E;
 
@@ -991,7 +1029,12 @@ void mbedtls_rsa_export( int radix_N, char *input_N,
                                      strlen( input_D ) ? &D : NULL,
                                      strlen( input_E ) ? &E : NULL ) == 0 );
 
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
 
     /*
      * Export parameters and compare to original ones.
@@ -1128,6 +1171,8 @@ void mbedtls_rsa_export_raw( data_t *input_N, data_t *input_P,
                              data_t *input_E, int is_priv,
                              int successive )
 {
+    int res;
+
     /* Exported buffers */
     unsigned char bufNe[1000];
     unsigned char bufPe[1000];
@@ -1147,7 +1192,12 @@ void mbedtls_rsa_export_raw( data_t *input_N, data_t *input_P,
                                input_D->len ? input_D->x : NULL, input_D->len,
                                input_E->len ? input_E->x : NULL, input_E->len ) == 0 );
 
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == 0 );
 
     /*
      * Export parameters and compare to original ones.
@@ -1226,6 +1276,8 @@ void mbedtls_rsa_import_raw( data_t *input_N,
                              int res_check,
                              int res_complete )
 {
+    int res;
+
     /* Buffers used for encryption-decryption test */
     unsigned char *buf_orig = NULL;
     unsigned char *buf_enc  = NULL;
@@ -1283,7 +1335,12 @@ void mbedtls_rsa_import_raw( data_t *input_N,
                                ( input_E->len > 0 ) ? input_E->x : NULL, input_E->len ) == 0 );
     }
 
-    TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == res_complete );
+    res = mbedtls_rsa_complete( &ctx );
+#if defined(MBEDTLS_RSA_ALT)
+    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
+        goto exit;
+#endif
+    TEST_ASSERT( res == res_complete );
 
     /* On expected success, perform some public and private
      * key operations to check if the key is working properly. */

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -49,8 +49,7 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
 
@@ -140,8 +139,7 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
 
@@ -362,8 +360,7 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
 
@@ -468,8 +465,7 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
@@ -911,8 +907,7 @@ void mbedtls_rsa_import( int radix_N, char *input_N,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == res_complete );
 
@@ -1031,8 +1026,7 @@ void mbedtls_rsa_export( int radix_N, char *input_N,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
 
@@ -1194,8 +1188,7 @@ void mbedtls_rsa_export_raw( data_t *input_N, data_t *input_P,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == 0 );
 
@@ -1337,8 +1330,7 @@ void mbedtls_rsa_import_raw( data_t *input_N,
 
     res = mbedtls_rsa_complete( &ctx );
 #if defined(MBEDTLS_RSA_ALT)
-    if( res == MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION )
-        goto exit;
+    TEST_ASSUME( res != MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION );
 #endif
     TEST_ASSERT( res == res_complete );
 


### PR DESCRIPTION
__Summary:__ Alternative implementations of the RSA module may apply restrictions to supported input parameters that do not apply to the default software implementation. In this case, the documentation stated that implementations should return `MBEDTLS_ERR_RSA_BAD_INPUT_DATA`.

This PR changes this to require the use of the error code `MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION` for limitations specific to the alternative implementations in question.

Furthermore, the commit adapts the RSA test suite, which must be prepared to receive this error code in case `MBEDTLS_RSA_ALT` is set, and preempt the respective tests in this case instead of reporting a failure, as was done before.