### PR TITLE
Fix 'may be used unitialized' warning

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -771,7 +771,7 @@ static int cmac_test_subkeys( int verbose,
                               int block_size,
                               int num_tests )
 {
-    int i, ret;
+    int i, ret = 0;
     mbedtls_cipher_context_t ctx;
     const mbedtls_cipher_info_t *cipher_info;
     unsigned char K1[MBEDTLS_CIPHER_BLKSIZE_MAX];
@@ -853,7 +853,7 @@ static int cmac_test_wth_cipher( int verbose,
                                  int num_tests )
 {
     const mbedtls_cipher_info_t *cipher_info;
-    int i, ret;
+    int i, ret = 0;
     unsigned char output[MBEDTLS_CIPHER_BLKSIZE_MAX];
 
     cipher_info = mbedtls_cipher_info_from_type( cipher_type );


### PR DESCRIPTION
Gcc isn't quite smart enough to realize that these functions are always
called with a >0 `num_tests` value, which restults in warnings like:

    .../mbedtls/library/cmac.c: In function ‘cmac_test_subkeys’:
    .../mbedtls/library/cmac.c:768:12: error: ‘ret’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         int i, ret;
                ^~~
    .../mbedtls/library/cmac.c: In function ‘cmac_test_wth_cipher’:
    .../mbedtls/library/cmac.c:886:11: error: ‘ret’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         return( ret );
               ^

As seen in https://github.com/zephyrproject-rtos/zephyr/issues/3770 for
example.

Fix this by giving `ret` a successful return value to use in the case if
`num_tests` were zero.

Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
