### PR TITLE
ssl_tls: ssl_write_real: Document MBEDTLS_ERR_SSL_WANT_WRITE behavior

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7163,6 +7163,31 @@ static int ssl_write_real( mbedtls_ssl_context *ssl,
             len = max_len;
     }
 
+    /*
+     * Possibility of MBEDTLS_ERR_SSL_WANT_WRITE being returned from the
+     * application send callback requires some subtle handling. There are
+     * 4 possibilities:
+     * a) This is an initial call to ssl_write_real() (i.e. very first,
+     *    or after previous successful call to the function), and it is
+     *    spooled completely to the send callback, without it returning
+     *    MBEDTLS_ERR_SSL_WANT_WRITE. In this case, we return len param
+     *    (capped to max_len).
+     * b) The initial call, but callback returns MBEDTLS_ERR_SSL_WANT_WRITE
+     *    (possibly, after spooling some partial data). In this case, encoded
+     *    TLS record remains in our output buffer, we return
+     *    MBEDTLS_ERR_SSL_WANT_WRITE, and expect (and require) the application
+     *    to call write function with the *same* buf and len argument.
+     * c) The repeating call after previously MBEDTLS_ERR_SSL_WANT_WRITE was
+     *    returned, and send callback returned MBEDTLS_ERR_SSL_WANT_WRITE again
+     *    before remaining data in output buffer was spooled. Just as in case
+     *    b), we return MBEDTLS_ERR_SSL_WANT_WRITE and expected being called
+     *    with the same buf and len params as before.
+     * d) The repeating call, but the output buffer was finally spooled
+     *    completely without interruption. As we were called with the same
+     *    len param as for the call which started all the process, we just
+     *    return it (capped to max_len), to signal completion of the cycle,
+     *    next call to the write will start from a).
+     */
     if( ssl->out_left != 0 )
     {
         if( ( ret = mbedtls_ssl_flush_output( ssl ) ) != 0 )


### PR DESCRIPTION
This adds a code comment documenting the function behavior when
the underlying send callback returns MBEDTLS_ERR_SSL_WANT_WRITE.
This tries to alleviate confusion which happened in #1356,
(which even was filed as CVE-2018-1000061), and (apparently)
previously in commit 1fd00bfe82af7c52f, later reverted in
887bd502d2f2052 (all this back in 2011).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>

Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 

**Accepted, my developer.mbed.org username is "pfalcon" (the same as on github).**

   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY**

## Requires Backporting

NO  

## Migrations

NO

## Steps to test or reproduce
Addresses confusion in #1356.
