### PR TITLE
Fix ILP32 issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -269,6 +269,7 @@ Bugfix
      Vranken.
    * Fix a numerical underflow leading to stack overflow in mpi_read_file()
      that was triggered uppon reading an empty line. Found by Guido Vranken.
+   * Fix test_suite_pk to work on 64-bit ILP32 systems. #849
 
 Changes
    * Send fatal alerts in more cases. The previous behaviour was to skip

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -662,23 +662,29 @@ if uname -a | grep -F x86_64 >/dev/null; then
 
     msg "test: 64-bit ILP32, make, gcc"
     make test
-
-    msg "build: gcc, force 32-bit compilation"
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl unset MBEDTLS_HAVE_ASM
-    scripts/config.pl unset MBEDTLS_AESNI_C
-    scripts/config.pl unset MBEDTLS_PADLOCK_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
-
-    msg "build: gcc, force 64-bit compilation"
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl unset MBEDTLS_HAVE_ASM
-    scripts/config.pl unset MBEDTLS_AESNI_C
-    scripts/config.pl unset MBEDTLS_PADLOCK_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
 fi # x86_64
+
+msg "build: gcc, force 32-bit bignum limbs"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
+
+msg "test: gcc, force 32-bit bignum limbs"
+make test
+
+msg "build: gcc, force 64-bit bignum limbs"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
+
+msg "test: gcc, force 64-bit bignum limbs"
+make test
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -678,17 +678,6 @@ if uname -a | grep -F x86_64 >/dev/null; then
     scripts/config.pl unset MBEDTLS_AESNI_C
     scripts/config.pl unset MBEDTLS_PADLOCK_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
-
-    msg "test: gcc, force 64-bit compilation"
-    make test
-
-    msg "build: gcc, force 64-bit compilation"
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl unset MBEDTLS_HAVE_ASM
-    scripts/config.pl unset MBEDTLS_AESNI_C
-    scripts/config.pl unset MBEDTLS_PADLOCK_C
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -653,6 +653,16 @@ if uname -a | grep -F x86_64 >/dev/null; then
     cleanup
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -m32'
 
+    msg "test: i386, make, gcc"
+    make test
+
+    msg "build: 64-bit ILP32, make, gcc" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
+
+    msg "test: 64-bit ILP32, make, gcc"
+    make test
+
     msg "build: gcc, force 32-bit compilation"
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -6,6 +6,7 @@
 #include "mbedtls/rsa.h"
 
 #include <limits.h>
+#include <stdint.h>
 
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );
 

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -5,8 +5,7 @@
 #include "mbedtls/ecp.h"
 #include "mbedtls/rsa.h"
 
-/* For detecting 64-bit compilation */
-#include "mbedtls/bignum.h"
+#include <limits.h>
 
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );
 
@@ -413,11 +412,14 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_RSA_C:MBEDTLS_HAVE_INT64 */
+/* BEGIN_CASE depends_on:MBEDTLS_RSA_C */
 void pk_rsa_overflow( )
 {
     mbedtls_pk_context pk;
-    size_t hash_len = (size_t)-1;
+    size_t hash_len = SIZE_MAX;
+
+    if( SIZE_MAX <= UINT_MAX )
+        return;
 
     mbedtls_pk_init( &pk );
 
@@ -486,13 +488,13 @@ void pk_rsa_alt( )
     TEST_ASSERT( strcmp( mbedtls_pk_get_name( &alt ), "RSA-alt" ) == 0 );
 
     /* Test signature */
-    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, sizeof hash,
-                          sig, &sig_len, rnd_std_rand, NULL ) == 0 );
-#if defined(MBEDTLS_HAVE_INT64)
-    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, (size_t)-1,
-                          NULL, NULL, rnd_std_rand, NULL ) ==
+#if SIZE_MAX > UINT_MAX
+    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, SIZE_MAX,
+                                  sig, &sig_len, rnd_std_rand, NULL ) ==
                  MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#endif /* MBEDTLS_HAVE_INT64 */
+#endif /* SIZE_MAX > UINT_MAX */
+    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, sizeof hash,
+                                  sig, &sig_len, rnd_std_rand, NULL ) == 0 );
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( mbedtls_pk_verify( &rsa, MBEDTLS_MD_NONE,
                             hash, sizeof hash, sig, sig_len ) == 0 );


### PR DESCRIPTION
1. Rebase of #900: Add a build and a test runs to `all.sh` to ensure that mbed TLS builds and works with the GCC flags `-m32` and `-mx32`. Fixes #849

2. Fix tests with forced 64-bit or 32-bit bignum limb size: execute them once, regardless of the architecture.

Internal ref: IOTSSL-1300

Note to reviewers: the first three commits are from #900 (previously approved), rebased on top of current development, which meant adjusting to the changes in `all.sh`. The subsequent commits are new, to fix issue 2 which I noticed.

Backports (of (1) + other ILP32 fixes as applicable; (2) does not apply): #1334, #1335
