### PR TITLE
vsnprintf macroification ala snprintf

### DIFF
--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -57,6 +57,13 @@ extern "C" {
 #define MBEDTLS_PLATFORM_STD_SNPRINTF   snprintf /**< The default \c snprintf function to use.  */
 #endif
 #endif
+#if !defined(MBEDTLS_PLATFORM_STD_VSNPRINTF)
+#if defined(_WIN32)
+#define MBEDTLS_PLATFORM_STD_VSNPRINTF   mbedtls_platform_win32_vsnprintf /**< The default \c vsnprintf function to use.  */
+#else
+#define MBEDTLS_PLATFORM_STD_VSNPRINTF   vsnprintf /**< The default \c vsnprintf function to use.  */
+#endif
+#endif
 #if !defined(MBEDTLS_PLATFORM_STD_PRINTF)
 #define MBEDTLS_PLATFORM_STD_PRINTF   printf /**< The default \c printf function to use. */
 #endif
@@ -213,6 +220,27 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
 #define mbedtls_snprintf   snprintf
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_MACRO */
 #endif /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
+
+#if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
+extern int (*mbedtls_vsnprintf)( char * s, size_t n, const char * format, va_list argp );
+
+/**
+ * \brief   This function allows configuring a custom \c vsnprintf function
+ *          pointer.
+ *
+ * \param vsnprintf_func   The \c vsnprintf function implementation.
+ *
+ * \return    \c 0 on success.
+ */
+int mbedtls_platform_set_vsnprintf( int (*vsnprintf_func)( char * s, size_t n,
+                                                 const char * format, va_list argp ) );
+#else /* MBEDTLS_PLATFORM_VSNPRINTF_ALT */
+#if defined(MBEDTLS_PLATFORM_VSNPRINTF_MACRO)
+#define mbedtls_vsnprintf  MBEDTLS_PLATFORM_VSNPRINTF_MACRO
+#else
+#define mbedtls_vsnprintf  vsnprintf
+#endif /* MBEDTLS_PLATFORM_VSNPRINTF_MACRO */
+#endif /* MBEDTLS_PLATFORM_VSNPRINTF_ALT */
 
 /*
  * The function pointers for exit

--- a/library/debug.c
+++ b/library/debug.c
@@ -90,20 +90,7 @@ void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
         return;
 
     va_start( argp, format );
-#if defined(_WIN32)
-#if defined(_TRUNCATE)
-    ret = _vsnprintf_s( str, DEBUG_BUF_SIZE, _TRUNCATE, format, argp );
-#else
-    ret = _vsnprintf( str, DEBUG_BUF_SIZE, format, argp );
-    if( ret < 0 || (size_t) ret == DEBUG_BUF_SIZE )
-    {
-        str[DEBUG_BUF_SIZE-1] = '\0';
-        ret = -1;
-    }
-#endif
-#else
-    ret = vsnprintf( str, DEBUG_BUF_SIZE, format, argp );
-#endif
+    ret = mbedtls_vsnprintf( str, DEBUG_BUF_SIZE, format, argp );
     va_end( argp );
 
     if( ret >= 0 && ret < DEBUG_BUF_SIZE - 1 )


### PR DESCRIPTION
## Description

The debug.c logic uses vsnprintf, which, like snprintf, may not be available on all platforms (and, notably, wasn't/isn't on the ESP8266).  Allow it to be replaced by a macro, too.

## Status
**READY**

## Requires Backporting
NO
