### PR TITLE
Backport 2.7: Compile PBES2 in PKCS5 only if ASN1 is enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Bugfix
 Changes
    * Support cmake build where Mbed TLS is a subproject. Fix
      contributed independently by Matthieu Volat and Arne Schwabe.
+   * Provide an empty implementation of mbedtls_pkcs5_pbes2() when
+     MBEDTLS_ASN1_PARSE_C is not enabled. This allows the use of PBKDF2
+     without PBES2. Fixed by Marcos Del Sol Vives.
 
 = mbed TLS 2.7.2 branch released 2018-03-16
 

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -38,13 +38,14 @@
 #if defined(MBEDTLS_PKCS5_C)
 
 #include "mbedtls/pkcs5.h"
-#include <string.h>
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 #include "mbedtls/asn1.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/oid.h"
-#endif
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
+#include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -38,11 +38,13 @@
 #if defined(MBEDTLS_PKCS5_C)
 
 #include "mbedtls/pkcs5.h"
+#include <string.h>
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
 #include "mbedtls/asn1.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/oid.h"
-
-#include <string.h>
+#endif
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -51,6 +53,22 @@
 #define mbedtls_printf printf
 #endif
 
+#if !defined(MBEDTLS_ASN1_PARSE_C)
+int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
+                 const unsigned char *pwd,  size_t pwdlen,
+                 const unsigned char *data, size_t datalen,
+                 unsigned char *output )
+{
+    ((void) pbe_params);
+    ((void) mode);
+    ((void) pwd);
+    ((void) pwdlen);
+    ((void) data);
+    ((void) datalen);
+    ((void) output);
+    return( MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE );
+}
+#else
 static int pkcs5_parse_pbkdf2_params( const mbedtls_asn1_buf *params,
                                       mbedtls_asn1_buf *salt, int *iterations,
                                       int *keylen, mbedtls_md_type_t *md_type )
@@ -211,6 +229,7 @@ exit:
 
     return( ret );
 }
+#endif /* MBEDTLS_ASN1_PARSE_C */
 
 int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *password,
                        size_t plen, const unsigned char *salt, size_t slen,

--- a/tests/suites/test_suite_pkcs5.function
+++ b/tests/suites/test_suite_pkcs5.function
@@ -46,7 +46,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_ASN1_PARSE_C */
 void mbedtls_pkcs5_pbes2( int params_tag, char *params_hex, char *pw_hex,
                   char *data_hex, int ref_ret, char *ref_out_hex )
 {


### PR DESCRIPTION
## Description
This PR is a backport of https://github.com/ARMmbed/mbedtls/pull/1523. Please refer to that PR for details.

## Status
**READY**