### PR TITLE
Backport 2.7: IOTSSL-1879 buffer overflow in server key exchange parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,8 @@ Security
    * Change default choice of DHE parameters from untrustworthy RFC 5114
      to RFC 3526 containing parameters generated in a nothing-up-my-sleeve
      manner.
+   * Fix a buffer overread in ssl_parse_server_key_exchange() that could cause
+     a crash on invalid input.
 
 Features
    * Allow comments in test data files.
@@ -180,6 +182,8 @@ Bugfix
    * In mbedtls_entropy_free(), properly free the message digest context.
    * Fix status handshake status message in programs/ssl/dtls_client.c. Found
      and fixed by muddog.
+   * Fix a possible arithmetic overflow in ssl_parse_server_key_exchange()
+     that could cause a key exchange to fail on valid data.
 
 Changes
    * Extend cert_write example program by options to set the certificate version

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2478,6 +2478,13 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         /*
          * Read signature
          */
+        if( p > end - 2 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
+            mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                            MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
+            return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+        }
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2488,7 +2488,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 
-        if( end != p + sig_len )
+        if( p != end - sig_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,


### PR DESCRIPTION
Backport of #1439 to 2.7