### PR TITLE
Improve mbedtls_zeroize() implementation

### DIFF
--- a/include/mbedtls/zeromem.h
+++ b/include/mbedtls/zeromem.h
@@ -2,5 +2,5 @@
 #ifdef _MSC_VER
 #define mbedtls_zeroize RtlSecureZeroMemory
 #else
-static void mbedtls_zeroize( void *v, size_t n );
+void mbedtls_zeroize( void *v, size_t n );
 #endif 

--- a/include/mbedtls/zeromem.h
+++ b/include/mbedtls/zeromem.h
@@ -1,0 +1,6 @@
+ /* Implementation that should never be optimized out by the compiler */
+#ifdef _MSC_VER
+#define mbedtls_zeroize RtlSecureZeroMemory
+#else
+static void mbedtls_zeroize( void *v, size_t n );
+#endif 

--- a/include/mbedtls/zeromem.h
+++ b/include/mbedtls/zeromem.h
@@ -2,5 +2,6 @@
 #ifdef _MSC_VER
 #define mbedtls_zeroize RtlSecureZeroMemory
 #else
+#include <stddef.h> 
 void mbedtls_zeroize( void *v, size_t n );
 #endif 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -57,6 +57,7 @@ set(src_crypto
     version.c
     version_features.c
     xtea.c
+    zeromem.c
 )
 
 set(src_x509

--- a/library/Makefile
+++ b/library/Makefile
@@ -62,7 +62,7 @@ OBJS_CRYPTO=	aes.o		aesni.o		arc4.o		\
 		ripemd160.o	rsa_internal.o	rsa.o  		\
 		sha1.o		sha256.o	sha512.o	\
 		threading.o	timing.o	version.o	\
-		version_features.o		xtea.o
+		version_features.o		xtea.o		zeromem.o
 
 OBJS_X509=	certs.o		pkcs11.o	x509.o		\
 		x509_create.o	x509_crl.o	x509_crt.o	\

--- a/library/aes.c
+++ b/library/aes.c
@@ -54,10 +54,7 @@
 
 #if !defined(MBEDTLS_AES_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (little endian)

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -47,10 +47,7 @@
 
 #if !defined(MBEDTLS_ARC4_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx )
 {

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -43,10 +43,7 @@
 #define mbedtls_free       free
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * ASN.1 DER decoding routines

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -58,19 +58,17 @@
 #define mbedtls_free       free
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_mpi_zeroize( mbedtls_mpi_uint *v, size_t n ) {
-    volatile mbedtls_mpi_uint *p = v; while( n-- ) *p++ = 0;
-}
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
-
 #define ciL    (sizeof(mbedtls_mpi_uint))         /* chars in limb  */
 #define biL    (ciL << 3)               /* bits  in limb  */
 #define biH    (ciL << 2)               /* half limb size */
+
+#include "mbedtls/zeromem.h"
+
+ /* Implementation that should never be optimized out by the compiler */
+static void mbedtls_mpi_zeroize(mbedtls_mpi_uint *v, size_t n)
+{
+	mbedtls_zeroize(v, ciL * n);
+}
 
 #define MPI_SIZE_T_MAX  ( (size_t) -1 ) /* SIZE_T_MAX is not standard */
 

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -39,10 +39,7 @@
 
 #if !defined(MBEDTLS_BLOWFISH_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -48,10 +48,7 @@
 
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -51,10 +51,7 @@
 
 #if !defined(MBEDTLS_CCM_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 #define CCM_ENCRYPT 0
 #define CCM_DECRYPT 1

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -60,10 +60,7 @@
 #define MBEDTLS_CIPHER_MODE_STREAM
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 static int supported_init = 0;
 

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -67,10 +67,7 @@
 
 #if !defined(MBEDTLS_CMAC_ALT) || defined(MBEDTLS_SELF_TEST)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Multiplication by u in the Galois field of GF(2^n)

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -49,10 +49,7 @@
 #endif /* MBEDTLS_PLATFORM_C */
 #endif /* MBEDTLS_SELF_TEST */
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * CTR_DRBG context initialization

--- a/library/des.c
+++ b/library/des.c
@@ -48,10 +48,7 @@
 
 #if !defined(MBEDTLS_DES_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -58,10 +58,7 @@
 #endif
 
 #if !defined(MBEDTLS_DHM_ALT)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * helper to validate the mbedtls_mpi size and import it

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -301,7 +301,7 @@ cleanup:
  */
 static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
                               const mbedtls_ecp_group *grp,
-                              const int pf, 
+                              const int pf,
                               const mbedtls_ecp_point *G,
                               const mbedtls_mpi *x,
                               const mbedtls_ecp_point *X,

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -72,10 +72,7 @@
 #define inline __inline
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 #if defined(MBEDTLS_SELF_TEST)
 /*

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -59,10 +59,7 @@
 #include "mbedtls/havege.h"
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 #define ENTROPY_MAX_LOOP    256     /**< Maximum amount to loop before error */
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -44,7 +44,7 @@
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__)
+    !defined(__APPLE__) && !defined(_WIN32)
 #error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in config.h"
 #endif
 

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -80,10 +80,7 @@
 }
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Initialize a context

--- a/library/havege.c
+++ b/library/havege.c
@@ -39,10 +39,7 @@
 
 #include <string.h>
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /* ------------------------------------------------------------------------
  * On average, one iteration accesses two 8-word blocks in the havege WALK

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -50,10 +50,7 @@
 #endif /* MBEDTLS_SELF_TEST */
 #endif /* MBEDTLS_PLATFORM_C */
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * HMAC_DRBG context initialization

--- a/library/md.c
+++ b/library/md.c
@@ -48,10 +48,7 @@
 #include <stdio.h>
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Reminder: update profiles in x509_crt.c when adding a new hash!

--- a/library/md2.c
+++ b/library/md2.c
@@ -48,10 +48,7 @@
 
 #if !defined(MBEDTLS_MD2_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 static const unsigned char PI_SUBST[256] =
 {

--- a/library/md4.c
+++ b/library/md4.c
@@ -48,10 +48,7 @@
 
 #if !defined(MBEDTLS_MD4_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (little endian)

--- a/library/md5.c
+++ b/library/md5.c
@@ -47,10 +47,7 @@
 
 #if !defined(MBEDTLS_MD5_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (little endian)

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -42,10 +42,7 @@
 #include "mbedtls/threading.h"
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 #define MAGIC1       0xFF00AA55
 #define MAGIC2       0xEE119966

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -28,7 +28,7 @@
 #if defined(MBEDTLS_NET_C)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__)
+    !defined(__APPLE__) && !defined(_WIN32)
 #error "This module only works on Unix and Windows, see MBEDTLS_NET_C in config.h"
 #endif
 
@@ -271,7 +271,7 @@ static int net_would_block( const mbedtls_net_context *ctx )
 static int net_would_block( const mbedtls_net_context *ctx )
 {
     int err = errno;
-    
+
     /*
      * Never return 'WOULD BLOCK' on a non-blocking socket
      */

--- a/library/pem.c
+++ b/library/pem.c
@@ -45,10 +45,7 @@
 #endif
 
 #if defined(MBEDTLS_PEM_PARSE_C)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 void mbedtls_pem_init( mbedtls_pem_context *ctx )
 {

--- a/library/pk.c
+++ b/library/pk.c
@@ -42,10 +42,7 @@
 #include <limits.h>
 #include <stdint.h>
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Initialise a mbedtls_pk_context

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -53,10 +53,7 @@
 #include <stdint.h>
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 #endif
 
 #if defined(MBEDTLS_RSA_C)

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -47,10 +47,7 @@
 #include "mbedtls/des.h"
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 static int pkcs12_parse_pbe_params( mbedtls_asn1_buf *params,
                                     mbedtls_asn1_buf *salt, int *iterations )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -62,10 +62,7 @@
 
 #if defined(MBEDTLS_FS_IO) || \
     defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 #endif
 
 #if defined(MBEDTLS_FS_IO)

--- a/library/platform.c
+++ b/library/platform.c
@@ -31,10 +31,7 @@
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED) && \
     !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS) && defined(MBEDTLS_FS_IO)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_MEMORY)

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -71,10 +71,7 @@
 }
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx )
 {

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -70,10 +70,7 @@
 
 #if !defined(MBEDTLS_RSA_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 #if defined(MBEDTLS_PKCS1_V15)
 /* constant-time buffer comparison */

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -47,10 +47,7 @@
 
 #if !defined(MBEDTLS_SHA1_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -50,10 +50,7 @@
 
 #if !defined(MBEDTLS_SHA256_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -56,10 +56,7 @@
 
 #if !defined(MBEDTLS_SHA512_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 64-bit integer manipulation macros (big endian)

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -48,10 +48,7 @@
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 #endif
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -355,7 +352,7 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     *olen = 6;
 }
-#endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C || 
+#endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C ||
           MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
@@ -1261,7 +1258,7 @@ static int ssl_parse_supported_point_formats_ext( mbedtls_ssl_context *ssl,
                                     MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE );
     return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
 }
-#endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C || 
+#endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C ||
           MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -43,10 +43,7 @@
 
 #include <string.h>
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * If DTLS is in use, then at least one of SHA-1, SHA-256, SHA-512 is

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -50,10 +50,7 @@
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
@@ -793,7 +790,7 @@ static int ssl_ciphersuite_match( mbedtls_ssl_context *ssl, int suite_id,
     const mbedtls_ssl_ciphersuite_t *suite_info;
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
-    defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)    
+    defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     mbedtls_pk_type_t sig_type;
 #endif
 
@@ -2961,7 +2958,7 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
             return( ret );
         }
 
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)        
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
         dig_signed = p;
         dig_signed_len = len;
 #endif
@@ -3050,7 +3047,7 @@ curve_matching_done:
 
         /*
          * 3.1: Choose hash algorithm:
-         * A: For TLS 1.2, obey signature-hash-algorithm extension 
+         * A: For TLS 1.2, obey signature-hash-algorithm extension
          *    to choose appropriate hash.
          * B: For SSL3, TLS1.0, TLS1.1 and ECDHE_ECDSA, use SHA1
          *    (RFC 4492, Sec. 5.4)
@@ -3071,7 +3068,7 @@ curve_matching_done:
                                                           sig_alg ) ) == MBEDTLS_MD_NONE )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-                /* (... because we choose a cipher suite 
+                /* (... because we choose a cipher suite
                  *      only if there is a matching hash.) */
                 return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
             }

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -39,10 +39,7 @@
 
 #include <string.h>
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Initialze context

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -53,10 +53,7 @@
 #include "mbedtls/oid.h"
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /* Length of the "epoch" field in the record header */
 static inline size_t ssl_ep_len( const mbedtls_ssl_context *ssl )

--- a/library/timing.c
+++ b/library/timing.c
@@ -39,7 +39,7 @@
 #if !defined(MBEDTLS_TIMING_ALT)
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
-    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__)
+    !defined(__APPLE__) && !defined(_WIN32)
 #error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in config.h"
 #endif
 

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -66,10 +66,7 @@
 #include <stdio.h>
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  *  Version  ::=  INTEGER  {  v1(0), v2(1)  }

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -90,10 +90,7 @@ typedef struct {
  */
 #define X509_MAX_VERIFY_CHAIN_SIZE    ( MBEDTLS_X509_MAX_INTERMEDIATE_CA + 2 )
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * Default profile
@@ -733,7 +730,7 @@ static int x509_crt_parse_der_core( mbedtls_x509_crt *crt, const unsigned char *
 
     memcpy( p, buf, crt->raw.len );
 
-    // Direct pointers to the new buffer 
+    // Direct pointers to the new buffer
     p += crt->raw.len - len;
     end = crt_end = p + len;
 

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -60,10 +60,7 @@
 #include <stdio.h>
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  *  Version  ::=  INTEGER  {  v1(0)  }

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -44,10 +44,7 @@
 #include "mbedtls/pem.h"
 #endif /* MBEDTLS_PEM_WRITE_C */
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx )
 {

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -43,10 +43,7 @@
 #include "mbedtls/pem.h"
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx )
 {

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -42,10 +42,7 @@
 
 #if !defined(MBEDTLS_XTEA_ALT)
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
+#include "mbedtls/zeromem.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/library/zeromem.c
+++ b/library/zeromem.c
@@ -1,3 +1,5 @@
+#include <zeromem.h> 
+
 #ifndef _MSC_VER
 /* Implementation that should never be optimized out by the compiler */
 void mbedtls_zeroize( void *v, size_t n ) {

--- a/library/zeromem.c
+++ b/library/zeromem.c
@@ -1,4 +1,4 @@
-#include <zeromem.h> 
+#include "mbedtls/zeromem.h"
 
 #ifndef _MSC_VER
 /* Implementation that should never be optimized out by the compiler */

--- a/library/zeromem.c
+++ b/library/zeromem.c
@@ -1,0 +1,6 @@
+#ifndef _MSC_VER
+/* Implementation that should never be optimized out by the compiler */
+void mbedtls_zeroize( void *v, size_t n ) {
+    volatile char *p = (char *)v; while( n-- ) *p++ = 0;
+}
+#endif

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -217,6 +217,7 @@
     <ClInclude Include="..\..\include\mbedtls\x509_crt.h" />
     <ClInclude Include="..\..\include\mbedtls\x509_csr.h" />
     <ClInclude Include="..\..\include\mbedtls\xtea.h" />
+    <ClInclude Include="..\..\include\mbedtls\zeromem.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\library\aes.c" />
@@ -291,6 +292,7 @@
     <ClCompile Include="..\..\library\x509write_crt.c" />
     <ClCompile Include="..\..\library\x509write_csr.c" />
     <ClCompile Include="..\..\library\xtea.c" />
+    <ClCompile Include="..\..\library\zeromem.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
## Description
The current implementation of memory cleaning is inefficient, especially for embedded systems.

Firstly, over 40 modules include a copy of the code, and automatic optimizers most probably will fail here.

Secondly, special functions exist that never would be optimized away. For example: `RtlSecureZeroMemory` in Visual Studio, or `memset_s` in C++11 compilers.

## Status
**READY**

## Requires Backporting
NO  

## Which branch?
development

## Migrations
NO

## Additional comments
Saves several kilobytes of code in an executable file.