### PR TITLE
Backport 2.7: fix compilation error when MBEDTLS_CIPHER_NULL_CIPHER defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix compilation error when MBEDTLS_ARC4_C is disabled and
+     MBEDTLS_CIPHER_NULL_CIPHER is enabled. Found by TrinityTonic in #1719.
+
 = mbed TLS 2.7.3 branch released 2018-04-30
 
 Security

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -43,7 +43,7 @@
 #define MBEDTLS_CIPHER_MODE_WITH_PADDING
 #endif
 
-#if defined(MBEDTLS_ARC4_C)
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
 #define MBEDTLS_CIPHER_MODE_STREAM
 #endif
 

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -34,10 +34,6 @@
 
 #include "cipher.h"
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -34,6 +34,10 @@
 
 #include "cipher.h"
 
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
+#define MBEDTLS_CIPHER_MODE_STREAM
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -56,10 +56,6 @@
 #define mbedtls_free   free
 #endif
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER)
-#define MBEDTLS_CIPHER_MODE_STREAM
-#endif
-
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
     volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;


### PR DESCRIPTION
## Description
Backport of #1737 to mbedtls-2.7


## Status
**READY**

