### PR TITLE
2.1 only: all.sh: add test with MBEDTLS_DEPRECATED_REMOVED

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -495,11 +495,23 @@ if_build_succeeded tests/ssl-opt.sh -f Default
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 
-msg "build: cmake, full config + DEPRECATED_REMOVED, clang, C99"
-# No cleanup: tweak the configuration, keep the makefiles
+msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl full
 scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+# Build with -O -Wextra to catch a maximum of issues.
+make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
+make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+
+msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
+# No cleanup, just tweak the configuration and rebuild
+make clean
+scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
 scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
-make
+# Build with -O -Wextra to catch a maximum of issues.
+make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
+make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
 
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -495,6 +495,12 @@ if_build_succeeded tests/ssl-opt.sh -f Default
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 
+msg "build: cmake, full config + DEPRECATED_REMOVED, clang, C99"
+# No cleanup: tweak the configuration, keep the makefiles
+scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
+make
+
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup
 cmake -D CMAKE_BUILD_TYPE:String=Debug .


### PR DESCRIPTION
Backport of the test added in #1390. The corresponding issue does not apply to 2.1.

There is no bug to fix in 2.1 but I am backporting to keep the tests aligned.
