### PR TITLE
Fix for undeclared len variable used in AES-XTS self-test

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1713,8 +1713,10 @@ int mbedtls_aes_self_test( int verbose )
 #if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_CFB)
     size_t offset;
 #endif
-#if defined(MBEDTLS_CIPHER_MODE_CTR)
+#if defined(MBEDTLS_CIPHER_MODE_CTR) || defined(MBEDTLS_CIPHER_MODE_XTS)
     int len;
+#endif
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
     unsigned char nonce_counter[16];
     unsigned char stream_block[16];
 #endif


### PR DESCRIPTION
## Description
The AES XTS self-test was using a variable len, which was declared only when CTR
was enabled. Changed the declaration of len to be conditional on CTR and XTS.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
