### PR TITLE
Parameter validation tests for cipher module

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -68,8 +68,8 @@
 
 #if defined( MBEDTLS_CHECK_PARAMS )
 #define MBEDTLS_CIPHER_VALIDATE( cond )   do { if( !(cond) ) \
-                                            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
-                                        } while( 0 )
+                                              return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
+                                          } while( 0 )
 #else
 #define MBEDTLS_CIPHER_VALIDATE( cond )
 #endif

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -309,7 +309,8 @@ const int *mbedtls_cipher_list( void );
  * \brief               This function retrieves the cipher-information
  *                      structure associated with the given cipher name.
  *
- * \param cipher_name   Name of the cipher to search for.
+ * \param cipher_name   Name of the cipher to search for. If NULL, a NULL pointer
+ *                      shall be returned.
  *
  * \return              The cipher information structure associated with the
  *                      given \p cipher_name.
@@ -371,6 +372,8 @@ MBEDTLS_DEPRECATED void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function initializes a \p cipher_context as NONE.
+ *
+ * \return              0 if successful.
  */
 int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
 
@@ -378,6 +381,8 @@ int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
  * \brief               This function frees and clears the cipher-specific
  *                      context of \p ctx. Freeing \p ctx itself remains the
  *                      responsibility of the caller.
+ *
+ * \return              0 if successful.
  */
 int mbedtls_cipher_free_ret( mbedtls_cipher_context_t *ctx );
 

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -66,6 +66,14 @@
 #define MBEDTLS_CIPHER_VARIABLE_IV_LEN     0x01    /**< Cipher accepts IVs of variable length. */
 #define MBEDTLS_CIPHER_VARIABLE_KEY_LEN    0x02    /**< Cipher accepts keys of variable length. */
 
+#if defined( MBEDTLS_CHECK_PARAMS )
+#define MBEDTLS_CIPHER_VALIDATE( cond )   do { if( !(cond) ) \
+                                            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA ); \
+                                        } while( 0 )
+#else
+#define MBEDTLS_CIPHER_VALIDATE( cond )
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -339,17 +347,39 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_ciph
                                               int key_bitlen,
                                               const mbedtls_cipher_mode_t mode );
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
 /**
  * \brief               This function initializes a \p cipher_context as NONE.
  */
-void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
+MBEDTLS_DEPRECATED void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function frees and clears the cipher-specific
  *                      context of \p ctx. Freeing \p ctx itself remains the
  *                      responsibility of the caller.
  */
-void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+MBEDTLS_DEPRECATED void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+/**
+ * \brief               This function initializes a \p cipher_context as NONE.
+ */
+int mbedtls_cipher_init_ret( mbedtls_cipher_context_t *ctx );
+
+/**
+ * \brief               This function frees and clears the cipher-specific
+ *                      context of \p ctx. Freeing \p ctx itself remains the
+ *                      responsibility of the caller.
+ */
+int mbedtls_cipher_free_ret( mbedtls_cipher_context_t *ctx );
 
 
 /**

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -221,6 +221,25 @@
  */
 //#define MBEDTLS_DEPRECATED_REMOVED
 
+/**
+ * \def MBEDTLS_CHECK_PARAMS
+ *
+ * This configuration controls whether the library validates parameters passed
+ * to it.
+ *
+ * Application code that deals with 3rd party input may wish to enable such
+ * validation, whilst code on closed systems, such as embedded systems, where
+ * the input is controlled and predictable, may wish to disable it entirely to
+ * reduce the code size of the library.
+ *
+ * When the symbol is not defined, no parameter validation except that required
+ * to ensure the integrity or security of the library are performed.
+ *
+ * When the symbol is defined, all parameters will be validated, and an error
+ * code returned where appropriate.
+ */
+#define MBEDTLS_CHECK_PARAMS
+
 /* \} name SECTION: System support */
 
 /**

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -168,9 +168,7 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )
 
 int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info )
 {
-    MBEDTLS_CIPHER_VALIDATE( NULL != ctx && NULL != cipher_info &&
-            NULL != cipher_info->base &&
-            NULL != cipher_info->base->ctx_alloc_func );
+    MBEDTLS_CIPHER_VALIDATE( NULL != ctx && NULL != cipher_info );
 
     memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
 
@@ -197,7 +195,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx, const unsigned char *k
         int key_bitlen, const mbedtls_operation_t operation )
 {
     MBEDTLS_CIPHER_VALIDATE( NULL != ctx && NULL != ctx->cipher_info &&
-            NULL != ctx->cipher_info->base && NULL != key );
+            NULL != key );
 
     if( ( ctx->cipher_info->flags & MBEDTLS_CIPHER_VARIABLE_KEY_LEN ) == 0 &&
         (int) ctx->cipher_info->key_bitlen != key_bitlen )
@@ -257,7 +255,7 @@ int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
 
 int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx )
 {
-    MBEDTLS_CIPHER_VALIDATE( NULL != ctx );
+    MBEDTLS_CIPHER_VALIDATE( NULL != ctx && NULL != ctx->cipher_info );
     ctx->unprocessed_len = 0;
     return( 0 );
 }

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -81,6 +81,9 @@ static const char *features[] = {
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
     "MBEDTLS_DEPRECATED_REMOVED",
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+    "MBEDTLS_CHECK_PARAMS",
+#endif /* MBEDTLS_CHECK_PARAMS */
 #if defined(MBEDTLS_TIMING_ALT)
     "MBEDTLS_TIMING_ALT",
 #endif /* MBEDTLS_TIMING_ALT */

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -24,70 +24,216 @@ void mbedtls_cipher_list( )
 /* BEGIN_CASE */
 void cipher_null_args( )
 {
-    mbedtls_cipher_context_t ctx;
-    const mbedtls_cipher_info_t *info = mbedtls_cipher_info_from_type( *( mbedtls_cipher_list() ) );
-    unsigned char buf[1] = { 0 };
-    size_t olen;
+    mbedtls_cipher_context_t ctx_zero_initialized;
+    const mbedtls_cipher_info_t *info =
+        mbedtls_cipher_info_from_type( *( mbedtls_cipher_list() ) );
+    unsigned char arbitrary_buffer[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+    mbedtls_operation_t arbitrary_operation = 1;
+    mbedtls_cipher_padding_t arbitrary_padding_mode = 0;
+    int arbitrary_int = 0;
+    size_t arbitrary_size_t = 0;
 
-    mbedtls_cipher_init( &ctx );
+    mbedtls_cipher_init( &ctx_zero_initialized );
+
+    TEST_ASSERT( mbedtls_cipher_init_ret( &ctx_zero_initialized ) == 0 );
+    TEST_ASSERT( mbedtls_cipher_init_ret( NULL ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_free_ret( NULL ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
     TEST_ASSERT( mbedtls_cipher_get_block_size( NULL ) == 0 );
-    TEST_ASSERT( mbedtls_cipher_get_block_size( &ctx ) == 0 );
+    TEST_ASSERT( mbedtls_cipher_get_block_size( &ctx_zero_initialized ) == 0 );
 
     TEST_ASSERT( mbedtls_cipher_get_cipher_mode( NULL ) == MBEDTLS_MODE_NONE );
-    TEST_ASSERT( mbedtls_cipher_get_cipher_mode( &ctx ) == MBEDTLS_MODE_NONE );
+    TEST_ASSERT( mbedtls_cipher_get_cipher_mode( &ctx_zero_initialized ) ==
+        MBEDTLS_MODE_NONE );
 
     TEST_ASSERT( mbedtls_cipher_get_iv_size( NULL ) == 0 );
-    TEST_ASSERT( mbedtls_cipher_get_iv_size( &ctx ) == 0 );
+    TEST_ASSERT( mbedtls_cipher_get_iv_size( &ctx_zero_initialized ) == 0 );
 
     TEST_ASSERT( mbedtls_cipher_info_from_string( NULL ) == NULL );
 
-    TEST_ASSERT( mbedtls_cipher_setup( &ctx, NULL )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_setup( NULL, info )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setup( &ctx_zero_initialized, NULL ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setup( NULL, info ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_cipher_setkey( NULL, buf, 0, MBEDTLS_ENCRYPT )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_setkey( &ctx, buf, 0, MBEDTLS_ENCRYPT )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( NULL, arbitrary_buffer, 0,
+        MBEDTLS_ENCRYPT ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( &ctx_zero_initialized, arbitrary_buffer,
+        0, MBEDTLS_ENCRYPT ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_int, arbitrary_operation ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_int, arbitrary_operation ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( NULL, arbitrary_buffer, arbitrary_int,
+        arbitrary_operation ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( &ctx_zero_initialized, NULL, arbitrary_int,
+        arbitrary_operation ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_setkey( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_int, arbitrary_operation ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_cipher_set_iv( NULL, buf, 0 )
+    TEST_ASSERT( mbedtls_cipher_set_iv( NULL, arbitrary_buffer, 0 )
                  == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_set_iv( &ctx, buf, 0 )
+    TEST_ASSERT( mbedtls_cipher_set_iv( &ctx_zero_initialized, arbitrary_buffer, 0 )
                  == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_set_iv( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_set_iv( &ctx_zero_initialized, NULL,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_cipher_reset( NULL ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_reset( &ctx ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_reset( NULL ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_reset( &ctx_zero_initialized ) ==
+        MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_GCM_C)
-    TEST_ASSERT( mbedtls_cipher_update_ad( NULL, buf, 0 )
+    TEST_ASSERT( mbedtls_cipher_update_ad( NULL, arbitrary_buffer, 0 )
                  == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_update_ad( &ctx, buf, 0 )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update_ad( &ctx_zero_initialized,
+        arbitrary_buffer, 0 ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update_ad( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update_ad( &ctx_zero_initialized, NULL,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 #endif
 
-    TEST_ASSERT( mbedtls_cipher_update( NULL, buf, 0, buf, &olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_update( &ctx, buf, 0, buf, &olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( NULL, arbitrary_buffer, 0, arbitrary_buffer,
+        &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( &ctx_zero_initialized, arbitrary_buffer, 0,
+        arbitrary_buffer, &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t ) ==
+            MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( &ctx_zero_initialized, NULL,
+        arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t ) ==
+            MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t, NULL, &arbitrary_size_t ) ==
+            MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_update( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t, arbitrary_buffer, NULL ) ==
+            MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_cipher_finish( NULL, buf, &olen )
+    TEST_ASSERT( mbedtls_cipher_finish( NULL, arbitrary_buffer, &arbitrary_size_t )
                  == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_finish( &ctx, buf, &olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_finish( &ctx_zero_initialized, arbitrary_buffer,
+        &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_finish( &ctx_zero_initialized, arbitrary_buffer,
+        &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_finish( &ctx_zero_initialized, NULL,
+        &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_finish( &ctx_zero_initialized, arbitrary_buffer,
+        NULL) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_cipher_set_padding_mode( NULL,
+        arbitrary_padding_mode ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_set_padding_mode( &ctx_zero_initialized,
+        arbitrary_padding_mode ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_GCM_C)
-    TEST_ASSERT( mbedtls_cipher_write_tag( NULL, buf, olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_write_tag( &ctx, buf, olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_write_tag( NULL, arbitrary_buffer,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_write_tag( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_write_tag( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_write_tag( &ctx_zero_initialized,
+        NULL, arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    TEST_ASSERT( mbedtls_cipher_check_tag( NULL, buf, olen )
+    TEST_ASSERT( mbedtls_cipher_check_tag( NULL, arbitrary_buffer, arbitrary_size_t )
                  == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
-    TEST_ASSERT( mbedtls_cipher_check_tag( &ctx, buf, olen )
-                 == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_check_tag( &ctx_zero_initialized, arbitrary_buffer,
+        arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_check_tag( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_check_tag( &ctx_zero_initialized,
+        NULL, arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 #endif
+
+    TEST_ASSERT( mbedtls_cipher_crypt( NULL,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_crypt( &ctx_zero_initialized,
+        NULL, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, &arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_crypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, NULL, arbitrary_size_t,
+        arbitrary_buffer, &arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_crypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        NULL, &arbitrary_size_t ) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_crypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, NULL) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( NULL,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        NULL, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, NULL, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        NULL, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, NULL, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, NULL,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_encrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        NULL, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( NULL,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        NULL, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, NULL, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        NULL, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, NULL, &arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, NULL,
+        arbitrary_buffer, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    TEST_ASSERT( mbedtls_cipher_auth_decrypt( &ctx_zero_initialized,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, arbitrary_size_t,
+        arbitrary_buffer, arbitrary_size_t, arbitrary_buffer, &arbitrary_size_t,
+        NULL, arbitrary_size_t) == MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+exit:
+    mbedtls_cipher_free( &ctx_zero_initialized );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
This PR introduces unit test code the validation of the public API function parameters against NULL pointers.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported