### PR TITLE
Backport 2.7: x509.c: Remove unused includes 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix the key_app_writer example which was writing a leading zero byte which
      was creating an invalid ASN.1 tag. Found by Aryeh R. Fixes #1257.
+   * Remove unused headers included in x509.c. Found by Chris Hanson and fixed
+     by Brendan Shanks. Part of a fix for #992.
 
 = mbed TLS 2.7.4 branch released 2018-06-18
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -70,15 +70,6 @@
 #include <time.h>
 #endif
 
-#if defined(MBEDTLS_FS_IO)
-#include <stdio.h>
-#if !defined(_WIN32)
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#endif
-#endif
-
 #define CHECK(code) if( ( ret = code ) != 0 ){ return( ret ); }
 #define CHECK_RANGE(min, max, val) if( val < min || val > max ){ return( ret ); }
 


### PR DESCRIPTION
## Description
This is a backport of #1563, which is part of a fix for #992.

The PR removes unused headers included in x509.c, guarded by MBEDTLS_FS_IO, which doesn't appear anywhere else in the file. 

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
