### PR TITLE
Backport 2.1: IOTSSL-1879 buffer overflow in server key exchange parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -446,6 +446,10 @@ Changes
 
 = mbed TLS 2.1.0 released 2015-09-04
 
+Security
+   * Fix a buffer overread in ssl_parse_server_key_exchange() that could cause
+     a crash on invalid input.
+
 Features
    * Added support for yotta as a build system.
    * Primary open source license changed to Apache 2.0 license.
@@ -481,6 +485,8 @@ Bugfix
    * Fix unused function warning when using MBEDTLS_MDx_ALT or
      MBEDTLS_SHAxxx_ALT (found by Henrik) (#239)
    * Fix memory corruption in pkey programs (found by yankuncheng) (#210)
+   * Fix a possible arithmetic overflow in ssl_parse_server_key_exchange()
+     that could cause a key exchange to fail on valid data.
 
 Changes
    * The PEM parser now accepts a trailing space at end of lines (#226).

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2246,7 +2246,7 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 
-        if( end != p + sig_len )
+        if( p != end - sig_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2236,6 +2236,13 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         /*
          * Read signature
          */
+        if( p > end - 2 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
+            mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                            MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
+            return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
+        }
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 


### PR DESCRIPTION
Backport of #1439 to 2.1