### PR TITLE
Parameter validation for DHM

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -87,6 +87,14 @@
 #define MBEDTLS_ERR_DHM_HW_ACCEL_FAILED                   -0x3500  /**< DHM hardware accelerator failed. */
 #define MBEDTLS_ERR_DHM_SET_GROUP_FAILED                  -0x3580  /**< Setting the modulus and generator failed. */
 
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_DHM_VALIDATE( cond )   do { if( !(cond) ) \
+                                           return( MBEDTLS_ERR_DHM_BAD_INPUT_DATA ); \
+                                       } while( 0 )
+#else
+#define MBEDTLS_DHM_VALIDATE( cond )
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,12 +124,38 @@ mbedtls_dhm_context;
 #include "dhm_alt.h"
 #endif /* MBEDTLS_DHM_ALT */
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
 /**
  * \brief          This function initializes the DHM context.
  *
  * \param ctx      The DHM context to initialize.
  */
-void mbedtls_dhm_init( mbedtls_dhm_context *ctx );
+MBEDTLS_DEPRECATED void mbedtls_dhm_init( mbedtls_dhm_context *ctx );
+
+/**
+ * \brief          This function frees and clears the components of a DHM context.
+ *
+ * \param ctx      The DHM context to free and clear.
+ */
+MBEDTLS_DEPRECATED void mbedtls_dhm_free( mbedtls_dhm_context *ctx );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief          This function initializes the DHM context.
+ *
+ * \param ctx      The DHM context to initialize.
+ *
+ * \return         0 if successful.
+ */
+int mbedtls_dhm_init_ret( mbedtls_dhm_context *ctx );
 
 /**
  * \brief          This function parses the ServerKeyExchange parameters.
@@ -259,8 +293,10 @@ int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
  * \brief          This function frees and clears the components of a DHM context.
  *
  * \param ctx      The DHM context to free and clear.
+ *
+ * \return         0 if successful.
  */
-void mbedtls_dhm_free( mbedtls_dhm_context *ctx );
+int mbedtls_dhm_free_ret( mbedtls_dhm_context *ctx );
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 /** \ingroup x509_module */

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */


### PR DESCRIPTION
## Description
This PR introduces the validation of the public API function parameters against NULL pointers.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
Certain functions in the current API take pointers but don't return any result making it impossible to signal an error upon detecting incorrect input. These functions have been marked as deprecated and replacements have been proposed in their place that enable returning error codes in appropriate situations.

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
