### PR TITLE
Backport 2.1: Doxygen: don't traverse symbolic links

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -702,7 +702,7 @@ EXCLUDE                = configs
 # directories that are symbolic links (a Unix file system feature) are excluded
 # from the input.
 
-EXCLUDE_SYMLINKS       = NO
+EXCLUDE_SYMLINKS       = YES
 
 # If the value of the INPUT tag contains directories, you can use the
 # EXCLUDE_PATTERNS tag to specify one or more wildcard patterns to exclude


### PR DESCRIPTION
We don't use symbolic links as part of our build process, so tell
Doxygen not to traverse them. In particular, if I have a symbolic link
to a directory outside the build tree, I don't want Doxygen to follow
it.

Backport of #1234 