### PR TITLE
2.1 only: generate_code: add #line directives

### DIFF
--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -41,11 +41,37 @@ my $test_helpers = <TEST_HELPERS>;
 close(TEST_HELPERS);
 
 open(TEST_MAIN, "$test_main_file") or die "Opening test main '$test_main_file': $!";
-my $test_main = <TEST_MAIN>;
+my @test_main_lines = split/^/,  <TEST_MAIN>;
+my $test_main;
+my $index = 2;
+for my $line (@test_main_lines) {
+    $line =~ s/!LINE_NO!/$index/;
+    $test_main = $test_main.$line;
+    $index++;
+}
 close(TEST_MAIN);
 
 open(TEST_CASES, "$test_case_file") or die "Opening test cases '$test_case_file': $!";
-my $test_cases = <TEST_CASES>;
+my @test_cases_lines = split/^/,  <TEST_CASES>;
+my $test_cases;
+my $index = 2;
+for my $line (@test_cases_lines) {
+    if ($line =~ /^\/\* BEGIN_SUITE_HELPERS .*\*\//)
+    {
+        $line = $line."#line $index \"$test_case_file\"\n";
+    }
+
+    if ($line =~ /^\/\* BEGIN_CASE .*\*\//)
+    {
+        $line = $line."#line $index \"$test_case_file\"\n";
+    }
+
+    $line =~ s/!LINE_NO!/$index/;
+
+    $test_cases = $test_cases.$line;
+    $index++;
+}
+
 close(TEST_CASES);
 
 open(TEST_DATA, "$test_case_data") or die "Opening test data '$test_case_data': $!";
@@ -104,16 +130,19 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
     my $function_decl = $2;
 
     # Sanity checks of function
-    if ($function_decl !~ /^void /)
+    if ($function_decl !~ /^#line\s*.*\nvoid /)
     {
         die "Test function does not have 'void' as return type\n";
+            "Function declaration:\n" .
+            $function_decl;
     }
-    if ($function_decl !~ /^void (\w+)\(\s*(.*?)\s*\)\s*{(.*)}/ms)
+    if ($function_decl !~ /^(#line\s*.*)\nvoid (\w+)\(\s*(.*?)\s*\)\s*{(.*)}/ms)
     {
         die "Function declaration not in expected format\n";
     }
-    my $function_name = $1;
-    my $function_params = $2;
+    my $line_directive = $1;
+    my $function_name = $2;
+    my $function_params = $3;
     my $function_pre_code;
     my $function_post_code;
     my $param_defs;
@@ -124,7 +153,7 @@ while($test_cases =~ /\/\* BEGIN_CASE *([\w:]*) \*\/\n(.*?)\n\/\* END_CASE \*\//
     my $mapping_regex = "".$function_name;
     my $mapping_count = 0;
 
-    $function_decl =~ s/^void /void test_suite_/;
+    $function_decl =~ s/(^#line\s*.*)\nvoid /$1\nvoid test_suite_/;
 
     # Add exit label if not present
     if ($function_decl !~ /^exit:$/m)

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -1,3 +1,4 @@
+#line 1 "helpers.function"
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -1,3 +1,4 @@
+#line 1 "main_test.function"
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
@@ -20,6 +21,7 @@
 static int test_errors = 0;
 
 SUITE_PRE_DEP
+#line !LINE_NO! "main_test.function"
 #define TEST_SUITE_ACTIVE
 
 static void test_fail( const char *test )
@@ -103,6 +105,7 @@ MAPPING_CODE
 
 FUNCTION_CODE
 SUITE_POST_DEP
+#line !LINE_NO! "main_test.function"
 
 int dep_check( char *str )
 {
@@ -110,6 +113,7 @@ int dep_check( char *str )
         return( 1 );
 
 DEP_CHECK_CODE
+#line !LINE_NO! "main_test.function"
 
     return( 1 );
 }
@@ -123,6 +127,7 @@ int dispatch_test(int cnt, char *params[50])
 #if defined(TEST_SUITE_ACTIVE)
 DISPATCH_FUNCTION
     {
+#line !LINE_NO! "main_test.function"
         mbedtls_fprintf( stdout, "FAILED\nSkipping unknown test function '%s'\n", params[0] );
         fflush( stdout );
         return( 1 );


### PR DESCRIPTION
When generating .c files from .function files, add #line directives so
that errors in the generated files are reported with the correct line
number. Also add #line directives to the template .function files, for
the same reason.

This is a backport of things that got added later than 2.1 in several stages, so there's no corresponding PR for other branches.

No ChangeLog entry because this isn't mentioned in ChangeLog in development.