### PR TITLE
Backport 1.3: Add documentation warnings for weak algorithms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,8 @@ Changes
      and the message digest. Further, allow enabling/disabling of authority
      identifier, subject identifier and basic constraints extensions.
    * Improve makefiles on Windows: don't run find, and call perl explicitly.
+   * Add explicit warnings for the use of MD2, MD4, MD5, SHA-1, DES and ARC4
+     throughout the library.
 
 = mbed TLS 1.3.21 branch released 2017-08-10
 

--- a/include/polarssl/arc4.h
+++ b/include/polarssl/arc4.h
@@ -20,6 +20,10 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   ARC4 is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ *
  */
 #ifndef POLARSSL_ARC4_H
 #define POLARSSL_ARC4_H
@@ -42,6 +46,11 @@ extern "C" {
 
 /**
  * \brief          ARC4 context structure
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 typedef struct
 {
@@ -55,6 +64,11 @@ arc4_context;
  * \brief          Initialize ARC4 context
  *
  * \param ctx      ARC4 context to be initialized
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 void arc4_init( arc4_context *ctx );
 
@@ -62,6 +76,11 @@ void arc4_init( arc4_context *ctx );
  * \brief          Clear ARC4 context
  *
  * \param ctx      ARC4 context to be cleared
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 void arc4_free( arc4_context *ctx );
 
@@ -71,6 +90,11 @@ void arc4_free( arc4_context *ctx );
  * \param ctx      ARC4 context to be setup
  * \param key      the secret key
  * \param keylen   length of the key, in bytes
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 void arc4_setup( arc4_context *ctx, const unsigned char *key,
                  unsigned int keylen );
@@ -84,6 +108,11 @@ void arc4_setup( arc4_context *ctx, const unsigned char *key,
  * \param output   buffer for the output data
  *
  * \return         0 if successful
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 int arc4_crypt( arc4_context *ctx, size_t length, const unsigned char *input,
                 unsigned char *output );
@@ -104,6 +133,11 @@ extern "C" {
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        ARC4 is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
+ *
  */
 int arc4_self_test( int verbose );
 

--- a/include/polarssl/cipher.h
+++ b/include/polarssl/cipher.h
@@ -66,6 +66,13 @@
 extern "C" {
 #endif
 
+/**
+ * \brief     Enumeration of supported ciphers
+ *
+ * \warning   ARC4 and DES are considered weak ciphers and their use
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
+ */
 typedef enum {
     POLARSSL_CIPHER_ID_NONE = 0,
     POLARSSL_CIPHER_ID_NULL,
@@ -77,6 +84,14 @@ typedef enum {
     POLARSSL_CIPHER_ID_ARC4,
 } cipher_id_t;
 
+/**
+ * \brief     Enumeration of supported (cipher,mode) pairs
+ *
+ * \warning   ARC4 and DES are considered weak ciphers and their use
+ *            constitutes a security risk. We recommend considering stronger
+ *            ciphers instead.
+ *
+ */
 typedef enum {
     POLARSSL_CIPHER_NONE = 0,
     POLARSSL_CIPHER_NULL,

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -256,6 +256,12 @@
  *
  * Uncomment a macro to enable alternate implementation for core algorithm
  * functions
+ *
+ * \warning   MD2, MD4, MD5, ARC4, DES and SHA-1 are considered weak and their
+ *            use constitutes a security risk. If possible, we recommend
+ *            avoiding dependencies on them, and considering stronger message
+ *            digests and ciphers instead.
+ *
  */
 //#define POLARSSL_AES_ALT
 //#define POLARSSL_ARC4_ALT
@@ -370,6 +376,9 @@
  *      TLS_DHE_RSA_WITH_DES_CBC_SHA
  *
  * Uncomment this macro to enable weak ciphersuites
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 //#define POLARSSL_ENABLE_WEAK_CIPHERSUITES
 
@@ -1349,6 +1358,11 @@
  *      TLS_RSA_WITH_RC4_128_MD5
  *      TLS_RSA_PSK_WITH_RC4_128_SHA
  *      TLS_PSK_WITH_RC4_128_SHA
+ *
+ * \warning  ARC4 is considered a weak cipher and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger ciphers instead.
+ *
  */
 #define POLARSSL_ARC4_C
 
@@ -1563,6 +1577,9 @@
  *      TLS_PSK_WITH_3DES_EDE_CBC_SHA
  *
  * PEM_PARSE uses DES/3DES for decrypting encrypted keys.
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
  */
 #define POLARSSL_DES_C
 
@@ -1722,6 +1739,11 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD2-signed X.509 certs.
+ *
+ * \warning  MD2 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
+ *
  */
 //#define POLARSSL_MD2_C
 
@@ -1734,6 +1756,11 @@
  * Caller:
  *
  * Uncomment to enable support for (rare) MD4-signed X.509 certs.
+ *
+ * \warning  MD4 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
+ *
  */
 //#define POLARSSL_MD4_C
 
@@ -1747,8 +1774,15 @@
  *          library/pem.c
  *          library/ssl_tls.c
  *
- * This module is required for SSL/TLS and X.509.
- * PEM_PARSE uses MD5 for decrypting encrypted keys.
+ * This module is required for SSL/TLS up to version 1.1, and it can be used in
+ * TLS 1.2 through the choice on handshake parameters. Further, it is used for
+ * checking MD5-signed certificates, and for PBKDF1 when decrypting PEM-encoded
+ * encrypted keys.
+ *
+ * \warning  MD5 is considered a weak message digest and its use constitutes a
+ *           security risk. If possible, we recommend avoiding dependencies on
+ *           it, and considering stronger message digests instead.
+ *
  */
 #define POLARSSL_MD5_C
 
@@ -2025,6 +2059,11 @@
  *          library/x509write_crt.c
  *
  * This module is required for SSL/TLS and SHA1-signed certificates.
+ *
+ * \warning  SHA-1 is considered a weak message digest and its use constitutes
+ *           a security risk. If possible, we recommend avoiding dependencies
+ *           on it, and considering stronger message digests instead.
+ *
  */
 #define POLARSSL_SHA1_C
 

--- a/include/polarssl/des.h
+++ b/include/polarssl/des.h
@@ -20,6 +20,10 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   DES is considered a weak cipher and its use constitutes a
+ *            security risk. We recommend considering stronger ciphers instead.
+ *
  */
 #ifndef POLARSSL_DES_H
 #define POLARSSL_DES_H
@@ -56,6 +60,10 @@ extern "C" {
 
 /**
  * \brief          DES context structure
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 typedef struct
 {
@@ -78,6 +86,10 @@ des3_context;
  * \brief          Initialize DES context
  *
  * \param ctx      DES context to be initialized
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_init( des_context *ctx );
 
@@ -85,6 +97,10 @@ void des_init( des_context *ctx );
  * \brief          Clear DES context
  *
  * \param ctx      DES context to be cleared
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_free( des_context *ctx );
 
@@ -109,6 +125,10 @@ void des3_free( des3_context *ctx );
  *                 a parity bit to allow verification.
  *
  * \param key      8-byte secret key
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
 
@@ -121,6 +141,10 @@ void des_key_set_parity( unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0 is parity was ok, 1 if parity was not correct.
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
 
@@ -130,6 +154,10 @@ int des_key_check_key_parity( const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0 if no weak key was found, 1 if a weak key was identified.
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
 
@@ -140,6 +168,10 @@ int des_key_check_weak( const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -150,6 +182,10 @@ int des_setkey_enc( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
  * \param key      8-byte secret key
  *
  * \return         0
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_setkey_dec( des_context *ctx, const unsigned char key[DES_KEY_SIZE] );
 
@@ -205,6 +241,10 @@ int des3_set3key_dec( des3_context *ctx,
  * \param output   64-bit output block
  *
  * \return         0 if successful
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_crypt_ecb( des_context *ctx,
                     const unsigned char input[8],
@@ -228,6 +268,10 @@ int des_crypt_ecb( des_context *ctx,
  * \param iv       initialization vector (updated after use)
  * \param input    buffer holding the input data
  * \param output   buffer holding the output data
+ *
+ * \warning        DES is considered a weak cipher and its use constitutes a
+ *                 security risk. We recommend considering stronger ciphers
+ *                 instead.
  */
 int des_crypt_cbc( des_context *ctx,
                     int mode,

--- a/include/polarssl/md.h
+++ b/include/polarssl/md.h
@@ -47,6 +47,13 @@
 extern "C" {
 #endif
 
+/**
+ * \brief     Enumeration of supported message digests
+ *
+ * \warning   MD2, MD4, MD5 and SHA-1 are considered weak message digests and
+ *            their use constitutes a security risk. We recommend considering
+ *            stronger message digests instead.
+ */
 typedef enum {
     POLARSSL_MD_NONE=0,
     POLARSSL_MD_MD2,

--- a/include/polarssl/md2.h
+++ b/include/polarssl/md2.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   MD2 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
+ *
  */
 #ifndef POLARSSL_MD2_H
 #define POLARSSL_MD2_H
@@ -44,6 +49,11 @@ extern "C" {
 
 /**
  * \brief          MD2 context structure
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 typedef struct
 {
@@ -61,6 +71,11 @@ md2_context;
  * \brief          Initialize MD2 context
  *
  * \param ctx      MD2 context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_init( md2_context *ctx );
 
@@ -68,6 +83,11 @@ void md2_init( md2_context *ctx );
  * \brief          Clear MD2 context
  *
  * \param ctx      MD2 context to be cleared
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_free( md2_context *ctx );
 
@@ -75,6 +95,11 @@ void md2_free( md2_context *ctx );
  * \brief          MD2 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_starts( md2_context *ctx );
 
@@ -84,6 +109,11 @@ void md2_starts( md2_context *ctx );
  * \param ctx      MD2 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -92,6 +122,11 @@ void md2_update( md2_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD2 context
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_finish( md2_context *ctx, unsigned char output[16] );
 
@@ -113,6 +148,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD2 checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -123,6 +163,11 @@ void md2( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD2 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD2_FILE_IO_ERROR
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md2_file( const char *path, unsigned char output[16] );
 
@@ -132,6 +177,11 @@ int md2_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
                       size_t keylen );
@@ -142,6 +192,11 @@ void md2_hmac_starts( md2_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_hmac_update( md2_context *ctx, const unsigned char *input,
                       size_t ilen );
@@ -151,6 +206,11 @@ void md2_hmac_update( md2_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   MD2 HMAC checksum result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
 
@@ -158,6 +218,11 @@ void md2_hmac_finish( md2_context *ctx, unsigned char output[16] );
  * \brief          MD2 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_hmac_reset( md2_context *ctx );
 
@@ -169,6 +234,11 @@ void md2_hmac_reset( md2_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD2 result
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md2_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -178,6 +248,11 @@ void md2_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD2 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md2_self_test( int verbose );
 

--- a/include/polarssl/md4.h
+++ b/include/polarssl/md4.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   MD4 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
+ *
  */
 #ifndef POLARSSL_MD4_H
 #define POLARSSL_MD4_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          MD4 context structure
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ md4_context;
  * \brief          Initialize MD4 context
  *
  * \param ctx      MD4 context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_init( md4_context *ctx );
 
@@ -74,6 +89,11 @@ void md4_init( md4_context *ctx );
  * \brief          Clear MD4 context
  *
  * \param ctx      MD4 context to be cleared
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_free( md4_context *ctx );
 
@@ -81,6 +101,11 @@ void md4_free( md4_context *ctx );
  * \brief          MD4 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_starts( md4_context *ctx );
 
@@ -90,6 +115,11 @@ void md4_starts( md4_context *ctx );
  * \param ctx      MD4 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +128,11 @@ void md4_update( md4_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD4 context
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_finish( md4_context *ctx, unsigned char output[16] );
 
@@ -119,6 +154,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD4 checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -129,6 +169,11 @@ void md4( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD4 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD4_FILE_IO_ERROR
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md4_file( const char *path, unsigned char output[16] );
 
@@ -138,6 +183,11 @@ int md4_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
                       size_t keylen );
@@ -148,6 +198,11 @@ void md4_hmac_starts( md4_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_hmac_update( md4_context *ctx, const unsigned char *input,
                       size_t ilen );
@@ -157,6 +212,11 @@ void md4_hmac_update( md4_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   MD4 HMAC checksum result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
 
@@ -164,6 +224,11 @@ void md4_hmac_finish( md4_context *ctx, unsigned char output[16] );
  * \brief          MD4 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_hmac_reset( md4_context *ctx );
 
@@ -175,6 +240,11 @@ void md4_hmac_reset( md4_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD4 result
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md4_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -184,6 +254,11 @@ void md4_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD4 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md4_self_test( int verbose );
 

--- a/include/polarssl/md5.h
+++ b/include/polarssl/md5.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   MD5 is considered a weak message digest and its use constitutes a
+ *            security risk. We recommend considering stronger message digests
+ *            instead.
+ *
  */
 #ifndef POLARSSL_MD5_H
 #define POLARSSL_MD5_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          MD5 context structure
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ md5_context;
  * \brief          Initialize MD5 context
  *
  * \param ctx      MD5 context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_init( md5_context *ctx );
 
@@ -74,6 +89,11 @@ void md5_init( md5_context *ctx );
  * \brief          Clear MD5 context
  *
  * \param ctx      MD5 context to be cleared
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_free( md5_context *ctx );
 
@@ -81,6 +101,11 @@ void md5_free( md5_context *ctx );
  * \brief          MD5 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_starts( md5_context *ctx );
 
@@ -90,6 +115,11 @@ void md5_starts( md5_context *ctx );
  * \param ctx      MD5 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +128,11 @@ void md5_update( md5_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      MD5 context
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_finish( md5_context *ctx, unsigned char output[16] );
 
@@ -122,6 +157,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   MD5 checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
 
@@ -132,6 +172,11 @@ void md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
  * \param output   MD5 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_MD5_FILE_IO_ERROR
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md5_file( const char *path, unsigned char output[16] );
 
@@ -141,6 +186,11 @@ int md5_file( const char *path, unsigned char output[16] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_hmac_starts( md5_context *ctx,
                       const unsigned char *key, size_t keylen );
@@ -151,6 +201,11 @@ void md5_hmac_starts( md5_context *ctx,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_hmac_update( md5_context *ctx,
                       const unsigned char *input, size_t ilen );
@@ -160,6 +215,11 @@ void md5_hmac_update( md5_context *ctx,
  *
  * \param ctx      HMAC context
  * \param output   MD5 HMAC checksum result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
 
@@ -167,6 +227,11 @@ void md5_hmac_finish( md5_context *ctx, unsigned char output[16] );
  * \brief          MD5 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_hmac_reset( md5_context *ctx );
 
@@ -178,6 +243,11 @@ void md5_hmac_reset( md5_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-MD5 result
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void md5_hmac( const unsigned char *key, size_t keylen,
                const unsigned char *input, size_t ilen,
@@ -187,6 +257,11 @@ void md5_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        MD5 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int md5_self_test( int verbose );
 

--- a/include/polarssl/sha1.h
+++ b/include/polarssl/sha1.h
@@ -20,6 +20,11 @@
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * \warning   SHA-1 is considered a weak message digest and its use constitutes
+ *            a security risk. We recommend considering stronger message
+ *            digests instead.
+ *
  */
 #ifndef POLARSSL_SHA1_H
 #define POLARSSL_SHA1_H
@@ -51,6 +56,11 @@ extern "C" {
 
 /**
  * \brief          SHA-1 context structure
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 typedef struct
 {
@@ -67,6 +77,11 @@ sha1_context;
  * \brief          Initialize SHA-1 context
  *
  * \param ctx      SHA-1 context to be initialized
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_init( sha1_context *ctx );
 
@@ -74,6 +89,11 @@ void sha1_init( sha1_context *ctx );
  * \brief          Clear SHA-1 context
  *
  * \param ctx      SHA-1 context to be cleared
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_free( sha1_context *ctx );
 
@@ -81,6 +101,11 @@ void sha1_free( sha1_context *ctx );
  * \brief          SHA-1 context setup
  *
  * \param ctx      context to be initialized
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_starts( sha1_context *ctx );
 
@@ -90,6 +115,11 @@ void sha1_starts( sha1_context *ctx );
  * \param ctx      SHA-1 context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
 
@@ -98,6 +128,11 @@ void sha1_update( sha1_context *ctx, const unsigned char *input, size_t ilen );
  *
  * \param ctx      SHA-1 context
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_finish( sha1_context *ctx, unsigned char output[20] );
 
@@ -122,6 +157,11 @@ extern "C" {
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   SHA-1 checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
 
@@ -132,6 +172,11 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
  * \param output   SHA-1 checksum result
  *
  * \return         0 if successful, or POLARSSL_ERR_SHA1_FILE_IO_ERROR
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int sha1_file( const char *path, unsigned char output[20] );
 
@@ -141,6 +186,11 @@ int sha1_file( const char *path, unsigned char output[20] );
  * \param ctx      HMAC context to be initialized
  * \param key      HMAC secret key
  * \param keylen   length of the HMAC key
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
                        size_t keylen );
@@ -151,6 +201,11 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key,
  * \param ctx      HMAC context
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
                        size_t ilen );
@@ -160,6 +215,11 @@ void sha1_hmac_update( sha1_context *ctx, const unsigned char *input,
  *
  * \param ctx      HMAC context
  * \param output   SHA-1 HMAC checksum result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
 
@@ -167,6 +227,11 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] );
  * \brief          SHA-1 HMAC context reset
  *
  * \param ctx      HMAC context to be reset
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_hmac_reset( sha1_context *ctx );
 
@@ -178,6 +243,11 @@ void sha1_hmac_reset( sha1_context *ctx );
  * \param input    buffer holding the  data
  * \param ilen     length of the input data
  * \param output   HMAC-SHA-1 result
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 void sha1_hmac( const unsigned char *key, size_t keylen,
                 const unsigned char *input, size_t ilen,
@@ -187,6 +257,11 @@ void sha1_hmac( const unsigned char *key, size_t keylen,
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
  */
 int sha1_self_test( int verbose );
 


### PR DESCRIPTION
This PR is a subset of #1111. It only adds the documentation warnings introduced by #1111 and no other changes.

Backport to 1.3 of #1336 
