### PR TITLE
Add dependency for version features in tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Bugfix
    * Fix the name of a DHE parameter that was accidentally changed in 2.7.0.
      Fixes #1358.
    * Fix test_suite_pk to work on 64-bit ILP32 systems. #849
+   * Add dependency for MBEDTLS_VERSION_FEATURES_C in check_version_feature test,
+     to skip unneeded tests. Raised by trinitytonic in #1299
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/tests/suites/test_suite_version.function
+++ b/tests/suites/test_suite_version.function
@@ -64,7 +64,7 @@ void check_runtime_version( char *version_str )
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_VERSION_FEATURES */
 void check_feature( char *feature, int result )
 {
     int check = mbedtls_version_check_feature( feature );


### PR DESCRIPTION
Notes:

## Description
Add dependency for `MBEDTLS_VERSION_FEATURES` in test,
to skip test. Fixes #1299 


## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes
Which branch?
mbedtls-2.1
mbedtls-2.7

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
