### PR TITLE
Add pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ else()
     project("mbed TLS" C)
 endif()
 
+# Add CMake modules to the path
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)

--- a/cmake/PkgBuildConfig.cmake
+++ b/cmake/PkgBuildConfig.cmake
@@ -1,0 +1,95 @@
+# pkg-config file generation
+#
+# Uses the following globals:
+# - PKG_BUILD_PREFIX: the build location (aka prefix). Defaults to CMAKE_INSTALL_PREFIX
+# - PKG_BUILD_LIBDIR: the libdir location. Defaults to ${prefix}/lib.
+# - PKG_BUILD_INCLUDEDIR: the includedir location. Defaults to ${prefix}/include.
+#
+function(pkg_build_config)
+    set(options)
+    set(oneValueArgs NAME DESCRIPTION VERSION FILENAME)
+    set(multiValueArgs LIBS PRIVATE_LIBS REQUIRES CFLAGS)
+
+    cmake_parse_arguments(PKGCONFIG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT DEFINED PKGCONFIG_FILENAME AND DEFINED PKGCONFIG_NAME)
+        set(PKGCONFIG_FILENAME ${PKGCONFIG_NAME})
+    endif()
+    if (NOT DEFINED PKGCONFIG_FILENAME)
+        message(FATAL_ERROR "Missing FILENAME argument")
+    endif()
+    set(PKGCONFIG_FILE "${PROJECT_BINARY_DIR}/${PKGCONFIG_FILENAME}.pc")
+
+    if (NOT DEFINED PKGCONFIG_DESCRIPTION)
+        message(FATAL_ERROR "Missing DESCRIPTION argument")
+    endif()
+
+    if (NOT DEFINED PKGCONFIG_VERSION)
+        message(FATAL_ERROR "Missing VERSION argument")
+    endif()
+
+    if (DEFINED PKG_BUILD_PREFIX)
+        set(PKGCONFIG_PREFIX ${PKG_BUILD_PREFIX})
+    else()
+        set(PKGCONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+    endif()
+
+    if(DEFINED PKG_BUILD_LIBDIR)
+        if (IS_ABSOLUTE ${PKG_BUILD_LIBDIR})
+            set(PKGCONFIG_LIBDIR ${PKG_BUILD_LIBDIR})
+        else()
+            set(PKGCONFIG_LIBDIR "\${prefix}/${PKG_BUILD_LIBDIR}")
+        endif()
+    else()
+        set(PKGCONFIG_LIBDIR "\${prefix}/lib")
+    endif()
+
+    if(DEFINED PKG_BUILD_INCLUDEDIR)
+        if (IS_ABSOLUTE ${PKG_BUILD_INCLUDEDIR})
+            set(PKGCONFIG_INCLUDEDIR ${PKG_BUILD_INCLUDEDIR})
+        else()
+            set(PKGCONFIG_INCLUDEDIR "\${prefix}/${PKG_BUILD_INCLUDEDIR}")
+        endif()
+    else()
+        set(PKGCONFIG_INCLUDEDIR "\${prefix}/include")
+    endif()
+
+    file(WRITE "${PKGCONFIG_FILE}"
+        "prefix=${PKGCONFIG_PREFIX}\n"
+        "libdir=${PKGCONFIG_LIBDIR}\n"
+        "includedir=${PKGCONFIG_INCLUDEDIR}\n"
+        "\n"
+        "Name: ${PKGCONFIG_NAME}\n"
+        "Description: ${PKGCONFIG_DESCRIPTION}\n"
+        "Version: ${PKGCONFIG_VERSION}\n"
+    )
+
+    if(NOT DEFINED PKGCONFIG_LIBS)
+        set(PKGCONFIG_LIBS "-l${PKGCONFIG_NAME}")
+    else()
+        list(INSERT PKGCONFIG_LIBS 0 "-l${PKGCONFIG_NAME}")
+    endif()
+    list(REMOVE_DUPLICATES PKGCONFIG_LIBS)
+    string(REPLACE ";" " " PKGCONFIG_LIBS "${PKGCONFIG_LIBS}")
+    file(APPEND "${PKGCONFIG_FILE}" "Libs: -L\${libdir} ${PKGCONFIG_LIBS}\n")
+
+    if(DEFINED PKGCONFIG_PRIVATE_LIBS)
+        string(REPLACE ";" " " PKGCONFIG_PRIVATE_LIBS "${PKGCONFIG_PRIVATE_LIBS}")
+        file(APPEND "${PKGCONFIG_FILE}" "Libs.private: ${PKGCONFIG_PRIVATE_LIBS}\n")
+    endif()
+    if(DEFINED PKGCONFIG_REQUIRES)
+        list(REMOVE_DUPLICATES PKGCONFIG_REQUIRES)
+        string(REPLACE ";" " " PKGCONFIG_REQUIRES "${PKGCONFIG_REQUIRES}")
+        file(APPEND "${PKGCONFIG_FILE}" "Requires.private: ${PKGCONFIG_REQUIRES}\n")
+    endif()
+    if(DEFINED PKGCONFIG_CFLAGS)
+        string(REPLACE ";" " " PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS}")
+    else()
+        set(PKGCONFIG_CFLAGS "")
+    endif()
+    file(APPEND "${PKGCONFIG_FILE}" "Cflags: -I\${includedir} ${PKGCONFIG_CFLAGS}\n")
+
+    install(FILES "${PKGCONFIG_FILE}"
+        DESTINATION "${PKGCONFIG_PREFIX}/${PKGCONFIG_LIBDIR}/pkgconfig"
+    )
+endfunction()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -117,13 +117,16 @@ endif()
 
 # mbedx509 libs
 set(mbedx509_libs mbedcrypto)
+list(APPEND mbedx509_PKGCONFIG_REQUIRES mbedcrypto)
 
 if(USE_PKCS11_HELPER_LIBRARY)
     set(mbedx509_libs ${mbedx509_libs} pkcs11-helper)
+    list(APPEND mbedx509_PKGCONFIG_REQUIRES libpkcs11-helper-1)
 endif(USE_PKCS11_HELPER_LIBRARY)
 
 # mbedtls libs
 set(mbedtls_libs mbedcrypto mbedx509)
+set(mbedtls_PKGCONFIG_REQUIRES mbedx509)
 if(WIN32)
     set(mbedtls_libs ${mbedtls_libs} ws2_32)
 endif(WIN32)
@@ -134,10 +137,12 @@ endif(HAIKU)
 
 if(ENABLE_ZLIB_SUPPORT)
     set(mbedtls_libs ${mbedtls_libs} ${ZLIB_LIBRARIES})
+    set(mbedtls_PKGCONFIG_PRIVATE_LIBS ${ZLIB_LIBRARIES})
 endif(ENABLE_ZLIB_SUPPORT)
 
 if(LINK_WITH_PTHREAD)
     set(mbedtls_libs ${mbedtls_libs} pthread)
+    list(APPEND mbedtls_PKGCONFIG_PRIVATE_LIBS -lpthread)
 endif()
 
 if (NOT USE_STATIC_MBEDTLS_LIBRARY AND NOT USE_SHARED_MBEDTLS_LIBRARY)
@@ -202,3 +207,22 @@ add_custom_target(lib DEPENDS mbedx509 mbedtls)
 if(USE_STATIC_MBEDTLS_LIBRARY AND USE_SHARED_MBEDTLS_LIBRARY)
     add_dependencies(lib mbedx509_static mbedtls_static)
 endif()
+
+include(PkgBuildConfig)
+
+set(PKG_BUILD_LIBDIR ${LIB_INSTALL_DIR})
+set(PKG_BUILD_INCLUDEDIR ${INCLUDE_INSTALL_DIR})
+pkg_build_config(NAME mbedx509
+    VERSION ${MBEDTLS_VERSION_STRING}
+    DESCRIPTION "The mbedTLS X.509 library"
+    LIBS ${mbedx509_PKGCONFIG_LIBS}
+    PRIVATE_LIBS ${mbedx509_PKGCONFIG_PRIVATE_LIBS}
+    REQUIRES ${mbedx509_PKGCONFIG_REQUIRES}
+)
+pkg_build_config(NAME mbedtls
+    VERSION ${MBEDTLS_VERSION_STRING}
+    DESCRIPTION "The mbedTLS TLS library"
+    LIBS ${mbedtls_PKGCONFIG_LIBS}
+    PRIVATE_LIBS ${mbedtls_PKGCONFIG_PRIVATE_LIBS}
+    REQUIRES ${mbedtls_PKGCONFIG_REQUIRES}
+)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -108,10 +108,6 @@ if(UNSAFE_BUILD)
     set(CMAKE_C_FLAGS_ASANDBG "${CMAKE_C_FLAGS_ASANDBG} -Wno-error")
 endif(UNSAFE_BUILD)
 
-if(WIN32)
-    set(libs ${libs} ws2_32)
-endif(WIN32)
-
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
@@ -119,20 +115,29 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
-if(HAIKU)
-    set(libs ${libs} network)
-endif(HAIKU)
+# mbedx509 libs
+set(mbedx509_libs mbedcrypto)
 
 if(USE_PKCS11_HELPER_LIBRARY)
-    set(libs ${libs} pkcs11-helper)
+    set(mbedx509_libs ${mbedx509_libs} pkcs11-helper)
 endif(USE_PKCS11_HELPER_LIBRARY)
 
+# mbedtls libs
+set(mbedtls_libs mbedcrypto mbedx509)
+if(WIN32)
+    set(mbedtls_libs ${mbedtls_libs} ws2_32)
+endif(WIN32)
+
+if(HAIKU)
+    set(mbedtls_libs ${mbedtls_libs} network)
+endif(HAIKU)
+
 if(ENABLE_ZLIB_SUPPORT)
-    set(libs ${libs} ${ZLIB_LIBRARIES})
+    set(mbedtls_libs ${mbedtls_libs} ${ZLIB_LIBRARIES})
 endif(ENABLE_ZLIB_SUPPORT)
 
 if(LINK_WITH_PTHREAD)
-    set(libs ${libs} pthread)
+    set(mbedtls_libs ${mbedtls_libs} pthread)
 endif()
 
 if (NOT USE_STATIC_MBEDTLS_LIBRARY AND NOT USE_SHARED_MBEDTLS_LIBRARY)
@@ -150,17 +155,16 @@ elseif(USE_STATIC_MBEDTLS_LIBRARY)
 endif()
 
 if(USE_STATIC_MBEDTLS_LIBRARY)
-
     add_library(${mbedx509_static_target} STATIC ${src_x509})
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
-    target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
+    target_link_libraries(${mbedx509_static_target} ${mbedx509_libs})
     target_include_directories(${mbedx509_static_target}
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
-    target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
+    target_link_libraries(${mbedtls_static_target} ${mbedtls_libs})
     target_include_directories(${mbedtls_static_target}
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -90,6 +90,10 @@ set(src_tls
     ssl_tls.c
 )
 
+# Extract version from include/mbedtls/version.h
+file(STRINGS "${PROJECT_SOURCE_DIR}/include/mbedtls/version.h" MBEDTLS_VERSION_H REGEX "^#define *MBEDTLS_VERSION_STRING *\"[^\"]*\"$")
+string(REGEX REPLACE "^.*MBEDTLS_VERSION_STRING +\"([0-9.]*)\"$" "\\1" MBEDTLS_VERSION_STRING ${MBEDTLS_VERSION_H})
+
 if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes")
 endif(CMAKE_COMPILER_IS_GNUCC)
@@ -170,16 +174,15 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
-
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.17.0 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION ${MBEDTLS_VERSION_STRING} SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.17.0 SOVERSION 12)
+    set_target_properties(mbedtls PROPERTIES VERSION ${MBEDTLS_VERSION_STRING} SOVERSION 12)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${MBEDTLS_DIR}/include/


### PR DESCRIPTION
## Description

This add pkg-config generation support to the CMake build system so downstream libraries can just piggyback on that instead of juggling with link flags.

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments

Fixes #228, supersedes #1657. Be aware that I have limited experience with the pkgconfig things.

I might also be using CMake commands that are forbidden due to compatibility. I'd say 3.0+ is required, maybe ?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce

```sh
mkdir build && cd build
cmake ..
# you should see *.pc files in the current directory
cmake --build . --target install
# you should see *.pc files in $CMAKE_INSTALL_PREFIX/lib/pkgconfig
# (default prefix is /usr/local/)
```