### PR TITLE
Improve bignum speed on ARM with DSP instructions

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -630,6 +630,23 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
+#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+
+#define MULADDC_INIT                            \
+    asm(
+
+#define MULADDC_CORE                            \
+            "ldr    r0, [%0], #4        \n\t"   \
+            "ldr    r1, [%1]            \n\t"   \
+            "umaal  r1, %2, %3, r0      \n\t"   \
+            "str    r1, [%1], #4        \n\t"
+
+#define MULADDC_STOP                            \
+         : "=r" (s),  "=r" (d), "=r" (c)        \
+         : "r" (b), "0" (s), "1" (d), "2" (c)   \
+         : "r0", "r1", "memory"                 \
+         );
+
 #else
 
 #define MULADDC_INIT                                    \


### PR DESCRIPTION
## Description
These two patches improve the bignum code (used in particular for RSA computation) on ARM CPU which have the DSP extension, that is the ARMv7E-M like the Cortex M4 and Cortex M7, or the ARMv7-A, like the Cortex A series. It has been originally developed for a Cortex M4 application, but I have done all the tests on a Cortex A8.

## Status
READY

## Requires Backporting
NO (enhancement)

## Migrations
If there is any API change, what's the incentive and logic for it.

NO (this is just a different code path on supported CPU)