### PR TITLE
Backport 2.1: fix compilation error when MBEDTLS_CIPHER_NULL_CIPHER defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.xx branch released xxxx-xx-xx
+
+Bugfix
+   * Fix compilation error when MBEDTLS_ARC4_C is disabled and
+     MBEDTLS_CIPHER_NULL_CIPHER is enabled. Found by TrinityTonic in #1719.
+
 = mbed TLS 2.1.13 branch released 2018-06-18
 
 Bugfix

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -42,7 +42,7 @@
 #define MBEDTLS_CIPHER_MODE_WITH_PADDING
 #endif
 
-#if defined(MBEDTLS_ARC4_C)
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
 #define MBEDTLS_CIPHER_MODE_STREAM
 #endif
 

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -33,10 +33,6 @@
 
 #include "cipher.h"
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -33,6 +33,10 @@
 
 #include "cipher.h"
 
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#define MBEDTLS_CIPHER_MODE_STREAM
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -45,10 +45,6 @@
 #include "mbedtls/ccm.h"
 #endif
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = v; while( n-- ) *p++ = 0;


### PR DESCRIPTION
## Description
Backport of #1737 to mbedtls-2.1


## Status
**READY**


