### PR TITLE
Backport 2.1: AES test dependencies and CMAC robustness

### DIFF
--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -159,7 +159,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST:MBEDTLS_AES_C */
 void gcm_selftest()
 {
     TEST_ASSERT( mbedtls_gcm_self_test( 0 ) == 0 );


### PR DESCRIPTION
Backport of the test dependency fixes from #1331. That PR was centered on CMAC, but there is no CMAC in 2.1, which leaves a single test case to fix.

Manual testing done: `make check` in the default configuration minus `MBEDTLS_AES_C` and `MBEDTLS_CTR_DRBG_C`, and in the full configuration minus `MBEDTLS_AES_C` and `MBEDTLS_CTR_DRBG_C`.