### PR TITLE
Parameter validation for SHA512

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -76,6 +76,7 @@
  * SHA1      1                  0x0035-0x0035
  * SHA256    1                  0x0037-0x0037
  * SHA512    1                  0x0039-0x0039
+ *                              0x004F-0x004F
  *
  * High-level module nr (3 bits - 0x0...-0x7...)
  * Name      ID  Nr of Errors

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -75,7 +75,7 @@
  * RIPEMD160 1                  0x0031-0x0031
  * SHA1      1                  0x0035-0x0035
  * SHA256    1                  0x0037-0x0037
- * SHA512    1                  0x0039-0x0039
+ * SHA512    2                  0x0039-0x0039
  *                              0x004F-0x004F
  *
  * High-level module nr (3 bits - 0x0...-0x7...)

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -36,6 +36,15 @@
 #include <stdint.h>
 
 #define MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED                -0x0039  /**< SHA-512 hardware accelerator failed */
+#define MBEDTLS_ERR_SHA512_BAD_INPUT_DATA                 -0x004F  /**< Input invalid. */
+
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_SHA512_VALIDATE( cond )   do { if( !(cond) ) \
+                                              return( MBEDTLS_ERR_SHA512_BAD_INPUT_DATA ); \
+                                          } while( 0 )
+#else
+#define MBEDTLS_SHA512_VALIDATE( cond )
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,14 +80,14 @@ mbedtls_sha512_context;
  *
  * \param ctx      The SHA-512 context to initialize.
  */
-void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
+int mbedtls_sha512_init_ret( mbedtls_sha512_context *ctx );
 
 /**
  * \brief          This function clears a SHA-512 context.
  *
  * \param ctx      The SHA-512 context to clear.
  */
-void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
+int mbedtls_sha512_free_ret( mbedtls_sha512_context *ctx );
 
 /**
  * \brief          This function clones the state of a SHA-512 context.
@@ -86,8 +95,41 @@ void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
  * \param dst      The destination context.
  * \param src      The context to clone.
  */
-void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
-                           const mbedtls_sha512_context *src );
+int mbedtls_sha512_clone_ret( mbedtls_sha512_context *dst,
+                              const mbedtls_sha512_context *src );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
+/**
+ * \brief          This function initializes a SHA-512 context.
+ *
+ * \param ctx      The SHA-512 context to initialize.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-512 context.
+ *
+ * \param ctx      The SHA-512 context to clear.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-512 context.
+ *
+ * \param dst      The destination context.
+ * \param src      The context to clone.
+ */
+MBEDTLS_DEPRECATED void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
+                                              const mbedtls_sha512_context *src );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          This function starts a SHA-384 or SHA-512 checksum

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -79,6 +79,8 @@ mbedtls_sha512_context;
  * \brief          This function initializes a SHA-512 context.
  *
  * \param ctx      The SHA-512 context to initialize.
+ *
+ * \return         0 if successful.
  */
 int mbedtls_sha512_init_ret( mbedtls_sha512_context *ctx );
 
@@ -86,6 +88,8 @@ int mbedtls_sha512_init_ret( mbedtls_sha512_context *ctx );
  * \brief          This function clears a SHA-512 context.
  *
  * \param ctx      The SHA-512 context to clear.
+ *
+ * \return         0 if successful.
  */
 int mbedtls_sha512_free_ret( mbedtls_sha512_context *ctx );
 
@@ -94,6 +98,8 @@ int mbedtls_sha512_free_ret( mbedtls_sha512_context *ctx );
  *
  * \param dst      The destination context.
  * \param src      The context to clone.
+ *
+ * \return         0 if successful.
  */
 int mbedtls_sha512_clone_ret( mbedtls_sha512_context *dst,
                               const mbedtls_sha512_context *src );
@@ -148,7 +154,7 @@ int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
  *                 SHA-512 checksum calculation.
  *
  * \param ctx      The SHA-512 context.
- * \param input    The buffer holding the input data.
+ * \param input    The buffer holding the input data or NULL if ilen = 0.
  * \param ilen     The length of the input data.
  *
  * \return         \c 0 on success.
@@ -207,7 +213,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha512_starts( mbedtls_sha512_context *ctx,
  * \deprecated     Superseded by mbedtls_sha512_update_ret() in 2.7.0.
  *
  * \param ctx      The SHA-512 context.
- * \param input    The buffer holding the data.
+ * \param input    The buffer holding the data or NULL if ilen = 0.
  * \param ilen     The length of the input data.
  */
 MBEDTLS_DEPRECATED void mbedtls_sha512_update( mbedtls_sha512_context *ctx,
@@ -253,7 +259,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha512_process(
  *                 The SHA-512 result is calculated as
  *                 output = SHA-512(input buffer).
  *
- * \param input    The buffer holding the input data.
+ * \param input    The buffer holding the input data or NULL if ilen = 0.
  * \param ilen     The length of the input data.
  * \param output   The SHA-384 or SHA-512 checksum result.
  * \param is384    Determines which function to use:
@@ -284,7 +290,7 @@ int mbedtls_sha512_ret( const unsigned char *input,
  *
  * \deprecated     Superseded by mbedtls_sha512_ret() in 2.7.0
  *
- * \param input    The buffer holding the data.
+ * \param input    The buffer holding the data or NULL if ilen = 0.
  * \param ilen     The length of the input data.
  * \param output   The SHA-384 or SHA-512 checksum result.
  * \param is384    Determines which function to use:

--- a/library/error.c
+++ b/library/error.c
@@ -783,6 +783,8 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
 #if defined(MBEDTLS_SHA512_C)
     if( use_ret == -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED) )
         mbedtls_snprintf( buf, buflen, "SHA512 - SHA-512 hardware accelerator failed" );
+    if( use_ret == -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA) )
+        mbedtls_snprintf( buf, buflen, "SHA512 - Input invalid" );
 #endif /* MBEDTLS_SHA512_C */
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -88,30 +88,57 @@
 }
 #endif /* PUT_UINT64_BE */
 
+int mbedtls_sha512_init_ret( mbedtls_sha512_context *ctx )
+{
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL );
+    memset( ctx, 0, sizeof( mbedtls_sha512_context ) );
+    return( 0 );
+}
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha512_init( mbedtls_sha512_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_sha512_context ) );
+    mbedtls_sha512_init_ret( ctx );
+}
+#endif
+
+int mbedtls_sha512_free_ret( mbedtls_sha512_context *ctx )
+{
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL );
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_sha512_context ) );
+    return( 0 );
 }
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha512_free( mbedtls_sha512_context *ctx )
 {
-    if( ctx == NULL )
-        return;
+    mbedtls_sha512_free_ret( ctx );
+}
+#endif
 
-    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_sha512_context ) );
+int mbedtls_sha512_clone_ret( mbedtls_sha512_context *dst,
+                           const mbedtls_sha512_context *src )
+{
+    MBEDTLS_SHA512_VALIDATE( dst != NULL && src != NULL );
+    *dst = *src;
+    return( 0 );
 }
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
                            const mbedtls_sha512_context *src )
 {
-    *dst = *src;
+    mbedtls_sha512_clone_ret( dst, src );
 }
+#endif
 
 /*
  * SHA-512 context setup
  */
 int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 )
 {
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL );
+
     ctx->total[0] = 0;
     ctx->total[1] = 0;
 
@@ -209,6 +236,8 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     uint64_t temp1, temp2, W[80];
     uint64_t A, B, C, D, E, F, G, H;
 
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL );
+
 #define  SHR(x,n) (x >> n)
 #define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
 
@@ -294,6 +323,8 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
     size_t fill;
     unsigned int left;
 
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL && ( input != NULL || ilen == 0 ) );
+
     if( ilen == 0 )
         return( 0 );
 
@@ -363,6 +394,8 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
     size_t last, padn;
     uint64_t high, low;
     unsigned char msglen[16];
+
+    MBEDTLS_SHA512_VALIDATE( ctx != NULL );
 
     high = ( ctx->total[0] >> 61 )
          | ( ctx->total[1] <<  3 );

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */


### PR DESCRIPTION
## Description
This PR introduces the validation of the public API function parameters against NULL pointers.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
Certain functions in the current API take pointers but don't return any result making it impossible to signal an error upon detecting incorrect input. These functions have been marked as deprecated and replacements have been proposed in their place that enable returning error codes in appropriate situations.

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
