### PR TITLE
Backport 2.1:Fix hmac_drbg failure in benchmark, with threading

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-    * Fix efailure in hmac_drbg in the benchmark sample application, when
+    * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
 
 = mbed TLS 2.1.14 branch released 2018-07-25

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+    * Fix efailure in hmac_drbg in the benchmark sample application, when
+     MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+
 = mbed TLS 2.1.14 branch released 2018-07-25
 
 Security

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 Bugfix
     * Fix failure in hmac_drbg in the benchmark sample application, when
-     MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
 
 = mbed TLS 2.1.14 branch released 2018-07-25
 

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -536,7 +536,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (NOPR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -545,7 +544,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (PR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
@@ -557,7 +555,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (NOPR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -566,8 +563,8 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (PR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
+        mbedtls_hmac_drbg_free( &hmac_drbg );
     }
 #endif
 


### PR DESCRIPTION
## Description
Backport of #1758 to `mbedtls-2.1`

## Status
**READY**

