### PR TITLE
Compilation warning fix on 32-bit platform with IAR

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Bugfix
      curves as well as RSA. Fixes #777 found by dbedev.
    * Fix for redefinition of _WIN32_WINNT to avoid overriding a definition
      used by user applications. Found and fixed by Fabio Alessandrelli.
+   * Fix compilation warnings with IAR toolchain, on 32 bit platform.
+     Reported by rahmanih in #683
 
 Changes
    * Changed CMake defaults for IAR to treat all compiler warnings as errors.

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2888,7 +2888,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
     if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECJPAKE )
     {
         int ret;
-        size_t len;
+        size_t len = 0;
 
         ret = mbedtls_ecjpake_write_round_two(
             &ssl->handshake->ecjpake_ctx,
@@ -2928,7 +2928,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
     if( mbedtls_ssl_ciphersuite_uses_dhe( ciphersuite_info ) )
     {
         int ret;
-        size_t len;
+        size_t len = 0;
 
         if( ssl->conf->dhm_P.p == NULL || ssl->conf->dhm_G.p == NULL )
         {
@@ -2993,7 +2993,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
         const mbedtls_ecp_curve_info **curve = NULL;
         const mbedtls_ecp_group_id *gid;
         int ret;
-        size_t len;
+        size_t len = 0;
 
         /* Match our preference list against the offered curves */
         for( gid = ssl->conf->curve_list; *gid != MBEDTLS_ECP_DP_NONE; gid++ )


### PR DESCRIPTION
## Description
This PR fixes a compilation warning with the IAR toolchain, on 32 bit platforms, originally reported by rahmanih in #683.

This is based on work by Ron Eldor in PR #750, some of which was independently fixed by Azim Khan and already merged in PR #1646.

This PR adds the missing fix, and corrects the ChangeLog.

## Status
**READY**

## Requires Backporting
Yes  
Which branch?
`mbedtls-2.7`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported