### PR TITLE
Backport 2.1: Add guard to out_left to avoid negative values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,9 +15,7 @@ Changes
    * Add guard to validate that out_left can not be negative. Raised by 
      samoconnor in #1245.
 
-
 = mbed TLS 2.1.10 branch released 2018-02-03
-
 
 Security
    * Fix a heap corruption issue in the implementation of the truncated HMAC

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,13 @@ Bugfix
      with flag MBEDTLS_X509_BADCERT_BAD_PK even when the key type was correct.
      In the context of SSL, this resulted in handshake failure. #1351
 
+Changes
+   * Add guard to validate that out_left can not be negative. Raised by 
+     samoconnor in #1245.
+
+
 = mbed TLS 2.1.10 branch released 2018-02-03
+
 
 Security
    * Fix a heap corruption issue in the implementation of the truncated HMAC

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,8 +12,9 @@ Bugfix
      In the context of SSL, this resulted in handshake failure. #1351
 
 Changes
-   * Add guard to validate that out_left can not be negative. Raised by 
-     samoconnor in #1245.
+   * Verify that when (f_send, f_recv and f_recv_timeout) send or receive 
+     more than the required length an error is returned. Raised by 
+     Sam O'Connor in #1245.
 
 = mbed TLS 2.1.10 branch released 2018-02-03
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2405,8 +2405,8 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
-                    ( "f_recv returned %d bytes but only %zu were requested", 
-                    ret, len ) );
+                    ( "f_recv returned %d bytes but only %lu were requested", 
+                    ret, (unsigned long)len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2460,8 +2460,8 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
-                ( "f_send returned %d bytes but only %zu bytes were sent", 
-                ret, ssl->out_left ) );
+                ( "f_send returned %d bytes but only %lu bytes were sent", 
+                ret, (unsigned long)ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2402,7 +2402,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            if ( (size_t)ret > len )
+            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
                     ( "f_recv returned %d bytes but only %zu were requested", 
@@ -2457,7 +2457,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
-        if( (size_t)ret > ssl->out_left )
+        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
                 ( "f_send returned %d bytes but only %zu bytes were sent", 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2402,6 +2402,14 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
+            // At this point ret value is positive, verify that adding ret 
+            // value to ssl->in_left doesn't cause a wraparound
+            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+            }
+
             ssl->in_left += ret;
         }
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2402,11 +2402,11 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            // At this point ret value is positive, verify that adding ret 
-            // value to ssl->in_left doesn't cause a wraparound
-            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            if ( (size_t)ret > len )
             {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                MBEDTLS_SSL_DEBUG_MSG( 1, 
+                    ( "f_recv returned %d bytes but only %zu were requested", 
+                    ret, len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2459,7 +2459,9 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
         if( (size_t)ret > ssl->out_left )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, 
+                ( "f_send returned %d bytes but only %zu bytes were sent", 
+                ret, ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2449,6 +2449,12 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
+        if( (size_t)ret > ssl->out_left )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        }
+
         ssl->out_left -= ret;
     }
 


### PR DESCRIPTION
backport of #1395 to branch 2.1