### PR TITLE
Backport 2.1: Fix ssl-opt.sh not starting when lsof is not available

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -254,7 +254,7 @@ if type lsof >/dev/null 2>/dev/null; then
         done
     }
 else
-    echo "Warning: lsof not available, wait_server_start = sleep $START_DELAY"
+    echo "Warning: lsof not available, wait_server_start = sleep"
     wait_server_start() {
         sleep "$START_DELAY"
     }


### PR DESCRIPTION
Backport of #1821