### PR TITLE
Backport 2.1: Write correct number of ciphersuites in log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
-mbed TLS ChangeLog (Sorted per branch, date)
+﻿mbed TLS ChangeLog (Sorted per branch, date)
+
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Log correct number of ciphersuites used in Client Hello message. Fix for #918.
 
 = mbed TLS 2.1.11 branch released xxxx-xx-xx
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -811,6 +811,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
+	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, got %d ciphersuites", n));
+
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
      */
@@ -836,8 +838,6 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
 
     *q++ = (unsigned char)( n >> 7 );
     *q++ = (unsigned char)( n << 1 );
-
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites", n ) );
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     offer_compress = 1;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -811,7 +811,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
-	MBEDTLS_SSL_DEBUG_MSG(3, ("client hello, got %d ciphersuites", n));
+	MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
 
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
@@ -820,6 +820,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     if( ssl->renego_status == MBEDTLS_SSL_INITIAL_HANDSHAKE )
 #endif
     {
+		MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO >> 8 );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO      );
         n++;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -811,7 +811,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         *p++ = (unsigned char)( ciphersuites[i]      );
     }
 
-	MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, got %d ciphersuites (excluding SCSVs)", n ) );
 
     /*
      * Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV
@@ -820,7 +820,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     if( ssl->renego_status == MBEDTLS_SSL_INITIAL_HANDSHAKE )
 #endif
     {
-		MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO >> 8 );
         *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO      );
         n++;


### PR DESCRIPTION
Change location of log, to fit the correct number of used ciphersuites
Fixes #918

Backport of #1064