### PR TITLE
fix compilation error when MBEDTLS_CIPHER_NULL_CIPHER defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
      Philippe Antoine. Fixes #1623.
+   * Fix compilation error when MBEDTLS_ARC4_C is disabled and
+     MBEDTLS_CIPHER_NULL_CIPHER is enabled. Found by TrinityTonic in #1719.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -45,7 +45,7 @@
 #define MBEDTLS_CIPHER_MODE_WITH_PADDING
 #endif
 
-#if defined(MBEDTLS_ARC4_C)
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
 #define MBEDTLS_CIPHER_MODE_STREAM
 #endif
 

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -34,10 +34,6 @@
 
 #include "cipher.h"
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -34,6 +34,10 @@
 
 #include "cipher.h"
 
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#define MBEDTLS_CIPHER_MODE_STREAM
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -65,11 +65,6 @@
 #define mbedtls_free   free
 #endif
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
-
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
 /* Compare the contents of two buffers in constant time.
  * Returns 0 if the contents are bitwise identical, otherwise returns


### PR DESCRIPTION
## Description
fix compilation error when ARC4 not MBEDTLS_CIPHER_NULL_CIPHER defined.
`MBEDTLS_CIPHER_MODE_STREAM` was defined in `cipher.c`, but it is already used in `cipher_internal.h`
resolves #1719 


## Status
**READY**

## Requires Backporting
Yes   
Which branch?
mbedtls-2.1
mbedtls-2.7

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
