### PR TITLE
Backport 2.1: Expand i386 all.sh tests to include full configuration ASan builds

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -55,7 +55,7 @@
  * This is done as the number of registers used in the assembly code doesn't
  * work with the -O0 option.
  */
-#if defined(__i386__) && !defined(__OPTIMIZE__)
+#if defined(__i386__) && defined(__OPTIMIZE__)
 
 #define MULADDC_INIT                        \
     asm(                                    \

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -597,13 +597,24 @@ if uname -a | grep -F Linux >/dev/null; then
 fi
 
 if uname -a | grep -F x86_64 >/dev/null; then
-    msg "build: i386, make, gcc (ASan build)" # ~ 30s
+    # Build once with -O0, to compile out the i386 specific inline assembly
+    msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -m32 -fsanitize=address'
+    make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
 
-    msg "test: i386, make, gcc (ASan build)"
+    msg "test: i386, make, gcc -O0 (ASan build)"
+    make test
+
+    # Build again with -O1, to compile in the i386 specific inline assembly
+    msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
+
+    msg "test: i386, make, gcc -O1 (ASan build)"
     make test
 
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -597,15 +597,19 @@ if uname -a | grep -F Linux >/dev/null; then
 fi
 
 if uname -a | grep -F x86_64 >/dev/null; then
-    msg "build: i386, make, gcc" # ~ 30s
+    msg "build: i386, make, gcc (ASan build)" # ~ 30s
     cleanup
-    make CC=gcc CFLAGS='-Werror -m32'
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -m32 -fsanitize=address'
 
-    msg "test: i386, make, gcc"
+    msg "test: i386, make, gcc (ASan build)"
     make test
 
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
     cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
 
     msg "test: 64-bit ILP32, make, gcc"


### PR DESCRIPTION
## Description
This is a backport of PR #1810.

The i386 test builds were only building the default configuration and had no address sanitisation. This pull request expands the test configuration to the full configuration in all.sh and generates ASan builds for test suite execution.

This pull request extends test coverage sufficiently that issue #1550, where the MPI assembly code on i386 which was fundamentally broken, would have been caught.

It also fixes the inline assembly which was previously only being included in builds with no optimisation, which was the opposite of what it should have been doing.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
