### PR TITLE
Backport 2.7: IOTSSL-1878 buffer overflow in server psk hint parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,8 @@ Security
    * Change default choice of DHE parameters from untrustworthy RFC 5114
      to RFC 3526 containing parameters generated in a nothing-up-my-sleeve
      manner.
+   * Fix a buffer overread in ssl_parse_server_psk_hint() that could cause a
+     crash on invalid input.
 
 Features
    * Allow comments in test data files.
@@ -180,6 +182,8 @@ Bugfix
    * In mbedtls_entropy_free(), properly free the message digest context.
    * Fix status handshake status message in programs/ssl/dtls_client.c. Found
      and fixed by muddog.
+   * Fix a possible arithmetic overflow in ssl_parse_server_psk_hint() that
+     could cause a key exchange to fail on valid data.
 
 Changes
    * Extend cert_write example program by options to set the certificate version

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2057,6 +2057,12 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
      *
      * opaque psk_identity_hint<0..2^16-1>;
      */
+    if( (*p) > end - 2 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
+                                    "(psk_identity_hint length)" ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+    }
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2066,7 +2066,7 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 
-    if( (*p) + len > end )
+    if( (*p) > end - len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
                                     "(psk_identity_hint length)" ) );


### PR DESCRIPTION
Backport of #1440 to 2.7