### PR TITLE
Backport 2.1: IOTSSL-1878 buffer overflow in server psk hint parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -446,6 +446,10 @@ Changes
 
 = mbed TLS 2.1.0 released 2015-09-04
 
+Security
+   * Fix a buffer overread in ssl_parse_server_psk_hint() that could cause a
+     crash on invalid input.
+
 Features
    * Added support for yotta as a build system.
    * Primary open source license changed to Apache 2.0 license.
@@ -481,6 +485,8 @@ Bugfix
    * Fix unused function warning when using MBEDTLS_MDx_ALT or
      MBEDTLS_SHAxxx_ALT (found by Henrik) (#239)
    * Fix memory corruption in pkey programs (found by yankuncheng) (#210)
+   * Fix a possible arithmetic overflow in ssl_parse_server_psk_hint() that
+     could cause a key exchange to fail on valid data.
 
 Changes
    * The PEM parser now accepts a trailing space at end of lines (#226).

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1850,6 +1850,12 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
      *
      * opaque psk_identity_hint<0..2^16-1>;
      */
+    if( (*p) > end - 2 )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
+                                    "(psk_identity_hint length)" ) );
+        return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+    }
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1859,7 +1859,7 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 
-    if( (*p) + len > end )
+    if( (*p) > end -len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
                                     "(psk_identity_hint length)" ) );


### PR DESCRIPTION
Backport of #1440 to 2.1