### PR TITLE
silence "no symbols" warnings on apple clang

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -95,6 +95,13 @@ if(WIN32)
     set(libs ${libs} ws2_32)
 endif(WIN32)
 
+if(APPLE)
+    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif(APPLE)
+
 if(USE_PKCS11_HELPER_LIBRARY)
     set(libs ${libs} pkcs11-helper)
 endif(USE_PKCS11_HELPER_LIBRARY)


### PR DESCRIPTION
## Description
fixes #1252
This is an addition of compiler settings to silence the "no symbols found" warnings when compiling as static lib for macos

## Status
READY

## Steps to test or reproduce
check out #1252 for the problem statement and steps to reproduce
