### PR TITLE
Fix memory leak in ecp_mul_comb() if ecp_precompute_comb() fails

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -86,6 +86,8 @@ Bugfix
    * Correct the documentation for `mbedtls_ssl_get_session()`. This API has
      deep copy of the session, and the peer certificate is not lost. Fixes #926.
    * Fix build using -std=c99. Fixed by Nick Wilson.
+   * Fix a memory leak in ecp_mul_comb() if ecp_precompute_comb() fails.
+     Fix contributed by Espressif Systems.
 
 Changes
    * Fail when receiving a TLS alert message with an invalid length, or invalid

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1446,7 +1446,12 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 
 cleanup:
 
-    if( T != NULL && ! p_eq_g )
+    /* There are two cases where T is not stored in grp:
+     * - P != G
+     * - An intermediate operation failed before setting grp->T
+     * In either case, T must be freed.
+     */
+    if( T != NULL && T != grp->T )
     {
         for( i = 0; i < pre_len; i++ )
             mbedtls_ecp_point_free( &T[i] );


### PR DESCRIPTION
## Description

In ecp_mul_comb(), if (!p_eq_g && grp->T == NULL) and ecp_precompute_comb() fails (which can
happen due to OOM), then the new array of points T will be leaked (as it's newly allocated, but
hasn't been assigned to grp->T yet).

Symptom was a memory leak in ECDHE key exchange under low memory conditions.

## Status

READY

## Requires Backporting

Yes? This is quite a subtle and uncommon bug. Will follow advice from maintainers about whether it should be backported or not (and to where).

## Migrations

NO

## Additional comments

Submission is from Espressif Systems and falls under corporate CLA..

## Todos
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce

This is quite difficult to reproduce easily (or write a unit test for) as there needs to be enough free memory that the calloc() inside ecp_mul_comb() succeeds, but then later allocations in ecp_precompute_comb() will fail. It was only reported under very certain circumstances.
