### PR TITLE
Backport 2.7: Documentation error in `mbedtls_ssl_get_session`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,16 +3,6 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix the key_app_writer example which was writing a leading zero byte which
-     was creating an invalid ASN.1 tag. Found by Aryeh R. Fixes #1257.
-   * Fix compilation error on C++, because of a variable named new.
-     Found and fixed by Hirotaka Niisato in #1783.
-   * Fix "no symbols" warning issued by ranlib when building on Mac OS X. Fix
-     contributed by tabascoeye in pull request #1600.
-   * Clarify documentation for mbedtls_ssl_write() to include 0 as a valid
-     return value. Found by @davidwu2000. #839
-   * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
-     Philippe Antoine. Fixes #1623.
    * Correct the documentation for `mbedtls_ssl_get_session()`.
      This API has deep copy of the session, and the peer
      certificate is not lost. Fixes #926.

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,19 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Remove wrong documentation for `mbedtls_ssl_get_session`.
+   * Fix the key_app_writer example which was writing a leading zero byte which
+     was creating an invalid ASN.1 tag. Found by Aryeh R. Fixes #1257.
+   * Fix compilation error on C++, because of a variable named new.
+     Found and fixed by Hirotaka Niisato in #1783.
+   * Fix "no symbols" warning issued by ranlib when building on Mac OS X. Fix
+     contributed by tabascoeye in pull request #1600.
+   * Clarify documentation for mbedtls_ssl_write() to include 0 as a valid
+     return value. Found by @davidwu2000. #839
+   * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
+     Philippe Antoine. Fixes #1623.
+   * Correct the documentation for `mbedtls_ssl_get_session()`.
      This API has deep copy of the session, and the peer
-     certificate is not lost. #926
+     certificate is not lost. Fixes #926.
 
 = mbed TLS 2.7.4 branch released 2018-06-18
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Remove wrong documentation for `mbedtls_ssl_get_session`.
+     This API has deep copy of the session, and the peer
+     certificate is not lost. #926
+
 = mbed TLS 2.7.4 branch released 2018-06-18
 
 Bugfix

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2377,12 +2377,12 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  * \return         0 if successful,
  *                 MBEDTLS_ERR_SSL_ALLOC_FAILED if memory allocation failed,
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
- *                 arguments are otherwise invalid
+ *                 arguments are otherwise invalid.
  *
  * \note           Only the server certificate is copied, and not the chain
  *                 but this is not a problem because the result of the chain
  *                 verification is stored in `verify_result` and can be checked
- *                 with \c mbedtls_ssl_get_verify_result()
+ *                 with \c mbedtls_ssl_get_verify_result().
  *
  * \sa             mbedtls_ssl_set_session()
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2379,10 +2379,16 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
  *                 arguments are otherwise invalid.
  *
- * \note           Only the server certificate is copied, and not the chain
- *                 but this is not a problem because the result of the chain
- *                 verification is stored in `verify_result` and can be checked
- *                 with \c mbedtls_ssl_get_verify_result().
+ * \note           Only the server certificate is copied, and not the full chain,
+ *                 so you should not attempt to validate the certificate again
+ *                 by calling \c mbedtls_x509_crt_verify() on it.
+ *                 Instead, you should use the results from the verification
+ *                 in the original handshake by calling \c mbedtls_ssl_get_verify_result()
+ *                 after loading the session again into a new SSL context
+ *                 using \c mbedtls_ssl_set_session().
+ *
+ * \note           Once the session object is not needed anymore, you should
+ *                 free it by calling \c mbedtls_ssl_session_free().
  *
  * \sa             mbedtls_ssl_set_session()
  */
@@ -2618,6 +2624,9 @@ void mbedtls_ssl_session_init( mbedtls_ssl_session *session );
 /**
  * \brief          Free referenced items in an SSL session including the
  *                 peer certificate and clear memory
+ *
+ * \note           A session object can be freed even if the SSL context
+ *                 that was used to retrieve the session is still in use.
  *
  * \param session  SSL session
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2370,7 +2370,6 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  * \brief          Save session in order to resume it later (client-side only)
  *                 Session data is copied to presented session structure.
  *
- * \warning        Currently, peer certificate is lost in the operation.
  *
  * \param ssl      SSL context
  * \param session  session context
@@ -2379,6 +2378,11 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 MBEDTLS_ERR_SSL_ALLOC_FAILED if memory allocation failed,
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used server-side or
  *                 arguments are otherwise invalid
+ *
+ * \note           Only the server certificate is copied, and not the chain
+ *                 but this is not a problem because the result of the chain
+ *                 verification is stored in `verify_result` and can be checked
+ *                 with \c mbedtls_ssl_get_verify_result()
  *
  * \sa             mbedtls_ssl_set_session()
  */


### PR DESCRIPTION
## Description
Backport of #927 to mbedtls-2.7


## Status
**READY**

