### PR TITLE
Backport 2.7:Fix hmac_drbg failure in benchmark, with threading

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix failure in hmac_drbg in the benchmark sample application, when
+     MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+
 = mbed TLS 2.7.5 branch released 2018-07-25
 
 Security

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -594,7 +594,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (NOPR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -603,7 +602,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (PR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
@@ -615,7 +613,6 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (NOPR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 
         if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
@@ -624,8 +621,8 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (PR)",
                 if( mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
                 mbedtls_exit(1) );
-        mbedtls_hmac_drbg_free( &hmac_drbg );
 #endif
+        mbedtls_hmac_drbg_free( &hmac_drbg );
     }
 #endif
 


### PR DESCRIPTION
## Description
Backport of #1758 to `mbedtls-2.7`


## Status
**READY**

