### PR TITLE
IOTSSL-1878 buffer overflow in server psk hint parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ Security
      implementation allowed an offline 2^80 brute force attack on the
      HMAC key of a single, uninterrupted connection (with no
      resumption of the session).
+   * Fix a buffer overread in ssl_parse_server_psk_hint() that could cause a
+     crash on invalid input.
 
 Features
    * Extend PKCS#8 interface by introducing support for the entire SHA
@@ -44,6 +46,8 @@ Bugfix
      Nick Wilson on issue #355
    * In test_suite_pk, pass valid parameters when testing for hash length
      overflow. #1179
+   * Fix a possible arithmetic overflow in ssl_parse_server_psk_hint() that
+     could cause a key exchange to fail on valid data.
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2057,6 +2057,12 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
      *
      * opaque psk_identity_hint<0..2^16-1>;
      */
+    if( (*p) > end - 2 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
+                                    "(psk_identity_hint length)" ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+    }
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2066,7 +2066,7 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 
-    if( (*p) + len > end )
+    if( (*p) > end - len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
                                     "(psk_identity_hint length)" ) );


### PR DESCRIPTION
## Description
This PR prevents two buffer overflow errors from happening in the ssl_parse_server_psk_hint function.


## Status
**READY**

## Requires Backporting
YES
This fix should most probably be backported to all supported branches as the vulnerabilities aren't version speciffic.

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests maybe?

## Steps to test or reproduce
None prepared
