### PR TITLE
Fix invalid buffer sizes during compression / decompression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,8 @@ Bugfix
      in the internal buffers; these cases lead to deadlocks in case
      event-driven I/O was used.
      Found and reported by Hubert Mis in #772.
+   * Fix invalid buffer sizes passed to zlib during record compression and
+     decompression.
 
 Changes
    * Remove some redundant code in bignum.c. Contributed by Alexey Skalozub.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2155,7 +2155,7 @@ static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
 {
     int ret;
     unsigned char *msg_post = ssl->in_msg;
-    ptrdiff_t bytes_written = ssl->in_msg - ssl->in_buf;
+    ptrdiff_t header_bytes = ssl->in_msg - ssl->in_buf;
     size_t len_pre = ssl->in_msglen;
     unsigned char *msg_pre = ssl->compress_buf;
 
@@ -2176,7 +2176,7 @@ static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
     ssl->transform_in->ctx_inflate.avail_in = len_pre;
     ssl->transform_in->ctx_inflate.next_out = msg_post;
     ssl->transform_in->ctx_inflate.avail_out = MBEDTLS_SSL_BUFFER_LEN -
-                                               bytes_written;
+                                               header_bytes;
 
     ret = inflate( &ssl->transform_in->ctx_inflate, Z_SYNC_FLUSH );
     if( ret != Z_OK )
@@ -2186,7 +2186,7 @@ static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
     }
 
     ssl->in_msglen = MBEDTLS_SSL_BUFFER_LEN -
-                     ssl->transform_in->ctx_inflate.avail_out - bytes_written;
+                     ssl->transform_in->ctx_inflate.avail_out - header_bytes;
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "after decompression: msglen = %d, ",
                    ssl->in_msglen ) );


### PR DESCRIPTION
This PR fixes the sizes of available buffers passed to zlib by reducing them by an amount of already written bytes.
More information available in IOTSSL-1401.