### PR TITLE
Fix miscalculations of maximum record expansion in mbedtls_ssl_get_record_expansion()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if
      MBEDTLS_ARC4_C and MBEDTLS_CIPHER_NULL_CIPHER weren't also defined. #1890
+   * Fix a miscalculation of the maximum record expansion in
+     mbedtls_ssl_get_record_expansion() in case of ChachaPoly ciphersuites,
+     or CBC ciphersuites in (D)TLS versions 1.1 or higher. Fixes #1913, #1914.
 
 = mbed TLS 2.12.0 branch released 2018-07-25
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6841,6 +6841,7 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
 {
     size_t transform_expansion;
     const mbedtls_ssl_transform *transform = ssl->transform_out;
+    unsigned block_size;
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->session_out->compression != MBEDTLS_SSL_COMPRESS_NULL )
@@ -6854,13 +6855,33 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
     {
         case MBEDTLS_MODE_GCM:
         case MBEDTLS_MODE_CCM:
+        case MBEDTLS_MODE_CHACHAPOLY:
         case MBEDTLS_MODE_STREAM:
             transform_expansion = transform->minlen;
             break;
 
         case MBEDTLS_MODE_CBC:
-            transform_expansion = transform->maclen
-                      + mbedtls_cipher_get_block_size( &transform->cipher_ctx_enc );
+
+            block_size = mbedtls_cipher_get_block_size(
+                &transform->cipher_ctx_enc );
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_1) || defined(MBEDTLS_SSL_PROTO_TLS1_2)
+            if( ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_2 )
+            {
+                /* Expansion due to addition of
+                 * - MAC
+                 * - CBC padding (theoretically up to 256 bytes, but
+                 *                we never use more than block_size)
+                 * - explicit IV
+                 */
+                transform_expansion = transform->maclen + 2 * block_size;
+            }
+            else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1_2 */
+            {
+                /* No explicit IV prior to TLS 1.1. */
+                transform_expansion = transform->maclen + block_size;
+            }
             break;
 
         default:


### PR DESCRIPTION
__Summary:__ This PR fixes miscalculations of the maximum record expansion in `mbedtls_ssl_get_record_expansion()` in the case of ChachaPoly ciphersuites, as well as CBC ciphersuites in (D)TLS versions 1.1 or higher. Fixes #1913 and #1914.

This PR has high relevance for the ongoing fragmentation work #1879, which uses `mbedtls_ssl_get_record_expansion()` to deduce from the configured MTU the maximum record payload.