### PR TITLE
Fix hmac_drbg failure in benchmark, with threading

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Bugfix
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.
      Contributed by fbrosson.
-   * Fix efailure in hmac_drbg in the benchmark sample application, when
+   * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
 
 = mbed TLS 2.11.0 branch released 2018-06-18

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@ Bugfix
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.
      Contributed by fbrosson.
+   * Fix efailure in hmac_drbg in the benchmark sample application, when
+     MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
 
 = mbed TLS 2.11.0 branch released 2018-06-18
 

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -700,7 +700,6 @@ int main( int argc, char *argv[] )
             mbedtls_exit(1);
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (NOPR)",
                 mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -708,7 +707,6 @@ int main( int argc, char *argv[] )
                                              MBEDTLS_HMAC_DRBG_PR_ON );
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (PR)",
                 mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
@@ -719,7 +717,6 @@ int main( int argc, char *argv[] )
             mbedtls_exit(1);
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (NOPR)",
                 mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -727,8 +724,8 @@ int main( int argc, char *argv[] )
                                              MBEDTLS_HMAC_DRBG_PR_ON );
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (PR)",
                 mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
+        mbedtls_hmac_drbg_free( &hmac_drbg );
     }
 #endif
 


### PR DESCRIPTION
## Description
Remove redunadnat calls to `hmac_drbg_free()` between seeding operations,
which make the mutex invalid. Fixes #1095


## Status
**READY**

## Requires Backporting
Yes
Which branch?
mbedtls-2.1
mbedtls-2.7

## Migrations
 NO


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
