### PR TITLE
Backport 2.1: Remove duplicated print error 2.1

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -129,15 +129,6 @@ do {                                                                    \
                      ( mbedtls_timing_hardclock() - tsc ) / ( jj * BUFSIZE ) );         \
 } while( 0 )
 
-#if defined(MBEDTLS_ERROR_C)
-#define PRINT_ERROR                                                     \
-        mbedtls_strerror( ret, ( char * )tmp, sizeof( tmp ) );          \
-        mbedtls_printf( "FAILED: %s\n", tmp );
-#else
-#define PRINT_ERROR                                                     \
-        mbedtls_printf( "FAILED: -0x%04x\n", -ret );
-#endif
-
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && defined(MBEDTLS_MEMORY_DEBUG)
 
 #define MEMORY_MEASURE_INIT                                             \


### PR DESCRIPTION
The PRINT_ERROR macros are already defined exactly the same in line
101ff, so we can remove them here.

Backport of #1036 for mbedtls-2.1