### PR TITLE
Backport 2.1: Support verbose output of the test suites

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ function(add_test_suite suite_name)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     add_executable(test_suite_${data_name} test_suite_${data_name}.c)
     target_link_libraries(test_suite_${data_name} ${libs})
-    add_test(${data_name}-suite test_suite_${data_name})
+    add_test(${data_name}-suite test_suite_${data_name} --verbose)
 endfunction(add_test_suite)
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)


### PR DESCRIPTION
generate add ctest test-suites, with the --verbose argument to be given
to the test suites.
The verbose output will be shown **only** if ctest is run with `-v` parameter
The verbose argument is to the test-suites, only when run through `ctest`

Backport of #985 to mbedtls-2.1