### PR TITLE
Backport 2.7: Separate psk and psk_identity buffers free

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,10 @@ Bugfix
      overflow. #1179
    * Fix memory allocation corner cases in memory_buffer_alloc.c module. Found
      by Guido Vranken. #639
+   * Fix possible memory leak in mbedtls_ssl_config_free().
+     This can occur only if the user doesn't use mbedtls_ssl_conf_psk() and
+     instead incorrectly manipulates conf->psk and/or conf->psk_identity
+     directly. Found and fix submitted by junyeonLEE in #1220.
 
 Changes
    * Clarify the documentation of mbedtls_ssl_setup.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7741,10 +7741,16 @@ void mbedtls_ssl_config_free( mbedtls_ssl_config *conf )
     if( conf->psk != NULL )
     {
         mbedtls_zeroize( conf->psk, conf->psk_len );
-        mbedtls_zeroize( conf->psk_identity, conf->psk_identity_len );
         mbedtls_free( conf->psk );
-        mbedtls_free( conf->psk_identity );
+        conf->psk = NULL;
         conf->psk_len = 0;
+    }
+
+    if( conf->psk_identity != NULL )
+    {
+        mbedtls_zeroize( conf->psk_identity, conf->psk_identity_len );
+        mbedtls_free( conf->psk_identity );
+        conf->psk_identity = NULL;
         conf->psk_identity_len = 0;
     }
 #endif


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/1474