### PR TITLE
AES and  RSA (bn_mul) optimizations for Visual Studio 64bit

### DIFF
--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -35,6 +35,11 @@
 #define MBEDTLS_HAVE_X86_64
 #endif
 
+#if defined(_MSC_VER) && defined(_M_X64) &&  \
+    ! defined(MBEDTLS_HAVE_X86_64)
+#define MBEDTLS_HAVE_X86_64
+#endif
+
 #if defined(MBEDTLS_HAVE_X86_64)
 
 #ifdef __cplusplus

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -832,9 +832,30 @@
     __asm   mov     s, esi                      \
 
 #endif /* SSE2 */
-#endif /* MSVC */
-
+#endif /* (MSVC && _M_IX86) || __WATCOMC__ */
 #endif /* MBEDTLS_HAVE_ASM */
+
+#if defined(_MSC_VER) && defined(_M_X64)
+
+#include <intrin.h>
+
+#define MULADDC_INIT                         \
+{                                            \
+    mbedtls_mpi_uint r0, r1;                 \
+    unsigned char carry;
+
+#define MULADDC_CORE                         \
+    r0 = _umul128( *(s++), b, &r1 );         \
+    carry = _addcarry_u64( 0, r0, c, &r0 );  \
+    _addcarry_u64( carry, r1, 0, &r1 );      \
+    carry = _addcarry_u64( 0, r0, *d, &r0 ); \
+    _addcarry_u64( carry, r1, 0, &r1 );      \
+    c = r1; *(d++) = r0;
+
+#define MULADDC_STOP                         \
+}
+
+#endif /* _MSC_VER && _M_X64 */
 
 #if !defined(MULADDC_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -66,7 +66,7 @@
 #error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
 #endif
 
-#if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM)
+#if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM) && !(defined(_MSC_VER) && defined(_M_X64))
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -201,18 +201,29 @@ unsigned long mbedtls_timing_hardclock( void )
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __ia64__ */
 
-#if !defined(HAVE_HARDCLOCK) && defined(_MSC_VER) && \
+#if !defined(HAVE_HARDCLOCK) && defined(_MSC_VER) && defined(_M_X64) && \
     !defined(EFIX64) && !defined(EFI32)
 
 #define HAVE_HARDCLOCK
 
 unsigned long mbedtls_timing_hardclock( void )
 {
-    LARGE_INTEGER offset;
+    LARGE_INTEGER tsc;
+    tsc.QuadPart = __rdtsc();
+    return( (unsigned long)tsc.u.LowPart );
+}
+#endif /* !HAVE_HARDCLOCK && _MSC_VER && _M_X64 && !EFIX64 && !EFI32 */
 
-    QueryPerformanceCounter( &offset );
+#if !defined(HAVE_HARDCLOCK) && defined(_MSC_VER) && \
+    !defined(EFIX64) && !defined(EFI32)
 
-    return( (unsigned long)( offset.QuadPart ) );
+#define HAVE_HARDCLOCK
+
+unsigned long mbedtls_timing_hardclock(void)
+{
+    LARGE_INTEGER tsc;
+    QueryPerformanceCounter(&offset);
+    return((unsigned long)tsc.u.LowPart);
 }
 #endif /* !HAVE_HARDCLOCK && _MSC_VER && !EFIX64 && !EFI32 */
 


### PR DESCRIPTION
## Description
The changes improve mbedtls performance when compiling with Visual Studio for 64bit by adding code paths that use intrinsic functions, particularly:
 - AES encryption/decryption using AES-NI
 - bignum multiplication by using 128bit umul and adc instructions

Also switch to TSC timing as QueryPerformanceCounter resolution is too low and it doesn't return CPU cycles.

## Status
**READY/IN DEVELOPMENT**

## Requires Backporting
NO 
- This PR is a new feature\enhancement

## Migrations
NO

## Additional comments
I ran the compat.sh tests (with some modification that are not part of this PR) on Windows in WSL/bash environment and they do pass. Although I noticed some instabilities, related to shutting down the client (./tests/compat.sh: 1052: kill: No such process) but those are not related to this PR.

As tests are not run as CI under Windows (afaiu), I'm interested how to ensure ongoing correctness of the code I'm submitting.

Also, and it's related to testing, as at least the current versions of clang and probably gcc appear to support intrinsic functions for AES-NI, CLMUL and ADC - I'm wondering if switching inline assembly to intrinsics would be feasible while deduplicating code for other than msvc/windows compilers too? I'm a bit worried about possible compiler/optimizer issues though.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

## Steps to test or reproduce
On Windows 64bit, compiled with Visual Studio, observe numbers from .\programs\test\benchmark.exe  without and with the PR. Selected numbers on my machine:

**before**
```
  AES-CBC-128              :     203930 KiB/s,         15 cycles/byte
  AES-CBC-192              :     171486 KiB/s,         18 cycles/byte
  AES-CBC-256              :     159248 KiB/s,         19 cycles/byte
  AES-XTS-128              :     175882 KiB/s,         17 cycles/byte
  AES-XTS-256              :     138802 KiB/s,         22 cycles/byte
  AES-GCM-128              :      95727 KiB/s,         33 cycles/byte
  AES-GCM-192              :      90064 KiB/s,         35 cycles/byte
  AES-GCM-256              :      85229 KiB/s,         37 cycles/byte
  AES-CCM-128              :     102824 KiB/s,         31 cycles/byte
  AES-CCM-192              :      90658 KiB/s,         35 cycles/byte
  AES-CCM-256              :      80782 KiB/s,         39 cycles/byte
  CTR_DRBG (NOPR)          :     174899 KiB/s,         18 cycles/byte
  CTR_DRBG (PR)            :     121910 KiB/s,         26 cycles/byte
  RSA-2048                 :    8674  public/s
  RSA-2048                 :     212 private/s
  RSA-4096                 :    2173  public/s
  RSA-4096                 :      33 private/s
```

**after**
```
  AES-CBC-128              :     432099 KiB/s,          7 cycles/byte
  AES-CBC-192              :     385591 KiB/s,          8 cycles/byte
  AES-CBC-256              :     360928 KiB/s,          9 cycles/byte
  AES-XTS-128              :     407371 KiB/s,          8 cycles/byte
  AES-XTS-256              :     336302 KiB/s,          9 cycles/byte
  AES-GCM-128              :     190789 KiB/s,         17 cycles/byte
  AES-GCM-192              :     171782 KiB/s,         18 cycles/byte
  AES-GCM-256              :     173023 KiB/s,         18 cycles/byte
  AES-CCM-128              :     260800 KiB/s,         12 cycles/byte
  AES-CCM-192              :     241114 KiB/s,         13 cycles/byte
  CTR_DRBG (NOPR)          :     397238 KiB/s,          8 cycles/byte
  CTR_DRBG (PR)            :     262009 KiB/s,         12 cycles/byte
  RSA-2048                 :   19703  public/s
  RSA-2048                 :     458 private/s
  RSA-4096                 :    5197  public/s
  RSA-4096                 :      76 private/s
```