### PR TITLE
Add missing MBEDTLS_DEPRECATED_REMOVED guards

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -832,6 +832,7 @@ static int cmac_test_subkeys( int verbose,
         mbedtls_cipher_free( &ctx );
     }
 
+    ret = 0;
     goto exit;
 
 cleanup:
@@ -887,6 +888,7 @@ static int cmac_test_wth_cipher( int verbose,
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
     }
+    ret = 0;
 
 exit:
     return( ret );

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -547,6 +547,12 @@ if_build_succeeded tests/ssl-opt.sh -f Default
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 
+msg "build: cmake, full config + DEPRECATED_REMOVED, clang, C99"
+# No cleanup: tweak the configuration, keep the makefiles
+scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
+make
+
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup
 cmake -D CMAKE_BUILD_TYPE:String=Debug .

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -547,11 +547,23 @@ if_build_succeeded tests/ssl-opt.sh -f Default
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 
-msg "build: cmake, full config + DEPRECATED_REMOVED, clang, C99"
-# No cleanup: tweak the configuration, keep the makefiles
+msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl full
 scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+# Build with -O -Wextra to catch a maximum of issues.
+make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
+make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+
+msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
+# No cleanup, just tweak the configuration and rebuild
+make clean
+scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
 scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
-make
+# Build with -O -Wextra to catch a maximum of issues.
+make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
+make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
 
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup


### PR DESCRIPTION
Add missing `MBEDTLS_DEPRECATED_REMOVED` guards to fix the build under `-Wmissing-prototypes -Werror`. Add a corresponding test to `all.sh`.

Fixes #1388

Note: the first commit with just the bug fix is in #1448

Note: this should be merged both into `mbedtls-2.7` and into `development` so that the testing remain aligned. Backport to 2.1 in #1391.