### PR TITLE
IOTSSL-1879 buffer overflow in server key exchange parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ Security
      implementation allowed an offline 2^80 brute force attack on the
      HMAC key of a single, uninterrupted connection (with no
      resumption of the session).
+   * Fix a buffer overread in ssl_parse_server_key_exchange() that could cause
+     a crash on invalid input.
 
 Features
    * Extend PKCS#8 interface by introducing support for the entire SHA
@@ -44,6 +46,8 @@ Bugfix
      Nick Wilson on issue #355
    * In test_suite_pk, pass valid parameters when testing for hash length
      overflow. #1179
+   * Fix a possible arithmetic overflow in ssl_parse_server_key_exchange()
+     that could cause a key exchange to fail on valid data.
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2489,7 +2489,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 
-        if( end != p + sig_len )
+        if( p != end - sig_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2478,6 +2478,14 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         /*
          * Read signature
          */
+
+        if( p > end - 2 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
+            mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                            MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
+            return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+        }
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 


### PR DESCRIPTION
## Description
This PR prevents two buffer overflow errors from happening in the ssl_parse_server_key_exchange function.


## Status
**READY**

## Requires Backporting
YES
This fix should most probably be backported to all supported branches as the vulnerabilities aren't version speciffic.

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests maybe?

## Steps to test or reproduce
None prepared
