### PR TITLE
Enable SSL test scripts to dump logs on stdout

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1087,7 +1087,7 @@ run_client() {
             cp $CLI_OUT c-cli-${TESTS}.log
             echo "  ! outputs saved to c-srv-${TESTS}.log, c-cli-${TESTS}.log"
 
-            if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot ]; then
+            if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot -o "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
                 echo "  ! server output:"
                 cat c-srv-${TESTS}.log
                 echo "  ! ==================================================="

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -231,7 +231,7 @@ fail() {
     fi
     echo "  ! outputs saved to o-XXX-${TESTS}.log"
 
-    if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot ]; then
+    if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot -o "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
         echo "  ! server output:"
         cat o-srv-${TESTS}.log
         echo "  ! ========================================================"


### PR DESCRIPTION
This PR changes ```ssl-opts.sh``` and ```compat.sh``` to dump logs in ```stdout``` if ```LOG_FAILURE_ON_STDOUT``` is set.
It partly implements IOTSSL-1957.