### PR TITLE
Fix out-of-tree testing symlinks on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,11 @@ function(link_to_source base_name)
         if (CMAKE_HOST_UNIX)
             set(command ln -s ${target} ${link})
         else()
-            set(command cmd.exe /c mklink /j ${link} ${target})
+            if (IS_DIRECTORY ${target})
+                set(command cmd.exe /c mklink /j ${link} ${target})
+            else()
+                set(command cmd.exe /c mklink ${link} ${target})
+            endif()
         endif()
 
         execute_process(COMMAND ${command}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ function(link_to_source base_name)
             if (IS_DIRECTORY ${target})
                 set(command cmd.exe /c mklink /j ${link} ${target})
             else()
-                set(command cmd.exe /c mklink ${link} ${target})
+                set(command cmd.exe /c mklink /h ${link} ${target})
             endif()
         endif()
 


### PR DESCRIPTION
Some of the symlinks in PR #1470 were being accidentally created as directory symlinks on Windows, this adds a check to create the symlink of the correct type. 

Backports will be needed for 2.7 and 2.1