### PR TITLE
Backport 2.1: Only redefine _WIN32_WINNT macro when < 0x0501

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Bugfix
      calling mbedtls_x509_crt_parse_path().
    * Fix redundant declaration of mbedtls_ssl_list_ciphersuites. Raised by
      TrinityTonic. #1359.
+   * Fix for redefinition of _WIN32_WINNT to avoid overriding a definition
+     used by user applications. Found and fixed by Fabio Alessandrelli.
 
 = mbed TLS 2.1.12 branch released 2018-04-30
 

--- a/library/net.c
+++ b/library/net.c
@@ -34,11 +34,12 @@
 #if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
     !defined(EFI32)
 
-#ifdef _WIN32_WINNT
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
 #undef _WIN32_WINNT
-#endif
 /* Enables getaddrinfo() & Co */
 #define _WIN32_WINNT 0x0501
+#endif
+
 #include <ws2tcpip.h>
 
 #include <winsock2.h>


### PR DESCRIPTION
## Description
This is a backport of #1555.

`net_sockets.c` was redefining the `_WIN32_WINNT` to ensure `getaddrinfo()` and the like to work.
This should only be done when `_WIN32_WINNT < 0x0501` or it might break builds when embedding in projects that require higher `_WIN32_WINNT` minimum version.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
