### PR TITLE
Add tests for deprecated MDx code

### DIFF
--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -21,6 +21,12 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( ret == 0 ) ;
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset( output, 0x00, sizeof output );
+    mbedtls_md2( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -40,6 +46,12 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset( output, 0x00, sizeof output );
+    mbedtls_md4( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -59,6 +71,12 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset( output, 0x00, sizeof output );
+    mbedtls_md5( src_str, strlen( (char *) src_str ), output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -27,7 +27,7 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset( output, 0x00, sizeof output );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_md2_init( &ctx );
     mbdetls_md2_starts( &ctx );
     mbedtls_md2_update( &ctx, src_str, strlen( (char *) src_str ) );
@@ -59,7 +59,7 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset( output, 0x00, sizeof output );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_md4_init( &ctx );
     mbdetls_md4_starts( &ctx );
     mbedtls_md4_update( &ctx, src_str, strlen( (char *) src_str ) );
@@ -91,7 +91,7 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset( output, 0x00, sizeof output );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_md5_init( &ctx );
     mbedtls_md5_starts( &ctx );
     mbedtls_md5_update( &ctx, src_str, strlen( (char *) src_str ) );
@@ -123,7 +123,7 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset( output, 0x00, sizeof(output) );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_ripemd160_init( &ctx );
     mbedtls_ripemd160_starts( &ctx );
     mbedtls_ripemd160_update( &ctx, src_str, strlen( (char *) src_str ) );

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -12,6 +12,10 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     unsigned char src_str[100];
     unsigned char output[16];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_md2_context ctx;
+#endif
+
     memset( src_str, 0x00, sizeof src_str );
     memset( output, 0x00, sizeof output );
 
@@ -24,7 +28,10 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     memset( output, 0x00, sizeof output );
-    mbedtls_md2( src_str, strlen( (char *) src_str ), output );
+    mbedtls_md2_init( &ctx );
+    mbdetls_md2_starts( &ctx );
+    mbedtls_md2_update( &ctx, src_str, strlen( (char *) src_str ) );
+    mbedtls_md2_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 #endif
 }
@@ -36,6 +43,10 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     int ret;
     unsigned char src_str[100];
     unsigned char output[16];
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_md4_context ctx;
+#endif
 
     memset( src_str, 0x00, sizeof src_str );
     memset( output, 0x00, sizeof output );
@@ -49,7 +60,10 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     memset( output, 0x00, sizeof output );
-    mbedtls_md4( src_str, strlen( (char *) src_str ), output );
+    mbedtls_md4_init( &ctx );
+    mbdetls_md4_starts( &ctx );
+    mbedtls_md4_update( &ctx, src_str, strlen( (char *) src_str ) );
+    mbedtls_md4_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 #endif
 }
@@ -61,6 +75,10 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     int ret;
     unsigned char src_str[100];
     unsigned char output[16];
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_md5_context ctx;
+#endif
 
     memset( src_str, 0x00, sizeof src_str );
     memset( output, 0x00, sizeof output );
@@ -74,7 +92,10 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     memset( output, 0x00, sizeof output );
-    mbedtls_md5( src_str, strlen( (char *) src_str ), output );
+    mbedtls_md5_init( &ctx );
+    mbedtls_md5_starts( &ctx );
+    mbedtls_md5_update( &ctx, src_str, strlen( (char *) src_str ) );
+    mbedtls_md5_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 #endif
 }
@@ -87,6 +108,10 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     unsigned char src_str[100];
     unsigned char output[20];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_ripemd160_context ctx;
+#endif
+
     memset(src_str, 0x00, sizeof src_str);
     memset(output, 0x00, sizeof output);
 
@@ -96,6 +121,15 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset( output, 0x00, sizeof(output) );
+    mbedtls_ripemd160_init( &ctx );
+    mbedtls_ripemd160_starts( &ctx );
+    mbedtls_ripemd160_update( &ctx, src_str, strlen( (char *) src_str ) );
+    mbedtls_ripemd160_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -29,7 +29,7 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     memset( output, 0x00, sizeof( output ) );
     mbedtls_md2_init( &ctx );
-    mbdetls_md2_starts( &ctx );
+    mbedtls_md2_starts( &ctx );
     mbedtls_md2_update( &ctx, src_str, strlen( (char *) src_str ) );
     mbedtls_md2_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
@@ -61,7 +61,7 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     memset( output, 0x00, sizeof( output ) );
     mbedtls_md4_init( &ctx );
-    mbdetls_md4_starts( &ctx );
+    mbedtls_md4_starts( &ctx );
     mbedtls_md4_update( &ctx, src_str, strlen( (char *) src_str ) );
     mbedtls_md4_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -9,12 +9,25 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[41];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_sha1_context ctx;
+#endif
+
     memset(output, 0x00, 41);
 
 
     TEST_ASSERT( mbedtls_sha1_ret( src_str->x, src_str->len, output ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset(output, 0x00, 41);
+    mbedtls_sha1_init( &ctx );
+    mbedtls_sha1_starts( &ctx );
+    mbedtls_sha1_update( &ctx, src_str, src_len );
+    mbedtls_sha1_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -23,12 +36,25 @@ void sha224( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[57];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_sha256_context ctx;
+#endif
+
     memset(output, 0x00, 57);
 
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset(output, 0x00, 57);
+    mbedtls_sha256_init( &ctx );
+    mbedtls_sha256_starts( &ctx, 1 );
+    mbedtls_sha256_update( &ctx, src_str, src_len );
+    mbedtls_sha256_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -37,12 +63,25 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[65];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_sha256_context ctx;
+#endif
+
     memset(output, 0x00, 65);
 
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset(output, 0x00, 65);
+    mbedtls_sha256_init( &ctx );
+    mbedtls_sha256_starts( &ctx, 0 );
+    mbedtls_sha256_update( &ctx, src_str, src_len );
+    mbedtls_sha256_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -51,12 +90,25 @@ void sha384( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[97];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_sha512_context ctx;
+#endif
+
     memset(output, 0x00, 97);
 
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset(output, 0x00, 97);
+    mbedtls_sha512_init( &ctx );
+    mbedtls_sha512_starts( &ctx, 1);
+    mbedtls_sha512_update( &ctx, src_str, src_len );
+    mbedtls_sha512_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 
@@ -65,12 +117,25 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[129];
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    mbedtls_sha512_context ctx;
+#endif
+
     memset(output, 0x00, 129);
 
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+    memset(output, 0x00, 129);
+    mbedtls_sha512_init( &ctx );
+    mbedtls_sha512_starts( &ctx, 0);
+    mbedtls_sha512_update( &ctx, src_str, src_len );
+    mbedtls_sha512_finish( &ctx, output );
+    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
+#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -21,7 +21,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, 41);
+    memset(output, 0x00, sizeof( output ) );
     mbedtls_sha1_init( &ctx );
     mbedtls_sha1_starts( &ctx );
     mbedtls_sha1_update( &ctx, src_str, src_len );
@@ -62,7 +62,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, 65);
+    memset(output, 0x00, sizeof( output ) );
     mbedtls_sha256_init( &ctx );
     mbedtls_sha256_starts( &ctx, 0 );
     mbedtls_sha256_update( &ctx, src_str, src_len );
@@ -103,7 +103,7 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, 129);
+    memset(output, 0x00, sizeof( output ) );
     mbedtls_sha512_init( &ctx );
     mbedtls_sha512_starts( &ctx, 0);
     mbedtls_sha512_update( &ctx, src_str, src_len );

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -36,25 +36,12 @@ void sha224( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[57];
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    mbedtls_sha256_context ctx;
-#endif
-
     memset(output, 0x00, 57);
 
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, 57);
-    mbedtls_sha256_init( &ctx );
-    mbedtls_sha256_starts( &ctx, 1 );
-    mbedtls_sha256_update( &ctx, src_str, src_len );
-    mbedtls_sha256_finish( &ctx, output );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
-#endif
 }
 /* END_CASE */
 
@@ -90,25 +77,12 @@ void sha384( data_t * src_str, data_t * hex_hash_string )
 {
     unsigned char output[97];
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    mbedtls_sha512_context ctx;
-#endif
-
     memset(output, 0x00, 97);
 
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, 97);
-    mbedtls_sha512_init( &ctx );
-    mbedtls_sha512_starts( &ctx, 1);
-    mbedtls_sha512_update( &ctx, src_str, src_len );
-    mbedtls_sha512_finish( &ctx, output );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
-#endif
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -21,7 +21,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, sizeof( output ) );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_sha1_init( &ctx );
     mbedtls_sha1_starts( &ctx );
     mbedtls_sha1_update( &ctx, src_str, src_len );
@@ -62,7 +62,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, sizeof( output ) );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_sha256_init( &ctx );
     mbedtls_sha256_starts( &ctx, 0 );
     mbedtls_sha256_update( &ctx, src_str, src_len );
@@ -103,9 +103,9 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
-    memset(output, 0x00, sizeof( output ) );
+    memset( output, 0x00, sizeof( output ) );
     mbedtls_sha512_init( &ctx );
-    mbedtls_sha512_starts( &ctx, 0);
+    mbedtls_sha512_starts( &ctx, 0 );
     mbedtls_sha512_update( &ctx, src_str, src_len );
     mbedtls_sha512_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -24,7 +24,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
     memset( output, 0x00, sizeof( output ) );
     mbedtls_sha1_init( &ctx );
     mbedtls_sha1_starts( &ctx );
-    mbedtls_sha1_update( &ctx, src_str, src_len );
+    mbedtls_sha1_update( &ctx, src_str->x, src_str->len );
     mbedtls_sha1_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
 #endif
@@ -65,7 +65,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
     memset( output, 0x00, sizeof( output ) );
     mbedtls_sha256_init( &ctx );
     mbedtls_sha256_starts( &ctx, 0 );
-    mbedtls_sha256_update( &ctx, src_str, src_len );
+    mbedtls_sha256_update( &ctx, src_str->x, src_str->len );
     mbedtls_sha256_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
 #endif
@@ -106,7 +106,7 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
     memset( output, 0x00, sizeof( output ) );
     mbedtls_sha512_init( &ctx );
     mbedtls_sha512_starts( &ctx, 0 );
-    mbedtls_sha512_update( &ctx, src_str, src_len );
+    mbedtls_sha512_update( &ctx, src_str->x, src_str->len );
     mbedtls_sha512_finish( &ctx, output );
     TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
 #endif


### PR DESCRIPTION
## Description
This PR enables execution of deprecated functions form the MDx API.

## Status
READY

## Requires Backporting
May be backported

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
None
