### PR TITLE
Refactor config.pl to make it easier to add presets

### DIFF
--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -12,8 +12,8 @@
 # are set in the 'config.h' file.
 #
 # Usage: config.pl [-f <file> | --file <file>] [-o | --force]
-#                   [set <symbol> <value> | unset <symbol> | get <symbol> |
-#                       full | realfull]
+#                  { set <symbol> <value> | unset <symbol> | get <symbol> |
+#                    full | realfull | baremetal }
 #
 # Full usage description provided below.
 #
@@ -115,8 +115,11 @@ MBEDTLS_PLATFORM_FPRINTF_ALT
 );
 
 # Things that should be enabled in "full" even if they match @excluded
+# These are all the platform ALT definitions, so that we test them in "full",
+# except MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT which requires a platform_alt.h
+# that we do not provide.
 my @non_excluded = qw(
-PLATFORM_[A-Z0-9]+_ALT
+MBEDTLS_PLATFORM_(?!SETUP_TEARDOWN)\w+_ALT
 );
 
 # Things that should be enabled in "baremetal"

--- a/tests/scripts/test-config-script.pl
+++ b/tests/scripts/test-config-script.pl
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+use warnings;
+use strict;
+use File::Basename;
+use File::Copy;
+use Getopt::Std;
+
+sub detect_root {
+    foreach my $dir ('.', '..', '../..',
+                     dirname($0) . '/../..') {
+        if (-d 'include/mbedtls' && -d 'scripts') {
+            return $dir;
+        }
+    }
+    die "Could not find the Mbed TLS root directory.\n";
+}
+
+sub detect_presets {
+    my ($script) = @_;
+    my @presets = ();
+    foreach my $line (`$script 2>&1`) {
+        if ($line =~ /^ +(\w(-|\w)*) + - /) {
+            push @presets, $1;
+        }
+    }
+    return @presets;
+}
+
+sub generate_configs {
+    my ($script, $input_file, $output_directory, @presets) = @_;
+    print STDERR "script=$script input=$input_file outdir=$output_directory presets=@presets\n";
+    my $fh;
+    foreach my $preset (@presets) {
+        my $tmp_file = "$output_directory/config-$preset.tmp";
+        my $output_file = "$output_directory/config-$preset.h";
+        copy($input_file, $tmp_file)
+          or die "copy($input_file, $tmp_file): $!";
+        system($script, '-f', $tmp_file, $preset)
+          and die "$script -f $tmp_file $preset: $?";
+        rename($tmp_file, $output_file)
+          or die "rename($tmp_file, $output_file): $!";
+    }
+}
+
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
+sub HELP_MESSAGE {
+    my ($fh, $package, $version, $switches) = @_;
+    print $fh <<EOF
+$0 [OPTION]... [PRESETS]
+Run config.pl for PRESETS. With no positional arguments, automatically
+detect the presets that config.pl supports.
+
+This can be used to test changes in config.pl: compare the output of
+this script before and after making the change.
+
+  -c INPUT      Config file to process (default: include/mbedtls/config.h from root)
+  -d DIR        Output directory (default: current directory)
+  -r DIR        Root of the Mbed TLS tree (default: autodetect)
+  -s SCRIPT     Script to run (default: scripts/config.pl from root)
+EOF
+}
+
+sub main {
+    my %options;
+    getopts('c:d:r:s:', \%options) or exit(3);
+    my $root = $options{r};
+    if (!defined $root && !(exists $options{c} &&
+                            exists $options{s})) {
+        $root = detect_root();
+    }
+    my $input_file = $options{c};
+    $input_file = "$root/include/mbedtls/config.h" if !defined $input_file;
+    my $script = $options{s};
+    $script = "$root/scripts/config.pl" if !defined $script;
+    my $output_directory = $options{d};
+    $output_directory = "." if !defined $output_directory;
+    my @presets = @ARGV ? @ARGV : detect_presets($script);
+    generate_configs($script, $input_file, $output_directory, @presets);
+}
+
+main;


### PR DESCRIPTION
This PR changes `scripts/config.pl`:

* New preset `crypto_all`, which is what I set out to do.
* Refactor the code to make it easier to add presets.
* New script `tests/scripts/test-config-script.pl` which can be used to see how changes to `config.pl` change its output.
* Enable `MBEDTLS_PLATFORM_NV_SEED_ALT` in the full configuration.

This should be backported to make the config scripts uniform, I'll do that once the reviews are in.
