### PR TITLE
all.sh: Return error on keep-going failure

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -339,6 +339,7 @@ $text"
             echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
             echo "${start_red}FAILED: $failure_count${end_color}$failure_summary"
             echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+            exit 1
         elif [ -z "${1-}" ]; then
             echo "SUCCESS :)"
         fi


### PR DESCRIPTION
When calling all.sh from a script and using "--keep-going", errors were
sometimes missed due to all.sh always returning 0 "success" return
code. Return 1 if there is any failure encountered during a "keep-going"
run.

## Status
**READY**
Testing done: ran `all.sh` with two failures. Then, did `echo $?` and got `1` (error) back.

## Requires Backporting
Yes