### PR TITLE
Backport 2.7: Fix Shared Library compilation issue with Cmake

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
-   * FIx compilation on windows when building shared library, by setting
-     Library search path to CMAKE_CURRENT_BINARY_DIR. #1130
+   * Fix compilation on Windows when building shared library, by setting
+     library search path to CMAKE_CURRENT_BINARY_DIR. #1130
 
 = mbed TLS 2.7.4 branch released 2018-06-18
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+   * FIx compilation on windows when building shared library, by setting
+     Library search path to CMAKE_CURRENT_BINARY_DIR. #1130
+
 = mbed TLS 2.7.4 branch released 2018-06-18
 
 Bugfix

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -140,6 +140,7 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
+    set(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR})
     add_library(mbedcrypto SHARED ${src_crypto})
     set_target_properties(mbedcrypto PROPERTIES VERSION 2.7.4 SOVERSION 2)
     target_link_libraries(mbedcrypto ${libs})


### PR DESCRIPTION
## Description
Backport of #1133 to mbedtls-2.7


## Status
**READY**

