### PR TITLE
Enable deprecated API wrappers for _ALT implementation

### DIFF
--- a/library/md2.c
+++ b/library/md2.c
@@ -158,6 +158,7 @@ int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
 
     return( 0 );
 }
+#endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md2_process( mbedtls_md2_context *ctx )
@@ -165,7 +166,6 @@ void mbedtls_md2_process( mbedtls_md2_context *ctx )
     mbedtls_internal_md2_process( ctx );
 }
 #endif
-#endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 /*
  * MD2 process buffer

--- a/library/md4.c
+++ b/library/md4.c
@@ -224,6 +224,7 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md4_process( mbedtls_md4_context *ctx,
@@ -232,7 +233,6 @@ void mbedtls_md4_process( mbedtls_md4_context *ctx,
     mbedtls_internal_md4_process( ctx, data );
 }
 #endif
-#endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 /*
  * MD4 process buffer

--- a/library/md5.c
+++ b/library/md5.c
@@ -243,6 +243,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md5_process( mbedtls_md5_context *ctx,
@@ -251,7 +252,6 @@ void mbedtls_md5_process( mbedtls_md5_context *ctx,
     mbedtls_internal_md5_process( ctx, data );
 }
 #endif
-#endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 /*
  * MD5 process buffer

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -277,6 +277,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
@@ -285,7 +286,6 @@ void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
     mbedtls_internal_sha1_process( ctx, data );
 }
 #endif
-#endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 /*
  * SHA-1 process buffer

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -246,6 +246,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
@@ -254,7 +255,6 @@ void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
     mbedtls_internal_sha256_process( ctx, data );
 }
 #endif
-#endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 /*
  * SHA-256 process buffer

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -277,6 +277,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 
     return( 0 );
 }
+#endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
@@ -285,7 +286,6 @@ void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
     mbedtls_internal_sha512_process( ctx, data );
 }
 #endif
-#endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 /*
  * SHA-512 process buffer


### PR DESCRIPTION
Wrappers ```mbedtls_.*_process``` are as good for _ALT implementations as they are for internal software implementation. Hence moved outside ```!MBEDTLS_.*_PROCESS_ALT``` flags.
Very urgent as blocks PR https://github.com/ARMmbed/mbed-os/pull/6176