### PR TITLE
Add check for Visual Studio generated files to `check-generated-files.sh` script

### DIFF
--- a/scripts/generate_visualc_files.pl
+++ b/scripts/generate_visualc_files.pl
@@ -1,10 +1,9 @@
 #!/usr/bin/perl
 
 # Generate files for MS Visual Studio:
-# - for VS6: main project (library) file, individual app files, workspace
 # - for VS2010: main file, individual apps, solution file
 #
-# Must be run from mbedTLS root or scripts directory.
+# Must be run from mbed TLS root or scripts directory.
 # Takes no argument.
 
 use warnings;
@@ -172,9 +171,10 @@ sub gen_vsx_solution {
 }
 
 sub main {
+
     if( ! check_dirs() ) {
         chdir '..' or die;
-        check_dirs or die "Must but run from mbedTLS root or scripts dir\n";
+        check_dirs or die "Must be run from mbed TLS root or scripts dir\n";
     }
 
     my @app_list = get_app_list();

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2012-2016, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# Verify if project files that are geneated from the source code are different
+# from what would be generated, if the script were run again.
+#
+# The script is non-destructive.
+#
+# Usage: check-generated-files.sh
+#
 
-# check if generated files are up-to-date
+
 
 set -eu
 
@@ -11,14 +25,17 @@ fi
 
 check()
 {
-    FILE=$1
+    TARGET=$1
     SCRIPT=$2
 
-    cp $FILE $FILE.bak
+    cp -apr $TARGET $TARGET.bak
     $SCRIPT
-    diff $FILE $FILE.bak
-    mv $FILE.bak $FILE
+    diff -r $TARGET $TARGET.bak
+    rm -rf $TARGET
+    mv $TARGET.bak $TARGET
 }
 
 check library/error.c scripts/generate_errors.pl
 check library/version_features.c scripts/generate_features.pl
+check visualc scripts/generate_visualc_files.pl
+


### PR DESCRIPTION
## Description

This PR adds the `generate_visualc_files.pl` to the `check-generated-files.sh` script, to ensure the generated Visual Studio files were not being checked for freshness in `all.sh`.
  
In addition the PR contains a minor update to remove obsolete references to Visual Studio 6, and corrects an error message in `generate_visualc_files.pl`.

## Status
**READY**

## Requires Backporting
Yes 
Which branch? `mbedtls-2.7` and `mbedtls-2.1`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

