### PR TITLE
Fixed mbedtls_x509write_csr_der documentation

### DIFF
--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -279,7 +279,8 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
  * \param f_rng     RNG function (for signature, see note)
  * \param p_rng     RNG parameter
  *
- * \return          0 if successful, or a specific error code
+ * \return          number of bytes written if successful, or a specific
+ *                  negative error code
  *
  * \note            f_rng may be NULL if RSA is used for signature and the
  *                  signature is made offline (otherwise f_rng is desirable


### PR DESCRIPTION
Original docstring states that 0 is returned on success, which is clearly not true because `mbedtls_x509write_csr_der()` explicitly returns the length of the generated der string (see x509write_csr.c:234). It isn't a bug since this behavior is used internally in the implementation of `mbedtls_x509write_csr_pem()` function (see x509write_csr.c:250). Hence the documentation had to be fixed.