### PR TITLE
Expose ClientHello random bytes for external ssl decoding tools.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -650,6 +650,9 @@ struct mbedtls_ssl_config
     int (*f_export_keys)( void *, const unsigned char *,
             const unsigned char *, size_t, size_t, size_t );
     void *p_export_keys;            /*!< context for key export callback    */
+    /** Callback to ClientHello random bytes                                */
+    int (*f_export_ch)( void *, const unsigned char * );
+    void *p_export_ch;            /*!< context for ClientHello callback     */
 #endif
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -1230,6 +1233,19 @@ typedef int mbedtls_ssl_export_keys_t( void *p_expkey,
                                 size_t maclen,
                                 size_t keylen,
                                 size_t ivlen );
+/**
+ * \brief           Callback type: Export ClientHello random bytes
+ *
+ * \note            This information is required for decrypting SSL with external tools.
+ *
+ * \param p_expkey  Context for the callback
+ * \param bytes     ClientHello random bytes (fixed length: 32 bytes)
+ *
+ * \return          0 if successful, or
+ *                  a specific MBEDTLS_ERR_XXX code.
+ */
+typedef int mbedtls_ssl_export_clienthello_t( void *p_expkey,
+                                              const unsigned char *bytes );
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 /**
@@ -1295,6 +1311,19 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
 void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_export_keys_t *f_export_keys,
         void *p_export_keys );
+/**
+ * \brief           Configure ClientHello export callback.
+ *                  (Default: none.)
+ *
+ * \note            See \c mbedtls_ssl_export_clienthello_t.
+ *
+ * \param conf      SSL configuration context
+ * \param f_export_ch     Callback for exporting ClientHello
+ * \param p_export_ch     Context for the callback
+ */
+void mbedtls_ssl_conf_export_ch_cb( mbedtls_ssl_config *conf,
+        mbedtls_ssl_export_clienthello_t *f_export_ch,
+        void *p_export_ch );
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 
 /**

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -777,6 +777,13 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, random bytes", p, 32 );
     p += 32;
 
+#if defined(MBEDTLS_SSL_EXPORT_KEYS)
+    if( ssl->conf->f_export_ch != NULL )
+    {
+        ssl->conf->f_export_ch( ssl->conf->p_export_ch, ssl->handshake->randbytes );
+    }
+#endif
+
     /*
      *    38  .  38   session id length
      *    39  . 39+n  session id

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6475,6 +6475,13 @@ void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
     conf->f_export_keys = f_export_keys;
     conf->p_export_keys = p_export_keys;
 }
+void mbedtls_ssl_conf_export_ch_cb( mbedtls_ssl_config *conf,
+        mbedtls_ssl_export_clienthello_t *f_export_ch,
+        void *p_export_ch )
+{
+    conf->f_export_ch = f_export_ch;
+    conf->p_export_ch = p_export_ch;
+}
 #endif
 
 /*


### PR DESCRIPTION

## Description
To be able to decrypt SSL/TLS with Wireshark and other tools there is a common approach with using NSS Key Log file (see https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format and https://support.citrix.com/article/CTX116557 ), this file contains ClientHello random bytes and Master Key. Currently it is only possible to get Master Key though a callback. This PR introduces ability to extract ClientHello random bytes.

## Status
READY

## Requires Backporting
NO  

## Migrations
NO
