### PR TITLE
Backport 2.7: Fix for returning correct error code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Bugfix
    * Fix spurious uninitialized variable warning in cmac.c. Fix independently
      contributed by Brian J Murray and David Brown.
+   * Fix overriding and ignoring return values when parsing and writing to
+     a file in pk_sign program. Found by kevlut in #1142.
 
 Changes
    * Support cmake build where Mbed TLS is a subproject. Fix

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -168,7 +168,7 @@ exit:
     fflush( stdout ); getchar();
 #endif
 
-    return( ret );
+    return( ret ? EXIT_FAILURE : EXIT_SUCCESS );
 }
 #endif /* MBEDTLS_BIGNUM_C && MBEDTLS_ENTROPY_C &&
           MBEDTLS_SHA256_C && MBEDTLS_PK_PARSE_C && MBEDTLS_FS_IO &&

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -29,6 +29,7 @@
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
+#include <stdlib.h>
 #define mbedtls_snprintf   snprintf
 #define mbedtls_printf     printf
 #endif

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -100,8 +100,7 @@ int main( int argc, char *argv[] )
 
     if( ( ret = mbedtls_pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
-        ret = 1;
-        mbedtls_printf( " failed\n  ! Could not open '%s'\n", argv[1] );
+        mbedtls_printf( " failed\n  ! Could not parse '%s'\n", argv[1] );
         goto exit;
     }
 
@@ -141,6 +140,7 @@ int main( int argc, char *argv[] )
 
     if( fwrite( buf, 1, olen, f ) != olen )
     {
+        ret = 1;
         mbedtls_printf( "failed\n  ! fwrite failed\n\n" );
         fclose( f );
         goto exit;


### PR DESCRIPTION
This PR is a backport of #1142 to Mbed TLS 2.7. Please refer to that PR for details.