### PR TITLE
Fix CBC mode decrypting an empty block as padding bytes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,8 @@ Bugfix
      seen when communicating with OpenSSL using TLS 1.0. Reported by @kFYatek
      (#1632) and by Conor Murphy on the forum. Fix contributed by Espressif
      Systems.
+   * Fail when receiving a TLS alert message with an invalid length, or invalid
+     zero-length messages when using TLS 1.2. Contributed by Espressif Systems.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,11 @@ Bugfix
      i386 with SSE2. Found by László Langó. Fixes #1550
    * Fix namespacing in header files. Remove the `mbedtls` namespacing in
      the `#include` in the header files. Resolves #857
+   * Fix decryption of zero length messages (all padding) in some circumstances:
+     DTLS 1.0 and 1.2, and CBC ciphersuites using encrypt-then-MAC. Most often
+     seen when communicating with OpenSSL using TLS 1.0. Reported by @kFYatek
+     (#1632) and by Conor Murphy on the forum. Fix contributed by Espressif
+     Systems.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2133,6 +2133,16 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
     if( ssl->in_msglen == 0 )
     {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3
+            && ssl->in_msgtype != MBEDTLS_SSL_MSG_APPLICATION_DATA )
+        {
+            /* TLS v1.2 explicitly disallows zero-length messages which are not application data */
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "invalid zero-length message type: %d", ssl->in_msgtype ) );
+            return( MBEDTLS_ERR_SSL_INVALID_RECORD );
+        }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
         ssl->nb_zero++;
 
         /*

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4187,6 +4187,16 @@ int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl )
 
     if( ssl->in_msgtype == MBEDTLS_SSL_MSG_ALERT )
     {
+        if( ssl->in_msglen != 2 )
+        {
+            /* Note: Standard allows for more than one 2 byte alert
+               to be packed in a single message, but Mbed TLS doesn't
+               currently support this. */
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "invalid alert message, len: %d",
+                           ssl->in_msglen ) );
+            return( MBEDTLS_ERR_SSL_INVALID_RECORD );
+        }
+
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "got an alert message, type: [%d:%d]",
                        ssl->in_msg[0], ssl->in_msg[1] ) );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1979,28 +1979,28 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
              * and fake check up to 256 bytes of padding
              */
             size_t pad_count = 0, real_count = 1;
-            size_t padding_idx = ssl->in_msglen - padlen - 1;
+            size_t padding_idx = ssl->in_msglen - padlen;
             size_t i;
 
             /*
              * Padding is guaranteed to be incorrect if:
-             *   1. padlen >= ssl->in_msglen
+             *   1. padlen > ssl->in_msglen
              *
-             *   2. padding_idx >= MBEDTLS_SSL_IN_CONTENT_LEN +
+             *   2. padding_idx > MBEDTLS_SSL_IN_CONTENT_LEN +
              *                     ssl->transform_in->maclen
              *
              * In both cases we reset padding_idx to a safe value (0) to
              * prevent out-of-buffer reads.
              */
-            correct &= ( ssl->in_msglen >= padlen + 1 );
-            correct &= ( padding_idx < MBEDTLS_SSL_IN_CONTENT_LEN +
+            correct &= ( padlen <= ssl->in_msglen );
+            correct &= ( padding_idx <= MBEDTLS_SSL_IN_CONTENT_LEN +
                                        ssl->transform_in->maclen );
 
             padding_idx *= correct;
 
-            for( i = 1; i <= 256; i++ )
+            for( i = 0; i < 256; i++ )
             {
-                real_count &= ( i <= padlen );
+                real_count &= ( i < padlen );
                 pad_count += real_count *
                              ( ssl->in_msg[padding_idx + i] == padlen - 1 );
             }


### PR DESCRIPTION
## Description

Test and fix for the issue described in #1632 : When CBC mode is used, a zero length TLS application data message (allowed by the standard and sometimes sent by openssl) would incorrectly decrypt as a full block of padding.

This PR includes one commit with this fix (and a unit test). Plus two more commits to check for undersized messages:

* Explicitly check for Alert messages less than 2 bytes (always invalid).
* Zero length messages (except for application data) are explicitly prohibited in TLS v1.2. This check is largely redundant as I think all zero length messages will be treated as invalid by checks in the message hander logic. I almost didn't add this, please let me know if you think it's unnecessary.

Happy to split the short message checks into a separate PR if that's preferred, or drop them if they're redundant.

## Status

READY

Note (just for information when planning the merge): this PR has non-trivial conflicts with #1633 

## Requires Backporting

Yes.

## Migrations

NO

## Additional comments

I don't believe this PR changes any timing in CBC mode.

Submission is from Espressif Systems and falls under corporate CLA..

## Todos
- [x] Tests
- [x] Changelog updated
- [ ] Backported

## Steps to test or reproduce

Issue #1632 gives an openssl s_server command line which works. Same command line is used to create the unit test in the PR.