### PR TITLE
Deprecate support for record compression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,10 @@ Features
      OpenVPN Inc. Fixes #1339
    * Add support for public keys encoded in PKCS#1 format. #1122
 
+New deprecations
+   * Deprecate support for record compression (configuration option
+     MBEDTLS_ZLIB_SUPPORT).
+
 Bugfix
    * Fix the name of a DHE parameter that was accidentally changed in 2.7.0.
      Fixes #1358.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -66,14 +66,6 @@
 #error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
 #endif
 
-#if defined(MBEDTLS_ZLIB_SUPPORT) && defined(MBEDTLS_DEPRECATED_WARNING)
-#warning "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and will likely be removed in a future version of the library"
-#endif
-
-#if defined(MBEDTLS_ZLIB_SUPPORT) && defined(MBEDTLS_DEPRECATED_REMOVED)
-#error "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and cannot be used if MBEDTLS_DEPRECATED_REMOVED is set"
-#endif
-
 #if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -66,6 +66,14 @@
 #error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
 #endif
 
+#if defined(MBEDTLS_ZLIB_SUPPORT) && defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and will likely be removed in a future version of the library"
+#endif
+
+#if defined(MBEDTLS_ZLIB_SUPPORT) && defined(MBEDTLS_DEPRECATED_REMOVED)
+#error "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and cannot be used if MBEDTLS_DEPRECATED_REMOVED is set"
+#endif
+
 #if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1541,8 +1541,8 @@
  *
  * \note Currently compression can't be used with DTLS.
  *
- * \deprecated This feature is deprecated and will likely be removed
- *             in a future version of the library.
+ * \deprecated This feature is deprecated and will be removed
+ *             in the next major revision of the library.
  *
  * Used in: library/ssl_tls.c
  *          library/ssl_cli.c

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1541,6 +1541,9 @@
  *
  * \note Currently compression can't be used with DTLS.
  *
+ * \deprecated This feature is deprecated and will likely be removed
+ *             in a future version of the library.
+ *
  * Used in: library/ssl_tls.c
  *          library/ssl_cli.c
  *          library/ssl_srv.c

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -49,6 +49,15 @@
 #endif
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
+
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and will be removed in the next major revision of the library"
+#endif
+
+#if defined(MBEDTLS_DEPRECATED_REMOVED)
+#error "Record compression support via MBEDTLS_ZLIB_SUPPORT is deprecated and cannot be used if MBEDTLS_DEPRECATED_REMOVED is set"
+#endif
+
 #include "zlib.h"
 #endif
 


### PR DESCRIPTION
__Summary:__ This PR deprecates the use of compression (configuration option `MBEDTLS_ZLIB_SUPPORT`). Support for compression is likely to be removed in the next major release of the library.

__Internal Reference:__ IOTSSL-2153

@mpg @gilles-peskine-arm Please review.