### PR TITLE
Backport 2.1: Fix braces in mbedtls_memory_buffer_alloc_status()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,7 @@ Changes
    * Improve robustness of mbedtls_ssl_derive_keys against the use of
      HMAC functions with non-HMAC ciphersuites. Independently contributed
      by Jiayuan Chen in #1377. Fixes #1437.
+   * Fix braces in mbedtls_memory_buffer_alloc_status(). Found by sbranden, #552.
 
 = mbed TLS 2.1.11 branch released 2018-03-16
 

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -522,7 +522,9 @@ void mbedtls_memory_buffer_alloc_status()
                       heap.alloc_count, heap.free_count );
 
     if( heap.first->next == NULL )
+    {
         mbedtls_fprintf( stderr, "All memory de-allocated in stack buffer\n" );
+    }
     else
     {
         mbedtls_fprintf( stderr, "Memory currently allocated:\n" );


### PR DESCRIPTION
This is a back port of #1182