### PR TITLE
Changes for Windows 64-bit builds

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -29,8 +29,17 @@
 #ifndef MBEDTLS_CONFIG_H
 #define MBEDTLS_CONFIG_H
 
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
+#ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_DEPRECATE 1
+#endif
+#include <winsock2.h>
+#include <tchar.h>
+#else
+#define _T(x) x
+#define TCHAR char
+#define _tfopen fopen
+#define _tcslen strlen
 #endif
 
 /**
@@ -1537,7 +1546,7 @@
  *
  * \warning TLS-level compression MAY REDUCE SECURITY! See for example the
  * CRIME attack. Before enabling this option, you should examine with care if
- * CRIME or similar exploits may be a applicable to your use case.
+ * CRIME or similar exploits may be applicable to your use case.
  *
  * \note Currently compression can't be used with DTLS.
  *

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -286,7 +286,7 @@ int mbedtls_ctr_drbg_random( void *p_rng,
  *                      #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on
  *                      failure.
  */
-int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
+int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const TCHAR *path );
 
 /**
  * \brief               This function reads and updates a seed file. The seed
@@ -300,7 +300,7 @@ int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char 
  *                      #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED or
  *                      #MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG on failure.
  */
-int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
+int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -278,7 +278,7 @@ int mbedtls_dhm_parse_dhm( mbedtls_dhm_context *dhm, const unsigned char *dhmin,
  * \return         \c 0 on success, or a specific DHM or PEM error code
  *                 on failure.
  */
-int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
+int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_ASN1_PARSE_C */
 

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -236,7 +236,7 @@ int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx );
  *                      MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR on file error, or
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *path );
+int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const TCHAR *path );
 
 /**
  * \brief               Read and update a seed file. Seed is added to this
@@ -250,7 +250,7 @@ int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *p
  *                      MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR on file error,
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *path );
+int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -267,7 +267,7 @@ void mbedtls_hmac_drbg_free( mbedtls_hmac_drbg_context *ctx );
  * \return              0 if successful, 1 on file error, or
  *                      MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
+int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const TCHAR *path );
 
 /**
  * \brief               Read and update a seed file. Seed is added to this
@@ -280,7 +280,7 @@ int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const cha
  *                      MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED or
  *                      MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG
  */
-int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
+int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -338,7 +338,7 @@ int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, si
  *                 #MBEDTLS_ERR_MD_FILE_IO_ERROR if file input failed, or
  *                 #MBEDTLS_ERR_MD_BAD_INPUT_DATA if \p md_info was NULL.
  */
-int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
+int mbedtls_md_file( const mbedtls_md_info_t *md_info, const TCHAR *path,
                      unsigned char *output );
 #endif /* MBEDTLS_FS_IO */
 

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -63,9 +63,26 @@ extern "C" {
  * (eg two file descriptors for combined IPv4 + IPv6 support, or additional
  * structures for hand-made UDP demultiplexing).
  */
+#ifdef _MSC_VER
+#define ISINVALID(s) (INVALID_SOCKET==(s))
+#else
+#ifndef SOCKET
+#define SOCKET int
+#endif
+#ifndef SSIZE_T
+typedef SSIZE_T ssize_t
+#endif
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET (-1)
+#endif
+#ifndef ISINVALID
+#define ISINVALID(s) (0>(s))
+#endif
+#endif
+
 typedef struct
 {
-    int fd;             /**< The underlying file descriptor                 */
+    SOCKET fd;             /**< The underlying socket handle or file descriptor */
 }
 mbedtls_net_context;
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -491,7 +491,7 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
  * \return          0 if successful, or a specific PK or PEM error code
  */
 int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
-                      const char *path, const char *password );
+                      const TCHAR *path, const char *password );
 
 /** \ingroup pk_module */
 /**
@@ -509,7 +509,7 @@ int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
-int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path );
+int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_PK_PARSE_C */
 
@@ -608,7 +608,7 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
  * know you do.
  */
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
+int mbedtls_pk_load_file( const TCHAR *path, unsigned char **buf, size_t *n );
 #endif
 
 #ifdef __cplusplus

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -133,7 +133,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const char *path );
+int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -98,7 +98,7 @@ mbedtls_x509_crt;
  * Build flag from an algorithm/curve identifier (pk, md, ecp)
  * Since 0 is always XXX_NONE, ignore it.
  */
-#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( id - 1 ) )
+#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( ( id ) - 1 ) )
 
 /**
  * Security profile for certificate verification.
@@ -205,7 +205,7 @@ int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain, const unsigned char *buf, s
  * \return         0 if all certificates parsed successfully, a positive number
  *                 if partly successful or a specific X509 or PEM error code
  */
-int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const char *path );
+int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const TCHAR *path );
 
 /**
  * \brief          Load one or more certificate files from a path and add them
@@ -220,7 +220,7 @@ int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const char *path );
  * \return         0 if all certificates parsed successfully, a positive number
  *                 if partly successful or a specific X509 or PEM error code
  */
-int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
+int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -120,7 +120,7 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const char *path );
+int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const TCHAR *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -475,13 +475,13 @@ int mbedtls_ctr_drbg_random( void *p_rng, unsigned char *output, size_t output_l
 }
 
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path )
+int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const TCHAR *path )
 {
     int ret = MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR;
     FILE *f;
     unsigned char buf[ MBEDTLS_CTR_DRBG_MAX_INPUT ];
 
-    if( ( f = fopen( path, "wb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "wb" ) ) ) == NULL )
         return( MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR );
 
     if( ( ret = mbedtls_ctr_drbg_random( ctx, buf, MBEDTLS_CTR_DRBG_MAX_INPUT ) ) != 0 )
@@ -499,14 +499,14 @@ exit:
     return( ret );
 }
 
-int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path )
+int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const TCHAR *path )
 {
     int ret = 0;
     FILE *f;
     size_t n;
     unsigned char buf[ MBEDTLS_CTR_DRBG_MAX_INPUT ];
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "rb" ) ) ) == NULL )
         return( MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR );
 
     fseek( f, 0, SEEK_END );

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -546,12 +546,12 @@ exit:
  * A terminating null byte is always appended. It is included in the announced
  * length only if the data looks like it is PEM encoded.
  */
-static int load_file( const char *path, unsigned char **buf, size_t *n )
+static int load_file( const TCHAR *path, unsigned char **buf, size_t *n )
 {
     FILE *f;
     long size;
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "rb" ) ) ) == NULL )
         return( MBEDTLS_ERR_DHM_FILE_IO_ERROR );
 
     fseek( f, 0, SEEK_END );
@@ -594,7 +594,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
 /*
  * Load and parse DHM parameters
  */
-int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path )
+int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const TCHAR *path )
 {
     int ret;
     size_t n;

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -465,13 +465,13 @@ int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx )
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *path )
+int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const TCHAR *path )
 {
     int ret = MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR;
     FILE *f;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE];
 
-    if( ( f = fopen( path, "wb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "wb" ) ) ) == NULL )
         return( MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR );
 
     if( ( ret = mbedtls_entropy_func( ctx, buf, MBEDTLS_ENTROPY_BLOCK_SIZE ) ) != 0 )
@@ -492,14 +492,14 @@ exit:
     return( ret );
 }
 
-int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *path )
+int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const TCHAR *path )
 {
     int ret = 0;
     FILE *f;
     size_t n;
     unsigned char buf[ MBEDTLS_ENTROPY_MAX_SEED_SIZE ];
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "rb" ) ) ) == NULL )
         return( MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR );
 
     fseek( f, 0, SEEK_END );

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -342,13 +342,13 @@ void mbedtls_hmac_drbg_free( mbedtls_hmac_drbg_context *ctx )
 }
 
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path )
+int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const TCHAR *path )
 {
     int ret;
     FILE *f;
     unsigned char buf[ MBEDTLS_HMAC_DRBG_MAX_INPUT ];
 
-    if( ( f = fopen( path, "wb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "wb" ) ) ) == NULL )
         return( MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR );
 
     if( ( ret = mbedtls_hmac_drbg_random( ctx, buf, sizeof( buf ) ) ) != 0 )
@@ -369,14 +369,14 @@ exit:
     return( ret );
 }
 
-int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path )
+int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const TCHAR *path )
 {
     int ret = 0;
     FILE *f;
     size_t n;
     unsigned char buf[ MBEDTLS_HMAC_DRBG_MAX_INPUT ];
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "rb" ) ) ) == NULL )
         return( MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR );
 
     fseek( f, 0, SEEK_END );

--- a/library/md.c
+++ b/library/md.c
@@ -279,7 +279,7 @@ int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, si
 }
 
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path, unsigned char *output )
+int mbedtls_md_file( const mbedtls_md_info_t *md_info, const TCHAR *path, unsigned char *output )
 {
     int ret;
     FILE *f;
@@ -290,7 +290,7 @@ int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path, unsigne
     if( md_info == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T( "rb" ) ) ) == NULL )
         return( MBEDTLS_ERR_MD_FILE_IO_ERROR );
 
     mbedtls_md_init( &ctx );

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -45,15 +45,7 @@
 #if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
     !defined(EFI32)
 
-#ifdef _WIN32_WINNT
-#undef _WIN32_WINNT
-#endif
-/* Enables getaddrinfo() & Co */
-#define _WIN32_WINNT 0x0501
 #include <ws2tcpip.h>
-
-#include <winsock2.h>
-#include <windows.h>
 
 #if defined(_MSC_VER)
 #if defined(_WIN32_WCE)
@@ -127,7 +119,7 @@ static int net_prepare( void )
  */
 void mbedtls_net_init( mbedtls_net_context *ctx )
 {
-    ctx->fd = -1;
+    ctx->fd = INVALID_SOCKET;
 }
 
 /*
@@ -155,9 +147,9 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,
     ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
     for( cur = addr_list; cur != NULL; cur = cur->ai_next )
     {
-        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
+        ctx->fd = socket( cur->ai_family, cur->ai_socktype,
                             cur->ai_protocol );
-        if( ctx->fd < 0 )
+        if( ISINVALID(ctx->fd) )
         {
             ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
             continue;
@@ -204,9 +196,9 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
     ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
     for( cur = addr_list; cur != NULL; cur = cur->ai_next )
     {
-        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
+        ctx->fd = socket( cur->ai_family, cur->ai_socktype,
                             cur->ai_protocol );
-        if( ctx->fd < 0 )
+        if( ISINVALID(ctx->fd) )
         {
             ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
             continue;
@@ -302,7 +294,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
                         mbedtls_net_context *client_ctx,
                         void *client_ip, size_t buf_size, size_t *ip_len )
 {
-    int ret;
+    SSIZE_T ret;
     int type;
 
     struct sockaddr_storage client_addr;
@@ -327,15 +319,15 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
     if( type == SOCK_STREAM )
     {
         /* TCP: actual accept() */
-        ret = client_ctx->fd = (int) accept( bind_ctx->fd,
-                                             (struct sockaddr *) &client_addr, &n );
+        client_ctx->fd = accept( bind_ctx->fd, (struct sockaddr *) &client_addr, &n );
+        ret = (SSIZE_T)client_ctx->fd;
     }
     else
     {
         /* UDP: wait for a message, but keep it in the queue */
         char buf[1] = { 0 };
 
-        ret = (int) recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
+        ret = (SSIZE_T) recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
                         (struct sockaddr *) &client_addr, &n );
 
 #if defined(_WIN32)
@@ -367,13 +359,13 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
             return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
 
         client_ctx->fd = bind_ctx->fd;
-        bind_ctx->fd   = -1; /* In case we exit early */
+        bind_ctx->fd   = INVALID_SOCKET; /* In case we exit early */
 
         n = sizeof( struct sockaddr_storage );
         if( getsockname( client_ctx->fd,
                          (struct sockaddr *) &local_addr, &n ) != 0 ||
-            ( bind_ctx->fd = (int) socket( local_addr.ss_family,
-                                           SOCK_DGRAM, IPPROTO_UDP ) ) < 0 ||
+            ISINVALID( bind_ctx->fd = socket( local_addr.ss_family,
+                                           SOCK_DGRAM, IPPROTO_UDP ) ) ||
             setsockopt( bind_ctx->fd, SOL_SOCKET, SO_REUSEADDR,
                         (const char *) &one, sizeof( one ) ) != 0 )
         {
@@ -463,17 +455,17 @@ void mbedtls_net_usleep( unsigned long usec )
  */
 int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
 {
-    int ret;
-    int fd = ((mbedtls_net_context *) ctx)->fd;
+    SSIZE_T ret;
+    SOCKET fd = ((mbedtls_net_context *) ctx)->fd;
 
-    if( fd < 0 )
+    if( ISINVALID( fd ) )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
-    ret = (int) read( fd, buf, len );
+    ret = (SSIZE_T)read( fd, buf, len );
 
     if( ret < 0 )
     {
-        if( net_would_block( ctx ) != 0 )
+        if( net_would_block((mbedtls_net_context *)ctx ) != 0 )
             return( MBEDTLS_ERR_SSL_WANT_READ );
 
 #if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
@@ -491,7 +483,7 @@ int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
         return( MBEDTLS_ERR_NET_RECV_FAILED );
     }
 
-    return( ret );
+    return( (int)ret );
 }
 
 /*
@@ -503,9 +495,9 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
     int ret;
     struct timeval tv;
     fd_set read_fds;
-    int fd = ((mbedtls_net_context *) ctx)->fd;
+    SOCKET fd = ((mbedtls_net_context *) ctx)->fd;
 
-    if( fd < 0 )
+    if( ISINVALID( fd ) )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
     FD_ZERO( &read_fds );
@@ -514,7 +506,7 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
     tv.tv_sec  = timeout / 1000;
     tv.tv_usec = ( timeout % 1000 ) * 1000;
 
-    ret = select( fd + 1, &read_fds, NULL, NULL, timeout == 0 ? NULL : &tv );
+    ret = select( (int)( fd + 1 ), &read_fds, NULL, NULL, timeout == 0 ? NULL : &tv );
 
     /* Zero fds ready means we timed out */
     if( ret == 0 )
@@ -543,17 +535,17 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
  */
 int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
 {
-    int ret;
-    int fd = ((mbedtls_net_context *) ctx)->fd;
+    SSIZE_T ret;
+    SOCKET fd = ((mbedtls_net_context *) ctx)->fd;
 
-    if( fd < 0 )
+    if( ISINVALID( fd ) )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
-    ret = (int) write( fd, buf, len );
+    ret = (SSIZE_T)write( fd, buf, len );
 
     if( ret < 0 )
     {
-        if( net_would_block( ctx ) != 0 )
+        if( net_would_block((mbedtls_net_context *)ctx ) != 0 )
             return( MBEDTLS_ERR_SSL_WANT_WRITE );
 
 #if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
@@ -571,7 +563,7 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
         return( MBEDTLS_ERR_NET_SEND_FAILED );
     }
 
-    return( ret );
+    return( (int)ret );
 }
 
 /*
@@ -579,13 +571,13 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
  */
 void mbedtls_net_free( mbedtls_net_context *ctx )
 {
-    if( ctx->fd == -1 )
+    if( ISINVALID( ctx->fd ) )
         return;
 
     shutdown( ctx->fd, 2 );
     close( ctx->fd );
 
-    ctx->fd = -1;
+    ctx->fd = INVALID_SOCKET;
 }
 
 #endif /* MBEDTLS_NET_C */

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -76,12 +76,12 @@ static void mbedtls_zeroize( void *v, size_t n ) {
  * A terminating null byte is always appended. It is included in the announced
  * length only if the data looks like it is PEM encoded.
  */
-int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n )
+int mbedtls_pk_load_file( const TCHAR *path, unsigned char **buf, size_t *n )
 {
     FILE *f;
     long size;
 
-    if( ( f = fopen( path, "rb" ) ) == NULL )
+    if( ( f = _tfopen( path, _T("rb") ) ) == NULL )
         return( MBEDTLS_ERR_PK_FILE_IO_ERROR );
 
     fseek( f, 0, SEEK_END );
@@ -125,7 +125,7 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n )
  * Load and parse a private key
  */
 int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
-                      const char *path, const char *pwd )
+                      const TCHAR *path, const char *pwd )
 {
     int ret;
     size_t n;
@@ -149,7 +149,7 @@ int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
 /*
  * Load and parse a public key
  */
-int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path )
+int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const TCHAR *path )
 {
     int ret;
     size_t n;

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -552,7 +552,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
 /*
  * Load one or more CRLs and add them to the chained list
  */
-int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const char *path )
+int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const TCHAR *path )
 {
     int ret;
     size_t n;

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -314,7 +314,7 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
 /*
  * Load a CSR into the structure
  */
-int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const char *path )
+int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const TCHAR *path )
 {
     int ret;
     size_t n;


### PR DESCRIPTION
## Description
Sockets in the current code are assumed to be signed integers, while in Windows sockets are _unsigned long_ or _unsigned long long_ depending on configuration.
Macros and minor code changes were made for better compatibility with Visual Studio.
Also Unicode file names are better handled as wide character strings.

## Status
**IN DEVELOPMENT**

## Requires Backporting
 NO  

## Which branch?
development

## Additional comments
The code tested in VS 2013/2015/2017, both 32- and 64-bit. 
VS 2010 projects will need testing.