### PR TITLE
Backport 2.7: Avoid defining and initialising global mutexes when not needed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,9 @@ Bugfix
 
 Changes
    * Clarify the documentation of mbedtls_ssl_setup.
+   * Do not define global mutexes around readdir() and gmtime() in
+     configurations where the feature is disabled. Found and fixed by Gergely
+     Budai.
 
 = mbed TLS 2.7.1 branch released 2018-02-23
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -96,8 +96,12 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 /*
  * Global mutexes
  */
+#if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
+#endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/library/threading.c
+++ b/library/threading.c
@@ -111,8 +111,12 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
     mbedtls_mutex_lock = mutex_lock;
     mbedtls_mutex_unlock = mutex_unlock;
 
+#if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
+#endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
     mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
+#endif
 }
 
 /*
@@ -120,8 +124,12 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
  */
 void mbedtls_threading_free_alt( void )
 {
+#if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
+#endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
     mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
+#endif
 }
 #endif /* MBEDTLS_THREADING_ALT */
 
@@ -131,7 +139,11 @@ void mbedtls_threading_free_alt( void )
 #ifndef MUTEX_INIT
 #define MUTEX_INIT
 #endif
+#if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
+#endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
+#endif
 
 #endif /* MBEDTLS_THREADING_C */


### PR DESCRIPTION
## Description
This is a backport for https://github.com/ARMmbed/mbedtls/pull/1477 to Mbed TLS 2.7. Please refer to that PR for details.

## Status
**READY**