### PR TITLE
Backport 2.7: benchmark: Fix incompatibility with C89 compilers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -73,6 +73,8 @@ Bugfix
      In the context of SSL, this resulted in handshake failure. Reported by
      daniel in the Mbed TLS forum. #1351
    * Fix Windows x64 builds with the included mbedTLS.sln file. #1347
+   * Fix C89 incompatibility in benchmark.c. Contributed by Brendan Shanks.
+     #1353
 
 Changes
    * Fix tag lengths and value ranges in the documentation of CCM encryption.

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -658,13 +658,13 @@ int main( int argc, char *argv[] )
     if( todo.dhm )
     {
         int dhm_sizes[] = { 2048, 3072 };
-        const unsigned char dhm_P_2048[] =
+        static const unsigned char dhm_P_2048[] =
             MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN;
-        const unsigned char dhm_P_3072[] =
+        static const unsigned char dhm_P_3072[] =
             MBEDTLS_DHM_RFC3526_MODP_3072_P_BIN;
-        const unsigned char dhm_G_2048[] =
+        static const unsigned char dhm_G_2048[] =
             MBEDTLS_DHM_RFC3526_MODP_2048_G_BIN;
-        const unsigned char dhm_G_3072[] =
+        static const unsigned char dhm_G_3072[] =
             MBEDTLS_DHM_RFC3526_MODP_3072_G_BIN;
 
         const unsigned char *dhm_P[] = { dhm_P_2048, dhm_P_3072 };


### PR DESCRIPTION
Backport of #1435 to Mbed TLS 2.7