### PR TITLE
Fix memory leak in mbedtls_x509_csr_parse

### DIFF
--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -279,7 +279,8 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
 
 #if defined(MBEDTLS_PEM_PARSE_C)
     /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
-    if( buf[buflen - 1] == '\0' ) {
+    if( buf[buflen - 1] == '\0' )
+    {
         mbedtls_pem_init( &pem );
         ret = mbedtls_pem_read_buffer( &pem,
                                "-----BEGIN CERTIFICATE REQUEST-----",

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -294,11 +294,9 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
         /*
          * Was PEM encoded, parse the result
          */
-        if( ( ret = mbedtls_x509_csr_parse_der( csr, pem.buf, pem.buflen ) ) != 0 )
-            return( ret );
-
+        ret = mbedtls_x509_csr_parse_der( csr, pem.buf, pem.buflen );
         mbedtls_pem_free( &pem );
-        return( 0 );
+        return( ret );
     }
     else if( ret != MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT )
     {

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -278,32 +278,24 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_PEM_PARSE_C)
-    mbedtls_pem_init( &pem );
-
     /* Avoid calling mbedtls_pem_read_buffer() on non-null-terminated string */
-    if( buf[buflen - 1] != '\0' )
-        ret = MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT;
-    else
+    if( buf[buflen - 1] == '\0' ) {
+        mbedtls_pem_init( &pem );
         ret = mbedtls_pem_read_buffer( &pem,
                                "-----BEGIN CERTIFICATE REQUEST-----",
                                "-----END CERTIFICATE REQUEST-----",
                                buf, NULL, 0, &use_len );
 
-    if( ret == 0 )
-    {
-        /*
-         * Was PEM encoded, parse the result
-         */
-        ret = mbedtls_x509_csr_parse_der( csr, pem.buf, pem.buflen );
+        if( ret == 0 )
+            /*
+             * Was PEM encoded, parse the result
+             */
+            ret = mbedtls_x509_csr_parse_der( csr, pem.buf, pem.buflen );
+
         mbedtls_pem_free( &pem );
-        return( ret );
+        if( ret != MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT )
+            return( ret );
     }
-    else if( ret != MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT )
-    {
-        mbedtls_pem_free( &pem );
-        return( ret );
-    }
-    else
 #endif /* MBEDTLS_PEM_PARSE_C */
     return( mbedtls_x509_csr_parse_der( csr, buf, buflen ) );
 }


### PR DESCRIPTION
## Description
Fix memory leak in mbedtls_x509_csr_parse

## Status
READY

## Requires Backporting
Yes

Which branch? I did not check

## Migrations
No

## Additional comments
Found using oss-fuzz

## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog updated
- [X] Backported


## Steps to test or reproduce
Allocated memory in previous call to mbedtls_pem_read_buffer does not get freed without this patch