### PR TITLE
check_config: fix TLSv1.2 prerequisites check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -464,6 +464,8 @@ Bugfix
    * In mbedtls_entropy_free(), properly free the message digest context.
    * Fix status handshake status message in programs/ssl/dtls_client.c. Found
      and fixed by muddog.
+   * Fix broken check for TLSv1.2 prerequisites, requires SHA256, SHA512
+     to be compiled as a prerequisite of TLSv1.2, SHA1 is not a requirement.
 
 Changes
    * Extend cert_write example program by options to set the certificate version

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -511,8 +511,8 @@
 #error "MBEDTLS_SSL_PROTO_TLS1_1 defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && ( !defined(MBEDTLS_SHA1_C) &&     \
-    !defined(MBEDTLS_SHA256_C) && !defined(MBEDTLS_SHA512_C) )
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && ( !defined(MBEDTLS_SHA256_C) ||     \
+    !defined(MBEDTLS_SHA512_C) )
 #error "MBEDTLS_SSL_PROTO_TLS1_2 defined, but not all prerequisites"
 #endif
 


### PR DESCRIPTION
ssl client can fail calculate checksums if sha256/512 aren't supported

Signed-off-by: Idan Freiberg <speidy@gmail.com>

## Description
the current code allows TLSv1.2 to be build without SHA256/512 module, since the TLSv1.2 prerequisites check in `check_config.h` seems to be incorrect.

I found that when trying to built an ssl client supporting only TLSv1.2 w.o. SHA256 support. (but SHA1 and SHA512 were supported) the handshake process might be failed if such algorithm isn't supported.

The broken check can cause the following codepath which "should never happen" to occur, making it impossible to set a dispatch function for `update_checksum`: https://github.com/ARMmbed/mbedtls/blob/development/library/ssl_tls.c#L4886

SHA1 is also not a requirement for TLSv1.2; for example its unused in `config-suite-b.h`.

## Status
**READY**

## Requires Backporting
**Yes**
Which branch? mbedtls stable branches including TLSv1.2 support

## Migrations
**NO**

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
