### PR TITLE
Platform setup and teardown calls addition to test suites

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -93,6 +93,7 @@ Changes
    * Improve robustness of mbedtls_ssl_derive_keys against the use of
      HMAC functions with non-HMAC ciphersuites. Independently contributed
      by Jiayuan Chen in #1377. Fixes #1437.
+   * Add platform setup and teardown calls in test suites.
 
 = mbed TLS 2.8.0 branch released 2018-03-16
 

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -133,7 +133,7 @@ mbedtls_platform_context platform_ctx;
 static int platform_setup()
 {
 #if defined(MBEDTLS_PLATFORM_C)
-    if( mbedtls_platform_setup( &platform_ctx ) )
+    if( mbedtls_platform_setup( &platform_ctx ) != 0 )
     {
         return -1;
     }

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -109,7 +109,9 @@ static struct
 }
 test_info;
 
+#if defined(MBEDTLS_PLATFORM_C)
 mbedtls_platform_context platform_ctx;
+#endif
 
 /*----------------------------------------------------------------------------*/
 /* Helper flags for complex dependencies */
@@ -128,6 +130,23 @@ mbedtls_platform_context platform_ctx;
 
 /*----------------------------------------------------------------------------*/
 /* Helper Functions */
+static int platform_setup()
+{
+#if defined(MBEDTLS_PLATFORM_C)
+    if( mbedtls_platform_setup( &platform_ctx ) )
+    {
+        return -1;
+    }
+#endif /* MBEDTLS_PLATFORM_C */
+    return 0;
+}
+
+static void platform_teardown()
+{
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown( &platform_ctx );
+#endif /* MBEDTLS_PLATFORM_C */
+}
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 static int redirect_output( FILE** out_stream, const char* path )

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -132,13 +132,11 @@ mbedtls_platform_context platform_ctx;
 /* Helper Functions */
 static int platform_setup()
 {
+    int ret = 0;
 #if defined(MBEDTLS_PLATFORM_C)
-    if( mbedtls_platform_setup( &platform_ctx ) != 0 )
-    {
-        return -1;
-    }
+    ret = mbedtls_platform_setup( &platform_ctx );
 #endif /* MBEDTLS_PLATFORM_C */
-    return 0;
+    return( ret );
 }
 
 static void platform_teardown()

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -109,6 +109,7 @@ static struct
 }
 test_info;
 
+mbedtls_platform_context platform_ctx;
 
 /*----------------------------------------------------------------------------*/
 /* Helper flags for complex dependencies */

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -282,10 +282,14 @@ int main(int argc, const char *argv[])
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
     unsigned char alloc_buf[1000000];
 #endif 
-    if( platform_setup() != 0 )
+    /* Platform setup should be called in the beginning */
+    ret = platform_setup();
+    if( ret != 0 )
     {
-        mbedtls_fprintf( stderr, "FATAL: Failed to initialize platform" );
-        return -1;
+        mbedtls_fprintf( stderr,
+                         "FATAL: Failed to initialize platform - error %d\n",
+                         ret );
+        return( -1 );
     }
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
@@ -312,7 +316,7 @@ int main(int argc, const char *argv[])
     {
         mbedtls_fprintf( stderr, "the snprintf implementation is broken\n" );
         platform_teardown();
-        return( 0 );
+        return( 1 );
     }
 
     while( arg_index < argc)

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -282,7 +282,7 @@ int main(int argc, const char *argv[])
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
     unsigned char alloc_buf[1000000];
 #endif 
-    if( platform_setup() )
+    if( platform_setup() != 0 )
     {
         mbedtls_fprintf( stderr, "FATAL: Failed to initialize platform" );
         return -1;

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -282,7 +282,7 @@ int main(int argc, const char *argv[])
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
     unsigned char alloc_buf[1000000];
 #endif 
-    if( mbedtls_platform_setup( &platform_ctx ) )
+    if( platform_setup() )
     {
         mbedtls_fprintf( stderr, "FATAL: Failed to initialize platform" );
         return -1;
@@ -301,7 +301,7 @@ int main(int argc, const char *argv[])
     if( pointer != NULL )
     {
         mbedtls_fprintf( stderr, "all-bits-zero is not a NULL pointer\n" );
-        mbedtls_platform_teardown( &platform_ctx );
+        platform_teardown();
         return( 1 );
     }
 
@@ -311,7 +311,7 @@ int main(int argc, const char *argv[])
     if( run_test_snprintf() != 0 )
     {
         mbedtls_fprintf( stderr, "the snprintf implementation is broken\n" );
-        mbedtls_platform_teardown( &platform_ctx );
+        platform_teardown();
         return( 0 );
     }
 
@@ -328,7 +328,7 @@ int main(int argc, const char *argv[])
                  strcmp(next_arg, "-h" ) == 0 )
         {
             mbedtls_fprintf( stdout, USAGE );
-            mbedtls_platform_teardown( &platform_ctx );
+            platform_teardown();
             mbedtls_exit( EXIT_SUCCESS );
         }
         else
@@ -368,7 +368,7 @@ int main(int argc, const char *argv[])
         {
             mbedtls_fprintf( stderr, "Failed to open test file: %s\n",
                              test_filename );
-            mbedtls_platform_teardown( &platform_ctx );
+            platform_teardown();
             return( 1 );
         }
 
@@ -378,7 +378,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr,
                     "FATAL: Dep count larger than zero at start of loop\n" );
-                mbedtls_platform_teardown( &platform_ctx );
+                platform_teardown();
                 mbedtls_exit( MBEDTLS_EXIT_FAILURE );
             }
             unmet_dep_count = 0;
@@ -415,7 +415,7 @@ int main(int argc, const char *argv[])
                         if(  unmet_dependencies[ unmet_dep_count ] == NULL )
                         {
                             mbedtls_fprintf( stderr, "FATAL: Out of memory\n" );
-                            mbedtls_platform_teardown( &platform_ctx );
+                            platform_teardown();
                             mbedtls_exit( MBEDTLS_EXIT_FAILURE );
                         }
                         unmet_dep_count++;
@@ -441,8 +441,8 @@ int main(int argc, const char *argv[])
                     stdout_fd = redirect_output( &stdout, "/dev/null" );
                     if( stdout_fd == -1 )
                     {
+                        platform_teardown();
                         /* Redirection has failed with no stdout so exit */
-                        mbedtls_platform_teardown( &platform_ctx );
                         exit( 1 );
                     }
                 }
@@ -454,7 +454,7 @@ int main(int argc, const char *argv[])
                 if( !option_verbose && restore_output( &stdout, stdout_fd ) )
                 {
                         /* Redirection has failed with no stdout so exit */
-                        mbedtls_platform_teardown( &platform_ctx );
+                        platform_teardown();
                         exit( 1 );
                 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
@@ -506,7 +506,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
                 fclose( file );
-                mbedtls_platform_teardown( &platform_ctx );
+                platform_teardown();
                 mbedtls_exit( 2 );
             }
             else
@@ -518,7 +518,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr, "Should be empty %d\n",
                                  (int) strlen( buf ) );
-                mbedtls_platform_teardown( &platform_ctx );
+                platform_teardown();
                 return( 1 );
             }
         }
@@ -551,6 +551,6 @@ int main(int argc, const char *argv[])
         close_output( stdout );
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
-    mbedtls_platform_teardown( &platform_ctx );
+    platform_teardown();
     return( total_errors != 0 );
 }

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -281,6 +281,14 @@ int main(int argc, const char *argv[])
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
     !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
     unsigned char alloc_buf[1000000];
+#endif 
+    if( mbedtls_platform_setup( &platform_ctx ) )
+    {
+        mbedtls_fprintf( stderr, "FATAL: Failed to initialize platform" );
+        return -1;
+    }
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && \
+    !defined(TEST_SUITE_MEMORY_BUFFER_ALLOC)
     mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
 #endif
 
@@ -293,6 +301,7 @@ int main(int argc, const char *argv[])
     if( pointer != NULL )
     {
         mbedtls_fprintf( stderr, "all-bits-zero is not a NULL pointer\n" );
+        mbedtls_platform_teardown( &platform_ctx );
         return( 1 );
     }
 
@@ -302,6 +311,7 @@ int main(int argc, const char *argv[])
     if( run_test_snprintf() != 0 )
     {
         mbedtls_fprintf( stderr, "the snprintf implementation is broken\n" );
+        mbedtls_platform_teardown( &platform_ctx );
         return( 0 );
     }
 
@@ -318,6 +328,7 @@ int main(int argc, const char *argv[])
                  strcmp(next_arg, "-h" ) == 0 )
         {
             mbedtls_fprintf( stdout, USAGE );
+            mbedtls_platform_teardown( &platform_ctx );
             mbedtls_exit( EXIT_SUCCESS );
         }
         else
@@ -357,6 +368,7 @@ int main(int argc, const char *argv[])
         {
             mbedtls_fprintf( stderr, "Failed to open test file: %s\n",
                              test_filename );
+            mbedtls_platform_teardown( &platform_ctx );
             return( 1 );
         }
 
@@ -366,6 +378,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr,
                     "FATAL: Dep count larger than zero at start of loop\n" );
+                mbedtls_platform_teardown( &platform_ctx );
                 mbedtls_exit( MBEDTLS_EXIT_FAILURE );
             }
             unmet_dep_count = 0;
@@ -402,6 +415,7 @@ int main(int argc, const char *argv[])
                         if(  unmet_dependencies[ unmet_dep_count ] == NULL )
                         {
                             mbedtls_fprintf( stderr, "FATAL: Out of memory\n" );
+                            mbedtls_platform_teardown( &platform_ctx );
                             mbedtls_exit( MBEDTLS_EXIT_FAILURE );
                         }
                         unmet_dep_count++;
@@ -428,6 +442,7 @@ int main(int argc, const char *argv[])
                     if( stdout_fd == -1 )
                     {
                         /* Redirection has failed with no stdout so exit */
+                        mbedtls_platform_teardown( &platform_ctx );
                         exit( 1 );
                     }
                 }
@@ -439,6 +454,7 @@ int main(int argc, const char *argv[])
                 if( !option_verbose && restore_output( &stdout, stdout_fd ) )
                 {
                         /* Redirection has failed with no stdout so exit */
+                        mbedtls_platform_teardown( &platform_ctx );
                         exit( 1 );
                 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
@@ -490,6 +506,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
                 fclose( file );
+                mbedtls_platform_teardown( &platform_ctx );
                 mbedtls_exit( 2 );
             }
             else
@@ -501,6 +518,7 @@ int main(int argc, const char *argv[])
             {
                 mbedtls_fprintf( stderr, "Should be empty %d\n",
                                  (int) strlen( buf ) );
+                mbedtls_platform_teardown( &platform_ctx );
                 return( 1 );
             }
         }
@@ -533,5 +551,6 @@ int main(int argc, const char *argv[])
         close_output( stdout );
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
+    mbedtls_platform_teardown( &platform_ctx );
     return( total_errors != 0 );
 }


### PR DESCRIPTION
This PR adds platform setup and teardown calls to test suites and a global platform context object.
This enables running tests on custom targets requiring an additional setup, and is a step towards accessing the platform context in test suites which will need it.