### PR TITLE
Backport 2.1: Use "#!/usr/bin/env perl" as shebang line.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,8 @@ Changes
    * Improve robustness of mbedtls_ssl_derive_keys against the use of
      HMAC functions with non-HMAC ciphersuites. Independently contributed
      by Jiayuan Chen in #1377. Fixes #1437.
+   * Change the shebang line in Perl scripts to look up perl in the PATH.
+     Contributed by fbrosson in #1533.
 
 = mbed TLS 2.1.11 branch released 2018-03-16
 

--- a/scripts/config.pl
+++ b/scripts/config.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # This file is part of mbed TLS (https://tls.mbed.org)
 #

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Generate error.c
 #

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 
 use strict;

--- a/scripts/generate_visualc_files.pl
+++ b/scripts/generate_visualc_files.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Generate files for MS Visual Studio:
 # - for VS6: main project (library) file, individual app files, workspace

--- a/scripts/massif_max.pl
+++ b/scripts/massif_max.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Parse a massif.out.xxx file and output peak total memory usage
 

--- a/scripts/rename.pl
+++ b/scripts/rename.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # rename identifiers (functions, types, enum constant, etc)
 # on upgrades of major version according to a list

--- a/tests/scripts/check-doxy-blocks.pl
+++ b/tests/scripts/check-doxy-blocks.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Detect comment blocks that are likely meant to be doxygen blocks but aren't.
 #

--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # curves.pl
 #

--- a/tests/scripts/depends-hashes.pl
+++ b/tests/scripts/depends-hashes.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # depends-hashes.pl
 #

--- a/tests/scripts/depends-pkalgs.pl
+++ b/tests/scripts/depends-pkalgs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # depends-pkalgs.pl
 #

--- a/tests/scripts/gen_ctr_drbg.pl
+++ b/tests/scripts/gen_ctr_drbg.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Based on NIST CTR_DRBG.rsp validation file
 # Only uses AES-256-CTR cases that use a Derivation function

--- a/tests/scripts/gen_gcm_decrypt.pl
+++ b/tests/scripts/gen_gcm_decrypt.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Based on NIST gcmDecryptxxx.rsp validation files
 # Only first 3 of every set used for compile time saving

--- a/tests/scripts/gen_gcm_encrypt.pl
+++ b/tests/scripts/gen_gcm_encrypt.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Based on NIST gcmEncryptIntIVxxx.rsp validation files
 # Only first 3 of every set used for compile time saving

--- a/tests/scripts/gen_pkcs1_v21_sign_verify.pl
+++ b/tests/scripts/gen_pkcs1_v21_sign_verify.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 
 use strict;

--- a/tests/scripts/key-exchanges.pl
+++ b/tests/scripts/key-exchanges.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # key-exchanges.pl
 #

--- a/tests/scripts/list-enum-consts.pl
+++ b/tests/scripts/list-enum-consts.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use warnings;
 use strict;

--- a/tests/scripts/recursion.pl
+++ b/tests/scripts/recursion.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Find functions making recursive calls to themselves.
 # (Multiple recursion where a() calls b() which calls a() not covered.)

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use warnings;
 use strict;

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # test standard configurations:
 # - build


### PR DESCRIPTION
Backport of #1533 for 2.1 branch.