### PR TITLE
Add guard to out_left to avoid negative values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ Changes
      Contributed by Mathieu Briand.
    * Fix typo in a comment ctr_drbg.c. Contributed by Paul Sokolovsky.
    * Remove support for the library reference configuration for picocoin.
+   * Add guard to validate that out_left can not be negative. Raised by 
+     samoconnor in #1245.
 
 = mbed TLS 2.7.0 branch released 2018-02-03
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,8 +23,9 @@ Changes
      Contributed by Mathieu Briand.
    * Fix typo in a comment ctr_drbg.c. Contributed by Paul Sokolovsky.
    * Remove support for the library reference configuration for picocoin.
-   * Add guard to validate that out_left can not be negative. Raised by 
-     samoconnor in #1245.
+   * Verify that when (f_send, f_recv and f_recv_timeout) send or receive 
+     more than the required length an error is returned. Raised by 
+     Sam O'Connor in #1245.
 
 = mbed TLS 2.7.0 branch released 2018-02-03
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2425,8 +2425,8 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
-                    ( "f_recv returned %d bytes but only %zu were requested", 
-                    ret, len ) );
+                    ( "f_recv returned %d bytes but only %lu were requested", 
+                    ret, (unsigned long)len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2480,8 +2480,8 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
-                ( "f_send returned %d bytes but only %zu bytes were sent", 
-                ret, ssl->out_left ) );
+                ( "f_send returned %d bytes but only %lu bytes were sent", 
+                ret, (unsigned long)ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2422,7 +2422,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            if ( (size_t)ret > len )
+            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
                     ( "f_recv returned %d bytes but only %zu were requested", 
@@ -2477,7 +2477,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
-        if( (size_t)ret > ssl->out_left )
+        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
                 ( "f_send returned %d bytes but only %zu bytes were sent", 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2422,11 +2422,11 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            // At this point ret value is positive, verify that adding ret 
-            // value to ssl->in_left doesn't cause a wraparound
-            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            if ( (size_t)ret > len )
             {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                MBEDTLS_SSL_DEBUG_MSG( 1, 
+                    ( "f_recv returned %d bytes but only %zu were requested", 
+                    ret, len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2479,7 +2479,9 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
         if( (size_t)ret > ssl->out_left )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, 
+                ( "f_send returned %d bytes but only %zu bytes were sent", 
+                ret, ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2422,6 +2422,14 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
+            // At this point ret value is positive, verify that adding ret 
+            // value to ssl->in_left doesn't cause a wraparound
+            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+            }
+
             ssl->in_left += ret;
         }
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2469,6 +2469,12 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
+        if( (size_t)ret > ssl->out_left )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        }
+
         ssl->out_left -= ret;
     }
 


### PR DESCRIPTION
## Description
Return error when f_send return a value greater than out_left
Fixes #1245 

## Status
**READY**

## Requires Backporting

Yes
Which branch?
mbedtls 2.1
mbedtls 2.7


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
