### PR TITLE
Backport 2.7: Fix braces in mbedtls_memory_buffer_alloc_status()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.7.4 branch released xxxx-xx-xx
+
+Bugfix
+   * Fix braces in mbedtls_memory_buffer_alloc_status(). Found by sbranden, #552.
+
 = mbed TLS 2.7.3 branch released 2018-04-30
 
 Security

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -522,7 +522,9 @@ void mbedtls_memory_buffer_alloc_status()
                       heap.alloc_count, heap.free_count );
 
     if( heap.first->next == NULL )
+    {
         mbedtls_fprintf( stderr, "All memory de-allocated in stack buffer\n" );
+    }
     else
     {
         mbedtls_fprintf( stderr, "Memory currently allocated:\n" );


### PR DESCRIPTION
This is a back port of #1182