### PR TITLE
Backport 2.7: Compilation warning fix on 32-bit platform with IAR

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Bugfix
    * Fix redundant declaration of mbedtls_ssl_list_ciphersuites. Raised by
      TrinityTonic. #1359.
+   * Fix compilation warnings with IAR toolchain, on 32 bit platform.
+     Reported by rahmanih in #683
 
 Changes
    * Support TLS testing in out-of-source builds using cmake. Fixes #1193.

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2843,7 +2843,7 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME_PFS__ENABLED)
     unsigned char *p = ssl->out_msg + 4;
-    size_t len;
+    size_t len = 0;
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED)
     unsigned char *dig_signed = p;
     size_t dig_signed_len = 0;


### PR DESCRIPTION
## Description
This PR fixes a compilation warning with the IAR toolchain, on 32 bit platforms, originally reported by rahmanih in #683.

This is based on work by Ron Eldor in PR #750, some of which was independently fixed by Azim Khan and already merged in PR #1646.

This PR adds the missing fix, and corrects the ChangeLog.

This is a backport of PR #1727.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported