### PR TITLE
Enhance for integrating into optee_os

### DIFF
--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -70,6 +70,13 @@ extern "C" {
  */
 typedef struct {
     mbedtls_cipher_context_t cipher_ctx;    /*!< The cipher context used. */
+    unsigned char b[16];
+    unsigned char y[16];
+    unsigned char ctr[16];
+    unsigned char q;
+    size_t iv_len;
+    size_t add_len;
+    int mode;                   /*!< Encrypt or Decrypt */
 }
 mbedtls_ccm_context;
 
@@ -85,6 +92,22 @@ mbedtls_ccm_context;
  * \param ctx       The CCM context to initialize.
  */
 void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
+
+int mbedtls_ccm_clone( mbedtls_ccm_context *dst, const mbedtls_ccm_context *src );
+
+int mbedtls_ccm_starts( mbedtls_ccm_context *ctx, int mode, size_t length,
+                        const unsigned char *iv, size_t iv_len,
+                        const unsigned char *add, size_t add_len,
+                        size_t tag_len );
+
+int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
+                        size_t length,
+                        const unsigned char *input,
+                        unsigned char *output );
+
+int mbedtls_ccm_finish( mbedtls_ccm_context *ctx,
+                        unsigned char *tag,
+                        size_t tag_len );
 
 /**
  * \brief           This function initializes the CCM context set in the

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -381,6 +381,20 @@ void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
  */
 void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
 
+/**
+ * \brief           Clone the state of an cipher context
+ *
+ * \note            The two contexts must have been setup to the same type
+ *                  (cloning from AES to DES make no sense).
+ *
+ * \param dst       The destination context
+ * \param src       The context to be cloned
+ *
+ * \return          \c 0 on success,
+ *                  \c MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on parameter failure.
+ */
+int mbedtls_cipher_clone( mbedtls_cipher_context_t *dst,
+                          const mbedtls_cipher_context_t *src );
 
 /**
  * \brief               This function initializes and fills the cipher-context
@@ -401,6 +415,17 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
  * mbedtls_cipher_init() on the structure first.
  */
 int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info );
+
+/**
+ * \brief               setup the cipher info structure.
+ *
+ * \param ctx           cipher's context. Must have been initialised.
+ * \param cipher_info   cipher to use.
+ *
+ * \return              0 on success,
+ *                      MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on parameter failure
+ */
+int mbedtls_cipher_setup_info( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info );
 
 /**
  * \brief        This function returns the block size of the given cipher.

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -103,6 +103,9 @@ struct mbedtls_cipher_base_t
     /** Allocate a new context */
     void * (*ctx_alloc_func)( void );
 
+    /** Clone context **/
+    void (*ctx_clone_func)( void *dst, const void *src );
+
     /** Free the given context */
     void (*ctx_free_func)( void *ctx );
 

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -68,6 +68,20 @@ struct mbedtls_cmac_context_t
 #endif /* !MBEDTLS_CMAC_ALT */
 
 /**
+ * \brief               Initialises and allocat cmac context memory
+ *                      Must be called with an initialized cipher context.
+ *
+ * \param ctx           The cipher context used for the CMAC operation, initialized
+ *                      as one of the following types: MBEDTLS_CIPHER_AES_128_ECB,
+ *                      MBEDTLS_CIPHER_AES_192_ECB, MBEDTLS_CIPHER_AES_256_ECB,
+ *                      or MBEDTLS_CIPHER_DES_EDE3_ECB.
+ * \return              \c 0 on success.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_cmac_setup(mbedtls_cipher_context_t *ctx);
+
+
+/**
  * \brief               This function sets the CMAC key, and prepares to authenticate
  *                      the input data.
  *                      Must be called with an initialized cipher context.

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -72,6 +72,11 @@ mbedtls_gcm_context;
 #include "gcm_alt.h"
 #endif /* !MBEDTLS_GCM_ALT */
 
+int mbedtls_gcm_clone( mbedtls_gcm_context *dst,
+                       const mbedtls_gcm_context *src );
+
+int mbedtls_gcm_gen_table( mbedtls_gcm_context *ctx );
+
 /**
  * \brief           This function initializes the specified GCM context,
  *                  to make references valid, and prepares the context

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -29,6 +29,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include <string.h>
+
 #if defined(MBEDTLS_CIPHER_C)
 
 #include "mbedtls/cipher_internal.h"
@@ -97,6 +99,11 @@ static void *gcm_ctx_alloc( void )
     return( ctx );
 }
 
+static void gcm_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_gcm_context ) );
+}
+
 static void gcm_ctx_free( void *ctx )
 {
     mbedtls_gcm_free( ctx );
@@ -114,6 +121,11 @@ static void *ccm_ctx_alloc( void )
         mbedtls_ccm_init( (mbedtls_ccm_context *) ctx );
 
     return( ctx );
+}
+
+static void ccm_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_ccm_context ) );
 }
 
 static void ccm_ctx_free( void *ctx )
@@ -220,6 +232,11 @@ static void * aes_ctx_alloc( void )
     return( aes );
 }
 
+static void aes_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_aes_context ) );
+}
+
 static void aes_ctx_free( void *ctx )
 {
     mbedtls_aes_free( (mbedtls_aes_context *) ctx );
@@ -250,6 +267,7 @@ static const mbedtls_cipher_base_t aes_info = {
     aes_setkey_enc_wrap,
     aes_setkey_dec_wrap,
     aes_ctx_alloc,
+    aes_ctx_clone,
     aes_ctx_free
 };
 
@@ -451,6 +469,11 @@ static void *xts_aes_ctx_alloc( void )
     return( xts_ctx );
 }
 
+static void xts_aes_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_aes_xts_context ) );
+}
+
 static void xts_aes_ctx_free( void *ctx )
 {
     mbedtls_aes_xts_context *xts_ctx = ctx;
@@ -486,6 +509,7 @@ static const mbedtls_cipher_base_t xts_aes_info = {
     xts_aes_setkey_enc_wrap,
     xts_aes_setkey_dec_wrap,
     xts_aes_ctx_alloc,
+    xts_aes_ctx_clone,
     xts_aes_ctx_free
 };
 
@@ -544,6 +568,7 @@ static const mbedtls_cipher_base_t gcm_aes_info = {
     gcm_aes_setkey_wrap,
     gcm_aes_setkey_wrap,
     gcm_ctx_alloc,
+    gcm_ctx_clone,
     gcm_ctx_free,
 };
 
@@ -613,6 +638,7 @@ static const mbedtls_cipher_base_t ccm_aes_info = {
     ccm_aes_setkey_wrap,
     ccm_aes_setkey_wrap,
     ccm_ctx_alloc,
+    ccm_ctx_clone,
     ccm_ctx_free,
 };
 
@@ -716,6 +742,11 @@ static void * camellia_ctx_alloc( void )
     return( ctx );
 }
 
+static void camellia_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_camellia_context ) );
+}
+
 static void camellia_ctx_free( void *ctx )
 {
     mbedtls_camellia_free( (mbedtls_camellia_context *) ctx );
@@ -746,6 +777,7 @@ static const mbedtls_cipher_base_t camellia_info = {
     camellia_setkey_enc_wrap,
     camellia_setkey_dec_wrap,
     camellia_ctx_alloc,
+    camellia_ctx_clone,
     camellia_ctx_free
 };
 
@@ -919,6 +951,7 @@ static const mbedtls_cipher_base_t gcm_camellia_info = {
     gcm_camellia_setkey_wrap,
     gcm_camellia_setkey_wrap,
     gcm_ctx_alloc,
+    gcm_ctx_clone,
     gcm_ctx_free,
 };
 
@@ -988,6 +1021,7 @@ static const mbedtls_cipher_base_t ccm_camellia_info = {
     ccm_camellia_setkey_wrap,
     ccm_camellia_setkey_wrap,
     ccm_ctx_alloc,
+    ccm_ctx_clone,
     ccm_ctx_free,
 };
 
@@ -1092,6 +1126,11 @@ static void * aria_ctx_alloc( void )
     return( ctx );
 }
 
+static void aria_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_aria_context ) );
+}
+
 static void aria_ctx_free( void *ctx )
 {
     mbedtls_aria_free( (mbedtls_aria_context *) ctx );
@@ -1122,6 +1161,7 @@ static const mbedtls_cipher_base_t aria_info = {
     aria_setkey_enc_wrap,
     aria_setkey_dec_wrap,
     aria_ctx_alloc,
+    aria_ctx_clone,
     aria_ctx_free
 };
 
@@ -1295,6 +1335,7 @@ static const mbedtls_cipher_base_t gcm_aria_info = {
     gcm_aria_setkey_wrap,
     gcm_aria_setkey_wrap,
     gcm_ctx_alloc,
+    gcm_ctx_clone,
     gcm_ctx_free,
 };
 
@@ -1364,6 +1405,7 @@ static const mbedtls_cipher_base_t ccm_aria_info = {
     ccm_aria_setkey_wrap,
     ccm_aria_setkey_wrap,
     ccm_ctx_alloc,
+    ccm_ctx_clone,
     ccm_ctx_free,
 };
 
@@ -1497,6 +1539,11 @@ static void * des_ctx_alloc( void )
     return( des );
 }
 
+static void des_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_des_context ) );
+}
+
 static void des_ctx_free( void *ctx )
 {
     mbedtls_des_free( (mbedtls_des_context *) ctx );
@@ -1514,6 +1561,11 @@ static void * des3_ctx_alloc( void )
     mbedtls_des3_init( des3 );
 
     return( des3 );
+}
+
+static void des3_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_des3_context ) );
 }
 
 static void des3_ctx_free( void *ctx )
@@ -1546,6 +1598,7 @@ static const mbedtls_cipher_base_t des_info = {
     des_setkey_enc_wrap,
     des_setkey_dec_wrap,
     des_ctx_alloc,
+    des_ctx_clone,
     des_ctx_free
 };
 
@@ -1597,6 +1650,7 @@ static const mbedtls_cipher_base_t des_ede_info = {
     des3_set2key_enc_wrap,
     des3_set2key_dec_wrap,
     des3_ctx_alloc,
+    des3_ctx_clone,
     des3_ctx_free
 };
 
@@ -1648,6 +1702,7 @@ static const mbedtls_cipher_base_t des_ede3_info = {
     des3_set3key_enc_wrap,
     des3_set3key_dec_wrap,
     des3_ctx_alloc,
+    des3_ctx_clone,
     des3_ctx_free
 };
 
@@ -1733,6 +1788,11 @@ static void * blowfish_ctx_alloc( void )
     return( ctx );
 }
 
+static void blowfish_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_blowfish_context ) );
+}
+
 static void blowfish_ctx_free( void *ctx )
 {
     mbedtls_blowfish_free( (mbedtls_blowfish_context *) ctx );
@@ -1763,6 +1823,7 @@ static const mbedtls_cipher_base_t blowfish_info = {
     blowfish_setkey_wrap,
     blowfish_setkey_wrap,
     blowfish_ctx_alloc,
+    blowfish_ctx_clone,
     blowfish_ctx_free
 };
 
@@ -1849,6 +1910,11 @@ static void * arc4_ctx_alloc( void )
     return( ctx );
 }
 
+static void arc4_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_arc4_context ) );
+}
+
 static void arc4_ctx_free( void *ctx )
 {
     mbedtls_arc4_free( (mbedtls_arc4_context *) ctx );
@@ -1879,6 +1945,7 @@ static const mbedtls_cipher_base_t arc4_base_info = {
     arc4_setkey_wrap,
     arc4_setkey_wrap,
     arc4_ctx_alloc,
+    arc4_ctx_clone,
     arc4_ctx_free
 };
 
@@ -1934,6 +2001,11 @@ static void * chacha20_ctx_alloc( void )
     return( ctx );
 }
 
+static void chacha20_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_chacha20_context ) );
+}
+
 static void chacha20_ctx_free( void *ctx )
 {
     mbedtls_chacha20_free( (mbedtls_chacha20_context *) ctx );
@@ -1964,6 +2036,7 @@ static const mbedtls_cipher_base_t chacha20_base_info = {
     chacha20_setkey_wrap,
     chacha20_setkey_wrap,
     chacha20_ctx_alloc,
+    chacha20_ctx_clone,
     chacha20_ctx_free
 };
 static const mbedtls_cipher_info_t chacha20_info = {
@@ -2006,6 +2079,11 @@ static void * chachapoly_ctx_alloc( void )
     return( ctx );
 }
 
+static void chachapoly_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_chachapoly_context ) );
+}
+
 static void chachapoly_ctx_free( void *ctx )
 {
     mbedtls_chachapoly_free( (mbedtls_chachapoly_context *) ctx );
@@ -2036,6 +2114,7 @@ static const mbedtls_cipher_base_t chachapoly_base_info = {
     chachapoly_setkey_wrap,
     chachapoly_setkey_wrap,
     chachapoly_ctx_alloc,
+    chachapoly_ctx_clone,
     chachapoly_ctx_free
 };
 static const mbedtls_cipher_info_t chachapoly_info = {
@@ -2075,6 +2154,12 @@ static void * null_ctx_alloc( void )
     return( (void *) 1 );
 }
 
+static void null_ctx_clone( void *dst, const void *src )
+{
+    ((void) dst);
+    ((void) src);
+}
+
 static void null_ctx_free( void *ctx )
 {
     ((void) ctx);
@@ -2104,6 +2189,7 @@ static const mbedtls_cipher_base_t null_base_info = {
     null_setkey,
     null_setkey,
     null_ctx_alloc,
+    null_ctx_clone,
     null_ctx_free
 };
 

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -210,7 +210,7 @@ int mbedtls_cipher_cmac_setup(mbedtls_cipher_context_t *ctx)
 
     ctx->cmac_ctx = cmac_ctx;
 
-    mbedtls_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
+    mbedtls_platform_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
     return 0;
 }
 

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -89,6 +89,26 @@ void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
     memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
 }
 
+int mbedtls_gcm_clone( mbedtls_gcm_context *dst,
+                       const mbedtls_gcm_context *src )
+{
+    if( dst == NULL || src == NULL )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    mbedtls_cipher_clone( &dst->cipher_ctx, &src->cipher_ctx );
+    memcpy( dst->HL, src->HL, 16 * sizeof(uint64_t ) );
+    memcpy( dst->HH, src->HH, 16 * sizeof(uint64_t ) );
+    dst->len = src->len;
+    dst->add_len = src->add_len;
+    memcpy( dst->base_ectr, src->base_ectr, 16 );
+    memcpy( dst->y, src->y, 16 );
+    memcpy( dst->buf, src->buf, 16 );
+    dst->mode = src->mode;
+    return( 0 );
+}
+
 /*
  * Precompute small multiples of H, that is set
  *      HH[i] || HL[i] = H times i,
@@ -97,7 +117,7 @@ void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
  * is the high-order bit of HH corresponds to P^0 and the low-order bit of HL
  * corresponds to P^127.
  */
-static int gcm_gen_table( mbedtls_gcm_context *ctx )
+int mbedtls_gcm_gen_table( mbedtls_gcm_context *ctx )
 {
     int ret, i, j;
     uint64_t hi, lo;
@@ -183,7 +203,7 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
         return( ret );
     }
 
-    if( ( ret = gcm_gen_table( ctx ) ) != 0 )
+    if( ( ret = mbedtls_gcm_gen_table( ctx ) ) != 0 )
         return( ret );
 
     return( 0 );

--- a/library/md.c
+++ b/library/md.c
@@ -209,6 +209,9 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
 
     dst->md_info->clone_func( dst->md_ctx, src->md_ctx );
 
+    if( dst->hmac_ctx != NULL && src->hmac_ctx != NULL )
+        memcpy( dst->hmac_ctx, src->hmac_ctx, 2 * src->md_info->block_size );
+
     return( 0 );
 }
 


### PR DESCRIPTION
## Description
For integrating into optee_os, it needs some enhancement for mebdTLS:
1. add mbedtls_cipher_clone() for cipher to copy context between two operations.
2. add mbedtls_cipher_setup_info() for cipher. cipher need to get its "cipher_info" according the key length, while the key length is not an input in allocate function. So, use a default key len in the beginning.  It need to reset the cipher info again in init function.
3. add mbedtls_cipher_cmac_setup() for cmac. This function is separate  from mbedtls_cipher_cmac_starts().
4. copy hmac context in md.
5. Add clone interface for GCM and CCM to support optee os.
6. Split ccm_auth_crypt() into 3 interfaces: mbedtls_ccm_starts(), mbedtls_ccm_update(), bedtls_ccm_finish(). They are used to support optee interfaces. 