### PR TITLE
Backport 2.1: Fix ILP32 issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,7 @@ Bugfix
    * Fix assembly sequences in bn_mul.h and aesni.c to avoid segmentation
      faults and errors when building for the 64-bit ILP32 ABI. Found and fixed
      by James Cowgill.
+   * Fix test_suite_pk to work on 64-bit ILP32 systems. #849
 
 Changes
    * Extend cert_write example program by options to set the CRT version

--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,9 @@ Bugfix
    * Fix bug in cipher decryption with MBEDTLS_PADDING_ONE_AND_ZEROS that
      sometimes accepted invalid padding. (Not used in TLS.) Found and fixed
      by Micha Kraus.
+   * Fix assembly sequences in bn_mul.h and aesni.c to avoid segmentation
+     faults and errors when building for the 64-bit ILP32 ABI. Found and fixed
+     by James Cowgill.
 
 Changes
    * Extend cert_write example program by options to set the CRT version

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -162,10 +162,6 @@
 
 #define MULADDC_INIT                        \
     asm(                                    \
-        "movq   %3, %%rsi           \n\t"   \
-        "movq   %4, %%rdi           \n\t"   \
-        "movq   %5, %%rcx           \n\t"   \
-        "movq   %6, %%rbx           \n\t"   \
         "xorq   %%r8, %%r8          \n\t"
 
 #define MULADDC_CORE                        \
@@ -181,12 +177,9 @@
         "addq   $8,      %%rdi      \n\t"
 
 #define MULADDC_STOP                        \
-        "movq   %%rcx, %0           \n\t"   \
-        "movq   %%rdi, %1           \n\t"   \
-        "movq   %%rsi, %2           \n\t"   \
-        : "=m" (c), "=m" (d), "=m" (s)                      \
-        : "m" (s), "m" (d), "m" (c), "m" (b)                \
-        : "rax", "rcx", "rdx", "rbx", "rsi", "rdi", "r8"    \
+        : "+c" (c), "+D" (d), "+S" (s)      \
+        : "b" (b)                           \
+        : "rax", "rdx", "r8"                \
     );
 
 #endif /* AMD64 */

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -100,7 +100,7 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
     asm( "movdqu    (%3), %%xmm0    \n\t" // load input
          "movdqu    (%1), %%xmm1    \n\t" // load round key 0
          "pxor      %%xmm1, %%xmm0  \n\t" // round 0
-         "addq      $16, %1         \n\t" // point to next round key
+         "add       $16, %1         \n\t" // point to next round key
          "subl      $1, %0          \n\t" // normal rounds = nr - 1
          "test      %2, %2          \n\t" // mode?
          "jz        2f              \n\t" // 0 = decrypt
@@ -108,7 +108,7 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
          "1:                        \n\t" // encryption loop
          "movdqu    (%1), %%xmm1    \n\t" // load round key
          AESENC     xmm1_xmm0      "\n\t" // do round
-         "addq      $16, %1         \n\t" // point to next round key
+         "add       $16, %1         \n\t" // point to next round key
          "subl      $1, %0          \n\t" // loop
          "jnz       1b              \n\t"
          "movdqu    (%1), %%xmm1    \n\t" // load round key
@@ -118,7 +118,7 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
          "2:                        \n\t" // decryption loop
          "movdqu    (%1), %%xmm1    \n\t"
          AESDEC     xmm1_xmm0      "\n\t" // do round
-         "addq      $16, %1         \n\t"
+         "add       $16, %1         \n\t"
          "subl      $1, %0          \n\t"
          "jnz       2b              \n\t"
          "movdqu    (%1), %%xmm1    \n\t" // load round key

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -565,6 +565,16 @@ if uname -a | grep -F x86_64 >/dev/null; then
     msg "build: i386, make, gcc" # ~ 30s
     cleanup
     make CC=gcc CFLAGS='-Werror -m32'
+
+    msg "test: i386, make, gcc"
+    make test
+
+    msg "build: 64-bit ILP32, make, gcc" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
+
+    msg "test: 64-bit ILP32, make, gcc"
+    make test
 fi # x86_64
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -423,6 +423,9 @@ void pk_rsa_overflow( )
     mbedtls_pk_context pk;
     size_t hash_len = (size_t)-1;
 
+    if( sizeof( size_t ) <= sizeof( unsigned int ) )
+        return;
+
     mbedtls_pk_init( &pk );
 
     TEST_ASSERT( mbedtls_pk_setup( &pk,
@@ -493,9 +496,12 @@ void pk_rsa_alt( )
     TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, sizeof hash,
                           sig, &sig_len, rnd_std_rand, NULL ) == 0 );
 #if defined(MBEDTLS_HAVE_INT64)
-    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, (size_t)-1,
-                          NULL, NULL, rnd_std_rand, NULL ) ==
-                 MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+    if( sizeof( size_t ) > sizeof( unsigned int ) )
+    {
+        TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, (size_t)-1,
+                              NULL, NULL, rnd_std_rand, NULL ) ==
+                     MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+    }
 #endif /* MBEDTLS_HAVE_INT64 */
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( mbedtls_pk_verify( &rsa, MBEDTLS_MD_NONE,

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -5,8 +5,8 @@
 #include "mbedtls/ecp.h"
 #include "mbedtls/rsa.h"
 
-/* For detecting 64-bit compilation */
-#include "mbedtls/bignum.h"
+#include <limits.h>
+#include <stdint.h>
 
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );
 
@@ -417,13 +417,13 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_RSA_C:MBEDTLS_HAVE_INT64 */
+/* BEGIN_CASE depends_on:MBEDTLS_RSA_C */
 void pk_rsa_overflow( )
 {
     mbedtls_pk_context pk;
-    size_t hash_len = (size_t)-1;
+    size_t hash_len = SIZE_MAX;
 
-    if( sizeof( size_t ) <= sizeof( unsigned int ) )
+    if( SIZE_MAX <= UINT_MAX )
         return;
 
     mbedtls_pk_init( &pk );
@@ -493,16 +493,13 @@ void pk_rsa_alt( )
     TEST_ASSERT( strcmp( mbedtls_pk_get_name( &alt ), "RSA-alt" ) == 0 );
 
     /* Test signature */
+#if SIZE_MAX > UINT_MAX
+    TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, SIZE_MAX,
+                                  sig, &sig_len, rnd_std_rand, NULL ) ==
+                 MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+#endif /* SIZE_MAX > UINT_MAX */
     TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, sizeof hash,
-                          sig, &sig_len, rnd_std_rand, NULL ) == 0 );
-#if defined(MBEDTLS_HAVE_INT64)
-    if( sizeof( size_t ) > sizeof( unsigned int ) )
-    {
-        TEST_ASSERT( mbedtls_pk_sign( &alt, MBEDTLS_MD_NONE, hash, (size_t)-1,
-                              NULL, NULL, rnd_std_rand, NULL ) ==
-                     MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-    }
-#endif /* MBEDTLS_HAVE_INT64 */
+                                  sig, &sig_len, rnd_std_rand, NULL ) == 0 );
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( mbedtls_pk_verify( &rsa, MBEDTLS_MD_NONE,
                             hash, sizeof hash, sig, sig_len ) == 0 );


### PR DESCRIPTION
Rebase of #901 on top of current mbedtls-2.1:

> This PR does the following things:
> * Backports the changes in https://github.com/ARMmbed/mbedtls/pull/376
> * Fixes the tests `pk_rsa_overflow()` and `pk_rsa_alt()` in `test_suite_pk.function` that previously caused segfaults when building with `-mx32`.
> * Adds a build and tests to `all.sh` to compile and run mbed TLS with the flags `-m32` and `mx32` (backport of #900).

> These changes fixes the library problems when building with the 64-bit ILP32 ABI and addresses the issue at https://github.com/ARMmbed/mbedtls/issues/849

Internal ref: IOTSSL-1300

Note to reviewers: this is #901 (previously approved) rebased on top of current mbedtls-2.1, which meant adjusting to the changes in `all.sh`.

Backport of #1333, with additional bug fixes applicable to 2.1 only.