### PR TITLE
Backport 2.7: Add clarity to use of the rsa_internal.h interface

### DIFF
--- a/include/mbedtls/rsa_internal.h
+++ b/include/mbedtls/rsa_internal.h
@@ -2,6 +2,37 @@
  * \file rsa_internal.h
  *
  * \brief Context-independent RSA helper functions
+ *
+ *  This module declares some RSA-related helper functions useful when
+ *  implementing the RSA interface. These functions are provided in a separate
+ *  compilation unit in order to make it easy for designers of alternative RSA
+ *  implementations to use them in their own code, as it is conceived that the
+ *  functionality they provide will be necessary for most complete
+ *  implementations.
+ *
+ *  End-users of Mbed TLS who are not providing their own alternative RSA
+ *  implementations should not use these functions directly, and should instead
+ *  use only the functions declared in rsa.h.
+ *
+ *  The interface provided by this module will be maintained through LTS (Long
+ *  Term Support) branches of Mbed TLS, but may otherwise be subject to change,
+ *  and must be considered an internal interface of the library.
+ *
+ *  There are two classes of helper functions:
+ *
+ *  (1) Parameter-generating helpers. These are:
+ *      - mbedtls_rsa_deduce_primes
+ *      - mbedtls_rsa_deduce_private_exponent
+ *      - mbedtls_rsa_deduce_crt
+ *       Each of these functions takes a set of core RSA parameters and
+ *       generates some other, or CRT related parameters.
+ *
+ *  (2) Parameter-checking helpers. These are:
+ *      - mbedtls_rsa_validate_params
+ *      - mbedtls_rsa_validate_crt
+ *      They take a set of core or CRT related RSA parameters and check their
+ *      validity.
+ *
  */
 /*
  *  Copyright (C) 2006-2017, ARM Limited, All Rights Reserved
@@ -20,31 +51,6 @@
  *  limitations under the License.
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
- *
- *
- *  This file declares some RSA-related helper functions useful when
- *  implementing the RSA interface. They are public and provided in a
- *  separate compilation unit in order to make it easy for designers of
- *  alternative RSA implementations to use them in their code, as it is
- *  conceived that the functionality they provide will be necessary
- *  for most complete implementations.
- *
- *  End-users of Mbed TLS not intending to re-implement the RSA functionality
- *  are not expected to get into the need of making use of these functions directly,
- *  but instead should be able to use the functions declared in rsa.h.
- *
- *  There are two classes of helper functions:
- *  (1) Parameter-generating helpers. These are:
- *      - mbedtls_rsa_deduce_primes
- *      - mbedtls_rsa_deduce_private_exponent
- *      - mbedtls_rsa_deduce_crt
- *       Each of these functions takes a set of core RSA parameters
- *       and generates some other, or CRT related parameters.
- *  (2) Parameter-checking helpers. These are:
- *      - mbedtls_rsa_validate_params
- *      - mbedtls_rsa_validate_crt
- *      They take a set of core or CRT related RSA parameters
- *      and check their validity.
  *
  */
 


### PR DESCRIPTION
## Description
Added additional clarification to the use of the rsa_internal.h interface and as and when it can be used by whom. The policy hasn't changed, but it needed to be clearer who can and can't use it and the level of support for the interface by the project.

## Status
**READY**

## Requires Backporting
This is the backport.

## Migrations
NO
