### PR TITLE
Backport 2.1: mbedtls_net_accept: client_ip can be NULL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ Changes
    * Improve testing in configurations that omit certain hashes or
      public-key algorithms. Includes contributions by Gert van Dijk.
    * Improve negative testing of X.509 parsing.
+   * Improve the documentation of mbedtls_net_accept(). Contributed by Ivan Krylov.
 
 = mbed TLS 2.1.11 branch released 2018-03-16
 

--- a/include/mbedtls/net.h
+++ b/include/mbedtls/net.h
@@ -117,9 +117,10 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *
  * \param bind_ctx  Relevant socket
  * \param client_ctx Will contain the connected client socket
- * \param client_ip Will contain the client IP address
+ * \param client_ip Will contain the client IP address, can be NULL
  * \param buf_size  Size of the client_ip buffer
- * \param ip_len    Will receive the size of the client IP written
+ * \param ip_len    Will receive the size of the client IP written,
+ *                  can be NULL if client_ip is null
  *
  * \return          0 if successful, or
  *                  MBEDTLS_ERR_NET_ACCEPT_FAILED, or


### PR DESCRIPTION
## Description
This currently works and is used in example programs, but not explicitly documented (unlike mbedtls_net_bind).

Since only the official documentation and headers are the contract that developers are expected to adhere to and digging the source to gather information about library behavior might be relying on implementation details, I would like to clarify if mbedtls_net_accept is supposed to accept a NULL client_ip argument.

## Status
**READY**
This is #758 done against `mbedtls-2.1` branch as requested by @gilles-peskine-arm.

## Requires Backporting
Don't know, but only documentation is modified.

## Migrations
**NO**

## Todos
- [ ] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
None
