### PR TITLE
Replace Windows API threading with CRT functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Changes
+   * Change the use of Windows threading to use Microsoft Visual C++ runtime
+     calls, rather than Win32 API calls directly. This is necessary to avoid
+     conflict with C runtime usage. Found and fixed by irwir.
+
 = mbed TLS 2.11.0 branch released 2018-06-18
 
 Features

--- a/library/timing.c
+++ b/library/timing.c
@@ -51,6 +51,7 @@
 
 #include <windows.h>
 #include <winbase.h>
+#include <process.h>
 
 struct _hr_time
 {
@@ -266,18 +267,16 @@ unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int 
 /* It's OK to use a global because alarm() is supposed to be global anyway */
 static DWORD alarmMs;
 
-static DWORD WINAPI TimerProc( LPVOID TimerContext )
+static void TimerProc( void *TimerContext )
 {
-    ((void) TimerContext);
+    (void)TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
-    return( TRUE );
+    // Implicit call of _endthread() is better (see MS online docs)
 }
 
 void mbedtls_set_alarm( int seconds )
 {
-    DWORD ThreadId;
-
     if( seconds == 0 )
     {
         /* No need to create a thread for this simple case.
@@ -288,7 +287,7 @@ void mbedtls_set_alarm( int seconds )
 
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
-    CloseHandle( CreateThread( NULL, 0, TimerProc, NULL, 0, &ThreadId ) );
+    (void)_beginthread( TimerProc, 0, NULL );
 }
 
 #else /* _WIN32 && !EFIX64 && !EFI32 */

--- a/library/timing.c
+++ b/library/timing.c
@@ -269,7 +269,7 @@ static DWORD alarmMs;
 
 static void TimerProc( void *TimerContext )
 {
-    (void)TimerContext;
+    (void) TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
     // Implicit call of _endthread() is better (see MS online docs)
@@ -287,7 +287,7 @@ void mbedtls_set_alarm( int seconds )
 
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
-    (void)_beginthread( TimerProc, 0, NULL );
+    (void) _beginthread( TimerProc, 0, NULL );
 }
 
 #else /* _WIN32 && !EFIX64 && !EFI32 */

--- a/library/timing.c
+++ b/library/timing.c
@@ -272,7 +272,8 @@ static void TimerProc( void *TimerContext )
     (void) TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
-    // Implicit call of _endthread() is better (see MS online docs)
+    /* _endthread will be called implicitly on return
+     * That ensures execution of thread funcition's epilogue */
 }
 
 void mbedtls_set_alarm( int seconds )


### PR DESCRIPTION
## Description
In Visual C/C++ programs that use CRT library, should do threading with `_beginthread`, `_beginthreadex` and `_endthread`, `_endthreadex` functions instead of Windows API functions `CreateThread`, `ExitThread` and `CloseHandle`.
Otherwise some CRT funtions could fail, and memory leaks are possible.

Timer tests in `selftest.c` with the new code were successful.

## Status
**READY**

## Requires Backporting
Yes

## Which branch?
development

## Migrations
NO

## Additional comments
More information could be found in
- Microsoft KnowledgeBase Article Q104641
- Microsoft online documentation for _beginthread, _beginthreadex and _endthread, _endthreadex function