### PR TITLE
Backport 2.1: x509.c: Remove unused includes 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix the key_app_writer example which was writing a leading zero byte which
      was creating an invalid ASN.1 tag. Found by Aryeh R. Fixes #1257
+   * Remove unused headers included in x509.c. Found by Chris Hanson and fixed
+     by Brendan Shanks. Part of a fix for #992.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/x509.c
+++ b/library/x509.c
@@ -65,15 +65,6 @@
 #include <time.h>
 #endif
 
-#if defined(MBEDTLS_FS_IO)
-#include <stdio.h>
-#if !defined(_WIN32)
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#endif
-#endif
-
 #define CHECK(code) if( ( ret = code ) != 0 ){ return( ret ); }
 #define CHECK_RANGE(min, max, val) if( val < min || val > max ){ return( ret ); }
 


### PR DESCRIPTION
## Description
This is a backport of #1563, which is part of a fix for #992.

The PR removes unused headers included in x509.c, guarded by MBEDTLS_FS_IO, which doesn't appear anywhere else in the file. 

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
