### PR TITLE
Update the CONTRIBUTING.md file for LTS branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ As mentioned, tests that show the correctness of the feature or bug fix should b
 
 Mbed TLS includes a comprehensive set of test suites in the `tests/` directory that are dynamically generated to produce the actual test source files (e.g. `test_suite_mpi.c`). These files are generated from a `function file` (e.g. `suites/test_suite_mpi.function`) and a `data file` (e.g. `suites/test_suite_mpi.data`). The function file contains the test functions. The data file contains the test cases, specified as parameters that will be passed to the test function.
 
-[A knowledgebase article describing how to add additional tests is available on the Mbed TLS website](https://tls.mbed.org/kb/development/test_suites).
+[A Knowledge Base article describing how to add additional tests is available on the Mbed TLS website](https://tls.mbed.org/kb/development/test_suites).
 
 A test script `tests/scripts/basic-build-test.sh` is available to show test
 coverage of the library. New code contributions should provide a similar level

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,12 @@ We gratefully accept bug reports and contributions from the community. There are
  - As with any open source project, contributions will be reviewed by the project team and community and may need some modifications to be accepted.
  - The contribution should not break API or ABI, unless there is a real justification for that. If there is an API change, the contribution, if accepted, will be merged only when there will be a major release.
 
+
 Contributor License Agreement (CLA)
 -----------------------------------
 - All contributions, whether large or small, require a Contributor's License Agreement (CLA) to be accepted. This is because source code can possibly fall under copyright law and we need your consent to share in the ownership of the copyright.
 - To accept the Contributor’s License Agreement (CLA), individual contributors can do this by creating an Mbed account and [accepting the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/). Alternatively, for contributions from corporations, or those that do not wish to create an Mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/). This agreement should be signed and returned to Arm as described in the instructions given.
+
 
 Coding Standards
 ----------------
@@ -16,6 +18,7 @@ Coding Standards
 - The code should be written in a clean and readable style.
 - The code should be written in a portable generic way, that will benefit the whole community, and not only your own needs.
 - The code should be secure, and will be reviewed from a security point of view as well.
+
 
 Making a Contribution
 ---------------------
@@ -26,41 +29,74 @@ Making a Contribution
 1. For quick merging, the contribution should be short, and concentrated on a single feature or topic. The larger the contribution is, the longer it would take to review it and merge it.
 1. Mbed TLS is released under the Apache license, and as such, all the added files should include the Apache license header.
 
+
+API/ABI Compatibility
+---------------------
+
+API compatibility is maintained between versions of Mbed TLS on the main development branch. This is to ensure that when users of the library upgrade to a newer version of the library, there will be no API changes that may cause their code to fail to compile and it will not be necessary for them to make any changes to their own code.
+
+Where changes to the interface are necessary, functions in the public interface which need to be removed or replaced will be marked as 'deprecated', with the preprocessor symbols `MBEDTLS_DEPRECATED_WARNING` and `MBEDTLS_DEPRECATED_REMOVED`. Therefore when a build is made with those symbols defined, a compiler warning will be generated to warn a user that the function will be removed at some point in the future.
+
+It is also desirable to preserve ABI compatibility on the main development branch, and generally ABI changes need to be justifiable by enhancement and new features, to extend the interface. This is to again minimise the impact on users upgrading to newer versions of the library.
+
+As a consequence, this means there can be no change to the definition of functions in the public API, nor removal of elements in structs that make up part of the public interface. Instead if a function needs to be changed, a new function needs to be created alongside it, with a new name, and whatever change is necessary, such as a new parameter or the addition of a return value.
+
+Periodically, the library will remove deprecated functions from the library which will be a breaking change in the API, but such changes will be made only in a planned, structured wat that gives sufficient notice to users of the library.
+
+
 Long Term Support Branches
 --------------------------
-Mbed TLS maintains several LTS (Long Term Support) branches, which are maintained continuously for a given period. The LTS branches are provided to allow users of the library to have a maintained version of the library which contains security fixes and fixes for other defects, without encountering any API changes or requiring changes in their own code. To allow users to take advantage of the LTS branches, these branches maintain backwards compatibility for both the public API and ABI.
+Mbed TLS maintains several LTS (Long Term Support) branches, which are maintained continuously for a given period. The LTS branches are provided to allow users of the library to have a maintained, stable version of the library which contains only security fixes and fixes for other defects, without encountering additional features or API extensions which may introduce issues or change the code size or RAM usage, which can be significant considerations on some platforms. To allow users to take advantage of the LTS branches, these branches maintain backwards compatibility for both the public API and ABI.
 
 When backporting to these branches please observe the following rules:
 
- 1. Generally, all changes to the library which change the API cannot be backported.
- 2. All bug fixes must be backported to the LTS branches if they correct a defect in an LTS branch. If a bug fix introduces a change to the API such as a new function, the fix should be reworked to avoid the API change. API changes without very strong justification are unlikely to be accepted.
- 3. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be addtional test cases or quality improvements such as changes to scripts.
+ 1. Any change to the library which changes the API or ABI cannot be backported.
 
-It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development).
+ 2. All bug fixes that correct a defect that is also present in an LTS branch must be backported to that LTS branch. If a bug fix introduces a change to the API such as a new function, the fix should be reworked to avoid the API change. API changes without very strong justification are unlikely to be accepted.
+
+ 3. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be addtional test cases or quality improvements such as changes to build or test scripts.
+
+It would be highly appreciated if contributions are backported to LTS branches
+in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development) by contributors.
 
 Currently maintained LTS branches are:
 
 1. [mbedtls-2.1](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.1)
-1. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
+
+2. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
+
 
 Tests
 -----
-As mentioned, tests that show the correctness of the feature or bug fix should be added to the pull request, if no such tests exist.  
-Mbed TLS includes an elaborate test suite in `tests/` that initially requires Perl to generate the tests files (e.g. `test_suite_mpi.c`). These files are generated from a `function file` (e.g. `suites/test_suite_mpi.function`) and a `data file` (e.g. `suites/test_suite_mpi.data`). The function file contains the test functions. The data file contains the test cases, specified as parameters that will be passed to the test function.
+As mentioned, tests that show the correctness of the feature or bug fix should be added to the pull request, if no such tests exist.
+
+Mbed TLS includes a comprehensive set of test suites in the `tests/` directory that are dynamically generated to produce the actual test source files (e.g. `test_suite_mpi.c`). These files are generated from a `function file` (e.g. `suites/test_suite_mpi.function`) and a `data file` (e.g. `suites/test_suite_mpi.data`). The function file contains the test functions. The data file contains the test cases, specified as parameters that will be passed to the test function.
+
+A test script `tests/scripts/basic-build-test.sh` is available to show test
+coverage of the library. New code contributions should provide a similar level
+of code coverage to that which already exists for the library.
 
 Sample applications, if needed, should be modified as well.
 
+
 Continuous Integration Tests
 ----------------------------
-Once a PR has been made, the Continuous Integration (CI) tests are triggered and run. You should follow the result of the CI tests, and fix failures. 
+Once a PR has been made, the Continuous Integration (CI) tests are triggered and run. You should follow the result of the CI tests, and fix failures.
+
 It is advised to enable the [githooks scripts](https://github.com/ARMmbed/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
+
 
 Documentation
 -------------
 Mbed TLS should be well documented. If documentation is needed, speak out!
 
 1. All interfaces should be documented through Doxygen. New APIs should introduce Doxygen documentation.
-1. Complex parts in the code should include comments.
-1. If needed, a Readme file is advised.
-1. If a [Knowledge Base (KB)](https://tls.mbed.org/kb) article should be added, write this as a comment in the PR description.
-1. A [ChangeLog](https://github.com/ARMmbed/mbedtls/blob/development/ChangeLog) entry should be added for this contribution.
+
+2. Complex parts in the code should include comments.
+
+3. If needed, a Readme file is advised.
+
+4. If a [Knowledge Base (KB)](https://tls.mbed.org/kb) article should be added, write this as a comment in the PR description.
+
+5. A [ChangeLog](https://github.com/ARMmbed/mbedtls/blob/development/ChangeLog) entry should be added for this contribution.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,19 +26,22 @@ Making a Contribution
 1. For quick merging, the contribution should be short, and concentrated on a single feature or topic. The larger the contribution is, the longer it would take to review it and merge it.
 1. Mbed TLS is released under the Apache license, and as such, all the added files should include the Apache license header.
 
-Backports
----------
-Mbed TLS maintains some legacy branches, which are released as LTS versions. Mbed TLS should follow backwards compatibility rules, to fit with existing users. As such, backporting to these branches should be handled according to the following rules:
-  
-1. If the contribution is a new feature or enhancement, no backporting is needed.
-1. Bug fixes should be backported to the legacy branches containing these bugs.
-1. Changes in the API do not require backporting. If a bug fix introduced a new API, such as new error codes, the bug fix should be implemented differently in the legacy branch.
+Long Term Support Branches
+--------------------------
+Mbed TLS maintains several LTS (Long Term Support) branches, which are maintained continuously for a given period. The LTS branches are provided to allow users of the library to have a maintained version of the library which contains security fixes and fixes for other defects, without encountering any API changes or requiring changes in their own code. To allow users to take advantage of the LTS branches, these branches maintain backwards compatibility for both the public API and ABI.
 
-It would be highly appreciated if a contribution would be backported to a legacy branch in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development).
-At the moment, the legacy branches are:
-  
-1. [mbedtls-1.3](https://github.com/ARMmbed/mbedtls/tree/mbedtls-1.3)
+When backporting to these branches please observe the following rules:
+
+ 1. Generally, all changes to the library which change the API cannot be backported.
+ 2. All bug fixes must be backported to the LTS branches if they correct a defect in an LTS branch. If a bug fix introduces a change to the API such as a new function, the fix should be reworked to avoid the API change. API changes without very strong justification are unlikely to be accepted.
+ 3. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be addtional test cases or quality improvements such as changes to scripts.
+
+It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development).
+
+Currently maintained LTS branches are:
+
 1. [mbedtls-2.1](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.1)
+1. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
 
 Tests
 -----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,10 @@ We gratefully accept bug reports and contributions from the community. There are
  - As with any open source project, contributions will be reviewed by the project team and community and may need some modifications to be accepted.
  - The contribution should not break API or ABI, unless there is a real justification for that. If there is an API change, the contribution, if accepted, will be merged only when there will be a major release.
 
-
 Contributor License Agreement (CLA)
 -----------------------------------
 - All contributions, whether large or small, require a Contributor's License Agreement (CLA) to be accepted. This is because source code can possibly fall under copyright law and we need your consent to share in the ownership of the copyright.
 - To accept the Contributor’s License Agreement (CLA), individual contributors can do this by creating an Mbed account and [accepting the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/). Alternatively, for contributions from corporations, or those that do not wish to create an Mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/). This agreement should be signed and returned to Arm as described in the instructions given.
-
 
 Coding Standards
 ----------------
@@ -18,7 +16,6 @@ Coding Standards
 - The code should be written in a clean and readable style.
 - The code should be written in a portable generic way, that will benefit the whole community, and not only your own needs.
 - The code should be secure, and will be reviewed from a security point of view as well.
-
 
 Making a Contribution
 ---------------------
@@ -29,20 +26,19 @@ Making a Contribution
 1. For quick merging, the contribution should be short, and concentrated on a single feature or topic. The larger the contribution is, the longer it would take to review it and merge it.
 1. Mbed TLS is released under the Apache license, and as such, all the added files should include the Apache license header.
 
-
 API/ABI Compatibility
 ---------------------
+The project aims to minimise the impact on users upgrading to newer versions of the library and it should not be necessary for a user to make any changes to their own code to work with a newer version of the library. Unless the user has made an active decision to use newer features, a newer generation of the library or a change has been necessary due to a security issue or other significant software defect, no modifications to their own code should be necessary. To achieve this, API compatibility is maintained between different versions of Mbed TLS on the main development branch and in LTS (Long Term Support) branches.
 
-API compatibility is maintained between versions of Mbed TLS on the main development branch. This is to ensure that when users of the library upgrade to a newer version of the library, there will be no API changes that may cause their code to fail to compile and it will not be necessary for them to make any changes to their own code.
+To minimise such disruption to users, where a change to the interface is required, all changes to the ABI or API, even on the main development branch where new features are added, need to be justifiable by either being a significant enhancement, new feature or bug fix which is best resolved by an interface change.
 
-Where changes to the interface are necessary, functions in the public interface which need to be removed or replaced will be marked as 'deprecated', with the preprocessor symbols `MBEDTLS_DEPRECATED_WARNING` and `MBEDTLS_DEPRECATED_REMOVED`. Therefore when a build is made with those symbols defined, a compiler warning will be generated to warn a user that the function will be removed at some point in the future.
+Where changes to an existing interface are necessary, functions in the public interface which need to be changed, are marked as 'deprecated'. This is done with the preprocessor symbols `MBEDTLS_DEPRECATED_WARNING` and `MBEDTLS_DEPRECATED_REMOVED`. Then, a new function with a new name but similar if not identical behaviour to the original function containing the necessary changes should be created alongside the existing deprecated function.
 
-It is also desirable to preserve ABI compatibility on the main development branch, and generally ABI changes need to be justifiable by enhancement and new features, to extend the interface. This is to again minimise the impact on users upgrading to newer versions of the library.
+When a build is made with the deprecation preprocessor symbols defined, a compiler warning will be generated to warn a user that the function will be removed at some point in the future, notifying users that they should change from the older deprecated function to the newer function at their own convenience.
 
-As a consequence, this means there can be no change to the definition of functions in the public API, nor removal of elements in structs that make up part of the public interface. Instead if a function needs to be changed, a new function needs to be created alongside it, with a new name, and whatever change is necessary, such as a new parameter or the addition of a return value.
+Therefore, no changes are permitted to the definition of functions in the public interface which will change the API. Instead the interface can only be changed by its extension. As described above, if a function needs to be changed, a new function needs to be created alongside it, with a new name, and whatever change is necessary, such as a new parameter or the addition of a return value.
 
-Periodically, the library will remove deprecated functions from the library which will be a breaking change in the API, but such changes will be made only in a planned, structured wat that gives sufficient notice to users of the library.
-
+Periodically, the library will remove deprecated functions from the library which will be a breaking change in the API, but such changes will be made only in a planned, structured way that gives sufficient notice to users of the library.
 
 Long Term Support Branches
 --------------------------
@@ -78,17 +74,15 @@ of code coverage to that which already exists for the library.
 
 Sample applications, if needed, should be modified as well.
 
-
 Continuous Integration Tests
 ----------------------------
 Once a PR has been made, the Continuous Integration (CI) tests are triggered and run. You should follow the result of the CI tests, and fix failures.
 
 It is advised to enable the [githooks scripts](https://github.com/ARMmbed/mbedtls/tree/development/tests/git-scripts) prior to pushing your changes, for catching some of the issues as early as possible.
 
-
 Documentation
 -------------
-Mbed TLS should be well documented. If documentation is needed, speak out!
+Mbed TLS is well documented, but if you think documentation is needed, speak out!
 
 1. All interfaces should be documented through Doxygen. New APIs should introduce Doxygen documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ As mentioned, tests that show the correctness of the feature or bug fix should b
 
 Mbed TLS includes a comprehensive set of test suites in the `tests/` directory that are dynamically generated to produce the actual test source files (e.g. `test_suite_mpi.c`). These files are generated from a `function file` (e.g. `suites/test_suite_mpi.function`) and a `data file` (e.g. `suites/test_suite_mpi.data`). The function file contains the test functions. The data file contains the test cases, specified as parameters that will be passed to the test function.
 
+[A knowledgebase article describing how to add additional tests is available on the Mbed TLS website](https://tls.mbed.org/kb/development/test_suites).
+
 A test script `tests/scripts/basic-build-test.sh` is available to show test
 coverage of the library. New code contributions should provide a similar level
 of code coverage to that which already exists for the library.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Please note that setting `CFLAGS` overrides its default value of `-O2` and setti
 
 Depending on your platform, you might run into some issues. Please check the Makefiles in `library/`, `programs/` and `tests/` for options to manually add or remove for specific platforms. You can also check [the Mbed TLS Knowledge Base](https://tls.mbed.org/kb) for articles on your platform or issue.
 
-In case you find that you need to do something else as well, please let us know what, so we can add it to the [Mbed TLS knowledge base](https://tls.mbed.org/kb).
+In case you find that you need to do something else as well, please let us know what, so we can add it to the [Mbed TLS Knowledge Base](https://tls.mbed.org/kb).
 
 ### CMake
 
@@ -192,7 +192,7 @@ We provide some non-standard configurations focused on specific use cases in the
 Porting Mbed TLS
 ----------------
 
-Mbed TLS can be ported to many different architectures, OS's and platforms. Before starting a port, you may find the following knowledge base articles useful:
+Mbed TLS can be ported to many different architectures, OS's and platforms. Before starting a port, you may find the following Knowledge Base articles useful:
 
 -   [Porting Mbed TLS to a new environment or OS](https://tls.mbed.org/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS)
 -   [What external dependencies does Mbed TLS rely on?](https://tls.mbed.org/kb/development/what-external-dependencies-does-mbedtls-rely-on)


### PR DESCRIPTION
## Description
The `CONTRIBUTING.md` file referred to 'legacy' branches instead of LTS branches, and also referenced `mbedtls-1.3` which is no longer maintained, and omitted `mbedtls-2.7` which is.

This PR updates the language and also removed the `mbedtls-1.3` reference.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
