### PR TITLE
 Robustness fix in mbedtls_ssl_derive_keys

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -54,6 +54,9 @@ Changes
      Wilson #481
    * Improve the documentation of mbedtls_net_accept(). Contributed by Ivan
      Krylov.
+   * Improve robustness of mbedtls_ssl_derive_keys against the use of
+     HMAC functions with non-HMAC ciphersuites. Independently contributed
+     by Jiayuan Chen in #1377. Fixes #1437.
 
 = mbed TLS 2.8.0 branch released 2018-03-16
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -855,8 +855,13 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_1 )
     {
-        mbedtls_md_hmac_starts( &transform->md_ctx_enc, mac_enc, mac_key_len );
-        mbedtls_md_hmac_starts( &transform->md_ctx_dec, mac_dec, mac_key_len );
+        /* For HMAC-based ciphersuites, initialize the HMAC transforms.
+           For AEAD-based ciphersuites, there is nothing to do here. */
+        if( mac_key_len != 0 )
+        {
+            mbedtls_md_hmac_starts( &transform->md_ctx_enc, mac_enc, mac_key_len );
+            mbedtls_md_hmac_starts( &transform->md_ctx_dec, mac_dec, mac_key_len );
+        }
     }
     else
 #endif


### PR DESCRIPTION
In `mbedtls_ssl_derive_keys`, don't call `mbedtls_md_hmac_starts` in ciphersuites that don't use HMAC. This doesn't change the behavior of the code, but avoids relying on an uncaught error when attempting to start an HMAC operation that hadn't been initialized.

This is the root cause for #1437, see https://github.com/ARMmbed/mbedtls/pull/1421/files#r175520310. While #1437 could be best resolved as part of #1421, we can make this robustness fix independently, more for documentation than anything else since it doesn't change the behavior.

* Backport 2.1: #1461
* Backport 2.7: #1464
* A similar fix was contributed independently in #1377.

Fixes #1437 