### PR TITLE
Backport 2.1: remove additional zero byte when writing pub der

### DIFF
--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -128,7 +128,7 @@ static int write_public_key( mbedtls_pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof(output_buf) - len;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )


### PR DESCRIPTION
## Description
Backport of #1258 to mbedtls-2.1


## Status
**READY**