### PR TITLE
Updated version number to 2.10.0 for release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
-= mbed TLS x.x.x branch released xxxx-xx-xx
+= mbed TLS 2.10.0 branch released 2018-06-06
 
 Features
    * Add support for ARIA cipher (RFC 5794) and associated TLS ciphersuites

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.9.0 source code documentation
+ * @mainpage mbed TLS v2.10.0 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.9.0"
+PROJECT_NAME           = "mbed TLS v2.10.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  9
+#define MBEDTLS_VERSION_MINOR  10
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02090000
-#define MBEDTLS_VERSION_STRING         "2.9.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.9.0"
+#define MBEDTLS_VERSION_NUMBER         0x020A0000
+#define MBEDTLS_VERSION_STRING         "2.10.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.10.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -143,15 +143,15 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.9.0 SOVERSION 2)
+    set_target_properties(mbedcrypto PROPERTIES VERSION 2.10.0 SOVERSION 2)
     target_link_libraries(mbedcrypto ${libs})
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.9.0 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.10.0 SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.9.0 SOVERSION 10)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.10.0 SOVERSION 10)
     target_link_libraries(mbedtls ${libs} mbedx509)
 
     install(TARGETS mbedtls mbedx509 mbedcrypto

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.9.0"
+check_compiletime_version:"2.10.0"
 
 Check runtime library version
-check_runtime_version:"2.9.0"
+check_runtime_version:"2.10.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
## Description
Update the version number of the library on the `development` branch to 2.10.0 ready for release.

## Status
**READY**

## Requires Backporting
NO  

## Additional comments
This release will go into Mbed OS 5.9, and will not be released as a normal Mbed TLS release.
