### PR TITLE
Set first two bytes of array to remove CLANG checker warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,9 @@ Bugfix
      In the context of SSL, this resulted in handshake failure. Reported by
      daniel in the Mbed TLS forum. #1351
    * Fix Windows x64 builds with the included mbedTLS.sln file. #1347
+   * Improve the robustness of mbedtls_rsa_rsassa_pkcs1_v15_verify().
+     This silences a false positive from Clang Static Analyzer reported by
+     aaronmdjones. #1002
 
 = mbed TLS 2.1.10 branch released 2018-02-03
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1480,6 +1480,13 @@ int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
     mbedtls_md_type_t msg_md_alg;
     const mbedtls_md_info_t *md_info;
     mbedtls_asn1_buf oid;
+    
+    /* Set first two bytes of the buffer so that code checkers will not think
+       we are accessing uninitialized data (normally mbedtls_rsa_public or 
+       mbedtls_rsa_private would fill the buffer). 
+       values chosen are intentionally invalid */
+    buf[0] = 1; 
+    buf[1] = 0;
 
     if( mode == MBEDTLS_RSA_PRIVATE && ctx->padding != MBEDTLS_RSA_PKCS_V15 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );


### PR DESCRIPTION
## Description
Set first two bytes of the buffer so that the CLANG code checker will not think we are accessing uninitialized data (normally mbedtls_rsa_public or mbedtls_rsa_private would fill the buffer would set this data later in the function , but there is a possible code flow where they fail to do this). values chosen are intentionally invalid so that the original check will fail if the data has not been filled correctly.
Fixes #1002 reported by aaronmdjones.


## Status
READY

## Requires Backporting
 NO (fix only for 2.1 branch - issue no longer exists in v2.7) 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
