### PR TITLE
Backport 2.7: Add AR_DASH and make DLEXT variable configurable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,10 +9,11 @@ Bugfix
 Changes
    * Support cmake build where Mbed TLS is a subproject. Fix
      contributed independently by Matthieu Volat and Arne Schwabe.
-   * Allow configuring the prefix operator for the archiver tool when compiling
-     the library using the makefile. Found and fixed by Alex Hixon.
+   * Add an option in the makefile to support ar utilities where the operation
+     letter must not be prefixed by '-', such as LLVM. Found and fixed by
+     Alex Hixon.
    * Allow configuring the shared library extension by setting the DLEXT
-     variable when using the project makefile.
+     environment variable when using the project makefiles.
 
 = mbed TLS 2.7.2 branch released 2018-03-16
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Bugfix
 Changes
    * Support cmake build where Mbed TLS is a subproject. Fix
      contributed independently by Matthieu Volat and Arne Schwabe.
+   * Allow configuring the prefix operator for the archiver tool when compiling
+     the library using the makefile. Found and fixed by Alex Hixon.
+   * Allow configuring the shared library extension by setting the DLEXT
+     variable when using the project makefile.
 
 = mbed TLS 2.7.2 branch released 2018-03-16
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -38,6 +38,10 @@ SOEXT_CRYPTO=so.2
 # Set DLEXT=dylib to compile as a shared library for Mac OS X
 DLEXT ?= so
 
+# Set AR_DASH= (empty string) to use an ar implentation that does not accept
+# the - prefix for command line options (e.g. llvm-ar)
+AR_DASH ?= -
+
 # Windows shared library extension:
 ifdef WINDOWS_BUILD
 DLEXT=dll
@@ -90,9 +94,9 @@ shared: libmbedcrypto.$(DLEXT) libmbedx509.$(DLEXT) libmbedtls.$(DLEXT)
 # tls
 libmbedtls.a: $(OBJS_TLS)
 	echo "  AR    $@"
-	$(AR) -rc $@ $(OBJS_TLS)
+	$(AR) $(AR_DASH)rc $@ $(OBJS_TLS)
 	echo "  RL    $@"
-	$(AR) -s $@
+	$(AR) $(AR_DASH)s $@
 
 libmbedtls.$(SOEXT_TLS): $(OBJS_TLS) libmbedx509.so
 	echo "  LD    $@"
@@ -113,9 +117,9 @@ libmbedtls.dll: $(OBJS_TLS) libmbedx509.dll
 # x509
 libmbedx509.a: $(OBJS_X509)
 	echo "  AR    $@"
-	$(AR) -rc $@ $(OBJS_X509)
+	$(AR) $(AR_DASH)rc $@ $(OBJS_X509)
 	echo "  RL    $@"
-	$(AR) -s $@
+	$(AR) $(AR_DASH)s $@
 
 libmbedx509.$(SOEXT_X509): $(OBJS_X509) libmbedcrypto.so
 	echo "  LD    $@"
@@ -136,9 +140,9 @@ libmbedx509.dll: $(OBJS_X509) libmbedcrypto.dll
 # crypto
 libmbedcrypto.a: $(OBJS_CRYPTO)
 	echo "  AR    $@"
-	$(AR) -rc $@ $(OBJS_CRYPTO)
+	$(AR) $(AR_DASH)rc $@ $(OBJS_CRYPTO)
 	echo "  RL    $@"
-	$(AR) -s $@
+	$(AR) $(AR_DASH)s $@
 
 libmbedcrypto.$(SOEXT_CRYPTO): $(OBJS_CRYPTO)
 	echo "  LD    $@"

--- a/library/Makefile
+++ b/library/Makefile
@@ -35,9 +35,8 @@ SOEXT_TLS=so.10
 SOEXT_X509=so.0
 SOEXT_CRYPTO=so.2
 
-DLEXT=so
-# OSX shared library extension:
-# DLEXT=dylib
+# Set DLEXT=dylib to compile as a shared library for Mac OS X
+DLEXT ?= so
 
 # Windows shared library extension:
 ifdef WINDOWS_BUILD

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -35,7 +35,7 @@ ifdef SHARED
 SHARED_SUFFIX=.$(DLEXT)
 endif
 else
-DLEXT=so
+DLEXT ?= so
 EXEXT=
 SHARED_SUFFIX=
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,7 +35,7 @@ ifdef SHARED
 SHARED_SUFFIX=.$(DLEXT)
 endif
 else
-DLEXT=so
+DLEXT ?= so
 EXEXT=
 SHARED_SUFFIX=
 endif

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -41,6 +41,7 @@ die "$0: no test suite found\n" unless @suites;
 
 # in case test suites are linked dynamically
 $ENV{'LD_LIBRARY_PATH'} = '../library';
+$ENV{'DYLD_LIBRARY_PATH'} = '../library';
 
 my $prefix = $^O eq "MSWin32" ? '' : './';
 


### PR DESCRIPTION
## Description
This PR is a backport of https://github.com/ARMmbed/mbedtls/pull/1499 to Mbed TLS 2.7. Please refer to that PR for details.

## Status
**READY**