### PR TITLE
Change the default IP addresses for DTLS samples

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ API Changes
      Therefore, mbedtls_platform_zeroize() is moved to the platform module to
      facilitate testing and maintenance.
 
+Changes
+   * Change the dtls_client and dtls_server samples to work by default over
+     IPv6 and optionally by a build option over IPv4.
+
 = mbed TLS 2.9.0 branch released 2018-04-30
 
 Security

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -60,9 +60,18 @@ int main( void )
 #include "mbedtls/certs.h"
 #include "mbedtls/timing.h"
 
+/* Uncomment out the following line to default to IPv4 and disable IPv6 */
+//#define FORCE_IPV4
+
 #define SERVER_PORT "4433"
 #define SERVER_NAME "localhost"
-#define SERVER_ADDR "127.0.0.1" /* forces IPv4 */
+
+#ifdef FORCE_IPV4
+#define SERVER_ADDR "127.0.0.1"     /* Forces IPv4 */
+#else
+#define SERVER_ADDR "::1"
+#endif
+
 #define MESSAGE     "Echo this"
 
 #define READ_TIMEOUT_MS 1000

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -34,6 +34,15 @@
 #define mbedtls_time_t     time_t
 #endif
 
+/* Uncomment out the following line to default to IPv4 and disable IPv6 */
+//#define FORCE_IPV4
+
+#ifdef FORCE_IPV4
+#define BIND_IP     "0.0.0.0"     /* Forces IPv4 */
+#else
+#define BIND_IP     "::"
+#endif
+
 #if !defined(MBEDTLS_SSL_SRV_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \
     !defined(MBEDTLS_SSL_COOKIE_C) || !defined(MBEDTLS_NET_C) ||          \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||        \
@@ -170,7 +179,7 @@ int main( void )
     printf( "  . Bind on udp/*/4433 ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, BIND_IP, "4433", MBEDTLS_NET_PROTO_UDP ) ) != 0 )
     {
         printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;


### PR DESCRIPTION
## Description
Changes the IP address to bind to for dtls_server.c to be "::" or optionally "0.0.0.0" if the preprocessor symbol FORCE_IPV4 is defined.

Also changes the destinaton IP address for dtls_client.c to be "::1" or if FORCE_IPV4 symbol is defined "127.0.0.1".

This change allows `dtls_server.c` and `dtls_client.c` to be configured to use either IPv4 or IPv6 at build time, so out of the box they will work together.

Previously `dtls_server.c` might bind to IPv6 and `dtls_client.c` connect over IPv4, leading to a failure.

## Status
**READY**

## Requires Backporting
Yes

This is a configuration of the build and doesn't materially change the logic. There is definitely a bug here, as this issue is causing the sample to fail to work on OSX and possibly Windows.

I think the decision to back port should be part of the review of this PR however.

Which branch?

`mbedtls-2.7` and `mbedtls-2.1`

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported

