### PR TITLE
Backport 2.1:Add dependency for version features in tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ Bugfix
      faults and errors when building for the 64-bit ILP32 ABI. Found and fixed
      by James Cowgill.
    * Fix test_suite_pk to work on 64-bit ILP32 systems. #849
+   * Add dependency for MBEDTLS_VERSION_FEATURES_C in check_version_feature test,
+     to skip unneeded tests. Raised by trinitytonic in #1299
 
 = mbed TLS 2.1.10 branch released 2018-02-03
 

--- a/tests/suites/test_suite_version.function
+++ b/tests/suites/test_suite_version.function
@@ -64,7 +64,7 @@ void check_runtime_version( char *version_str )
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_VERSION_FEATURES */
 void check_feature( char *feature, int result )
 {
     int check = mbedtls_version_check_feature( feature );


### PR DESCRIPTION
Add dependency for `MBEDTLS_VERSION_FEATURES` in test,
to skip test. Backport of #1385 

