### PR TITLE
Parameter validation for CCM

### DIFF
--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -43,6 +43,13 @@
 #define MBEDTLS_ERR_CCM_AUTH_FAILED     -0x000F /**< Authenticated decryption failed. */
 #define MBEDTLS_ERR_CCM_HW_ACCEL_FAILED -0x0011 /**< CCM hardware accelerator failed. */
 
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_CCM_VALIDATE( cond )   do { if( !(cond) ) \
+                                           return( MBEDTLS_ERR_CCM_BAD_INPUT ); \
+                                       } while( 0 )
+#else
+#define MBEDTLS_CCM_VALIDATE( cond )
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +72,13 @@ mbedtls_ccm_context;
 #include "ccm_alt.h"
 #endif /* MBEDTLS_CCM_ALT */
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
 /**
  * \brief           This function initializes the specified CCM context,
  *                  to make references valid, and prepare the context
@@ -72,7 +86,29 @@ mbedtls_ccm_context;
  *
  * \param ctx       The CCM context to initialize.
  */
-void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
+MBEDTLS_DEPRECATED void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
+
+/**
+ * \brief   This function releases and clears the specified CCM context
+ *          and underlying cipher sub-context.
+ *
+ * \param ctx       The CCM context to clear.
+ */
+MBEDTLS_DEPRECATED void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief           This function initializes the specified CCM context,
+ *                  to make references valid, and prepare the context
+ *                  for mbedtls_ccm_setkey() or mbedtls_ccm_free().
+ *
+ * \param ctx       The CCM context to initialize.
+ *
+ * \return          0 if succeeded.
+ */
+int mbedtls_ccm_init_ret( mbedtls_ccm_context *ctx );
 
 /**
  * \brief           This function initializes the CCM context set in the
@@ -96,8 +132,10 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
  *          and underlying cipher sub-context.
  *
  * \param ctx       The CCM context to clear.
+ *
+ * \return          0 if succeeded
  */
-void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
+int mbedtls_ccm_free_ret( mbedtls_ccm_context *ctx );
 
 /**
  * \brief           This function encrypts a buffer using CCM.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -58,10 +58,19 @@
 /*
  * Initialize context
  */
+int mbedtls_ccm_init_ret( mbedtls_ccm_context *ctx )
+{
+    MBEDTLS_CCM_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
+    mbedtls_ccm_init_ret( ctx );
 }
+#endif
 
 int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
                         mbedtls_cipher_id_t cipher,
@@ -70,6 +79,8 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
 {
     int ret;
     const mbedtls_cipher_info_t *cipher_info;
+
+    MBEDTLS_CCM_VALIDATE( ctx != NULL && key != NULL );
 
     cipher_info = mbedtls_cipher_info_from_values( cipher, keybits, MBEDTLS_MODE_ECB );
     if( cipher_info == NULL )
@@ -95,11 +106,20 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
 /*
  * Free context
  */
-void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
+int mbedtls_ccm_free_ret( mbedtls_ccm_context *ctx )
 {
+    MBEDTLS_CCM_VALIDATE( ctx != NULL );
     mbedtls_cipher_free( &ctx->cipher_ctx );
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_ccm_context ) );
+    return( 0 );
 }
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
+{
+    mbedtls_ccm_free_ret( ctx );
+}
+#endif
 
 /*
  * Macros for common operations.
@@ -308,6 +328,8 @@ int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                          const unsigned char *input, unsigned char *output,
                          unsigned char *tag, size_t tag_len )
 {
+    MBEDTLS_CCM_VALIDATE( ctx != NULL && iv != NULL && add != NULL &&
+            input != NULL && output != NULL && tag != NULL );
     return( ccm_auth_crypt( ctx, CCM_ENCRYPT, length, iv, iv_len,
                             add, add_len, input, output, tag, tag_len ) );
 }
@@ -325,6 +347,9 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
     unsigned char check_tag[16];
     unsigned char i;
     int diff;
+
+    MBEDTLS_CCM_VALIDATE( ctx != NULL && iv != NULL && add != NULL &&
+            input != NULL && output != NULL && tag != NULL );
 
     if( ( ret = ccm_auth_crypt( ctx, CCM_DECRYPT, length,
                                 iv, iv_len, add, add_len,

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */


### PR DESCRIPTION
## Description
This PR introduces the validation of the public API function parameters against NULL pointers.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
Certain functions in the current API take pointers but don't return any result making it impossible to signal an error upon detecting incorrect input. These functions have been marked as deprecated and replacements have been proposed in their place that enable returning error codes in appropriate situations.

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
