### PR TITLE
Iotcrypt 255 rsa prime probability

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2084,6 +2084,19 @@ static int mpi_miller_rabin( const mbedtls_mpi *X,
           ( i >=  650 ) ?  4 : ( i >=  350 ) ?  8 :
           ( i >=  250 ) ? 12 : ( i >=  150 ) ? 18 : 27 );
 
+    /*
+     * FIPS 186-4, table C2
+     *
+     * The 512 bit case is omitted deliberately, because the rest of the
+     * generation process is not permitted for 1024 bit modulus size.
+     */
+    switch(i)
+    {
+        case 1024: n = 5; break;
+        case 1536: n = 4; break;
+        default: ;
+    }
+
     for( i = 0; i < n; i++ )
     {
         /*

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2094,11 +2094,11 @@ static int mpi_miller_rabin( const mbedtls_mpi *X, int fips_flag,
          * The 512 bit case is omitted deliberately, because the rest of the
          * generation process is not permitted for 1024 bit modulus size.
          */
-        switch(i)
+        switch( i )
         {
             case 1024: n = 5; break;
             case 1536: n = 4; break;
-            default: ;
+            default: break;
         }
     }
 


### PR DESCRIPTION
## Description
The number of rounds of Miller-Rabin prime generation was lower than the number prescribed by FIPS 186-4. To make the generation compliant we increase the number of Miller-Rabin rounds to match the values prescribed in Table C.2.

## Status
**READY

## Requires Backporting
NO  

## Migrations
NO