### PR TITLE
Backport 2.1: Fix alarm(0) failure on mingw32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,7 +57,7 @@ Bugfix
    * Fix word size check in in pk.c to not depend on MBEDTLS_HAVE_INT64.
    * Fix crash when calling mbedtls_ssl_cache_free() twice. Found by
      MilenkoMitrovic, #1104
-   * Fix mbedtls_timing_alarm(0) on Unix.
+   * Fix mbedtls_timing_alarm(0) on Unix and MinGw.
    * Fix use of uninitialized memory in mbedtls_timing_get_timer when reset=1.
    * Fix issue in RSA key generation program programs/x509/rsa_genkey
      where the failure of CTR DRBG initialization lead to freeing an

--- a/library/timing.c
+++ b/library/timing.c
@@ -273,6 +273,14 @@ void mbedtls_set_alarm( int seconds )
 {
     DWORD ThreadId;
 
+    if( seconds == 0 )
+    {
+        /* No need to create a thread for this simple case.
+         * Also, this shorcut is more reliable at least on MinGW32 */
+        mbedtls_timing_alarmed = 1;
+        return;
+    }
+
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
     CloseHandle( CreateThread( NULL, 0, TimerProc, NULL, 0, &ThreadId ) );


### PR DESCRIPTION
Bacport of https://github.com/ARMmbed/mbedtls/pull/1328
