### PR TITLE
Parameter validation for GCM

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -44,6 +44,14 @@
 #define MBEDTLS_ERR_GCM_HW_ACCEL_FAILED                   -0x0013  /**< GCM hardware accelerator failed. */
 #define MBEDTLS_ERR_GCM_BAD_INPUT                         -0x0014  /**< Bad input parameters to function. */
 
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_GCM_VALIDATE( cond )   do { if( !(cond) ) \
+                                           return( MBEDTLS_ERR_GCM_BAD_INPUT ); \
+                                       } while( 0 )
+#else
+#define MBEDTLS_GCM_VALIDATE( cond )
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -82,8 +90,10 @@ mbedtls_gcm_context;
  *                  mbedtls_gcm_setkey().
  *
  * \param ctx       The GCM context to initialize.
+ *
+ * \return          0 if succeeded.
  */
-void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
+int mbedtls_gcm_init_ret( mbedtls_gcm_context *ctx );
 
 /**
  * \brief           This function associates a GCM context with a
@@ -247,8 +257,10 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
  *                  cipher sub-context.
  *
  * \param ctx       The GCM context to clear.
+ *
+ * \return          0 if succeeded.
  */
-void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
+int mbedtls_gcm_free_ret( mbedtls_gcm_context *ctx );
 
 /**
  * \brief          The GCM checkup routine.
@@ -257,6 +269,37 @@ void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
  * \return         \c 1 on failure.
  */
 int mbedtls_gcm_self_test( int verbose );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
+/**
+ * \brief           This function clears a GCM context and the underlying
+ *                  cipher sub-context.
+ *
+ * \param ctx       The GCM context to clear.
+ */
+MBEDTLS_DEPRECATED void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
+
+/**
+ * \brief           This function initializes the specified GCM context,
+ *                  to make references valid, and prepares the context
+ *                  for mbedtls_gcm_setkey() or mbedtls_gcm_free().
+ *
+ *                  The function does not bind the GCM context to a particular
+ *                  cipher, nor set the key. For this purpose, use
+ *                  mbedtls_gcm_setkey().
+ *
+ * \param ctx       The GCM context to initialize.
+ */
+MBEDTLS_DEPRECATED void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -84,10 +84,20 @@
 /*
  * Initialize a context
  */
+
+int mbedtls_gcm_init_ret( mbedtls_gcm_context *ctx )
+{
+    MBEDTLS_GCM_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
+    mbedtls_gcm_init_ret( ctx );
 }
+#endif
 
 /*
  * Precompute small multiples of H, that is set
@@ -164,6 +174,8 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
 {
     int ret;
     const mbedtls_cipher_info_t *cipher_info;
+
+    MBEDTLS_GCM_VALIDATE( ctx != NULL && key != NULL );
 
     cipher_info = mbedtls_cipher_info_from_values( cipher, keybits, MBEDTLS_MODE_ECB );
     if( cipher_info == NULL )
@@ -273,7 +285,11 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     unsigned char work_buf[16];
     size_t i;
     const unsigned char *p;
-    size_t use_len, olen = 0;
+    size_t use_len, olen;
+
+    MBEDTLS_GCM_VALIDATE( ctx != NULL && iv != NULL && (add != NULL || add_len == 0) );
+
+    olen = 0;
 
     /* IV and AD are limited to 2^64 bits, so 2^61 bytes */
     /* IV is not allowed to be zero length */
@@ -354,8 +370,13 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
     unsigned char ectr[16];
     size_t i;
     const unsigned char *p;
-    unsigned char *out_p = output;
-    size_t use_len, olen = 0;
+    unsigned char *out_p;
+    size_t use_len, olen;
+
+    MBEDTLS_GCM_VALIDATE( ctx != NULL && input != NULL && output != NULL );
+
+    out_p = output;
+    olen = 0;
 
     if( output > input && (size_t) ( output - input ) < length )
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
@@ -412,6 +433,8 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     size_t i;
     uint64_t orig_len = ctx->len * 8;
     uint64_t orig_add_len = ctx->add_len * 8;
+
+    MBEDTLS_GCM_VALIDATE( ctx != NULL && tag != NULL );
 
     if( tag_len > 16 || tag_len < 4 )
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
@@ -501,11 +524,20 @@ int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
     return( 0 );
 }
 
-void mbedtls_gcm_free( mbedtls_gcm_context *ctx )
+int mbedtls_gcm_free_ret( mbedtls_gcm_context *ctx )
 {
+    MBEDTLS_GCM_VALIDATE( ctx != NULL );
     mbedtls_cipher_free( &ctx->cipher_ctx );
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_gcm_context ) );
+    return( 0 );
 }
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+void mbedtls_gcm_free( mbedtls_gcm_context *ctx )
+{
+    mbedtls_gcm_free_ret( ctx );
+}
+#endif
 
 #endif /* !MBEDTLS_GCM_ALT */
 

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */


### PR DESCRIPTION
## Description
This PR introduces the validation of the public API function parameters against NULL pointers.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
Certain functions in the current API take pointers but don't return any result making it impossible to signal an error upon detecting incorrect input. These functions have been marked as deprecated and replacements have been proposed in their place that enable returning error codes in appropriate situations.

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
