### PR TITLE
Automatically configure mbedtls_platform_zeroize under Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -225,6 +225,15 @@ API Changes
      output binary as part of redundant code elimination optimizations.
      Therefore, mbedtls_platform_zeroize() is moved to the platform module to
      facilitate testing and maintenance.
+   * Add an option MBEDTLS_PLATFORM_ZEROIZE_MACRO that allows configuring a
+     platform specific mbedtls_platform_zeroize function using the C
+     preprocessor. The configured function should be implemented such that it
+     securely zeroizes memory and will not be optimized away by the compiler.
+
+Features
+   * Add functionality to automatically configure mbedtls_platform_zeroize
+     to use RtlSecureZeroMemory when compiling for Windows. Contributed by
+     irwir in pull request #1522.
 
 Bugfix
    * Fix an issue with MicroBlaze support in bn_mul.h which was causing the

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -397,6 +397,10 @@
 #error "MBEDTLS_PLATFORM_PRINTF_MACRO and MBEDTLS_PLATFORM_STD_PRINTF/MBEDTLS_PLATFORM_PRINTF_ALT cannot be defined simultaneously"
 #endif
 
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_MACRO) && defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
+#error "MBEDTLS_PLATFORM_ZEROIZE_MACRO and MBEDTLS_PLATFORM_ZEROIZE_ALT cannot be defined simultaneously"
+#endif
+
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) && !defined(MBEDTLS_PLATFORM_C)
 #error "MBEDTLS_PLATFORM_SNPRINTF_ALT defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3137,7 +3137,7 @@
  * RtlSecureZeroMemory when compiling for Windows. Refer to platform_utils.h
  * for more information.
  */
-//#define MBEDTLS_PLATFORM_ZEROIZE_MACRO( buf, len )    memset( buf, 0, len )
+//#define MBEDTLS_PLATFORM_ZEROIZE_MACRO( buf, len )    memset_s( buf, len, 0, len )
 
 /* \} name SECTION: Customisation configuration options */
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3128,6 +3128,17 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
+/**
+ * Define the macro MBEDTLS_PLATFORM_ZEROIZE_MACRO to replace all occurrences
+ * of mbedtls_platform_zeroize() with a platform specific implementation of
+ * that function.
+ *
+ * Note Mbed TLS automatically defines MBEDTLS_PLATFORM_ZEROIZE_MACRO to
+ * RtlSecureZeroMemory when compiling for Windows. Refer to platform_utils.h
+ * for more information.
+ */
+//#define MBEDTLS_PLATFORM_ZEROIZE_MACRO( buf, len )    memset( buf, 0, len )
+
 /* \} name SECTION: Customisation configuration options */
 
 /* Target and application specific configurations */

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -46,7 +46,7 @@ extern "C" {
 #define mbedtls_platform_zeroize( buf, len )  \
     MBEDTLS_PLATFORM_ZEROIZE_MACRO( buf, len )
 #else
-#if defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) || !defined(_MSC_VER)
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) || !defined(_WIN32)
 /**
  * \brief       Securely zeroize a buffer
  *
@@ -74,7 +74,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 /* Windows implementation */
 #include <windows.h>
 #define MBEDTLS_PLATFORM_ZEROIZE_MACRO  RtlSecureZeroMemory
-#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT || !_MSC_VER */
+#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT || !_WIN32 */
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_MACRO */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -31,6 +31,7 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include <string.h>
 #include <stddef.h>
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 #include "mbedtls/platform_time.h"
@@ -41,6 +42,11 @@
 extern "C" {
 #endif
 
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_MACRO)
+#define mbedtls_platform_zeroize( buf, len )  \
+    MBEDTLS_PLATFORM_ZEROIZE_MACRO( buf, len )
+#else
+#if defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) || !defined(_MSC_VER)
 /**
  * \brief       Securely zeroize a buffer
  *
@@ -64,6 +70,12 @@ extern "C" {
  *
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
+#else
+/* Windows implementation */
+#include <windows.h>
+#define MBEDTLS_PLATFORM_ZEROIZE_MACRO  RtlSecureZeroMemory
+#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT || !_MSC_VER */
+#endif /* MBEDTLS_PLATFORM_ZEROIZE_MACRO */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -37,12 +37,16 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/threading.h"
 
-#include <stddef.h>
-#include <string.h>
-
-#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
+#if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT) && \
+    !defined(MBEDTLS_PLATFORM_ZEROIZE_MACRO)
 /*
- * This implementation should never be optimized out by the compiler
+ * This default implementation should never be optimized out by the compiler.
+ * It is in use when none of the conditions below is satisfied:
+ *  - MBEDTLS_PLATFORM_ZEROIZE_MACRO is supplied
+ *  - A platform specific implementation is not provided using
+ *    MBEDTLS_PLATFORM_ZEROIZE_ALT
+ *  - The underlying system cannot be determined automatically using the
+ *    preprocessor
  *
  * This implementation for mbedtls_platform_zeroize() was inspired from Colin
  * Percival's blog article at:
@@ -73,7 +77,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 {
     memset_func( buf, 0, len );
 }
-#endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
+#endif /* !MBEDTLS_PLATFORM_ZEROIZE_ALT && !MBEDTLS_PLATFORM_ZEROIZE_MACRO */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>


### PR DESCRIPTION
This PR adds functionality to automatically configure Mbed TLS to use the appropriate secure zeroize functions under Windows.

The Windows detection and #define use the code in https://github.com/ARMmbed/mbedtls/pull/1522 as stated in the ChangeLog.

## Status
**READY**

## Requires Backporting
NO  