### PR TITLE
Backport 2.1: Fix Shared Library compilation issue with Cmake

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+   * FIx compilation on windows when building shared library, by setting
+     Library search path to CMAKE_CURRENT_BINARY_DIR. #1130
+     
 = mbed TLS 2.1.13 branch released 2018-06-18
 
 Bugfix

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS x.x.x branch released xxxx-xx-xx
-   * FIx compilation on windows when building shared library, by setting
+
+   * Fix compilation on windows when building shared library, by setting
      Library search path to CMAKE_CURRENT_BINARY_DIR. #1130
      
 = mbed TLS 2.1.13 branch released 2018-06-18

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -137,6 +137,7 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
+    set(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR})
     add_library(mbedcrypto SHARED ${src_crypto})
     set_target_properties(mbedcrypto PROPERTIES VERSION 2.1.13 SOVERSION 0)
     target_link_libraries(mbedcrypto ${libs})


### PR DESCRIPTION
## Description
Backport of #1133 to mbedtls-2.1


## Status
**READY/IN DEVELOPMENT/HOLD**

