### PR TITLE
Backport 2.7: Cleanup all.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,11 @@ the Mbed TLS source directory, use:
     make
 
 If you want to change `CC` or `CFLAGS` afterwards, you will need to remove the
-CMake cache. This can be done with the following command using GNU find:
+CMake cache. This can be done with the following command using GNU find, but
+please note it is destructive and should be adapted if you're using a VCS
+other than git or have other subdirectories that should be preserved:
 
-    find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
+    find . -name .git -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
 
 You can now make the desired change:
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -507,9 +507,6 @@ scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
 msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/ssl-opt.sh
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -672,6 +672,16 @@ msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
 tests/compat.sh -t RSA
 
 
+msg "build: default config with AES_ROM_TABLES enabled"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set MBEDTLS_AES_ROM_TABLES
+make CC=gcc CFLAGS='-Werror -Wall -Wextra'
+
+msg "test: AES_ROM_TABLES"
+make test
+
+
 ################################################################
 #### 3. Various targets (adapted config)
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -55,9 +55,10 @@
 # Notes for maintainers
 # ---------------------
 #
-# The tests are roughly in order from fastest to slowest. This doesn't
-# have to be exact, but in general you should add slower tests towards
-# the end and fast checks near the beginning.
+# The tests are grouped by section: basic tests, config, target...
+# In each section, in general you should add slower tests towards
+# the end and fast checks near the beginning.  Indicative running
+# times are given for reference (measured on the developer's machine).
 #
 # Sanity checks have the following form:
 #   1. msg "short description of what is about to be done"
@@ -429,19 +430,8 @@ fi
 
 
 ################################################################
-#### Basic checks
+#### 0. Quick sanity checks
 ################################################################
-
-#
-# Test Suites to be executed
-#
-# The test ordering tries to optimize for the following criteria:
-# 1. Catch possible problems early, by running first tests that run quickly
-#    and/or are more likely to fail than others (eg I use Clang most of the
-#    time, so start with a GCC build).
-# 2. Minimize total running time, by avoiding useless rebuilds
-#
-# Indicative running times are given for reference.
 
 msg "info: output_env.sh"
 OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
@@ -469,16 +459,11 @@ tests/scripts/doxygen.sh
 
 
 ################################################################
-#### Build and test many configurations and targets
+#### 1 Basic tests
 ################################################################
 
-if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
-    # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
-    # path, and uses whatever version of armcc it finds there.
-    msg "build: create and build yotta module" # ~ 30s
-    cleanup
-    record_status tests/scripts/yotta-build.sh
-fi
+# 1.1 Basic tests: default config
+#################################
 
 msg "build: cmake, gcc, ASan" # ~ 1 min 50s
 cleanup
@@ -491,40 +476,11 @@ make test
 msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
 if_build_succeeded tests/ssl-opt.sh
 
-msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-record_status tests/scripts/test-ref-configs.pl
-
-msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
-make
-
 msg "test: compat.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/compat.sh
 
-msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
-
-msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-tests/ssl-opt.sh -f RSA
-
-msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-tests/compat.sh -t RSA
+# 1.2 Basic tests: full config
+##############################
 
 msg "build: cmake, full config, clang" # ~ 50s
 cleanup
@@ -544,6 +500,19 @@ msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3' -e ''
 
+
+
+################################################################
+#### 2. Various configurations (default target)
+################################################################
+
+# 2.1 Various configs: scripted
+###############################
+
+msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+cleanup
+record_status tests/scripts/test-ref-configs.pl
+
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup
 record_status tests/scripts/curves.pl
@@ -560,9 +529,58 @@ msg "test/build: key-exchanges (gcc)" # ~ 1 min
 cleanup
 record_status tests/scripts/key-exchanges.pl
 
-msg "build: Unix make, -Os (gcc)" # ~ 30s
+# 2.2 Various configs: SSL build options
+########################################
+
+msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
 cleanup
-make CC=gcc CFLAGS='-Werror -Os'
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl full
+scripts/config.pl unset MBEDTLS_SSL_SRV_C
+make CC=gcc CFLAGS='-Werror -O1'
+
+msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl full
+scripts/config.pl unset MBEDTLS_SSL_CLI_C
+make CC=gcc CFLAGS='-Werror -O1'
+
+
+msg "build: default config except MFL extension (ASan build)" # ~ 30s
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: ssl-opt.sh, MFL-related tests"
+if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
+
+
+msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
+if_build_succeeded tests/ssl-opt.sh
+
+
+msg "build: allow SHA1 in certificates by default"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
+make CFLAGS='-Werror -O1'
+
+msg "test: allow SHA1 in certificates by default"
+make test
+if_build_succeeded tests/ssl-opt.sh -f SHA-1
+
+# 2.3 Various configs: misc
+###########################
 
 # Full configuration build, without platform support, file IO and net sockets.
 # This should catch missing mbedtls_printf definitions, and by disabling file
@@ -595,20 +613,6 @@ scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
 scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
 make CC=gcc CFLAGS='-Werror -O1'
 
-msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_SRV_C
-make CC=gcc CFLAGS='-Werror -O1'
-
-msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_CLI_C
-make CC=gcc CFLAGS='-Werror -O1'
-
 # Note, C99 compliance can only be tested with the sockets support disabled,
 # as that requires a POSIX platform (which isn't the same as C99).
 # We could use -D_DEFAULT_SOURCE here too, but without it we can make sure our
@@ -621,15 +625,6 @@ scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
 scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
 make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic' lib
 
-msg "build: default config except MFL extension (ASan build)" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: ssl-opt.sh, MFL-related tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
 
 msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
 cleanup
@@ -646,49 +641,30 @@ make
 msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
 make test
 
-if uname -a | grep -F Linux >/dev/null; then
-    msg "build/test: make shared" # ~ 40s
-    cleanup
-    make SHARED=1 all check
-fi
 
-if uname -a | grep -F x86_64 >/dev/null; then
-    msg "build: i386, make, gcc" # ~ 30s
-    cleanup
-    make CC=gcc CFLAGS='-Werror -O1 -m32'
-
-    msg "test: i386, make, gcc"
-    make test
-
-    msg "build: 64-bit ILP32, make, gcc" # ~ 30s
-    cleanup
-    make CC=gcc CFLAGS='-Werror -O1 -mx32'
-
-    msg "test: 64-bit ILP32, make, gcc"
-    make test
-fi # x86_64
-
-msg "build: gcc, force 32-bit bignum limbs"
+msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT32'
+scripts/config.pl set MBEDTLS_RSA_NO_CRT
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
 
-msg "test: gcc, force 32-bit bignum limbs"
+msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
 
-msg "build: gcc, force 64-bit bignum limbs"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT64'
+msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
+tests/ssl-opt.sh -f RSA
 
-msg "test: gcc, force 64-bit bignum limbs"
-make test
+msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
+tests/compat.sh -t RSA
+
+
+################################################################
+#### 3. Various targets (adapted config)
+################################################################
+
+# 3.1 ARM targets (build only)
+#################
 
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup
@@ -730,14 +706,8 @@ if [ $RUN_ARMCC -ne 0 ]; then
     armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
 fi
 
-msg "build: allow SHA1 in certificates by default"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
-make CFLAGS='-Werror -O1'
-msg "test: allow SHA1 in certificates by default"
-make test
-if_build_succeeded tests/ssl-opt.sh -f SHA-1
+# 3.2 Windows targets (build only)
+#####################
 
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
@@ -747,6 +717,94 @@ make WINDOWS_BUILD=1 clean
 msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
 make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1
 make WINDOWS_BUILD=1 clean
+
+# 3.3 Misc targets (build + some tests)
+##################
+
+# (mix of target and compile options related to the targed)
+if uname -a | grep -F x86_64 >/dev/null; then
+    msg "build: i386, make, gcc" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -O1 -m32'
+
+    msg "test: i386, make, gcc"
+    make test
+
+    msg "build: 64-bit ILP32, make, gcc" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -O1 -mx32'
+
+    msg "test: 64-bit ILP32, make, gcc"
+    make test
+fi # x86_64
+
+msg "build: gcc, force 32-bit bignum limbs"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT32'
+
+msg "test: gcc, force 32-bit bignum limbs"
+make test
+
+msg "build: gcc, force 64-bit bignum limbs"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_HAVE_ASM
+scripts/config.pl unset MBEDTLS_AESNI_C
+scripts/config.pl unset MBEDTLS_PADLOCK_C
+make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT64'
+
+msg "test: gcc, force 64-bit bignum limbs"
+make test
+
+
+
+################################################################
+#### 4. Build systems
+################################################################
+
+msg "build: Unix make, -Os (gcc)" # ~ 30s
+cleanup
+make CC=gcc CFLAGS='-Werror -Os'
+
+
+if uname -a | grep -F Linux >/dev/null; then
+    msg "build/test: make shared" # ~ 40s
+    cleanup
+    make SHARED=1 all check
+fi
+
+
+msg "build: cmake 'out-of-source' build"
+cleanup
+MBEDTLS_ROOT_DIR="$PWD"
+mkdir "$OUT_OF_SOURCE_DIR"
+cd "$OUT_OF_SOURCE_DIR"
+cmake "$MBEDTLS_ROOT_DIR"
+make
+
+msg "test: cmake 'out-of-source' build"
+make test
+cd "$MBEDTLS_ROOT_DIR"
+rm -rf "$OUT_OF_SOURCE_DIR"
+
+
+if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
+    # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
+    # path, and uses whatever version of armcc it finds there.
+    msg "build: create and build yotta module" # ~ 30s
+    cleanup
+    record_status tests/scripts/yotta-build.sh
+fi
+
+
+
+################################################################
+#### 5. Slow outside Linux-x86_64: MemSan or memcheck
+################################################################
 
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then
@@ -782,7 +840,7 @@ else # no MemSan
     make memcheck
 
     # Optional part(s)
-    # Currently broken, programs don't seem to receive signals
+    # Currently broken on OS X: programs don't seem to receive signals
     # under valgrind on OS X
 
     if [ "$MEMORY" -gt 0 ]; then
@@ -796,19 +854,6 @@ else # no MemSan
     fi
 
 fi # MemSan
-
-msg "build: cmake 'out-of-source' build"
-cleanup
-MBEDTLS_ROOT_DIR="$PWD"
-mkdir "$OUT_OF_SOURCE_DIR"
-cd "$OUT_OF_SOURCE_DIR"
-cmake "$MBEDTLS_ROOT_DIR"
-make
-
-msg "test: cmake 'out-of-source' build"
-make test
-cd "$MBEDTLS_ROOT_DIR"
-rm -rf "$OUT_OF_SOURCE_DIR"
 
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -681,13 +681,13 @@ make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werro
 echo "Checking that software 64-bit division is not required"
 ! grep __aeabi_uldiv library/*.o
 
-msg "build: ARM Compiler 5, make" # ~ 1 min 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl baremetal
-
 if [ $RUN_ARMCC -ne 0 ]; then
+    msg "build: ARM Compiler 5, make" # ~ 1 min 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl baremetal
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+    # keep config for next tests, so 'make clean' instead of 'cleanup'
     make clean
 
     # ARM Compiler 6 - Target ARMv7-A

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -819,6 +819,8 @@ if uname -a | grep 'Linux.*x86_64' >/dev/null; then
     msg "build: MSan (clang)" # ~ 1 min
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
     make
@@ -840,6 +842,7 @@ else # no MemSan
 
     msg "build: Release (clang)"
     cleanup
+    scripts/config.pl full
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -584,8 +584,7 @@ scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
 scripts/config.pl unset MBEDTLS_FS_IO
 # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
 # to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -O1' test
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE'
 
 # catch compile bugs in _uninit functions
 msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
@@ -610,8 +609,10 @@ scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_CLI_C
 make CC=gcc CFLAGS='-Werror -O1'
 
-# Note, C99 compliance can also be tested with the sockets support disabled,
+# Note, C99 compliance can only be tested with the sockets support disabled,
 # as that requires a POSIX platform (which isn't the same as C99).
+# We could use -D_DEFAULT_SOURCE here too, but without it we can make sure our
+# use of platform-dependant things is limited to the options disabled here.
 msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
@@ -787,15 +788,11 @@ make test
 
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 lib programs
-
-# note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1
 make WINDOWS_BUILD=1 clean
 
 msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1
 make WINDOWS_BUILD=1 clean
 
 # MemSan currently only available on Linux 64 bits

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -322,6 +322,12 @@ else
     fi
 fi
 
+if [ $RUN_ARMCC -eq 0 ] && [ $YOTTA -ne 0 ]; then
+    err_msg "Error - yotta testing needs armcc."
+    echo "You can either disable yotta or enable armcc."
+    exit 1
+fi
+
 build_status=0
 if [ $KEEP_GOING -eq 1 ]; then
     failure_summary=
@@ -799,7 +805,7 @@ cd "$MBEDTLS_ROOT_DIR"
 rm -rf "$OUT_OF_SOURCE_DIR"
 
 
-if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
+if [ $YOTTA -ne 0 ]; then
     # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
     # path, and uses whatever version of armcc it finds there.
     msg "build: create and build yotta module" # ~ 6 min 30s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -482,7 +482,7 @@ if_build_succeeded tests/compat.sh
 # 1.2 Basic tests: full config
 ##############################
 
-msg "build: cmake, full config, clang" # ~ 50s
+msg "build: make, full config, clang" # ~ 50s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -465,15 +465,15 @@ tests/scripts/doxygen.sh
 # 1.1 Basic tests: default config
 #################################
 
-msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+msg "build: cmake, gcc, ASan" # ~ 1 min
 cleanup
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
+msg "test: main suites (inc. selftests) (ASan build)" # < 10s
 make test
 
-msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
+msg "test: ssl-opt.sh (ASan build)" # ~ 2 min
 if_build_succeeded tests/ssl-opt.sh
 
 msg "test: compat.sh (ASan build)" # ~ 6 min
@@ -489,14 +489,14 @@ scripts/config.pl full
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
 make CC='clang' CFLAGS='-Werror -O2'
 
-msg "test: main suites (full config)" # ~ 5s
+msg "test: main suites (full config)" # < 10s
 make test
 
 # test things not in the default config, and Default handshake for parameters choice
-msg "test: ssl-opt.sh (full config)" # ~ 1s
+msg "test: ssl-opt.sh (full config)" # < 10s
 if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|RC4'
 
-msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 2 min
+msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 3 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3' -e ''
 
@@ -509,11 +509,11 @@ if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3' -
 # 2.1 Various configs: scripted
 ###############################
 
-msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+msg "test/build: ref-configs (ASan build)" # ~ 3 min
 cleanup
 record_status tests/scripts/test-ref-configs.pl
 
-msg "test/build: curves.pl (gcc)" # ~ 4 min
+msg "test/build: curves.pl (gcc)" # ~ 6 min
 cleanup
 record_status tests/scripts/curves.pl
 
@@ -532,14 +532,14 @@ record_status tests/scripts/key-exchanges.pl
 # 2.2 Various configs: SSL build options
 ########################################
 
-msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
+msg "build: full config except ssl_srv.c, make, gcc" # ~ 20s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_SRV_C
 make CC=gcc CFLAGS='-Werror -O1'
 
-msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
+msg "build: full config except ssl_cli.c, make, gcc" # ~ 20s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
@@ -547,18 +547,18 @@ scripts/config.pl unset MBEDTLS_SSL_CLI_C
 make CC=gcc CFLAGS='-Werror -O1'
 
 
-msg "build: default config except MFL extension (ASan build)" # ~ 30s
+msg "build: default config except MFL extension (ASan build)" # ~ 45s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: ssl-opt.sh, MFL-related tests"
+msg "test: ssl-opt.sh, MFL-related tests" # < 5s
 if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
 
 
-msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
+msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 45s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
@@ -569,13 +569,13 @@ msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # < 5s
 if_build_succeeded tests/ssl-opt.sh -f '[Rr]enego'
 
 
-msg "build: allow SHA1 in certificates by default"
+msg "build: allow SHA1 in certificates by default" # ~ 20s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
 make CFLAGS='-Werror -O1'
 
-msg "test: allow SHA1 in certificates by default"
+msg "test: allow SHA1 in certificates by default" # ~ 30s
 make test
 if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
@@ -585,7 +585,7 @@ if_build_succeeded tests/ssl-opt.sh -f SHA-1
 # Full configuration build, without platform support, file IO and net sockets.
 # This should catch missing mbedtls_printf definitions, and by disabling file
 # IO, it should catch missing '#include <stdio.h>'
-msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
+msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 15s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
@@ -605,7 +605,7 @@ scripts/config.pl unset MBEDTLS_FS_IO
 make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE'
 
 # catch compile bugs in _uninit functions
-msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
+msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 15s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
@@ -617,7 +617,7 @@ make CC=gcc CFLAGS='-Werror -O1'
 # as that requires a POSIX platform (which isn't the same as C99).
 # We could use -D_DEFAULT_SOURCE here too, but without it we can make sure our
 # use of platform-dependant things is limited to the options disabled here.
-msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
+msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # < 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
@@ -626,7 +626,7 @@ scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
 make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic' lib
 
 
-msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
+msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)" # ~ 50s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
@@ -638,7 +638,7 @@ scripts/config.pl unset MBEDTLS_HAVEGE_C
 CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
 make
 
-msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
+msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)" # < 10s
 make test
 
 
@@ -666,13 +666,13 @@ tests/compat.sh -t RSA
 # 3.1 ARM targets (build only)
 #################
 
-msg "build: arm-none-eabi-gcc, make" # ~ 10s
+msg "build: arm-none-eabi-gcc, make" # < 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl baremetal
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
-msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # < 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl baremetal
@@ -681,7 +681,7 @@ make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werro
 echo "Checking that software 64-bit division is not required"
 ! grep __aeabi_uldiv library/*.o
 
-msg "build: ARM Compiler 5, make"
+msg "build: ARM Compiler 5, make" # ~ 1 min 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl baremetal
@@ -691,30 +691,30 @@ if [ $RUN_ARMCC -ne 0 ]; then
     make clean
 
     # ARM Compiler 6 - Target ARMv7-A
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a" # < 10s
 
     # ARM Compiler 6 - Target ARMv7-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m" # < 10s
 
     # ARM Compiler 6 - Target ARMv8-A - AArch32
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a" # < 10s
 
     # ARM Compiler 6 - Target ARMv8-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main" # < 10s
 
     # ARM Compiler 6 - Target ARMv8-A - AArch64
-    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
+    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a" # < 10s
 fi
 
 # 3.2 Windows targets (build only)
 #####################
 
-msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 20s
 cleanup
 make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1
 make WINDOWS_BUILD=1 clean
 
-msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
+msg "build: Windows cross build - mingw64, make (DLL)" # ~ 20s
 make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1
 make WINDOWS_BUILD=1 clean
 
@@ -723,7 +723,7 @@ make WINDOWS_BUILD=1 clean
 
 # (mix of target and compile options related to the targed)
 if uname -a | grep -F x86_64 >/dev/null; then
-    msg "build: i386, make, gcc" # ~ 30s
+    msg "build: i386, make, gcc" # ~ 20s
     cleanup
     make CC=gcc CFLAGS='-Werror -O1 -m32'
 
@@ -738,7 +738,7 @@ if uname -a | grep -F x86_64 >/dev/null; then
     make test
 fi # x86_64
 
-msg "build: gcc, force 32-bit bignum limbs"
+msg "build: gcc, force 32-bit bignum limbs" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_HAVE_ASM
@@ -749,7 +749,7 @@ make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT32'
 msg "test: gcc, force 32-bit bignum limbs"
 make test
 
-msg "build: gcc, force 64-bit bignum limbs"
+msg "build: gcc, force 64-bit bignum limbs" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_HAVE_ASM
@@ -766,19 +766,19 @@ make test
 #### 4. Build systems
 ################################################################
 
-msg "build: Unix make, -Os (gcc)" # ~ 30s
+msg "build: Unix make, -Os (gcc)" # ~ 20s
 cleanup
 make CC=gcc CFLAGS='-Werror -Os'
 
 
 if uname -a | grep -F Linux >/dev/null; then
-    msg "build/test: make shared" # ~ 40s
+    msg "build+test: make shared" # ~ 30s
     cleanup
     make SHARED=1 all check
 fi
 
 
-msg "build: cmake 'out-of-source' build"
+msg "build: cmake 'out-of-source' build" # ~ 20s
 cleanup
 MBEDTLS_ROOT_DIR="$PWD"
 mkdir "$OUT_OF_SOURCE_DIR"
@@ -786,7 +786,7 @@ cd "$OUT_OF_SOURCE_DIR"
 cmake "$MBEDTLS_ROOT_DIR"
 make
 
-msg "test: cmake 'out-of-source' build"
+msg "test: cmake 'out-of-source' build" # < 10s
 make test
 cd "$MBEDTLS_ROOT_DIR"
 rm -rf "$OUT_OF_SOURCE_DIR"
@@ -795,7 +795,7 @@ rm -rf "$OUT_OF_SOURCE_DIR"
 if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
     # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
     # path, and uses whatever version of armcc it finds there.
-    msg "build: create and build yotta module" # ~ 30s
+    msg "build: create and build yotta module" # ~ 6 min 30s
     cleanup
     record_status tests/scripts/yotta-build.sh
 fi
@@ -809,23 +809,23 @@ fi
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then
 
-    msg "build: MSan (clang)" # ~ 1 min 20s
+    msg "build: MSan (clang)" # ~ 1 min
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
     make
 
-    msg "test: main suites (MSan)" # ~ 10s
+    msg "test: main suites (MSan)" # < 10s
     make test
 
-    msg "test: ssl-opt.sh (MSan)" # ~ 1 min
+    msg "test: ssl-opt.sh (MSan)" # ~ 3 min
     if_build_succeeded tests/ssl-opt.sh
 
     # Optional part(s)
 
     if [ "$MEMORY" -gt 0 ]; then
-        msg "test: compat.sh (MSan)" # ~ 6 min 20s
+        msg "test: compat.sh (MSan)" # ~ 6 min
         if_build_succeeded tests/compat.sh
     fi
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -492,9 +492,10 @@ make CC='clang' CFLAGS='-Werror -O2'
 msg "test: main suites (full config)" # < 10s
 make test
 
-# test things not in the default config, and Default handshake for parameters choice
+# test things that are in the full config but not in the default one,
+# plus Default handshake for parameters choice (+ large ClientHello)
 msg "test: ssl-opt.sh (full config)" # < 10s
-if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|RC4'
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|ECJPAKE'
 
 msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 3 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -565,8 +565,8 @@ scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
+msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # < 5s
+if_build_succeeded tests/ssl-opt.sh -f '[Rr]enego'
 
 
 msg "build: allow SHA1 in certificates by default"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -693,35 +693,13 @@ make test
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+scripts/config.pl baremetal
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
 msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+scripts/config.pl baremetal
 scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 echo "Checking that software 64-bit division is not required"
@@ -730,22 +708,7 @@ echo "Checking that software 64-bit division is not required"
 msg "build: ARM Compiler 5, make"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_HAVE_TIME
-scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
+scripts/config.pl baremetal
 
 if [ $RUN_ARMCC -ne 0 ]; then
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -387,6 +387,12 @@ if_build_succeeded () {
     fi
 }
 
+# to be used instead of ! for commands run with
+# record_status or if_build_succeeded
+not() {
+    ! "$@"
+}
+
 if [ $RELEASE -eq 1 ]; then
     # Fix the seed value to 1 to ensure that the tests are deterministic.
     SEED=1
@@ -680,7 +686,7 @@ scripts/config.pl baremetal
 scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 echo "Checking that software 64-bit division is not required"
-! grep __aeabi_uldiv library/*.o
+if_build_succeeded not grep __aeabi_uldiv library/*.o
 
 if [ $RUN_ARMCC -ne 0 ]; then
     msg "build: ARM Compiler 5, make" # ~ 1 min 30s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -500,23 +500,6 @@ make
 msg "test: compat.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/compat.sh
 
-msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
-
-msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
-
 msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
@@ -557,11 +540,13 @@ make
 msg "test: main suites (full config)" # ~ 5s
 make test
 
-msg "test: ssl-opt.sh default (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f Default
+# test things not in the default config, and Default handshake for parameters choice
+msg "test: ssl-opt.sh (full config)" # ~ 1s
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|RC4'
 
-msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
+msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
+if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3' -e ''
 
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -531,8 +531,7 @@ cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
-make
+make CC='clang' CFLAGS='-Werror -O2'
 
 msg "test: main suites (full config)" # ~ 5s
 make test
@@ -563,7 +562,7 @@ record_status tests/scripts/key-exchanges.pl
 
 msg "build: Unix make, -Os (gcc)" # ~ 30s
 cleanup
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
+make CC=gcc CFLAGS='-Werror -Os'
 
 # Full configuration build, without platform support, file IO and net sockets.
 # This should catch missing mbedtls_printf definitions, and by disabling file
@@ -585,8 +584,8 @@ scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
 scripts/config.pl unset MBEDTLS_FS_IO
 # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
 # to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE' lib programs
+make CC=gcc CFLAGS='-Werror -O1' test
 
 # catch compile bugs in _uninit functions
 msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
@@ -595,21 +594,21 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
 scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_SRV_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_CLI_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 # Note, C99 compliance can also be tested with the sockets support disabled,
 # as that requires a POSIX platform (which isn't the same as C99).
@@ -619,7 +618,7 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
 scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0 -std=c99 -pedantic' lib
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic' lib
 
 msg "build: default config except MFL extension (ASan build)" # ~ 30s
 cleanup
@@ -655,14 +654,14 @@ fi
 if uname -a | grep -F x86_64 >/dev/null; then
     msg "build: i386, make, gcc" # ~ 30s
     cleanup
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -m32'
+    make CC=gcc CFLAGS='-Werror -O1 -m32'
 
     msg "test: i386, make, gcc"
     make test
 
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
     cleanup
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
+    make CC=gcc CFLAGS='-Werror -O1 -mx32'
 
     msg "test: 64-bit ILP32, make, gcc"
     make test
@@ -674,7 +673,7 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_HAVE_ASM
 scripts/config.pl unset MBEDTLS_AESNI_C
 scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
+make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT32'
 
 msg "test: gcc, force 32-bit bignum limbs"
 make test
@@ -685,7 +684,7 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl unset MBEDTLS_HAVE_ASM
 scripts/config.pl unset MBEDTLS_AESNI_C
 scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
+make CC=gcc CFLAGS='-Werror -O1 -DMBEDTLS_HAVE_INT64'
 
 msg "test: gcc, force 64-bit bignum limbs"
 make test
@@ -705,7 +704,7 @@ scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
 scripts/config.pl unset MBEDTLS_THREADING_C
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
 msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
 cleanup
@@ -723,7 +722,7 @@ scripts/config.pl unset MBEDTLS_THREADING_C
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
 scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 echo "Checking that software 64-bit division is not required"
 ! grep __aeabi_uldiv library/*.o
 
@@ -771,7 +770,7 @@ msg "build: allow SHA1 in certificates by default"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
-make CFLAGS='-Werror -Wall -Wextra'
+make CFLAGS='-Werror -O1'
 msg "test: allow SHA1 in certificates by default"
 make test
 if_build_succeeded tests/ssl-opt.sh -f SHA-1
@@ -788,15 +787,15 @@ make test
 
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 lib programs
 
 # note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 tests
 make WINDOWS_BUILD=1 clean
 
 msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 lib programs
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 tests
 make WINDOWS_BUILD=1 clean
 
 # MemSan currently only available on Linux 64 bits

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -739,16 +739,6 @@ msg "test: allow SHA1 in certificates by default"
 make test
 if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
-msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
-make test
-
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
 make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -150,7 +150,7 @@ cleanup()
 {
     command make clean
 
-    find . -name yotta -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
+    find . -name yotta -prune -o -name .git -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
     rm -f include/Makefile include/mbedtls/Makefile programs/*/Makefile
     git update-index --no-skip-worktree Makefile library/Makefile programs/Makefile tests/Makefile
     git checkout -- Makefile library/Makefile programs/Makefile tests/Makefile

--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -55,7 +55,7 @@ for my $curve (@curves) {
     system( "scripts/config.pl unset $curve" )
         and abort "Failed to disable $curve\n";
 
-    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
+    system( "CFLAGS='-Werror -O1' make lib" )
         and abort "Failed to build lib: $curve\n";
     system( "cd tests && make" ) and abort "Failed to build tests: $curve\n";
     system( "make test" ) and abort "Failed test suite: $curve\n";

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -71,7 +71,7 @@ while( my ($conf, $data) = each %configs ) {
     system( "cp configs/$conf $config_h" )
         and abort "Failed to activate $conf\n";
 
-    system( "CFLAGS='-Os -Werror -Wall -Wextra' make" ) and abort "Failed to build: $conf\n";
+    system( "CFLAGS='-O1 -Werror' make" ) and abort "Failed to build: $conf\n";
     system( "make test" ) and abort "Failed test suite: $conf\n";
 
     my $compat = $data->{'compat'};

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2335,7 +2335,7 @@ run_test    "Authentication: client no cert, openssl server required" \
             -c "! mbedtls_ssl_handshake returned"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
-run_test    "Authentication: client no cert, ssl3" \
+run_test    "Authentication: client no cert, SSLv3" \
             "$P_SRV debug_level=3 auth_mode=optional force_version=ssl3" \
             "$P_CLI debug_level=3 crt_file=none key_file=none min_version=ssl3" \
             0 \
@@ -3361,7 +3361,7 @@ run_test    "ECJPAKE: working, DTLS, nolog" \
 # Tests for ciphersuites per version
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
-run_test    "Per-version suites: SSL3" \
+run_test    "Per-version suites: SSLv3" \
             "$P_SRV min_version=ssl3 version_suites=TLS-RSA-WITH-3DES-EDE-CBC-SHA,TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
             "$P_CLI force_version=ssl3" \
             0 \


### PR DESCRIPTION
This is a backport of https://github.com/ARMmbed/mbedtls/pull/1243

This is a fairly straightforward backport, but Compared to the original, there are two additional commits:
- one just before the re-ordering, that removes a duplicated test: the duplication was not present in the development branch but only in 2.7 for some reason.
- one at the end, backporting a test that was added in development but not 2.7.

The following additional checks were made:
- that the reordering commit only does what it's supposed to, using the method described in the commit message
- the diff of `all.sh` with development was checked to be fully justifiable: it only consists of tests for `AES_FEWER_TABLES`, a feature that was added in 2.8.0.
- `all.sh -k -r` passed locally