### PR TITLE
Fix coverity defects

### DIFF
--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -66,7 +66,7 @@ int main( int argc, char** argv )
     char buf[BUFFER_LEN];
     char *p = buf;
     char *end = p + BUFFER_LEN;
-    char c;
+    int c;
 
     if( argc != 2 )
     {
@@ -83,7 +83,7 @@ int main( int argc, char** argv )
     }
 
     while( ( c = fgetc( fp ) ) != EOF && p < end - 1 )
-        *p++ = c;
+        *p++ = (char)c;
     *p = '\0';
 
     if( p - buf != 0 )


### PR DESCRIPTION
Coverity reported error in line ```while( ( c = fgetc( fp ) ) != EOF && p < end - 1 )```:
```
>*** CID 278842:  API usage errors  (CHAR_IO)
>/programs/test/zeroize.c: 85 in main()
>79         if( fp == NULL )
>80         {
>81             mbedtls_printf( "Could not open file '%s'\n", argv[1] );
>82             return( exit_code );
>83         }
>84     
>>>>     CID 278842:  API usage errors  (CHAR_IO)
>>>>     Assigning the return value of "fgetc" to char "c" truncates its
>>>>value.
>85         while( ( c = fgetc( fp ) ) != EOF && p < end - 1 )
>86             *p++ = c;
>87         *p = '\0';
>88     
>89         if( p - buf != 0 )
>90         {
```

It is clear that check ```!= EOF``` will not work as the ```int``` return is first truncated and then compared to ```EOF```. 