### PR TITLE
Fix missing preprocessor condition in AES self-test

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1397,7 +1397,8 @@ int mbedtls_aes_self_test( int verbose )
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     unsigned char prv[16];
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_CFB)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_CFB) || \
+    defined(MBEDTLS_CIPHER_MODE_OFB)
     size_t offset;
 #endif
 #if defined(MBEDTLS_CIPHER_MODE_CTR)


### PR DESCRIPTION
## Description
The AES OFB self-test made use of a variable `offset` but failed to have a preprocessor condition around it, so unless CTR and CBC were enabled, the variable would be undeclared.

## Status
**READY**

## Requires Backporting
NO  

OFB is not present in the maintained branches.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
