### PR TITLE
Backport 2.1: Cleanup all.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,11 @@ the Mbed TLS source directory, use:
     make
 
 If you want to change `CC` or `CFLAGS` afterwards, you will need to remove the
-CMake cache. This can be done with the following command using GNU find:
+CMake cache. This can be done with the following command using GNU find, but
+please note it is destructive and should be adapted if you're using a VCS
+other than git or have other subdirectories that should be preserved:
 
-    find . -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
+    find . -name .git -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} +
 
 You can now make the desired change:
 

--- a/library/debug.c
+++ b/library/debug.c
@@ -70,7 +70,7 @@ static inline void debug_send_line( const mbedtls_ssl_context *ssl, int level,
      */
 #if defined(MBEDTLS_THREADING_C)
     char idstr[20 + DEBUG_BUF_SIZE]; /* 0x + 16 nibbles + ': ' */
-    mbedtls_snprintf( idstr, sizeof( idstr ), "%p: %s", ssl, str );
+    mbedtls_snprintf( idstr, sizeof( idstr ), "%p: %s", (void*) ssl, str );
     ssl->conf->f_dbg( ssl->conf->p_dbg, level, file, line, idstr );
 #else
     ssl->conf->f_dbg( ssl->conf->p_dbg, level, file, line, str );

--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -1,0 +1,114 @@
+#! /usr/bin/env sh
+
+# output_env.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2016, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# To print out all the relevant information about the development environment.
+#
+# This includes:
+#   - architecture of the system
+#   - type and version of the operating system
+#   - version of armcc, clang, gcc-arm and gcc compilers
+#   - version of libc, clang, asan and valgrind if installed
+#   - version of gnuTLS and OpenSSL
+
+print_version()
+{
+    BIN="$1"
+    shift
+    ARGS="$1"
+    shift
+    FAIL_MSG="$1"
+    shift
+
+    if ! `type "$BIN" > /dev/null 2>&1`; then
+        echo "* $FAIL_MSG"
+        return 0
+    fi
+
+    BIN=`which "$BIN"`
+    VERSION_STR=`$BIN $ARGS 2>&1`
+
+    # Apply all filters
+    while [ $# -gt 0 ]; do
+        FILTER="$1"
+        shift
+        VERSION_STR=`echo "$VERSION_STR" | $FILTER`
+    done
+
+    echo "* ${BIN##*/}: $BIN: $VERSION_STR"
+}
+
+print_version "uname" "-a" ""
+echo
+
+: ${ARMC5_CC:=armcc}
+print_version "$ARMC5_CC" "--vsn" "armcc not found!" "head -n 2"
+echo
+
+: ${ARMC6_CC:=armclang}
+print_version "$ARMC6_CC" "--vsn" "armclang not found!" "head -n 2"
+echo
+
+print_version "arm-none-eabi-gcc" "--version" "gcc-arm not found!" "head -n 1"
+echo
+
+print_version "gcc" "--version" "gcc not found!" "head -n 1"
+echo
+
+print_version "clang" "--version" "clang not found" "head -n 2"
+echo
+
+print_version "ldd" "--version"                     \
+    "No ldd present: can't determine libc version!" \
+    "head -n 1"
+echo
+
+print_version "valgrind" "--version" "valgrind not found!"
+echo
+
+: ${OPENSSL:=openssl}
+print_version "$OPENSSL" "version" "openssl not found!"
+echo
+
+if [ -n "${OPENSSL_LEGACY+set}" ]; then
+    print_version "$OPENSSL_LEGACY" "version" "openssl legacy version not found!"
+    echo
+fi
+
+: ${GNUTLS_CLI:=gnutls-cli}
+print_version "$GNUTLS_CLI" "--version" "gnuTLS client not found!" "head -n 1"
+echo
+
+: ${GNUTLS_SERV:=gnutls-serv}
+print_version "$GNUTLS_SERV" "--version" "gnuTLS server not found!" "head -n 1"
+echo
+
+if [ -n "${GNUTLS_LEGACY_CLI+set}" ]; then
+    print_version "$GNUTLS_LEGACY_CLI" "--version" \
+        "gnuTLS client legacy version not found!"  \
+        "head -n 1"
+    echo
+fi
+
+if [ -n "${GNUTLS_LEGACY_SERV+set}" ]; then
+    print_version "$GNUTLS_LEGACY_SERV" "--version" \
+        "gnuTLS server legacy version not found!"   \
+        "head -n 1"
+    echo
+fi
+
+if `hash dpkg > /dev/null 2>&1`; then
+    echo "* asan:"
+    dpkg -s libasan2 2> /dev/null | grep -i version
+    dpkg -s libasan1 2> /dev/null | grep -i version
+    dpkg -s libasan0 2> /dev/null | grep -i version
+else
+    echo "* No dpkg present: can't determine asan version!"
+fi
+echo

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -501,23 +501,6 @@ make
 msg "test: compat.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/compat.sh
 
-msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
-
-msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
-
 msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
@@ -558,11 +541,13 @@ make
 msg "test: main suites (full config)" # ~ 5s
 make test
 
-msg "test: ssl-opt.sh default (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f Default
+# test things not in the default config, and Default handshake for parameters choice
+msg "test: ssl-opt.sh (full config)" # ~ 1s
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|RC4'
 
-msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
+msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
+if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3' -e ''
 
 msg "test/build: curves.pl (gcc)" # ~ 4 min
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -423,6 +423,12 @@ fi
 #
 # Indicative running times are given for reference.
 
+msg "info: output_env.sh"
+OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
+    GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
+    GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
+    ARMC6_CC="$ARMC6_CC" scripts/output_env.sh
+
 msg "test: recursion.pl" # < 1s
 tests/scripts/recursion.pl library/*.c
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -654,6 +654,16 @@ msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
 tests/compat.sh -t RSA
 
 
+msg "build: default config with AES_ROM_TABLES enabled"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set MBEDTLS_AES_ROM_TABLES
+make CC=gcc CFLAGS='-Werror -Wall -Wextra'
+
+msg "test: AES_ROM_TABLES"
+make test
+
+
 ################################################################
 #### 3. Various targets (adapted config)
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -769,6 +769,8 @@ if uname -a | grep 'Linux.*x86_64' >/dev/null; then
     msg "build: MSan (clang)" # ~ 1 min
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
     make
@@ -790,6 +792,7 @@ else # no MemSan
 
     msg "build: Release (clang)"
     cleanup
+    scripts/config.pl full
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
     make
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -654,13 +654,13 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl baremetal
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
-msg "build: ARM Compiler 5, make" # ~ 1 min 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl baremetal
-
 if [ $RUN_ARMCC -ne 0 ]; then
+    msg "build: ARM Compiler 5, make" # ~ 1 min 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl baremetal
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+    # keep config for next tests, so 'make clean' instead of 'cleanup'
     make clean
 
     # ARM Compiler 6 - Target ARMv7-A

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -327,6 +327,12 @@ else
     fi
 fi
 
+if [ $RUN_ARMCC -eq 0 ] && [ $YOTTA -ne 0 ]; then
+    err_msg "Error - yotta testing needs armcc."
+    echo "You can either disable yotta or enable armcc."
+    exit 1
+fi
+
 build_status=0
 if [ $KEEP_GOING -eq 1 ]; then
     failure_summary=
@@ -749,7 +755,7 @@ cd "$MBEDTLS_ROOT_DIR"
 rm -rf "$OUT_OF_SOURCE_DIR"
 
 
-if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
+if [ $YOTTA -ne 0 ]; then
     # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
     # path, and uses whatever version of armcc it finds there.
     msg "build: create and build yotta module" # ~ 6 min 30s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -401,7 +401,7 @@ export GNUTLS_SERV="$GNUTLS_SERV"
 # Make sure the tools we need are available.
 check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
             "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-            "arm-none-eabi-gcc"
+            "arm-none-eabi-gcc" "i686-w64-mingw32-gcc"
 if [ $RUN_ARMCC -ne 0 ]; then
     check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
 fi
@@ -702,14 +702,18 @@ msg "test: allow SHA1 in certificates by default"
 make test
 if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
-if which i686-w64-mingw32-gcc >/dev/null; then
-    msg "build: cross-mingw64, make" # ~ 30s
-    cleanup
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1
-    make WINDOWS_BUILD=1 clean
-    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS=-Werror WINDOWS_BUILD=1 SHARED=1
-    make WINDOWS_BUILD=1 clean
-fi
+msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+cleanup
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
+
+# note Make tests only builds the tests, but doesn't run them
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
+make WINDOWS_BUILD=1 clean
+
+msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
+make WINDOWS_BUILD=1 clean
 
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -508,9 +508,6 @@ scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
 msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/ssl-opt.sh
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -655,38 +655,13 @@ fi # x86_64
 msg "build: arm-none-eabi-gcc, make" # ~ 10s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+scripts/config.pl baremetal
 make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
 msg "build: ARM Compiler 5, make"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_HAVE_TIME
-scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
+scripts/config.pl baremetal
 
 if [ $RUN_ARMCC -ne 0 ]; then
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -583,8 +583,7 @@ scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
 scripts/config.pl unset MBEDTLS_FS_IO
 # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
 # to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -O1' test
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE'
 
 # catch compile bugs in _uninit functions
 msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
@@ -608,8 +607,10 @@ scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_CLI_C
 make CC=gcc CFLAGS='-Werror -O1'
 
-# Note, C99 compliance can also be tested with the sockets support disabled,
+# Note, C99 compliance can only be tested with the sockets support disabled,
 # as that requires a POSIX platform (which isn't the same as C99).
+# We could use -D_DEFAULT_SOURCE here too, but without it we can make sure our
+# use of platform-dependant things is limited to the options disabled here.
 msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
@@ -718,15 +719,11 @@ if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 lib programs
-
-# note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1
 make WINDOWS_BUILD=1 clean
 
 msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1
 make WINDOWS_BUILD=1 clean
 
 # MemSan currently only available on Linux 64 bits

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -392,6 +392,12 @@ if_build_succeeded () {
     fi
 }
 
+# to be used instead of ! for commands run with
+# record_status or if_build_succeeded
+not() {
+    ! "$@"
+}
+
 if [ $RELEASE -eq 1 ]; then
     # Fix the seed value to 1 to ensure that the tests are deterministic.
     SEED=1

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -532,8 +532,7 @@ cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
-make
+make CC='clang' CFLAGS='-Werror -O2'
 
 msg "test: main suites (full config)" # ~ 5s
 make test
@@ -584,8 +583,8 @@ scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
 scripts/config.pl unset MBEDTLS_FS_IO
 # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
 # to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic -D_DEFAULT_SOURCE' lib programs
+make CC=gcc CFLAGS='-Werror -O1' test
 
 # catch compile bugs in _uninit functions
 msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
@@ -593,21 +592,21 @@ cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-make CC=gcc CFLAGS='-Werror -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_SRV_C
-make CC=gcc CFLAGS='-Werror -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_SSL_CLI_C
-make CC=gcc CFLAGS='-Werror -O0'
+make CC=gcc CFLAGS='-Werror -O1'
 
 # Note, C99 compliance can also be tested with the sockets support disabled,
 # as that requires a POSIX platform (which isn't the same as C99).
@@ -617,7 +616,7 @@ cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
 scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
 scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
-make CC=gcc CFLAGS='-Werror -O0 -std=c99 -pedantic' lib
+make CC=gcc CFLAGS='-Werror -O1 -std=c99 -pedantic' lib
 
 msg "build: default config except MFL extension (ASan build)" # ~ 30s
 cleanup
@@ -639,14 +638,14 @@ fi
 if uname -a | grep -F x86_64 >/dev/null; then
     msg "build: i386, make, gcc" # ~ 30s
     cleanup
-    make CC=gcc CFLAGS='-Werror -m32'
+    make CC=gcc CFLAGS='-Werror -O1 -m32'
 
     msg "test: i386, make, gcc"
     make test
 
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
     cleanup
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
+    make CC=gcc CFLAGS='-Werror -O1 -mx32'
 
     msg "test: 64-bit ILP32, make, gcc"
     make test
@@ -666,7 +665,7 @@ scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
 scripts/config.pl unset MBEDTLS_THREADING_C
 scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
 scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS=-Werror lib
+make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1' lib
 
 msg "build: ARM Compiler 5, make"
 cleanup
@@ -712,22 +711,22 @@ msg "build: allow SHA1 in certificates by default"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
-make CFLAGS='-Werror -Wall -Wextra'
+make CFLAGS='-Werror -O1'
 msg "test: allow SHA1 in certificates by default"
 make test
 if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
 msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
 cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 lib programs
 
 # note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 tests
 make WINDOWS_BUILD=1 clean
 
 msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 lib programs
+make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -O1' WINDOWS_BUILD=1 SHARED=1 tests
 make WINDOWS_BUILD=1 clean
 
 # MemSan currently only available on Linux 64 bits

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -95,6 +95,7 @@ FORCE=0
 KEEP_GOING=0
 RELEASE=0
 RUN_ARMCC=1
+YOTTA=0
 
 # Default commands, can be overriden by the environment
 : ${OPENSSL:="openssl"}
@@ -124,9 +125,11 @@ General options:
   -m|--memory           Additional optional memory tests.
      --armcc            Run ARM Compiler builds (on by default).
      --no-armcc         Skip ARM Compiler builds.
+     --no-yotta         Skip yotta module build (always skipped)
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
   -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
   -s|--seed             Integer seed value to use for this test run.
+     --yotta            Build yotta module (ignored).
 
 Tool path options:
      --armc5-bin-dir=<ARMC5_bin_dir_path>       ARM Compiler 5 bin directory.
@@ -253,6 +256,9 @@ while [ $# -gt 0 ]; do
         --no-armcc)
             RUN_ARMCC=0
             ;;
+        --no-yotta)
+            YOTTA=0
+            ;;
         --openssl)
             shift
             OPENSSL="$1"
@@ -272,6 +278,9 @@ while [ $# -gt 0 ]; do
             shift
             SEED="$1"
             ;;
+        --yotta)
+            YOTTA=1
+            ;;
         *)
             echo >&2 "Unknown option: $1"
             echo >&2 "Run $0 --help for usage."
@@ -281,13 +290,21 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+if [ $YOTTA -eq 1 ]; then
+    err_msg "Warning: yotta requested but not supported on 2.1 - ignoring"
+    # override value rather than exiting to ease uniforme use across versions
+    YOTTA=0
+fi
+
 if [ $FORCE -eq 1 ]; then
-    rm -rf yotta/module "$OUT_OF_SOURCE_DIR"
+    if [ $YOTTA -eq 1 ]; then
+        rm -rf yotta/module "$OUT_OF_SOURCE_DIR"
+    fi
     git checkout-index -f -q $CONFIG_H
     cleanup
 else
 
-    if [ -d yotta/module ]; then
+    if [ $YOTTA -ne 0 ] && [ -d yotta/module ]; then
         err_msg "Warning - there is an existing yotta module in the directory 'yotta/module'"
         echo "You can either delete your work and retry, or force the test to overwrite the"
         echo "test by rerunning the script as: $0 --force"
@@ -456,10 +473,13 @@ tests/scripts/check-names.sh
 #### Build and test many configurations and targets
 ################################################################
 
-# Yotta not supported in 2.1 branch
-#msg "build: create and build yotta module" # ~ 30s
-#cleanup
-#record_status tests/scripts/yotta-build.sh
+if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
+    # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
+    # path, and uses whatever version of armcc it finds there.
+    msg "build: create and build yotta module" # ~ 30s
+    cleanup
+    record_status tests/scripts/yotta-build.sh
+fi
 
 msg "build: cmake, gcc, ASan" # ~ 1 min 50s
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -474,16 +474,6 @@ make
 msg "test: compat.sh (ASan build)" # ~ 6 min
 if_build_succeeded tests/compat.sh
 
-msg "build: default config except MFL extension (ASan build)" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: ssl-opt.sh, MFL-related tests"
-tests/ssl-opt.sh -f "Max fragment length"
-
 msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
@@ -614,6 +604,17 @@ scripts/config.pl full
 scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
 scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
 make CC=gcc CFLAGS='-Werror -O0 -std=c99 -pedantic' lib
+
+msg "build: default config except MFL extension (ASan build)" # ~ 30s
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: ssl-opt.sh, MFL-related tests"
+if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
+
 
 if uname -a | grep -F Linux >/dev/null; then
     msg "build/test: make shared" # ~ 40s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -566,8 +566,8 @@ scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
 CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
+msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # < 5s
+if_build_succeeded tests/ssl-opt.sh -f '[Rr]enego'
 
 
 msg "build: allow SHA1 in certificates by default"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -149,7 +149,7 @@ cleanup()
 {
     command make clean
 
-    find . -name yotta -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
+    find . -name yotta -prune -o -name .git -prune -o -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
     rm -f include/Makefile include/mbedtls/Makefile programs/*/Makefile
     git update-index --no-skip-worktree Makefile library/Makefile programs/Makefile tests/Makefile
     git checkout -- Makefile library/Makefile programs/Makefile tests/Makefile

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -493,9 +493,10 @@ make CC='clang' CFLAGS='-Werror -O2'
 msg "test: main suites (full config)" # < 10s
 make test
 
-# test things not in the default config, and Default handshake for parameters choice
+# test things that are in the full config but not in the default one,
+# plus Default handshake for parameters choice (+ large ClientHello)
 msg "test: ssl-opt.sh (full config)" # < 10s
-if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|RC4'
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|SSLv3\|ECJPAKE'
 
 msg "test: compat.sh SSLv3, RC4, DES & NULL (full config)" # ~ 3 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env sh
 
 # all.sh
 #
@@ -79,8 +79,11 @@
 # Abort on errors (and uninitialised variables)
 set -eu
 
-if [ -d library -a -d include -a -d tests ]; then :; else
-    err_msg "Must be run from mbed TLS root"
+if [ "$( uname )" != "Linux" ]; then
+    echo "This script only works in Linux" >&2
+    exit 1
+elif [ -d library -a -d include -a -d tests ]; then :; else
+    echo "Must be run from mbed TLS root" >&2
     exit 1
 fi
 
@@ -103,6 +106,11 @@ RUN_ARMCC=1
 : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
 : ${ARMC5_BIN_DIR:=/usr/bin}
 : ${ARMC6_BIN_DIR:=/usr/bin}
+
+# if MAKEFLAGS is not set add the -j option to speed up invocations of make
+if [ -n "${MAKEFLAGS+set}" ]; then
+    export MAKEFLAGS="-j"
+fi
 
 usage()
 {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -483,7 +483,7 @@ if_build_succeeded tests/compat.sh
 # 1.2 Basic tests: full config
 ##############################
 
-msg "build: cmake, full config, clang" # ~ 50s
+msg "build: make, full config, clang" # ~ 50s
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full

--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -55,7 +55,8 @@ for my $curve (@curves) {
     system( "scripts/config.pl unset $curve" )
         and abort "Failed to disable $curve\n";
 
-    system( "make lib" ) and abort "Failed to build lib: $curve\n";
+    system( "CFLAGS='-Werror -O1' make lib" )
+        and abort "Failed to build lib: $curve\n";
     system( "cd tests && make" ) and abort "Failed to build tests: $curve\n";
     system( "make test" ) and abort "Failed test suite: $curve\n";
 

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -59,7 +59,7 @@ while( my ($conf, $args) = each %configs ) {
     system( "cp configs/$conf $config_h" )
         and abort "Failed to activate $conf\n";
 
-    system( "make CFLAGS='-Os -Werror'" ) and abort "Failed to build: $conf\n";
+    system( "CFLAGS='-O1 -Werror' make" ) and abort "Failed to build: $conf\n";
     system( "make test" ) and abort "Failed test suite: $conf\n";
 
     if( $args )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2127,7 +2127,7 @@ run_test    "Authentication: client no cert, openssl server optional" \
             -C "! mbedtls_ssl_handshake returned"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
-run_test    "Authentication: client no cert, ssl3" \
+run_test    "Authentication: client no cert, SSLv3" \
             "$P_SRV debug_level=3 auth_mode=optional force_version=ssl3" \
             "$P_CLI debug_level=3 crt_file=none key_file=none min_version=ssl3" \
             0 \
@@ -3013,7 +3013,7 @@ run_test    "PSK callback: wrong key" \
 # Tests for ciphersuites per version
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
-run_test    "Per-version suites: SSL3" \
+run_test    "Per-version suites: SSLv3" \
             "$P_SRV min_version=ssl3 version_suites=TLS-RSA-WITH-3DES-EDE-CBC-SHA,TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
             "$P_CLI force_version=ssl3" \
             0 \


### PR DESCRIPTION
This is the 2.1 backport of https://github.com/ARMmbed/mbedtls/pull/1243

Compared to the original:
- there are a few extra commits at the beginning that bring the 2.1 version closer to the 2.7 version. This makes it easier to cherry-pick commits from the original PR and I think it's generally a good thing to have more uniform testing across versions.
- in the end there's a fix for a compiler warning, that for some reason hadn't been backported previously

Additional checks made:
- that the reordering commit only does what it's supposed to, using the method described in the commit message
- checked the final diff with the 2.7 version:
    - `doxygen.sh` not in 2.1: is that on purpose? if not, should we add it?
    - some tests in 2.7 disable config settings that are not in 2.1:
        `TIME_ALT`, `NV_SEED`
    - some tests in 2.7 are about a config setting that is not in 2.1:
        `NULL_ENTROPY`, `NO_UDBL_DIVISION`, `HAVE_INT32`, `HAVE_INT64`
- `all.sh -k -r` passed locally
