### PR TITLE
Minor HKDF changes (2)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ Bugfix
      return value. Found by @davidwu2000. #839
    * Fix a memory leak in mbedtls_x509_csr_parse(), found by catenacyber,
      Philippe Antoine. Fixes #1623.
+   * Change the default behaviour of mbedtls_hkdf_extract() to return an error
+     when calling with a NULL salt and non-zero salt_len. Contributed by
+     Brian J Murray
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -62,6 +62,11 @@ int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
     {
         size_t hash_len;
 
+        if( salt_len != 0 )
+        {
+            return MBEDTLS_ERR_HKDF_BAD_INPUT_DATA;
+        }
+
         hash_len = mbedtls_md_get_size( md );
 
         if( hash_len == 0 )

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -114,6 +114,10 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
         n++;
     }
 
+    /*
+     * Per RFC 5869 Section 2.3, okm_len must not exceed
+     * 255 times the hash length
+     */
     if( n > 255 )
     {
         return( MBEDTLS_ERR_HKDF_BAD_INPUT_DATA );
@@ -126,7 +130,10 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
         goto exit;
     }
 
-    /* RFC 5869 Section 2.3. */
+    /*
+     * Compute T = T(1) | T(2) | T(3) | ... | T(N)
+     * Where T(N) is defined in RFC 5869 Section 2.3
+     */
     for( i = 1; i <= n; i++ )
     {
         size_t num_to_copy;
@@ -150,7 +157,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
             goto exit;
         }
 
-        /* The constant concatenated to the end of each t(n) is a single octet.
+        /* The constant concatenated to the end of each T(n) is a single octet.
          * */
         ret = mbedtls_md_hmac_update( &ctx, &c, 1 );
         if( ret != 0 )


### PR DESCRIPTION
There was an ugly merge PR #1781. I don't like rewriting history, so I'm opening a duplicate PR with a clean commit log.

The changes are the same as in #1781. I updated `mbedtls_hkdf_extract()` to return an error when calling with a NULL salt and non-zero `salt_len`. I also made some minor improvements to the comments.