### PR TITLE
Backport 2.7: AES test dependencies and CMAC robustness

### DIFF
--- a/tests/suites/test_suite_cmac.data
+++ b/tests/suites/test_suite_cmac.data
@@ -22,15 +22,15 @@ mbedtls_cmac_setkey:MBEDTLS_CIPHER_DES_EDE3_ECB:192:0
 
 CMAC init #5 AES-224: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #6 AES-0: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #7 Camellia: wrong cipher
 depends_on:MBEDTLS_CAMELLIA_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_CAMELLIA:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_CAMELLIA_128_ECB:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC Single Blocks #1 - Empty block, no updates
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":-1:"":-1:"":-1:"":-1:"bb1d6929e95937287fa37d129b756746"

--- a/tests/suites/test_suite_cmac.data
+++ b/tests/suites/test_suite_cmac.data
@@ -33,32 +33,42 @@ depends_on:MBEDTLS_CAMELLIA_C
 mbedtls_cmac_setkey:MBEDTLS_CIPHER_CAMELLIA_128_ECB:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC Single Blocks #1 - Empty block, no updates
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":-1:"":-1:"":-1:"":-1:"bb1d6929e95937287fa37d129b756746"
 
 CMAC Single Blocks #2 - Single 16 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172a":16:"":-1:"":-1:"":-1:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Single Blocks #3 - Single 64 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":64:"":-1:"":-1:"":-1:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #1 - Multiple 8 byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96":8:"e93d7e117393172a":8:"":-1:"":-1:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Multiple Blocks #2 - Multiple 16 byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172a":16:"ae2d8a571e03ac9c9eb76fac45af8e51":16:"30c81c46a35ce411e5fbc1191a0a52ef":16:"f69f2445df4f9b17ad2b417be66c3710":16:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #3 - Multiple variable sized blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96":8:"e93d7e117393172aae2d8a571e03ac9c":16:"9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52ef":24:"f69f2445df4f9b17ad2b417be66c3710":16:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #4 - Multiple 8 byte blocks with gaps
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":0:"6bc1bee22e409f96":8:"":0:"e93d7e117393172a":8:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Multiple Operations, same key #1 - Empty, empty
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367":"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367"
 
 CMAC Multiple Operations, same key #2 - Empty, 64 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367":"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":64:"":-1:"":-1:"a1d5df0eed790f794d77589659f39a11"
 
 CMAC Multiple Operations, same key #3 - variable byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51":32:"30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":32:"":-1:"a1d5df0eed790f794d77589659f39a11":"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51":32:"30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":32:"":-1:"a1d5df0eed790f794d77589659f39a11"
 

--- a/tests/suites/test_suite_cmac.function
+++ b/tests/suites/test_suite_cmac.function
@@ -30,7 +30,13 @@ void mbedtls_cmac_null_args( )
     TEST_ASSERT( mbedtls_cipher_cmac_update( &ctx, test_data, 16 ) ==
                                          MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
+#if defined(MBEDTLS_AES_C)
     cipher_info = mbedtls_cipher_info_from_type( MBEDTLS_CIPHER_AES_128_ECB );
+#elif defined(MBEDTLS_DES_C)
+    cipher_info = mbedtls_cipher_info_from_type( MBEDTLS_CIPHER_DES_EDE3_ECB );
+#else /* !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_AES_C) */
+    TEST_ASSERT( ! "MBEDTLS_CMAC_C defined, but no underlying block cipher!" );
+#endif
     TEST_ASSERT( mbedtls_cipher_setup( &ctx, cipher_info ) == 0 );
 
     TEST_ASSERT( mbedtls_cipher_cmac_starts( NULL, test_key, 128 ) ==
@@ -78,6 +84,7 @@ void mbedtls_cmac_null_args( )
                                       NULL ) ==
                                             MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
+#if defined(MBEDTLS_AES_C)
     TEST_ASSERT( mbedtls_aes_cmac_prf_128( NULL, 16,
                                            test_data, 16,
                                            test_output ) ==
@@ -92,6 +99,7 @@ void mbedtls_cmac_null_args( )
                                            test_data, 16,
                                            NULL ) ==
                                               MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+#endif /* MBEDTLS_AES_C */
 
 exit:
     mbedtls_cipher_free( &ctx );

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -159,7 +159,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST:MBEDTLS_AES_C */
 void gcm_selftest()
 {
     TEST_ASSERT( mbedtls_gcm_self_test( 1 ) == 0 );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -1126,7 +1126,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
 void mbedtls_rsa_validate_params( int radix_N, char *input_N,
                                   int radix_P, char *input_P,
                                   int radix_Q, char *input_Q,
@@ -1190,7 +1190,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C */
+/* BEGIN_CASE  */
 void mbedtls_rsa_export_raw( char *input_N, char *input_P,
                              char *input_Q, char *input_D,
                              char *input_E, int is_priv,


### PR DESCRIPTION
Backport of the test dependency fixes from #1331.

Manual testing done: `make check` in the default configuration minus `MBEDTLS_AES_C` and `MBEDTLS_CTR_DRBG_C`, and in the full configuration minus `MBEDTLS_AES_C` and `MBEDTLS_CTR_DRBG_C`.