### PR TITLE
Fix MSan build without MBEDTLS_TIMING_C

### DIFF
--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -25,13 +25,14 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include <string.h>
+
 #if defined(MBEDTLS_ENTROPY_C)
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
 
 #if defined(MBEDTLS_TIMING_C)
-#include <string.h>
 #include "mbedtls/timing.h"
 #endif
 #if defined(MBEDTLS_HAVEGE_C)


### PR DESCRIPTION
When `MBEDTLS_TIMING_C` was not defined in config.h, but the MemSan
memory sanitizer was activated, `entropy_poll.c` used `memset` without
declaring it. Fix this by including `string.h` unconditionally.

This PR should be merged into development and mbedtls-2.7. Backport to 2.1: #1673 
