### PR TITLE
Add to the networking module header a definition of the purpose and use of the module

### DIFF
--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -6,12 +6,13 @@
  *
  *          The network sockets module provides an example integration of the
  *          Mbed TLS library into a BSD sockets implementation. The module is
- *          intended to be both an example of how Mbed TLS can be integrated
- *          into a networking stack, and also act as Mbed TLS's integration on
- *          the supported platforms.
+ *          intended to be an example of how Mbed TLS can be integrated into a
+ *          networking stack, as well as to be Mbed TLS's network integration
+ *          for its supported platforms.
  *
- *          The module is intended only for the use of the Mbed TLS library and
- *          is not intended to be used by third party application software.
+ *          The module is intended only to be used with the Mbed TLS library and
+ *          is not intended to be used by third party application software
+ *          directly.
  *
  *          The supported platforms are as follows:
  *              * Microsoft Windows and Windows CE

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -1,7 +1,22 @@
 /**
  * \file net_sockets.h
  *
- * \brief Network communication functions
+ * \brief   Network sockets abstraction layer to integrate Mbed TLS into a
+ *          BSD-style sockets API.
+ *
+ *          The network sockets module provides an example integration of the
+ *          Mbed TLS library into a BSD sockets implementation. The module is
+ *          intended to be both an example of how Mbed TLS can be integrated
+ *          into a networking stack, and also act as Mbed TLS's integration on
+ *          the supported platforms.
+ *
+ *          The module is intended only for the use of the Mbed TLS library and
+ *          is not intended to be used by third party application software.
+ *
+ *          The supported platforms are as follows:
+ *              * Microsoft Windows and Windows CE
+ *              * POSIX/Unix platforms including Linux, OS X
+ *
  */
 /*
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved


### PR DESCRIPTION
## Description
The purpose of the networking module can sometimes be misunderstood. This adds a definition and explanation of what the networking module is and what it can be used for.

This PR changes the doxygen documentation only. 

## Status
**READY**

## Requires Backporting
NO  

Whilst the change only clarifies the purpose of the networking module, it is restrictive, and it seems unnecessary to retrospectively say what the module can or can't be used for on maintained branches.