### PR TITLE
Arm v8 ISA Crypto extensions

### DIFF
--- a/ChangeLog.d/armv8_crypto_extensions.txt
+++ b/ChangeLog.d/armv8_crypto_extensions.txt
@@ -1,0 +1,2 @@
+Features
+    * ARMv8 Crypto Extensions: Faster AES and GCM

--- a/ChangeLog.d/armv8_crypto_extensions.txt
+++ b/ChangeLog.d/armv8_crypto_extensions.txt
@@ -1,2 +1,2 @@
 Features
-    * ARMv8 Crypto Extensions: Faster AES and GCM
+    * Support ARMv8 Cryptography Extensions for AES and GCM.

--- a/docs/architecture/testing/test-framework.md
+++ b/docs/architecture/testing/test-framework.md
@@ -56,3 +56,37 @@ The outcome file has 6 fields:
 * **Test case**: the description of the test case.
 * **Result**: one of `PASS`, `SKIP` or `FAIL`.
 * **Cause**: more information explaining the result.
+
+## Testing with different architectures
+
+This section describes ways to test Mbed TLS if the target architecture is different from the architecture on the host.
+
+### QEMU syscall emulation
+
+QEMU supports syscall emulation, which combines instruction emulation with forwarding of Linux system calls to the host
+system to allow you to run cross-compiled Linux binaries as if they were native to the host. Moreover, emulation happens
+automatically if available, so that no changes to the command line are necessary.
+
+This implies that all test suites, test programs and test scripts can be invoked for cross-builds of Mbed TLS, provide
+an appropriate version of QEMU supporting syscall emulation for the target architecture is installed.
+
+#### Example: ARM-v8A AES Crypto Extensions
+
+This example explains how to test Mbed TLS' support for the ARM-v8A Cryptography Extensions using cross-compilation and
+QEMU syscall emulation.
+
+First, cross-compile Mbed TLS for ARM-v8A + Cryptography Extensions, e.g.:
+
+```
+export CC='aarch64-linux-gnu-gcc'
+export CFLAGS='-Ofast -march=armv8-a+crypto'
+export LDFLAGS='-static'
+./scripts/config.pl set MBEDTLS_ARMV8CE_AES_C
+make -j$(nproc)
+```
+
+Next, test programs and scripts can be run as if they were compiled for the host architecture, e.g.:
+
+```
+make test
+```

--- a/include/mbedtls/armv8ce_aes.h
+++ b/include/mbedtls/armv8ce_aes.h
@@ -2,6 +2,9 @@
  * \file armv8ce_aes.h
  *
  * \brief ARMv8 Cryptography Extensions -- Optimized code for AES and GCM
+ */
+
+/*
  *
  *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0

--- a/include/mbedtls/armv8ce_aes.h
+++ b/include/mbedtls/armv8ce_aes.h
@@ -1,0 +1,60 @@
+/**
+ * \file armv8ce_aes.h
+ *
+ * \brief ARMv8 Cryptography Extensions -- Optimized code for AES and GCM
+ *
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_ARMV8CE_AES_H
+#define MBEDTLS_ARMV8CE_AES_H
+
+#include "aes.h"
+
+/**
+ * \brief          [ARMv8 Crypto Extensions] AES-ECB block en(de)cryption
+ *
+ * \param ctx      AES context
+ * \param mode     MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT
+ * \param input    16-byte input block
+ * \param output   16-byte output block
+ *
+ * \return         0 on success (cannot fail)
+ */
+
+int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                                   int mode,
+                                   const unsigned char input[16],
+                                   unsigned char output[16] );
+
+/**
+ * \brief          [ARMv8 Crypto Extensions]  Multiply in GF(2^128) for GCM
+ *
+ * \param c        Result
+ * \param a        First operand
+ * \param b        Second operand
+ *
+ * \note           Both operands and result are bit strings interpreted as
+ *                 elements of GF(2^128) as per the GCM spec.
+ */
+
+void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
+                               const unsigned char a[16],
+                               const unsigned char b[16] );
+
+#endif /* MBEDTLS_ARMV8CE_AES_H */

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -73,6 +73,10 @@
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_ARMV8CE_AES_C) && !defined(MBEDTLS_HAVE_ASM)
+#error "MBEDTLS_ARMV8CE_AES_C defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_CTR_DRBG_C) && !defined(MBEDTLS_AES_C)
 #error "MBEDTLS_CTR_DRBG_C defined, but not all prerequisites"
 #endif
@@ -879,3 +883,4 @@
 typedef int mbedtls_iso_c_forbids_empty_translation_units;
 
 #endif /* MBEDTLS_CHECK_CONFIG_H */
+

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -46,10 +46,10 @@
  * Requires support for asm() in compiler.
  *
  * Used in:
+ *      library/armv8ce_aes.c
  *      library/aria.c
  *      library/timing.c
  *      include/mbedtls/bn_mul.h
- *		library/armv8ce_aes.c
  *
  * Required by:
  *      MBEDTLS_AESNI_C

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -49,6 +49,7 @@
  *      library/aria.c
  *      library/timing.c
  *      include/mbedtls/bn_mul.h
+ *		library/armv8ce_aes.c
  *
  * Required by:
  *      MBEDTLS_AESNI_C
@@ -2148,6 +2149,21 @@
  * This modules adds support for the AES-NI instructions on x86-64
  */
 #define MBEDTLS_AESNI_C
+
+/**
+ * \def MBEDTLS_ARMV8CE_AES_C
+ *
+ * Enable ARMv8 Crypto Extensions for AES and GCM
+ *
+ * Module:  library/aesni.c
+ * Caller:  library/aes.c
+ *          library/gcm.c
+ *
+ * Requires: MBEDTLS_HAVE_ASM
+ *
+ * This module utilizes ARMv8 Crypto Extensions for AES and GCM
+ */
+//#define MBEDTLS_ARMV8CE_AES_C
 
 /**
  * \def MBEDTLS_AES_C

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2161,7 +2161,7 @@
  *
  * Requires: MBEDTLS_HAVE_ASM
  *
- * This module utilizes ARMv8 Crypto Extensions for AES and GCM
+ * This module adds support for Armv8 Cryptography Extensions for AES and GCM.
  */
 //#define MBEDTLS_ARMV8CE_AES_C
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2155,7 +2155,7 @@
  *
  * Enable ARMv8 Crypto Extensions for AES and GCM
  *
- * Module:  library/aesni.c
+ * Module:  library/armv8ce_aes.c
  * Caller:  library/aes.c
  *          library/gcm.c
  *

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -15,6 +15,7 @@ set(src_crypto
     aesni.c
     arc4.c
     aria.c
+    armv8ce_aes.c
     asn1parse.c
     asn1write.c
     base64.c

--- a/library/Makefile
+++ b/library/Makefile
@@ -72,6 +72,7 @@ OBJS_CRYPTO= \
 	     aesni.o \
 	     arc4.o \
 	     aria.o \
+             armv8ce_aes.o \
 	     asn1parse.o \
 	     asn1write.o \
 	     base64.o \

--- a/library/aes.c
+++ b/library/aes.c
@@ -33,15 +33,19 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
+
 #if defined(MBEDTLS_PADLOCK_C)
 #include "mbedtls/padlock.h"
 #endif
+
 #if defined(MBEDTLS_AESNI_C)
 #include "mbedtls/aesni.h"
 #endif
+
 #if defined(MBEDTLS_ARMV8CE_AES_C)
 #include "mbedtls/armv8ce_aes.h"
 #endif
+
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/library/aes.c
+++ b/library/aes.c
@@ -39,7 +39,9 @@
 #if defined(MBEDTLS_AESNI_C)
 #include "mbedtls/aesni.h"
 #endif
-
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+#include "mbedtls/armv8ce_aes.h"
+#endif
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -1035,6 +1037,11 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
         return( mbedtls_aesni_crypt_ecb( ctx, mode, input, output ) );
+#endif
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+	// We don't do runtime checking for ARMv8 Crypto Extensions
+	return mbedtls_armv8ce_aes_crypt_ecb( ctx, mode, input, output );
 #endif
 
 #if defined(MBEDTLS_PADLOCK_C) && defined(MBEDTLS_HAVE_X86)

--- a/library/armv8ce_aes.c
+++ b/library/armv8ce_aes.c
@@ -49,12 +49,12 @@ int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
     const uint8_t *rk;
     uint8x16_t x, k;
 
-    x = vld1q_u8( input );                          // input block
-    rk = (const uint8_t *) ctx->rk;                 // round keys
+    x = vld1q_u8( input );                          /* input block */
+    rk = (const uint8_t *) ctx->rk;                 /* round keys  */
 
     if( mode == MBEDTLS_AES_ENCRYPT )
     {
-        for( i = ctx->nr - 1; i ; i-- )             // encryption loop
+        for( i = ctx->nr - 1; i != 0; i-- )         /* encryption loop */
         {
             k = vld1q_u8( rk );
             rk += 16;
@@ -67,7 +67,7 @@ int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
     }
     else
     {
-        for( i = ctx->nr - 1; i ; i-- )             // decryption loop
+        for( i = ctx->nr - 1; i != 0 ; i-- )         /* decryption loop */
         {
             k = vld1q_u8( rk );
             rk += 16;
@@ -79,9 +79,9 @@ int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
         x = vaesdq_u8( x, k );
     }
 
-    k = vld1q_u8( rk );                             // final key just XORed
+    k = vld1q_u8( rk );                             /* final key just XORed */
     x = veorq_u8( x, k );
-    vst1q_u8( output, x );                          // write out
+    vst1q_u8( output, x );                          /* write out */
 
     return ( 0 );
 }
@@ -99,42 +99,42 @@ void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
                                const unsigned char a[16],
                                const unsigned char b[16] )
 {
-    // GCM's GF(2^128) polynomial basis is x^128 + x^7 + x^2 + x + 1
-    const uint64x2_t base = { 0, 0x86 };            // note missing LS bit
+    /* GCM's GF(2^128) polynomial basis is x^128 + x^7 + x^2 + x + 1 */
+    const uint64x2_t base = { 0, 0x86 };            /* note missing LS bit */
 
-    register uint8x16_t vc asm( "v0" );             // named registers
-    register uint8x16_t va asm( "v1" );             // (to avoid conflict)
+    register uint8x16_t vc asm( "v0" );             /* named registers */
+    register uint8x16_t va asm( "v1" );             /* (to avoid conflict) */
     register uint8x16_t vb asm( "v2" );
     register uint64x2_t vp asm( "v3" );
 
-    va = vld1q_u8( a );                             // load inputs
+    va = vld1q_u8( a );                             /* load inputs */
     vb = vld1q_u8( b );
     vp = base;
 
     asm (
-        "rbit    %1.16b, %1.16b             \n\t"   // reverse bit order
+        "rbit    %1.16b, %1.16b             \n\t"   /* reverse bit order */
         "rbit    %2.16b, %2.16b             \n\t"
-        "pmull2  %0.1q,  %1.2d,  %2.2d      \n\t"   // v0 = a.hi * b.hi
-        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "pmull2  %0.1q,  %1.2d,  %2.2d      \n\t"   /* v0 = a.hi * b.hi */
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   /* mul v0 by x^64, reduce */
         "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
         "eor     %0.16b, %0.16b, v4.16b     \n\t"
-        "ext     v5.16b, %2.16b, %2.16b, #8 \n\t"   // (swap hi and lo in b)
-        "pmull   v4.1q,  %1.1d,  v5.1d      \n\t"   // v0 ^= a.lo * b.hi
+        "ext     v5.16b, %2.16b, %2.16b, #8 \n\t"   /* (swap hi and lo in b) */
+        "pmull   v4.1q,  %1.1d,  v5.1d      \n\t"   /* v0 ^= a.lo * b.hi */
         "eor     %0.16b, %0.16b, v4.16b     \n\t"
-        "pmull2  v4.1q,  %1.2d,  v5.2d      \n\t"   // v0 ^= a.hi * b.lo
+        "pmull2  v4.1q,  %1.2d,  v5.2d      \n\t"   /* v0 ^= a.hi * b.lo */
         "eor     %0.16b, %0.16b, v4.16b     \n\t"
-        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   /* mul v0 by x^64, reduce */
         "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
         "eor     %0.16b, %0.16b, v4.16b     \n\t"
-        "pmull   v4.1q,  %1.1d,  %2.1d      \n\t"   // v0 ^= a.lo * b.lo
+        "pmull   v4.1q,  %1.1d,  %2.1d      \n\t"   /* v0 ^= a.lo * b.lo */
         "eor     %0.16b, %0.16b, v4.16b     \n\t"
-        "rbit    %0.16b, %0.16b             \n\t"   // reverse bits for output
-        : "=w" (vc)                                 // q0:      output
-        : "w" (va), "w" (vb), "w" (vp)              // q1, q2:  input
-        : "v4", "v5"                                // q4, q5:  clobbered
+        "rbit    %0.16b, %0.16b             \n\t"   /* reverse bits for output */
+        : "=w" (vc)                                 /* q0:      output */
+        : "w" (va), "w" (vb), "w" (vp)              /* q1, q2:  input */
+        : "v4", "v5"                                /* q4, q5:  clobbered */
     );
 
-    vst1q_u8( c, vc );                              // write out
+    vst1q_u8( c, vc );                              /* write out */
 }
 
 #endif /* MBEDTLS_GCM_C */

--- a/library/armv8ce_aes.c
+++ b/library/armv8ce_aes.c
@@ -1,0 +1,143 @@
+/*
+ *  ARMv8 Cryptography Extensions -- Optimized code for AES and GCM
+ *
+ *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+
+#include <arm_neon.h>
+#include "mbedtls/armv8ce_aes.h"
+
+#ifndef asm
+#define asm __asm
+#endif
+
+/*
+ *  [ARMv8 Crypto Extensions]  AES-ECB block en(de)cryption
+ */
+
+#if defined(MBEDTLS_AES_C)
+
+int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
+                                   int mode,
+                                   const unsigned char input[16],
+                                   unsigned char output[16] )
+{
+    unsigned int i;
+    const uint8_t *rk;
+    uint8x16_t x, k;
+
+    x = vld1q_u8( input );                          // input block
+    rk = (const uint8_t *) ctx->rk;                 // round keys
+
+    if( mode == MBEDTLS_AES_ENCRYPT )
+    {
+        for( i = ctx->nr - 1; i ; i-- )             // encryption loop
+        {
+            k = vld1q_u8( rk );
+            rk += 16;
+            x = vaeseq_u8( x, k );
+            x = vaesmcq_u8( x );
+        }
+        k = vld1q_u8( rk );
+        rk += 16;
+        x = vaeseq_u8( x, k );
+    }
+    else
+    {
+        for( i = ctx->nr - 1; i ; i-- )             // decryption loop
+        {
+            k = vld1q_u8( rk );
+            rk += 16;
+            x = vaesdq_u8( x, k );
+            x = vaesimcq_u8( x );
+        }
+        k = vld1q_u8( rk );
+        rk += 16;
+        x = vaesdq_u8( x, k );
+    }
+
+    k = vld1q_u8( rk );                             // final key just XORed
+    x = veorq_u8( x, k );
+    vst1q_u8( output, x );                          // write out
+
+    return ( 0 );
+}
+
+#endif /* MBEDTLS_AES_C */
+
+
+/*
+ *  [ARMv8 Crypto Extensions]  Multiply in GF(2^128) for GCM
+ */
+
+#if defined(MBEDTLS_GCM_C)
+
+void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
+                               const unsigned char a[16],
+                               const unsigned char b[16] )
+{
+    // GCM's GF(2^128) polynomial basis is x^128 + x^7 + x^2 + x + 1
+    const uint64x2_t base = { 0, 0x86 };            // note missing LS bit
+
+    register uint8x16_t vc asm( "v0" );             // named registers
+    register uint8x16_t va asm( "v1" );             // (to avoid conflict)
+    register uint8x16_t vb asm( "v2" );
+    register uint64x2_t vp asm( "v3" );
+
+    va = vld1q_u8( a );                             // load inputs
+    vb = vld1q_u8( b );
+    vp = base;
+
+    asm (
+        "rbit    %1.16b, %1.16b             \n\t"   // reverse bit order
+        "rbit    %2.16b, %2.16b             \n\t"
+        "pmull2  %0.1q,  %1.2d,  %2.2d      \n\t"   // v0 = a.hi * b.hi
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "ext     v5.16b, %2.16b, %2.16b, #8 \n\t"   // (swap hi and lo in b)
+        "pmull   v4.1q,  %1.1d,  v5.1d      \n\t"   // v0 ^= a.lo * b.hi
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull2  v4.1q,  %1.2d,  v5.2d      \n\t"   // v0 ^= a.hi * b.lo
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull2  v4.1q,  %0.2d,  %3.2d      \n\t"   // mul v0 by x^64, reduce
+        "ext     %0.16b, %0.16b, %0.16b, #8 \n\t"
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "pmull   v4.1q,  %1.1d,  %2.1d      \n\t"   // v0 ^= a.lo * b.lo
+        "eor     %0.16b, %0.16b, v4.16b     \n\t"
+        "rbit    %0.16b, %0.16b             \n\t"   // reverse bits for output
+        : "=w" (vc)                                 // q0:      output
+        : "w" (va), "w" (vb), "w" (vp)              // q1, q2:  input
+        : "v4", "v5"                                // q4, q5:  clobbered
+    );
+
+    vst1q_u8( c, vc );                              // write out
+}
+
+#endif /* MBEDTLS_GCM_C */
+
+#endif /* MBEDTLS_ARMV8CE_AES_C */
+

--- a/library/armv8ce_aes.c
+++ b/library/armv8ce_aes.c
@@ -35,7 +35,7 @@
 #endif
 
 /*
- *  [ARMv8 Crypto Extensions]  AES-ECB block en(de)cryption
+ *  [Armv8 Cryptography Extensions]  AES-ECB block en(de)cryption
  */
 
 #if defined(MBEDTLS_AES_C)
@@ -90,7 +90,7 @@ int mbedtls_armv8ce_aes_crypt_ecb( mbedtls_aes_context *ctx,
 
 
 /*
- *  [ARMv8 Crypto Extensions]  Multiply in GF(2^128) for GCM
+ *  [Armv8 Cryptography Extensions]  Multiply in GF(2^128) for GCM
  */
 
 #if defined(MBEDTLS_GCM_C)
@@ -140,4 +140,3 @@ void mbedtls_armv8ce_gcm_mult( unsigned char c[16],
 #endif /* MBEDTLS_GCM_C */
 
 #endif /* MBEDTLS_ARMV8CE_AES_C */
-

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -600,6 +600,9 @@ static const char * const features[] = {
 #if defined(MBEDTLS_AESNI_C)
     "MBEDTLS_AESNI_C",
 #endif /* MBEDTLS_AESNI_C */
+#if defined(MBEDTLS_ARMV8CE_AES_C)
+    "MBEDTLS_ARMV8CE_AES_C",
+#endif /* MBEDTLS_ARMV8CE_AES_C */
 #if defined(MBEDTLS_AES_C)
     "MBEDTLS_AES_C",
 #endif /* MBEDTLS_AES_C */

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -167,6 +167,7 @@ def realfull_adapter(_name, active, section):
 # * Options that remove features.
 EXCLUDE_FROM_FULL = frozenset([
     #pylint: disable=line-too-long
+    'MBEDTLS_ARMV8CE_AES_C',
     'MBEDTLS_CTR_DRBG_USE_128_BIT_KEY', # interacts with ENTROPY_FORCE_SHA256
     'MBEDTLS_DEPRECATED_REMOVED', # conflicts with deprecated options
     'MBEDTLS_DEPRECATED_WARNING', # conflicts with deprecated options

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="..\..\include\mbedtls\aesni.h" />
     <ClInclude Include="..\..\include\mbedtls\arc4.h" />
     <ClInclude Include="..\..\include\mbedtls\aria.h" />
+    <ClInclude Include="..\..\include\mbedtls\armv8ce_aes.h" />
     <ClInclude Include="..\..\include\mbedtls\asn1.h" />
     <ClInclude Include="..\..\include\mbedtls\asn1write.h" />
     <ClInclude Include="..\..\include\mbedtls\base64.h" />
@@ -257,6 +258,7 @@
     <ClCompile Include="..\..\library\aesni.c" />
     <ClCompile Include="..\..\library\arc4.c" />
     <ClCompile Include="..\..\library\aria.c" />
+    <ClCompile Include="..\..\library\armv8ce_aes.c" />
     <ClCompile Include="..\..\library\asn1parse.c" />
     <ClCompile Include="..\..\library\asn1write.c" />
     <ClCompile Include="..\..\library\base64.c" />


### PR DESCRIPTION
ARMv8 Crypto Extensions - as written by @mjosaarinen and originally submitted as #1173. This PR is resubmitted as a branch on the mbedtls repository to allow other members of the Mbed TLS team to push commits to the branch and permit review and rework.

To quote the original PR:

> A compact patch that provides AES and GCM implementations that utilize the **ARMv8 Crypto Extensions**. The config flag is MBEDTLS_ARMV8CE_AES_C, which is disabled by default as we don't do runtime checking for the feature. The new implementation lives in `armv8ce_aes.c`.
> 
> Provides similar functionality to https://github.com/ARMmbed/mbedtls/pull/432
> Thanks to Barry O'Rourke and others for that contribtion.
> 
> Tested on a Cortex A53 device and QEMU. On a midrange phone the real AES-GCM throughput increases about 4x, while raw AES speed is up to 10x faster.
> 
> When cross-compiling, you want to set something like:
> 
> ```
> export CC='aarch64-linux-gnu-gcc'
> export CFLAGS='-Ofast -march=armv8-a+crypto'
> scripts/config.pl set MBEDTLS_ARMV8CE_AES_C
> ```
> 
> QEMU seems to also need 
> 
> ```
> export LDFLAGS='-static'
> ```
> Then run normal `make` or` cmake` etc.
> 