### PR TITLE
Backport 2.7: Fix memory leak in ecp_mul_comb() if ecp_precompute_comb() fails

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,8 @@ Bugfix
    * Correct the documentation for `mbedtls_ssl_get_session()`.
      This API has deep copy of the session, and the peer
      certificate is not lost. Fixes #926.
+   * Fix a memory leak in ecp_mul_comb() if ecp_precompute_comb() fails.
+     Fix contributed by Espressif Systems.
 
 Changes
    * Change the shebang line in Perl scripts to look up perl in the PATH.

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1448,7 +1448,12 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 
 cleanup:
 
-    if( T != NULL && ! p_eq_g )
+    /* There are two cases where T is not stored in grp:
+     * - P != G
+     * - An intermediate operation failed before setting grp->T
+     * In either case, T must be freed.
+     */
+    if( T != NULL && T != grp->T )
     {
         for( i = 0; i < pre_len; i++ )
             mbedtls_ecp_point_free( &T[i] );


### PR DESCRIPTION
## Description
Backport of #1834 to `mbedtls-2.7`


## Status
**READY**
