### PR TITLE
Return from debugging routines immediately if SSL context is unset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,8 +13,6 @@ Bugfix
    * Replace printf with mbedtls_printf in aria. Found by TrinityTonic in #1908.
    * Fix potential use-after-free in mbedtls_ssl_get_max_frag_len()
      and mbedtls_ssl_get_record_expansion() after a session reset. Fixes #1941.
-   * Return from various debugging routines immediately if the
-     provided SSL context is unset.
 
 Changes
    * Copy headers preserving timestamps when doing a "make install".
@@ -23,6 +21,8 @@ Changes
      Drozd. Fixes #1215 raised by randombit.
    * Improve compatibility with some alternative CCM implementations by using
      CCM test vectors from RAM.
+   * Return from various debugging routines immediately if the
+     provided SSL context is unset.
 
 = mbed TLS 2.12.0 branch released 2018-07-25
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Bugfix
    * Replace printf with mbedtls_printf in aria. Found by TrinityTonic in #1908.
    * Fix potential use-after-free in mbedtls_ssl_get_max_frag_len()
      and mbedtls_ssl_get_record_expansion() after a session reset. Fixes #1941.
+   * Return from various debugging routines immediately if the
+     provided SSL context is unset.
 
 Changes
    * Copy headers preserving timestamps when doing a "make install".

--- a/library/debug.c
+++ b/library/debug.c
@@ -86,8 +86,13 @@ void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
     char str[DEBUG_BUF_SIZE];
     int ret;
 
-    if( NULL == ssl || NULL == ssl->conf || NULL == ssl->conf->f_dbg || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     va_start( argp, format );
 #if defined(_WIN32)
@@ -121,8 +126,13 @@ void mbedtls_debug_print_ret( const mbedtls_ssl_context *ssl, int level,
 {
     char str[DEBUG_BUF_SIZE];
 
-    if( ssl->conf == NULL || ssl->conf->f_dbg == NULL || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     /*
      * With non-blocking I/O and examples that just retry immediately,
@@ -146,8 +156,13 @@ void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
     char txt[17];
     size_t i, idx = 0;
 
-    if( ssl->conf == NULL || ssl->conf->f_dbg == NULL || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     mbedtls_snprintf( str + idx, sizeof( str ) - idx, "dumping '%s' (%u bytes)\n",
               text, (unsigned int) len );
@@ -199,8 +214,13 @@ void mbedtls_debug_print_ecp( const mbedtls_ssl_context *ssl, int level,
 {
     char str[DEBUG_BUF_SIZE];
 
-    if( ssl->conf == NULL || ssl->conf->f_dbg == NULL || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     mbedtls_snprintf( str, sizeof( str ), "%s(X)", text );
     mbedtls_debug_print_mpi( ssl, level, file, line, str, &X->X );
@@ -219,8 +239,14 @@ void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
     int j, k, zeros = 1;
     size_t i, n, idx = 0;
 
-    if( ssl->conf == NULL || ssl->conf->f_dbg == NULL || X == NULL || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        NULL == X                ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     for( n = X->n - 1; n > 0; n-- )
         if( X->p[n] != 0 )
@@ -345,8 +371,14 @@ void mbedtls_debug_print_crt( const mbedtls_ssl_context *ssl, int level,
     char str[DEBUG_BUF_SIZE];
     int i = 0;
 
-    if( ssl->conf == NULL || ssl->conf->f_dbg == NULL || crt == NULL || level > debug_threshold )
+    if( NULL == ssl              ||
+        NULL == ssl->conf        ||
+        NULL == ssl->conf->f_dbg ||
+        NULL == crt              ||
+        level > debug_threshold )
+    {
         return;
+    }
 
     while( crt != NULL )
     {


### PR DESCRIPTION
The debugging functions
- `mbedtls_debug_print_ret`,
- `mbedtls_debug_print_buf`,
- `mbedtls_debug_print_ecp`,
- `mbedtls_debug_print_mpi`,
- `mbedtls_debug_print_crt`

return immediately if the SSL configuration bound to the passed SSL context is `NULL`, has no debugging functions configured, or if the debug threshold is below the debugging level. However, they do not check whether the provided SSL context is not `NULL` before accessing the SSL configuration bound to it, therefore leading to a segmentation fault if it is. 

In contrast, the debugging function `mbedtls_debug_print_msg` does check for `ssl != NULL` before accessing `ssl->conf`.

This PR unifies the checks by always returning immediately if `ssl == NULL`.

**Note to gatekeeper:** This should be merged in both development and 2.16. There is a 2.7 backport here: https://github.com/ARMmbed/mbedtls/pull/1976