### PR TITLE
Fix dynamic library builds for Mac OS X

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix dynamic library building process with Makefile on Mac OS X. Fixed by
+     mnacamura.
+
 = mbed TLS 2.7.0 branch released 2018-02-03
 
 Security

--- a/library/Makefile
+++ b/library/Makefile
@@ -103,9 +103,9 @@ libmbedtls.so: libmbedtls.$(SOEXT_TLS)
 	echo "  LN    $@ -> $<"
 	ln -sf $< $@
 
-libmbedtls.dylib: $(OBJS_TLS)
+libmbedtls.dylib: $(OBJS_TLS) libmbedx509.dylib
 	echo "  LD    $@"
-	$(CC) -dynamiclib $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
+	$(CC) -dynamiclib -L. -lmbedcrypto -lmbedx509 $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_TLS)
 
 libmbedtls.dll: $(OBJS_TLS) libmbedx509.dll
 	echo "  LD    $@"
@@ -126,9 +126,9 @@ libmbedx509.so: libmbedx509.$(SOEXT_X509)
 	echo "  LN    $@ -> $<"
 	ln -sf $< $@
 
-libmbedx509.dylib: $(OBJS_X509)
+libmbedx509.dylib: $(OBJS_X509) libmbedcrypto.dylib
 	echo "  LD    $@"
-	$(CC) -dynamiclib $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
+	$(CC) -dynamiclib -L. -lmbedcrypto  $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@ $(OBJS_X509)
 
 libmbedx509.dll: $(OBJS_X509) libmbedcrypto.dll
 	echo "  LD    $@"


### PR DESCRIPTION
## Description
This PR is the same as https://github.com/ARMmbed/mbedtls/pull/1383 but adds a ChangeLog entry.
Note that this PR fixes the immediate problem which is that the Makefile does not build a dynamic library for Mbed TLS in Mac OS X, but I have created the ticket https://github.com/ARMmbed/mbedtls/issues/1466 as the DLEXT cannot be set to `dylib` without editing the Makefile.

## Status
**READY**

## Requires Backporting
Yes
Which branch?
mbedlts-2.1: https://github.com/ARMmbed/mbedtls/pull/1469
mbedtls-2.7: https://github.com/ARMmbed/mbedtls/pull/1468

## Steps to test or reproduce
To test this you need a Mac OS X system and then run:
```
SHARED=1 make -C library
```
However, note that the Makefile must be edited to set `DLEXT=dylib`