### PR TITLE
Fix the i386 MPI multiply helper assembly code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix the inline assembly for the MPI multiply helper function for i386 and
+     i386 with SSE2. Found by László Langó. Fixes #1550
+
 = mbed TLS 2.11.0 branch released 2018-06-18
 
 Features

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -142,7 +142,7 @@
         "movl   %%esi, %3       \n\t"   \
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
-        : "eax", "ecx", "edx", "esi", "edi"             \
+        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
     );
 
 #else
@@ -154,7 +154,7 @@
         "movl   %%esi, %3       \n\t"   \
         : "=m" (t), "=m" (c), "=m" (d), "=m" (s)        \
         : "m" (t), "m" (s), "m" (d), "m" (c), "m" (b)   \
-        : "eax", "ecx", "edx", "esi", "edi"             \
+        : "eax", "ebx", "ecx", "edx", "esi", "edi"      \
     );
 #endif /* SSE2 */
 #endif /* i386 */

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -49,7 +49,14 @@
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && \
     ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
-#if defined(__i386__)
+
+/*
+ * Disable use of the i386 assembly code below if option -O0, to disable all
+ * compiler optimisations, is passed, detected with __OPTIMIZE__
+ * This is done as the number of registers used in the assembly code doesn't
+ * work with the -O0 option.
+ */
+#if defined(__i386__) && !defined(__OPTIMIZE__)
 
 #define MULADDC_INIT                        \
     asm(                                    \


### PR DESCRIPTION
## Description
This is a fix for GitHub issue #1550.

The `ebx` register was used by the assembly code but not listed in the clobber list, so when the compiler chose to also use it, `ebx` was getting corrupted. I'm surprised this wasn't spotted sooner.

The fix is very simply to add the `ebx` register to the clobber list for the i386 inline assembly
for the multiply helper function.

This fixes both i386 and its SSE2 variant which was also broken.

## Status
**READY**

## Requires Backporting
Yes
Which branch?
`mbedtls-2.1` and `mbedtls-2.7`. I'll backport once this one's been approved.

## Additional comments
This should have been caught by the CI, so I suggest `all.sh` needs to be extended. (I haven't checked where or how yet).

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
