### PR TITLE
Renaming "new" variable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix Renaming "new" variable #1783.
+     compile error(new variable) with arm-none-eabi-gcc(c++) on mbed TLS 2.7.0.
+
+
 = mbed TLS 2.11.0 branch released 2018-06-18
 
 Features

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix compilation error on c++, because of a variable named new. Found and fixed by Hirotaka Niisato in #1783 
+   * Fix compilation error on C++, because of a variable named new.
+     Found and fixed by Hirotaka Niisato in #1783 
 
 = mbed TLS 2.11.0 branch released 2018-06-18
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 Bugfix
    * Fix compilation error on C++, because of a variable named new.
-     Found and fixed by Hirotaka Niisato in #1783 
+     Found and fixed by Hirotaka Niisato in #1783.
 
 = mbed TLS 2.11.0 branch released 2018-06-18
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,9 +4,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix Renaming "new" variable #1783.
-     compile error(new variable) with arm-none-eabi-gcc(c++) on mbed TLS 2.7.0.
-
+   * Fix compilation error on c++, because of a variable named new. Found and fixed by Hirotaka Niisato in #1783 
 
 = mbed TLS 2.11.0 branch released 2018-06-18
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5995,27 +5995,27 @@ static int ssl_append_key_cert( mbedtls_ssl_key_cert **head,
                                 mbedtls_x509_crt *cert,
                                 mbedtls_pk_context *key )
 {
-    mbedtls_ssl_key_cert *new;
+    mbedtls_ssl_key_cert *new_cert;
 
-    new = mbedtls_calloc( 1, sizeof( mbedtls_ssl_key_cert ) );
-    if( new == NULL )
+    new_cert = mbedtls_calloc( 1, sizeof( mbedtls_ssl_key_cert ) );
+    if( new_cert == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-    new->cert = cert;
-    new->key  = key;
-    new->next = NULL;
+    new_cert->cert = cert;
+    new_cert->key  = key;
+    new_cert->next = NULL;
 
     /* Update head is the list was null, else add to the end */
     if( *head == NULL )
     {
-        *head = new;
+        *head = new_cert;
     }
     else
     {
         mbedtls_ssl_key_cert *cur = *head;
         while( cur->next != NULL )
             cur = cur->next;
-        cur->next = new;
+        cur->next = new_cert;
     }
 
     return( 0 );


### PR DESCRIPTION
## Description
Based on issue #1782 
Replace ```*new``` to ```*new_cert``` in ```ssl_append_key_cert``` function at ```ssl_tls.c```.

## Status
READY

## Requires Backporting
NO

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported