### PR TITLE
Clang tiny warning bitwise opt

### DIFF
--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -143,23 +143,23 @@
  * Comments refer to the status for using certificates. Status can be
  * different for writing certificates or reading CRLs or CSRs.
  */
-#define MBEDTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER    (1 << 0u)
-#define MBEDTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER      (1 << 1u)
-#define MBEDTLS_X509_EXT_KEY_USAGE                   (1 << 2u)
-#define MBEDTLS_X509_EXT_CERTIFICATE_POLICIES        (1 << 3u)
-#define MBEDTLS_X509_EXT_POLICY_MAPPINGS             (1 << 4u)
-#define MBEDTLS_X509_EXT_SUBJECT_ALT_NAME            (1 << 5u)    /* Supported (DNS) */
-#define MBEDTLS_X509_EXT_ISSUER_ALT_NAME             (1 << 6u)
-#define MBEDTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS     (1 << 7u)
-#define MBEDTLS_X509_EXT_BASIC_CONSTRAINTS           (1 << 8u)    /* Supported */
-#define MBEDTLS_X509_EXT_NAME_CONSTRAINTS            (1 << 9u)
-#define MBEDTLS_X509_EXT_POLICY_CONSTRAINTS          (1 << 10u)
-#define MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE          (1 << 11u)
-#define MBEDTLS_X509_EXT_CRL_DISTRIBUTION_POINTS     (1 << 12u)
-#define MBEDTLS_X509_EXT_INIHIBIT_ANYPOLICY          (1 << 13u)
-#define MBEDTLS_X509_EXT_FRESHEST_CRL                (1 << 14u)
+#define MBEDTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER    ((unsigned int)1 << 0u)
+#define MBEDTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER      ((unsigned int)1 << 1u)
+#define MBEDTLS_X509_EXT_KEY_USAGE                   ((unsigned int)1 << 2u)
+#define MBEDTLS_X509_EXT_CERTIFICATE_POLICIES        ((unsigned int)1 << 3u)
+#define MBEDTLS_X509_EXT_POLICY_MAPPINGS             ((unsigned int)1 << 4u)
+#define MBEDTLS_X509_EXT_SUBJECT_ALT_NAME            ((unsigned int)1 << 5u)    /* Supported (DNS) */
+#define MBEDTLS_X509_EXT_ISSUER_ALT_NAME             ((unsigned int)1 << 6u)
+#define MBEDTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS     ((unsigned int)1 << 7u)
+#define MBEDTLS_X509_EXT_BASIC_CONSTRAINTS           ((unsigned int)1 << 8u)    /* Supported */
+#define MBEDTLS_X509_EXT_NAME_CONSTRAINTS            ((unsigned int)1 << 9u)
+#define MBEDTLS_X509_EXT_POLICY_CONSTRAINTS          ((unsigned int)1 << 10u)
+#define MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE          ((unsigned int)1 << 11u)
+#define MBEDTLS_X509_EXT_CRL_DISTRIBUTION_POINTS     ((unsigned int)1 << 12u)
+#define MBEDTLS_X509_EXT_INIHIBIT_ANYPOLICY          ((unsigned int)1 << 13u)
+#define MBEDTLS_X509_EXT_FRESHEST_CRL                ((unsigned int)1 << 14u)
 
-#define MBEDTLS_X509_EXT_NS_CERT_TYPE                (1 << 16u)
+#define MBEDTLS_X509_EXT_NS_CERT_TYPE                ((unsigned int)1 << 16u)
 
 /*
  * Storage format identifiers

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -143,23 +143,23 @@
  * Comments refer to the status for using certificates. Status can be
  * different for writing certificates or reading CRLs or CSRs.
  */
-#define MBEDTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER    (1 << 0)
-#define MBEDTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER      (1 << 1)
-#define MBEDTLS_X509_EXT_KEY_USAGE                   (1 << 2)
-#define MBEDTLS_X509_EXT_CERTIFICATE_POLICIES        (1 << 3)
-#define MBEDTLS_X509_EXT_POLICY_MAPPINGS             (1 << 4)
-#define MBEDTLS_X509_EXT_SUBJECT_ALT_NAME            (1 << 5)    /* Supported (DNS) */
-#define MBEDTLS_X509_EXT_ISSUER_ALT_NAME             (1 << 6)
-#define MBEDTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS     (1 << 7)
-#define MBEDTLS_X509_EXT_BASIC_CONSTRAINTS           (1 << 8)    /* Supported */
-#define MBEDTLS_X509_EXT_NAME_CONSTRAINTS            (1 << 9)
-#define MBEDTLS_X509_EXT_POLICY_CONSTRAINTS          (1 << 10)
-#define MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE          (1 << 11)
-#define MBEDTLS_X509_EXT_CRL_DISTRIBUTION_POINTS     (1 << 12)
-#define MBEDTLS_X509_EXT_INIHIBIT_ANYPOLICY          (1 << 13)
-#define MBEDTLS_X509_EXT_FRESHEST_CRL                (1 << 14)
+#define MBEDTLS_X509_EXT_AUTHORITY_KEY_IDENTIFIER    (1 << 0u)
+#define MBEDTLS_X509_EXT_SUBJECT_KEY_IDENTIFIER      (1 << 1u)
+#define MBEDTLS_X509_EXT_KEY_USAGE                   (1 << 2u)
+#define MBEDTLS_X509_EXT_CERTIFICATE_POLICIES        (1 << 3u)
+#define MBEDTLS_X509_EXT_POLICY_MAPPINGS             (1 << 4u)
+#define MBEDTLS_X509_EXT_SUBJECT_ALT_NAME            (1 << 5u)    /* Supported (DNS) */
+#define MBEDTLS_X509_EXT_ISSUER_ALT_NAME             (1 << 6u)
+#define MBEDTLS_X509_EXT_SUBJECT_DIRECTORY_ATTRS     (1 << 7u)
+#define MBEDTLS_X509_EXT_BASIC_CONSTRAINTS           (1 << 8u)    /* Supported */
+#define MBEDTLS_X509_EXT_NAME_CONSTRAINTS            (1 << 9u)
+#define MBEDTLS_X509_EXT_POLICY_CONSTRAINTS          (1 << 10u)
+#define MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE          (1 << 11u)
+#define MBEDTLS_X509_EXT_CRL_DISTRIBUTION_POINTS     (1 << 12u)
+#define MBEDTLS_X509_EXT_INIHIBIT_ANYPOLICY          (1 << 13u)
+#define MBEDTLS_X509_EXT_FRESHEST_CRL                (1 << 14u)
 
-#define MBEDTLS_X509_EXT_NS_CERT_TYPE                (1 << 16)
+#define MBEDTLS_X509_EXT_NS_CERT_TYPE                (1 << 16u)
 
 /*
  * Storage format identifiers


### PR DESCRIPTION

## Description
A Clang-tiny warning is generated when a bitwise comparison is made with X.509 extension types in x509.h
'use of a signed integer operand with a binary bitwise operator'

Code like:
unsigned int a = 10;
if ( a & MBEDTLS_X509_EXT_KEY_USAGE ) printf("sth\n");


## Status
**READY**

## Requires Backporting
Yes? Please advise.
