### PR TITLE
Warn if using a memory sanitizer on AESNI

### DIFF
--- a/library/aesni.c
+++ b/library/aesni.c
@@ -32,6 +32,12 @@
 
 #if defined(MBEDTLS_AESNI_C)
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#warning "MBEDTLS_AESNI_C is known to cause spurious error reports with some memory sanitizers as they do not understand the assembly code."
+#endif
+#endif
+
 #include "mbedtls/aesni.h"
 
 #include <string.h>


### PR DESCRIPTION
Clang-Msan is known to report spurious errors when MBEDTLS_AESNI_C is
enabled (which is the case in the default configuration), due to the use of assembly code. The error reports don't
mention AES, so they can be difficult to trace back to the use of
AES-NI. Warn about this potential problem at compile time.

This would make sense in backports too, but it has a risk of breaking somebody's build, so I lean towards not backporting.
