### PR TITLE
Test suite test_suite_pk test pk_rsa_overflow passes valid parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,8 @@ Bugfix
      with flag MBEDTLS_X509_BADCERT_BAD_PK even when the key type was correct.
      In the context of SSL, this resulted in handshake failure. #1351
    * Fix Windows x64 builds with the included mbedTLS.sln file. #1347
+   * In test_suite_pk pass valid parameters when testing for hash length 
+     overflow. #1179
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -417,10 +417,14 @@ exit:
 void pk_rsa_overflow( )
 {
     mbedtls_pk_context pk;
-    size_t hash_len = SIZE_MAX;
+    size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
+    unsigned char hash[50], sig[100];
 
     if( SIZE_MAX <= UINT_MAX )
         return;
+
+    memset( hash, 0x2a, sizeof hash );
+    memset( sig, 0, sizeof sig );
 
     mbedtls_pk_init( &pk );
 
@@ -429,14 +433,14 @@ void pk_rsa_overflow( )
 
 #if defined(MBEDTLS_PKCS1_V21)
     TEST_ASSERT( mbedtls_pk_verify_ext( MBEDTLS_PK_RSASSA_PSS, NULL, &pk,
-                    MBEDTLS_MD_NONE, NULL, hash_len, NULL, 0 ) ==
+                    MBEDTLS_MD_NONE, hash, hash_len, sig, sig_len ) ==
                  MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 #endif /* MBEDTLS_PKCS1_V21 */
 
-    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_NONE, NULL, hash_len,
-                    NULL, 0 ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_NONE, hash, hash_len,
+                    sig, sig_len ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_NONE, NULL, hash_len, NULL, 0,
+    TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_NONE, hash, hash_len, sig, &sig_len,
                     rnd_std_rand, NULL ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 exit:


### PR DESCRIPTION
Test suite `test_suite_pk` test `pk_rsa_overflow` passing valid parameters for hash/hash_len and sig/sig_len. Resolves #1179 

## Status
**READY**

## Requires Backporting

Yes
Which branch?
mbedtls 2.1
mbedtls 2.7

## Todos
- [ ] Tests
- [ ] Documentation
- [X] Changelog updated
- [X] Backported

