### PR TITLE
Backport 2.1: Redundant declaration of mbedtls_ssl_list_ciphersuites

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix redundant declaration of mbedtls_ssl_list_ciphersuites. Raised by
+     TrinityTonic. #1359.
+
 = mbed TLS 2.1.12 branch released 2018-04-30
 
 Security

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -797,14 +797,6 @@ extern int (*mbedtls_ssl_hw_record_finish)(mbedtls_ssl_context *ssl);
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 
 /**
- * \brief Returns the list of ciphersuites supported by the SSL/TLS module.
- *
- * \return              a statically allocated array of ciphersuites, the last
- *                      entry is 0.
- */
-const int *mbedtls_ssl_list_ciphersuites( void );
-
-/**
  * \brief               Return the name of the ciphersuite associated with the
  *                      given ID
  *


### PR DESCRIPTION
backport of #1402 to branch 2.1
