### PR TITLE
Revert "Turn on MBEDTLS_SSL_ASYNC_PRIVATE by default"

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1157,7 +1157,7 @@
  * operation inside the library.
  *
  */
-#define MBEDTLS_SSL_ASYNC_PRIVATE
+//#define MBEDTLS_SSL_ASYNC_PRIVATE
 
 /**
  * \def MBEDTLS_SSL_DEBUG_ALL

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -531,8 +531,8 @@ make
 msg "test: main suites (full config)" # ~ 5s
 make test
 
-msg "test: ssl-opt.sh default, ECJPAKE (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f 'Default\|ECJPAKE'
+msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
+if_build_succeeded tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
 msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
 if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'


### PR DESCRIPTION
This reverts commit 5ffe41c8f9e53ddde74e63d58bd05fb5e67abca0.

Turn off MBEDTLS_SSL_ASYNC_PRIVATE by default because we don't want to
change the ABI yet.

## Status
**READY**