### PR TITLE
Minor HKDF changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
      Philippe Antoine. Fixes #1623.
+   * Change the default behaviour of mbedtls_hkdf_extract() to return an error
+     when calling with a NULL salt and non-zero salt_len. Contributed by
+     Brian J Murray
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -61,13 +61,10 @@ int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
     if( salt == NULL )
     {
         size_t hash_len;
-<<<<<<< HEAD
-=======
-        
+
         if( salt_len != 0 ) {
             return MBEDTLS_ERR_HKDF_BAD_INPUT_DATA;
         }
->>>>>>> per code review
 
         hash_len = mbedtls_md_get_size( md );
 
@@ -121,6 +118,10 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
         n++;
     }
 
+    /*
+     * Per RFC 5869 Section 2.3, okm_len must not exceed
+     * 255 times the hash length
+     */
     if( n > 255 )
     {
         return( MBEDTLS_ERR_HKDF_BAD_INPUT_DATA );
@@ -133,7 +134,10 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
         goto exit;
     }
 
-    /* RFC 5869 Section 2.3. */
+    /*
+     * Compute T = T(1) | T(2) | T(3) | ... | T(N)
+     * Where T(N) is defined in RFC 5869 Section 2.3
+     */
     for( i = 1; i <= n; i++ )
     {
         size_t num_to_copy;
@@ -157,7 +161,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
             goto exit;
         }
 
-        /* The constant concatenated to the end of each t(n) is a single octet.
+        /* The constant concatenated to the end of each T(n) is a single octet.
          * */
         ret = mbedtls_md_hmac_update( &ctx, &c, 1 );
         if( ret != 0 )

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -61,6 +61,13 @@ int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
     if( salt == NULL )
     {
         size_t hash_len;
+<<<<<<< HEAD
+=======
+        
+        if( salt_len != 0 ) {
+            return MBEDTLS_ERR_HKDF_BAD_INPUT_DATA;
+        }
+>>>>>>> per code review
 
         hash_len = mbedtls_md_get_size( md );
 


### PR DESCRIPTION
## Description
Minor changes and improvements to HKDF.

Summary of changes:
Major:
- If `salt == NULL`, require `salt_len == 0` to follow the convention used for other buffers.

Minor:
- Add references section.
- Add `const` keyword to `null_salt`.
- Move `hash_len` to top of function for C99 compliance.
- Add comment to explain origin of number constant.
- Refactor comment to better explain what is being computed.
- In comment, change t(n) to T(N) for consistency with notation used RFC 5869.

## Requires Backporting

NO  

## Migrations
NO

Brian J Murray