### PR TITLE
Only redefine _WIN32_WINNT macro when < 0x0501

### DIFF
--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -47,11 +47,12 @@
 
 #define IS_EINTR( ret ) ( ( ret ) == WSAEINTR )
 
-#ifdef _WIN32_WINNT
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #undef _WIN32_WINNT
-#endif
 /* Enables getaddrinfo() & Co */
 #define _WIN32_WINNT 0x0501
+#endif
+
 #include <ws2tcpip.h>
 
 #include <winsock2.h>


### PR DESCRIPTION
## Status
**READY**

## Requires Backporting
Yes (bugfix)

Which branch?
`mbedtls-2.7`, `mbedtls-2.8` (why is it not branched yet?!)

## Migrations
NO

## Additional comments
`net_sockets.c` was redefining the `_WIN32_WINNT` to ensure `getaddrinfo()` and the like to work.
This should only be done when `_WIN32_WINNT < 0x0501` or it might break builds when embedding in projects that require higher `_WIN32_WINNT` minimum version.

## Todos
- [ ] Tests
- [ ] Backported
