### PR TITLE
Backport 2.7: Add guard to out_left to avoid negative values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,8 +33,9 @@ Changes
    * Fix typo in a comment ctr_drbg.c. Contributed by Paul Sokolovsky.
    * MD functions deprecated in 2.7.0 are no longer inline, to provide
      a migration path for those depending on the library's ABI.
-   * Add guard to validate that out_left can not be negative. Raised by 
-     samoconnor in #1245.
+   * Verify that when (f_send, f_recv and f_recv_timeout) send or receive 
+     more than the required length an error is returned. Raised by 
+     Sam O'Connor in #1245.
 
 = mbed TLS 2.7.0 branch released 2018-02-03
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,8 @@ Changes
    * Fix typo in a comment ctr_drbg.c. Contributed by Paul Sokolovsky.
    * MD functions deprecated in 2.7.0 are no longer inline, to provide
      a migration path for those depending on the library's ABI.
+   * Add guard to validate that out_left can not be negative. Raised by 
+     samoconnor in #1245.
 
 = mbed TLS 2.7.0 branch released 2018-02-03
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2481,6 +2481,12 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
+        if( (size_t)ret > ssl->out_left )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+        }
+
         ssl->out_left -= ret;
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2437,8 +2437,8 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
-                    ( "f_recv returned %d bytes but only %zu were requested", 
-                    ret, len ) );
+                    ( "f_recv returned %d bytes but only %lu were requested", 
+                    ret, (unsigned long)len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2492,8 +2492,8 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
-                ( "f_send returned %d bytes but only %zu bytes were sent", 
-                ret, ssl->out_left ) );
+                ( "f_send returned %d bytes but only %lu bytes were sent", 
+                ret, (unsigned long)ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2434,11 +2434,11 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            // At this point ret value is positive, verify that adding ret 
-            // value to ssl->in_left doesn't cause a wraparound
-            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            if ( (size_t)ret > len )
             {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                MBEDTLS_SSL_DEBUG_MSG( 1, 
+                    ( "f_recv returned %d bytes but only %zu were requested", 
+                    ret, len ) );
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }
 
@@ -2491,7 +2491,9 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
 
         if( (size_t)ret > ssl->out_left )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "f_send returned value greater than out left size" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 1, 
+                ( "f_send returned %d bytes but only %zu bytes were sent", 
+                ret, ssl->out_left ) );
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2434,6 +2434,14 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
+            // At this point ret value is positive, verify that adding ret 
+            // value to ssl->in_left doesn't cause a wraparound
+            if (ssl->in_left + (size_t)ret < ssl->in_left)
+            {
+                MBEDTLS_SSL_DEBUG_MSG( 1, ( "wraparound happened over in_left value" ) );
+                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+            }
+
             ssl->in_left += ret;
         }
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2434,7 +2434,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            if ( (size_t)ret > len )
+            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, 
                     ( "f_recv returned %d bytes but only %zu were requested", 
@@ -2489,7 +2489,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
-        if( (size_t)ret > ssl->out_left )
+        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, 
                 ( "f_send returned %d bytes but only %zu bytes were sent", 


### PR DESCRIPTION
backport of #1395 to branch 2.7