### PR TITLE
Reliably detect GDB script failures in all.sh for zeroize test.

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -896,12 +896,29 @@ cd "$MBEDTLS_ROOT_DIR"
 rm -rf "$OUT_OF_SOURCE_DIR"
 unset MBEDTLS_ROOT_DIR
 
+# Test that the function mbedtls_platform_zeroize() is not optimized away by
+# different combinations of compilers and optimization flags by using an
+# auxiliary GDB script. Unfortunately, GDB does not return error values to the
+# system in all cases that the script fails, so we must manually search the
+# output to check whether the pass string is present and no failure strings
+# were printed.
 for optimization_flag in -O2 -O3 -Ofast -Os; do
     for compiler in clang gcc; do
         msg "test: $compiler $optimization_flag, mbedtls_platform_zeroize()"
         cleanup
-        CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag" make programs
-        gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx
+        make programs CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag"
+        if_build_succeeded gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx > test_zeroize.log 2>&1
+        if [ ! -s test_zeroize.log ]; then
+            err_msg "test_zeroize.log was not found or is empty"
+            record_status [ -s test_zeroize.log ]
+        elif ! grep "The buffer was correctly zeroized" test_zeroize.log >/dev/null 2>&1; then
+            err_msg "test_zeroize.log does not contain pass string"
+            record_status false
+        elif grep -i "error" test_zeroize.log >/dev/null 2>&1; then
+            err_msg "test_zeroize.log contains error string"
+            record_status false
+        fi
+        rm -f test_zeroize.log
     done
 done
 


### PR DESCRIPTION
## Description
The main goal of this patch is to fix the problem reported in #1723. Namely, that GDB does not return a failure code to the system when the command script passed to it fails to complete successfully. Instead of relying on GDB, this change dumps the GDB output to a file and uses grep to scan the output for success and failure strings.

This patch also integrates the zeroize test in all.sh with the --keep-going option. It fixes the following two problems:
* The zeroize test would cause all.sh to exit even if --keep-going was set
* When --keep-going was set, the `make` command was overridden to call a shell function before invoking make. This would cause some options to make to be discarded and the library for the zeroize test would be compiled without symbols, which causes a failure in the GDB script.

## Status
**READY**

## Requires Backporting
No. The zeroize test is only present in development, so #1723 does not affect older versions of the library.

## Additional comments
Ideally, GDB would have the correct behaviour, but in light of the problem I was trying to look for solutions that do not consider rebuilding the tool with a fix. As mentioned in #1723, the problem is caused because the test command uses the -batch command line option to GDB. Therefore, an alternative solution to the one presented in this batch is simply to remove -batch from the test in all.sh. The problem with this approach is that GDB will not terminate in the case of a failure and will start an interactive mode console instead. I do not think this is ideal because if all.sh is run on a CI the test will probably fail because of a timeout and it will be harder to make `--keep-going` work as expected.