### PR TITLE
Fix alarm(0) failure on mingw32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -108,7 +108,7 @@ Bugfix
    * Fix incorrect unit in benchmark output. #850
    * Fix crash when calling mbedtls_ssl_cache_free() twice. Found by
      MilenkoMitrovic, #1104
-   * Fix mbedtls_timing_alarm(0) on Unix.
+   * Fix mbedtls_timing_alarm(0) on Unix and MinGW.
    * Fix use of uninitialized memory in mbedtls_timing_get_timer when reset=1.
    * Fix possible memory leaks in mbedtls_gcm_self_test().
    * Added missing return code checks in mbedtls_aes_self_test().

--- a/library/timing.c
+++ b/library/timing.c
@@ -278,6 +278,14 @@ void mbedtls_set_alarm( int seconds )
 {
     DWORD ThreadId;
 
+    if( seconds == 0 )
+    {
+        /* No need to create a thread for this simple case.
+         * Also, this shorcut is more reliable at least on MinGW32 */
+        mbedtls_timing_alarmed = 1;
+        return;
+    }
+
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
     CloseHandle( CreateThread( NULL, 0, TimerProc, NULL, 0, &ThreadId ) );


### PR DESCRIPTION
## Description

A new test for mbedtls_timing_alarm(0) was introduced in PR 1136, which also
fixed it on Unix. Apparently test results on MinGW were not checked at that
point, so we missed that this new test was also failing on this platform.

This PR fixes the function in order to make the new test pass, in a way similar to the fix introduce in by #1136 for Unix.

## Status
**READY**

## Requires Backporting
Yes
 
[x] Mbed TLS 2.1 https://github.com/ARMmbed/mbedtls/pull/1329
[x] Mbed TLS 1.3 https://github.com/ARMmbed/mbedtls/pull/1330