### PR TITLE
Use preserve mode to copy headers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests: lib
 ifndef WINDOWS
 install: no_test
 	mkdir -p $(DESTDIR)/include/mbedtls
-	cp -r include/mbedtls $(DESTDIR)/include
+	cp -rp include/mbedtls $(DESTDIR)/include
 
 	mkdir -p $(DESTDIR)/lib
 	cp -RP library/libmbedtls.*    $(DESTDIR)/lib


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) .
    - account created: **xueruini@gmail.com**

## Description

I am building `curl` with `mbedtls` for an embedded device. One interesting phenomenon is `make curl` always rebuild its source files even no single `curl` file is edited. After debugging, I found the root cause is: the build system in my device will build and install mbedtls first, and then curl. During installing mbedtls, all mbedtls headers will be **copied** to the DESTDIR. However, on copying, the headers' mtime are updated even no mbedtls file is updated, so `make curl` thinks the dependencies are updated, so the entire `curl` will be rebuilt.

The fix is very simple: keep the mtime during copying with `cp -p`.  If mbedtls is not changed, the headers will not be regenerated, and `cp -p` will not update the headers mtime in DESTDIR.

## Status
**READY**