### PR TITLE
Redundant declaration of mbedtls_ssl_list_ciphersuites

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ API Changes
      Therefore, mbedtls_platform_zeroize() is moved to the platform module to
      facilitate testing and maintenance.
 
+Bugfix
+   * Fix redundant declaration of mbedtls_ssl_list_ciphersuites. Raised by
+     TrinityTonic. #1359.
+
 = mbed TLS 2.9.0 branch released 2018-04-30
 
 Security

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -947,14 +947,6 @@ extern int (*mbedtls_ssl_hw_record_finish)(mbedtls_ssl_context *ssl);
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 
 /**
- * \brief Returns the list of ciphersuites supported by the SSL/TLS module.
- *
- * \return              a statically allocated array of ciphersuites, the last
- *                      entry is 0.
- */
-const int *mbedtls_ssl_list_ciphersuites( void );
-
-/**
  * \brief               Return the name of the ciphersuite associated with the
  *                      given ID
  *


### PR DESCRIPTION
## Description
Remove double declaration of mbedtls_ssl_list_ciphersuites.
Fixes  #1359 

Internal ref: IOTSSL-2091

## Status
**READY**

## Requires Backporting
Yes 
Which branch?
mbedtls 2.1
mbedtls 2.7

## Todos
- [ ] Tests
- [ ] Documentation
- [X] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
