### PR TITLE
Add a disabled CMAC define in the no-entropy configuration

### DIFF
--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -82,6 +82,7 @@
 #define MBEDTLS_X509_USE_C
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_CRL_PARSE_C
+//#define MBEDTLS_CMAC_C
 
 /* Miscellaneous options */
 #define MBEDTLS_AES_ROM_TABLES


### PR DESCRIPTION
## Description
This PR introduces a commented out CMAC option in the no-entropy configuration file.
This option is needed downstream in the cases when the option needs to be enabled automatically also in the no entropy variant.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
None
