### PR TITLE
Remove unnecessary mark as unused #1098

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,9 @@ Bugfix
      by Brendan Shanks. Part of a fix for #992.
    * Fix compilation error when MBEDTLS_ARC4_C is disabled and
      MBEDTLS_CIPHER_NULL_CIPHER is enabled. Found by TrinityTonic in #1719.
+   * Fix compiler warning of 'use before initialisation' in
+     mbedtls_pk_parse_key(). Found by Martin Boye Petersen and fixed by Dawid
+     Drozd. #1098
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1261,7 +1261,6 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
         return( ret );
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 #else
-    ((void) ret);
     ((void) pwd);
     ((void) pwdlen);
 #endif /* MBEDTLS_PEM_PARSE_C */


### PR DESCRIPTION
## Description

`ret` is used always at line 1305 in statement:
`if( ( ret = pk_parse_key_pkcs8_unencrypted_der( pk, key, keylen ) ) == 0 )`

## Status
READY

## Requires Backporting
NO

## Migrations
NO
