### PR TITLE
Backport 2.7: Test suite test_suite_pk test pk_rsa_overflow passes valid parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Bugfix
    * Fix mbedtls_x509_crt_profile_suiteb, which used to reject all certificates
      with flag MBEDTLS_X509_BADCERT_BAD_PK even when the key type was correct.
      In the context of SSL, this resulted in handshake failure. #1351
+   * In test_suite_pk pass valid parameters when testing for hash length 
+     overflow. #1179
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -417,10 +417,14 @@ exit:
 void pk_rsa_overflow( )
 {
     mbedtls_pk_context pk;
-    size_t hash_len = SIZE_MAX;
+    size_t hash_len = SIZE_MAX, sig_len = SIZE_MAX;
+    unsigned char hash[50], sig[100];
 
     if( SIZE_MAX <= UINT_MAX )
         return;
+
+    memset( hash, 0x2a, sizeof hash );
+    memset( sig, 0, sizeof sig );
 
     mbedtls_pk_init( &pk );
 
@@ -429,14 +433,14 @@ void pk_rsa_overflow( )
 
 #if defined(MBEDTLS_PKCS1_V21)
     TEST_ASSERT( mbedtls_pk_verify_ext( MBEDTLS_PK_RSASSA_PSS, NULL, &pk,
-                    MBEDTLS_MD_NONE, NULL, hash_len, NULL, 0 ) ==
+                    MBEDTLS_MD_NONE, hash, hash_len, sig, sig_len ) ==
                  MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 #endif /* MBEDTLS_PKCS1_V21 */
 
-    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_NONE, NULL, hash_len,
-                    NULL, 0 ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_NONE, hash, hash_len,
+                    sig, sig_len ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_NONE, NULL, hash_len, NULL, 0,
+    TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_NONE, hash, hash_len, sig, &sig_len,
                     rnd_std_rand, NULL ) == MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 exit:


### PR DESCRIPTION
backport of #1407 to branch 2.7