### PR TITLE
benchmark: Fix incompatibility with C89 compilers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,8 @@ Bugfix
      In the context of SSL, this resulted in handshake failure. Reported by
      daniel in the Mbed TLS forum. #1351
    * Fix Windows x64 builds with the included mbedTLS.sln file. #1347
+   * Fix C89 incompatibility in benchmark.c. Contributed by Brendan Shanks.
+     #1353
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -658,13 +658,13 @@ int main( int argc, char *argv[] )
     if( todo.dhm )
     {
         int dhm_sizes[] = { 2048, 3072 };
-        const unsigned char dhm_P_2048[] =
+        static const unsigned char dhm_P_2048[] =
             MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN;
-        const unsigned char dhm_P_3072[] =
+        static const unsigned char dhm_P_3072[] =
             MBEDTLS_DHM_RFC3526_MODP_3072_P_BIN;
-        const unsigned char dhm_G_2048[] =
+        static const unsigned char dhm_G_2048[] =
             MBEDTLS_DHM_RFC3526_MODP_2048_G_BIN;
-        const unsigned char dhm_G_3072[] =
+        static const unsigned char dhm_G_3072[] =
             MBEDTLS_DHM_RFC3526_MODP_3072_G_BIN;
 
         const unsigned char *dhm_P[] = { dhm_P_2048, dhm_P_3072 };


### PR DESCRIPTION


Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
**DONE**
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
## Description
Initializing arrays using non-constant expressions is not permitted in
C89, and was causing errors when compiling with Metrowerks CodeWarrior
(for classic MacOS) in C89 mode. Clang also produces a warning when
compiling with '-Wc99-extensions':

test/benchmark.c:670:42: warning: initializer for aggregate is not a compile-time constant [-Wc99-extensions]
        const unsigned char *dhm_P[] = { dhm_P_2048, dhm_P_3072 };
                                         ^~~~~~~~~~
test/benchmark.c:674:42: warning: initializer for aggregate is not a compile-time constant [-Wc99-extensions]
        const unsigned char *dhm_G[] = { dhm_G_2048, dhm_G_3072 };
                                         ^~~~~~~~~~

Declaring the arrays as 'static' makes them constant expressions.

fixes #1353

## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO, this was a new bug introduced in 2.7

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.