### PR TITLE
Revert "Merge pull request #1399 from mazimkhan/feature-opaque-keys"

### DIFF
--- a/library/md2.c
+++ b/library/md2.c
@@ -158,7 +158,6 @@ int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
 
     return( 0 );
 }
-#endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md2_process( mbedtls_md2_context *ctx )
@@ -166,6 +165,7 @@ void mbedtls_md2_process( mbedtls_md2_context *ctx )
     mbedtls_internal_md2_process( ctx );
 }
 #endif
+#endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 /*
  * MD2 process buffer

--- a/library/md4.c
+++ b/library/md4.c
@@ -224,7 +224,6 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 
     return( 0 );
 }
-#endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md4_process( mbedtls_md4_context *ctx,
@@ -233,6 +232,7 @@ void mbedtls_md4_process( mbedtls_md4_context *ctx,
     mbedtls_internal_md4_process( ctx, data );
 }
 #endif
+#endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 /*
  * MD4 process buffer

--- a/library/md5.c
+++ b/library/md5.c
@@ -243,7 +243,6 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 
     return( 0 );
 }
-#endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_md5_process( mbedtls_md5_context *ctx,
@@ -252,6 +251,7 @@ void mbedtls_md5_process( mbedtls_md5_context *ctx,
     mbedtls_internal_md5_process( ctx, data );
 }
 #endif
+#endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 /*
  * MD5 process buffer

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -277,7 +277,6 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 
     return( 0 );
 }
-#endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
@@ -286,6 +285,7 @@ void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
     mbedtls_internal_sha1_process( ctx, data );
 }
 #endif
+#endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 /*
  * SHA-1 process buffer

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -246,7 +246,6 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
 
     return( 0 );
 }
-#endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
@@ -255,6 +254,7 @@ void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
     mbedtls_internal_sha256_process( ctx, data );
 }
 #endif
+#endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 /*
  * SHA-256 process buffer

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -277,7 +277,6 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 
     return( 0 );
 }
-#endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
@@ -286,6 +285,7 @@ void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
     mbedtls_internal_sha512_process( ctx, data );
 }
 #endif
+#endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 /*
  * SHA-512 process buffer


### PR DESCRIPTION
Reverting as this temporary change can be done directly to mbed-os PR. That way this branch can stay clean. In future once mbed-os _ALT implementations are fixed this branch can again be imported in mbed-os feature-opaque-key branch.