### PR TITLE
Increase the memory buffer size for ssl_server2.c

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -97,6 +97,10 @@ int main( void )
 #include <windows.h>
 #endif
 
+/* Size of memory to be allocated for the heap, when using the library's memory
+ * management and MBEDTLS_MEMORY_BUFFER_ALLOC_C is enabled. */
+#define MEMORY_HEAP_SIZE        120000
+
 #define DFL_SERVER_ADDR         NULL
 #define DFL_SERVER_PORT         "4433"
 #define DFL_DEBUG_LEVEL         0
@@ -1212,7 +1216,7 @@ int main( int argc, char *argv[] )
     const char *alpn_list[ALPN_LIST_SIZE];
 #endif
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-    unsigned char alloc_buf[120000];
+    unsigned char alloc_buf[MEMORY_HEAP_SIZE];
 #endif
 
     int i;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1212,7 +1212,7 @@ int main( int argc, char *argv[] )
     const char *alpn_list[ALPN_LIST_SIZE];
 #endif
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-    unsigned char alloc_buf[100000];
+    unsigned char alloc_buf[120000];
 #endif
 
     int i;


### PR DESCRIPTION
## Description

This pull request fixes issue #1874.

Newer features in the library have increased the overall RAM usage of the library, when all features are enabled. `ssl_server2.c`, with all features enabled was running out of memory for the `ssl-opt.sh` test 'Authentication: client max_int chain, server required'.

This commit increases the memory buffer allocation for `ssl_server2.c` to allow the test to work with all features enabled.

## Status
**READY**

## Requires Backporting
NO  

The memory allocation was big enough for all tests in `mbedtls-2.11.0` and previous releases. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
