### PR TITLE
Add missing MBEDTLS_DEPRECATED_REMOVED guards

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ Bugfix
    * Fix the name of a DHE parameter that was accidentally changed in 2.7.0.
      Fixes #1358.
    * Fix test_suite_pk to work on 64-bit ILP32 systems. #849
+   * Don't define mbedtls_aes_decrypt and mbedtls_aes_encrypt under
+     MBEDTLS_DEPRECATED_REMOVED. #1388
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/library/aes.c
+++ b/library/aes.c
@@ -765,12 +765,14 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
 }
 #endif /* !MBEDTLS_AES_ENCRYPT_ALT */
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
                           const unsigned char input[16],
                           unsigned char output[16] )
 {
     mbedtls_internal_aes_encrypt( ctx, input, output );
 }
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /*
  * AES-ECB block decryption
@@ -831,12 +833,14 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
 }
 #endif /* !MBEDTLS_AES_DECRYPT_ALT */
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
                           const unsigned char input[16],
                           unsigned char output[16] )
 {
     mbedtls_internal_aes_decrypt( ctx, input, output );
 }
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /*
  * AES-ECB block encryption/decryption


### PR DESCRIPTION
Add missing `MBEDTLS_DEPRECATED_REMOVED` guards around the definitions
of `mbedtls_aes_decrypt` and `mbedtls_aes_encrypt`.
This fixes the build under `-Wmissing-prototypes -Werror`.

Fixes #1388

This is just the first commit of #1390, with only the bug fix and not the additional test for which rework is needed.

Needs to be merged into 2.7 and development (does not apply to 2.1).