### PR TITLE
Make the memset call prior to FD_ZERO conditional to needing it

### DIFF
--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -459,11 +459,15 @@ int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout )
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
-    /* Ensure that memory sanitizers consider
-     * read_fds and write_fds as initialized even
-     * if FD_ZERO is implemented in assembly. */
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+    /* Ensure that memory sanitizers consider read_fds and write_fds as
+     * initialized even on platforms such as Glibc/x86_64 where FD_ZERO
+     * is implemented in assembly. */
     memset( &read_fds, 0, sizeof( read_fds ) );
     memset( &write_fds, 0, sizeof( write_fds ) );
+#endif
+#endif
 
     FD_ZERO( &read_fds );
     if( rw & MBEDTLS_NET_POLL_READ )


### PR DESCRIPTION
Clang-MSan does not recognize that `FD_ZERO(fdset)` initializes `fdset` on Glibc/x86_64 (because it's implemented in assembly). This can lead to false-positive reports of uninitialized memory. In #946 (https://github.com/ARMmbed/mbedtls/pull/946/commits/f4e5b7e87de2484f0e3dbb9d11e87dd275874cd0) this was resolved by adding a `memset` call before the call to `FD_ZERO`.

This PR makes the `memset` code conditional on using Msan, to save a bit of code size and time in production.
