### PR TITLE
Parameter validation for cipher modules

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -68,8 +68,8 @@
 
 #if defined( MBEDTLS_CHECK_PARAMS )
 #define MBEDTLS_CIPHER_VALIDATE( cond )   do { if( !(cond) ) \
-                                            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
-                                        } while( 0 )
+                                              return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
+                                          } while( 0 )
 #else
 #define MBEDTLS_CIPHER_VALIDATE( cond )
 #endif

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -309,7 +309,8 @@ const int *mbedtls_cipher_list( void );
  * \brief               This function retrieves the cipher-information
  *                      structure associated with the given cipher name.
  *
- * \param cipher_name   Name of the cipher to search for.
+ * \param cipher_name   Name of the cipher to search for. If NULL, a NULL pointer
+ *                      shall be returned.
  *
  * \return              The cipher information structure associated with the
  *                      given \p cipher_name.
@@ -371,6 +372,8 @@ MBEDTLS_DEPRECATED void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function initializes a \p cipher_context as NONE.
+ *
+ * \return              0 if successful.
  */
 int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
 
@@ -378,6 +381,8 @@ int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
  * \brief               This function frees and clears the cipher-specific
  *                      context of \p ctx. Freeing \p ctx itself remains the
  *                      responsibility of the caller.
+ *
+ * \return              0 if successful.
  */
 int mbedtls_cipher_free_ret( mbedtls_cipher_context_t *ctx );
 

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -66,6 +66,14 @@
 #define MBEDTLS_CIPHER_VARIABLE_IV_LEN     0x01    /**< Cipher accepts IVs of variable length. */
 #define MBEDTLS_CIPHER_VARIABLE_KEY_LEN    0x02    /**< Cipher accepts keys of variable length. */
 
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_CIPHER_VALIDATE( cond )   do { if( !(cond) ) \
+                                            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
+                                        } while( 0 )
+#else
+#define MBEDTLS_CIPHER_VALIDATE( cond )
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -339,17 +347,39 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_ciph
                                               int key_bitlen,
                                               const mbedtls_cipher_mode_t mode );
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
 /**
  * \brief               This function initializes a \p cipher_context as NONE.
  */
-void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
+MBEDTLS_DEPRECATED void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function frees and clears the cipher-specific
  *                      context of \p ctx. Freeing \p ctx itself remains the
  *                      responsibility of the caller.
  */
-void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+MBEDTLS_DEPRECATED void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief               This function initializes a \p cipher_context as NONE.
+ */
+int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
+
+/**
+ * \brief               This function frees and clears the cipher-specific
+ *                      context of \p ctx. Freeing \p ctx itself remains the
+ *                      responsibility of the caller.
+ */
+int mbedtls_cipher_free_ret( mbedtls_cipher_context_t *ctx );
 
 
 /**

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */


### PR DESCRIPTION
## Description
This PR introduces the validation of the public API function parameters against NULL pointers.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
Certain functions in the current API take pointers but don't return any result making it impossible to signal an error upon detecting incorrect input. These functions have been marked as deprecated and replacements have been proposed in their place that enable returning error codes in appropriate situations.

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
