### PR TITLE
Backport 2.1: Allow the entry_name size to be set in config.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.1.13 branch released 2018-xx-xx
+
+Bugfix
+   * Added the macro MBEDTLS_X509_MAX_FILE_PATH_LEN that enables the user to
+     configure the maximum length of a file path that can be buffered when
+     calling mbedtls_x509_crt_parse_path().
+
 = mbed TLS 2.1.12 branch released 2018-04-30
 
 Security
@@ -44,9 +51,6 @@ Bugfix
      buffer.
    * Fix invalid buffer sizes passed to zlib during record compression and
      decompression.
-   * Added the macro MBEDTLS_X509_MAX_FILE_PATH_LEN that enables the user to
-     configure the maximum length of a file path that can be buffered when
-     calling mbedtls_x509_crt_parse_path().
 
 Changes
    * Improve testing in configurations that omit certain hashes or

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,9 @@ Bugfix
      buffer.
    * Fix invalid buffer sizes passed to zlib during record compression and
      decompression.
+   * Added the macro MBEDTLS_X509_MAX_FILE_PATH_LEN that enables the user to
+     configure the maximum length of a file path that can be buffered when
+     calling mbedtls_x509_crt_parse_path().
 
 Changes
    * Improve testing in configurations that omit certain hashes or

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2492,6 +2492,7 @@
 
 /* X509 options */
 //#define MBEDTLS_X509_MAX_INTERMEDIATE_CA   8   /**< Maximum number of intermediate CAs in a verification chain. */
+//#define MBEDTLS_X509_MAX_FILE_PATH_LEN     512 /**< Maximum length of a path/filename string in bytes including the null terminator character ('\0'). */
 
 /**
  * Allow SHA-1 in the default TLS configuration for certificate signing.

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -120,6 +120,10 @@ mbedtls_x509_crt_profile;
 #define MBEDTLS_X509_RFC5280_MAX_SERIAL_LEN 32
 #define MBEDTLS_X509_RFC5280_UTC_TIME_LEN   15
 
+#if !defined( MBEDTLS_X509_MAX_FILE_PATH_LEN )
+#define MBEDTLS_X509_MAX_FILE_PATH_LEN 512
+#endif
+
 /**
  * Container for writing a certificate (CRT)
  */


### PR DESCRIPTION
## Description
Allow the size of the entry_name character array in `x509_crt.c` to be configurable through a macro in `config.h`. entry_name holds a path/filename string. The macro introduced in `MBEDTLS_X509_MAX_FILE_PATH_LEN`.

This addresses issue #492, and is a backport of #592 to `mbedtls-2.1` to address issue #1188.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
