### PR TITLE
Fix definition of SSL_SOME_MODES_USE_MAC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if
      MBEDTLS_ARC4_C and MBEDTLS_CIPHER_NULL_CIPHER weren't also defined. #1890
+   * Fix the internal definition of SSL_SOME_MODES_USE_MAC which previously
+     did not consider the presence of 3DES.
 
 = mbed TLS 2.12.0 branch released 2018-07-25
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1297,9 +1297,12 @@ static void ssl_mac( mbedtls_md_context_t *md_ctx,
 }
 #endif /* MBEDTLS_SSL_PROTO_SSL3 */
 
-#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER) ||     \
-    ( defined(MBEDTLS_CIPHER_MODE_CBC) &&                                  \
-      ( defined(MBEDTLS_AES_C) || defined(MBEDTLS_CAMELLIA_C) || defined(MBEDTLS_ARIA_C)) )
+#if defined(MBEDTLS_ARC4_C) || defined(MBEDTLS_CIPHER_NULL_CIPHER) ||   \
+    ( defined(MBEDTLS_CIPHER_MODE_CBC) &&                               \
+      ( defined(MBEDTLS_AES_C)      ||                                  \
+        defined(MBEDTLS_CAMELLIA_C) ||                                  \
+        defined(MBEDTLS_DES_C)      ||                                  \
+        defined(MBEDTLS_ARIA_C) ) )
 #define SSL_SOME_MODES_USE_MAC
 #endif
 


### PR DESCRIPTION
__Summary:__ This PR fixes the definition of the internal macro `SSL_SOME_MODES_USE_MAC` which previously did not consider the presence of 3DES.

Noted by @mpg and originally fixed in #1633 which is currently being rebased. 