### PR TITLE
Fix the ARIA test cases for new ECB function

### DIFF
--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -42,9 +42,8 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     {
         for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, MBEDTLS_ARIA_ENCRYPT,
-                                                 src_str + i, output + i )
-                         == 0 );
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
+                                                 == 0 );
         }
         hexify( dst_str, output, data_len );
 
@@ -82,8 +81,7 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     {
         for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, MBEDTLS_ARIA_DECRYPT,
-                                                 src_str + i, output + i )
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                          == 0 );
         }
         hexify( dst_str, output, data_len );


### PR DESCRIPTION
## Description

Commit 08c337d058be "Remove useless parameter from function" removed the
parameter mode from the functions `mbedtls_aria_crypt_ecb()` which broke their
respective test cases in the ARIA test suite.

This commit PR fixes those test cases.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
