### PR TITLE
Use gmtime() when neither gmtime_r nor gmtime_s are available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,8 +13,8 @@ API Changes
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if
      MBEDTLS_ARC4_C and MBEDTLS_CIPHER_NULL_CIPHER weren't also defined. #1890
-   * Fix build failures on where only gmtime() is available but neither
-     gmtime_r() nor gmtime_s() are present. Fixes #1907.
+   * Fix build failures on platforms where only gmtime() is available but
+     neither gmtime_r() nor gmtime_s() are present. Fixes #1907.
 
 = mbed TLS 2.12.0 branch released 2018-07-25
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,8 +7,8 @@ API Changes
      whose implementation should behave as a thread safe version of gmtime().
      This allows users to configure such an implementation at compile time when
      the target system cannot be deduced automatically. At this stage Mbed TLS
-     is only able to configure implementations for Windows and POSIX C
-     libraries.
+     is only able to automtically select implementations for Windows and POSIX
+     C libraries.
 
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,14 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
+API Changes
+   * Extend the platform module with an abstraction mbedtls_platform_gmtime()
+     whose implementation should behave as a thread safe version of gmtime().
+     This allows users to configure such an implementation at compile time when
+     the target system cannot be deduced automatically. At this stage Mbed TLS
+     is only able to configure implementations for Windows and POSIX C
+     libraries.
+
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if
      MBEDTLS_ARC4_C and MBEDTLS_CIPHER_NULL_CIPHER weren't also defined. #1890

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if
      MBEDTLS_ARC4_C and MBEDTLS_CIPHER_NULL_CIPHER weren't also defined. #1890
+   * Fix build failures on where only gmtime() is available but neither
+     gmtime_r() nor gmtime_s() are present. Fixes #1907.
 
 = mbed TLS 2.12.0 branch released 2018-07-25
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 API Changes
    * Extend the platform module with an abstraction mbedtls_platform_gmtime_r()
-     whose implementation should behave as a thread safe version of gmtime().
+     whose implementation should behave as a thread-safe version of gmtime().
      This allows users to configure such an implementation at compile time when
      the target system cannot be deduced automatically, by setting the option
      MBEDTLS_PLATFORM_GMTIME_R_ALT. At this stage Mbed TLS is only able to

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,8 +7,8 @@ API Changes
      whose implementation should behave as a thread safe version of gmtime().
      This allows users to configure such an implementation at compile time when
      the target system cannot be deduced automatically. At this stage Mbed TLS
-     is only able to automtically select implementations for Windows and POSIX
-     C libraries.
+     is only able to automatically select implementations for Windows, POSIX
+     C libraries and IAR.
 
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,8 +7,8 @@ API Changes
      whose implementation should behave as a thread safe version of gmtime().
      This allows users to configure such an implementation at compile time when
      the target system cannot be deduced automatically. At this stage Mbed TLS
-     is only able to automatically select implementations for Windows, POSIX
-     C libraries and IAR.
+     is only able to automatically select implementations for Windows and POSIX
+     C libraries.
 
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,12 +3,12 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 API Changes
-   * Extend the platform module with an abstraction mbedtls_platform_gmtime()
+   * Extend the platform module with an abstraction mbedtls_platform_gmtime_r()
      whose implementation should behave as a thread safe version of gmtime().
      This allows users to configure such an implementation at compile time when
-     the target system cannot be deduced automatically. At this stage Mbed TLS
-     is only able to automatically select implementations for Windows and POSIX
-     C libraries.
+     the target system cannot be deduced automatically, by setting the option
+     MBEDTLS_PLATFORM_GMTIME_R_ALT. At this stage Mbed TLS is only able to
+     automatically select implementations for Windows and POSIX C libraries.
 
 Bugfix
    * Fixes an issue with MBEDTLS_CHACHAPOLY_C which would not compile if

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3107,7 +3107,7 @@
  * system, the implementation of mbedtls_platform_gmtime_r() will default to
  * using the standard gmtime(). In this case, calls from the library to
  * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
- * if MBEDTLS_THREADING_C is enable. It is advised that calls from outside the
+ * if MBEDTLS_THREADING_C is enabled. It is advised that calls from outside the
  * library are also guarded with this mutex to avoid race conditions. However,
  * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
  * unconditionally use the implementation for mbedtls_platform_gmtime_r()

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -146,7 +146,7 @@
  * Comment if your system does not have a correct clock.
  *
  * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
- * when called behaves similarly to the gmtime() function from the C standard,
+ * behaves similarly to the gmtime() function from the C standard,
  * but is thread safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
  * POSIX and gmtime_s() for Windows). If this is not possible, then

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -149,7 +149,7 @@
  * when called behaves similarly to the gmtime() function from the C standard,
  * but is thread safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
- * POSIX and gmtime_s() for Windows and IAR). If this is not possible, then
+ * POSIX and gmtime_s() for Windows). If this is not possible, then
  * gmtime() will be used. Refer to the documentation for
  * mbedtls_platform_gmtime() for more information.
  *

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3107,7 +3107,7 @@
  * system, the implementation of mbedtls_platform_gmtime_r() will default to
  * using the standard gmtime(). In this case, calls from the library to
  * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
- * if MBEDTLS_THREADING_C is enabled. It is advised that calls from outside the
+ * if MBEDTLS_THREADING_C is enabled. We recommend that calls from outside the
  * library are also guarded with this mutex to avoid race conditions. However,
  * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
  * unconditionally use the implementation for mbedtls_platform_gmtime_r()

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3091,6 +3091,25 @@
  */
 //#define MBEDTLS_PLATFORM_ZEROIZE_ALT
 
+/**
+ * Uncomment the macro to let Mbed TLS use your alternate implementation of
+ * mbedtls_platform_gmtime(). This replaces the default implementation in
+ * platform_util.c.
+ *
+ * gmtime() is not a thread safe function as defined in the C standard. The
+ * library will try to use safer implementations of this function, such as
+ * gmtime_r() when available. However, if Mbed TLS cannot identify the target
+ * system, the implementation of mbedtls_platform_gmtime() will default to
+ * using the standard gmtime(). In this case, calls from the library to
+ * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
+ * if MBEDTLS_THREADING_C is enable. It is advised that calls from outside the
+ * library are also guarded with this mutex to avoid race conditions. However,
+ * if the macro MBEDTLS_PLATFORM_GMTIME_ALT is defined, Mbed TLS will
+ * unconditionally use the implementation for mbedtls_platform_time() supplied
+ * at compile time.
+ */
+//#define MBEDTLS_PLATFORM_GMTIME_ALT
+
 /* \} name SECTION: Customisation configuration options */
 
 /* Target and application specific configurations */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -137,12 +137,20 @@
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
  *
- * System has time.h and time(), gmtime() and the clock is correct.
+ * System has time.h and time(), gmtime_s() (Windows), gmtime_r() (POSIX) or
+ * gmtime() and the clock is correct.
  * The time needs to be correct (not necesarily very accurate, but at least
  * the date should be correct). This is used to verify the validity period of
  * X.509 certificates.
  *
  * Comment if your system does not have a correct clock.
+ *
+ * \warning gmtime() is used if the target platform is neither Windows nor
+ * POSIX. Unfortunately, gmtime() is not thread-safe, so a mutex is used when
+ * MBEDTLS_THREADING_C is defined to guarantee sequential usage of gmtime()
+ * across Mbed TLS threads. However, applications must ensure that calls to
+ * gmtime() from outside the library also use the mutex to avoid concurrency
+ * issues.
  */
 #define MBEDTLS_HAVE_TIME_DATE
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -137,20 +137,25 @@
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
  *
- * System has time.h and time(), gmtime_s() (Windows), gmtime_r() (POSIX) or
- * gmtime() and the clock is correct.
+ * System has time.h, time(), an implementation for mbedtls_platform_gmtime(),
+ * and the clock is correct.
  * The time needs to be correct (not necesarily very accurate, but at least
  * the date should be correct). This is used to verify the validity period of
  * X.509 certificates.
  *
  * Comment if your system does not have a correct clock.
  *
- * \warning gmtime() is used if the target platform is neither Windows nor
- * POSIX. Unfortunately, gmtime() is not thread-safe, so a mutex is used when
- * MBEDTLS_THREADING_C is defined to guarantee sequential usage of gmtime()
- * across Mbed TLS threads. However, applications must ensure that calls to
- * gmtime() from outside the library also use the mutex to avoid concurrency
- * issues.
+ * \note mbedtls_platform_gmtime() is an abstraction in platform_util.h that
+ * when called behaves similar to the gmtime() function from the C standard,
+ * but is thread safe. Mbed TLS will try to identify the underlying platform
+ * and configure an appropriate underlying implementation (e.g. gmtime_r() for
+ * POSIX and gmtime_s() for Windows). If this is not possible, then gmtime()
+ * will be used. Refer to the documentation for mbedtls_platform_gmtime() for
+ * more information.
+ *
+ * \note It is possible to configure an implementation for
+ * mbedtls_platform_gmtime() at compile-time by using the macro
+ * MBEDTLS_PLATFORM_GMTIME_ALT.
  */
 #define MBEDTLS_HAVE_TIME_DATE
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -137,8 +137,8 @@
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
  *
- * System has time.h, time(), an implementation for mbedtls_platform_gmtime(),
- * and the clock is correct.
+ * System has time.h, time(), an implementation for mbedtls_platform_gmtime()
+ * (see below), and the clock is correct.
  * The time needs to be correct (not necesarily very accurate, but at least
  * the date should be correct). This is used to verify the validity period of
  * X.509 certificates.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -146,12 +146,8 @@
  * Comment if your system does not have a correct clock.
  *
  * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
- * behaves similarly to the gmtime() function from the C standard,
- * but is thread-safe. Mbed TLS will try to identify the underlying platform
- * and configure an appropriate underlying implementation (e.g. gmtime_r() for
- * POSIX and gmtime_s() for Windows). If this is not possible, then
- * gmtime() will be used. Refer to the documentation for
- * mbedtls_platform_gmtime_r() for more information.
+ * behaves similarly to the gmtime_r() function from the C standard. Refer to
+ * the documentation for mbedtls_platform_gmtime_r() for more information.
  *
  * \note It is possible to configure an implementation for
  * mbedtls_platform_gmtime_r() at compile-time by using the macro

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -137,7 +137,7 @@
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
  *
- * System has time.h, time(), an implementation for mbedtls_platform_gmtime()
+ * System has time.h, time(), an implementation for mbedtls_platform_gmtime_r()
  * (see below), and the clock is correct.
  * The time needs to be correct (not necesarily very accurate, but at least
  * the date should be correct). This is used to verify the validity period of
@@ -145,17 +145,17 @@
  *
  * Comment if your system does not have a correct clock.
  *
- * \note mbedtls_platform_gmtime() is an abstraction in platform_util.h that
+ * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
  * when called behaves similarly to the gmtime() function from the C standard,
  * but is thread safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
  * POSIX and gmtime_s() for Windows). If this is not possible, then
  * gmtime() will be used. Refer to the documentation for
- * mbedtls_platform_gmtime() for more information.
+ * mbedtls_platform_gmtime_r() for more information.
  *
  * \note It is possible to configure an implementation for
- * mbedtls_platform_gmtime() at compile-time by using the macro
- * MBEDTLS_PLATFORM_GMTIME_ALT.
+ * mbedtls_platform_gmtime_r() at compile-time by using the macro
+ * MBEDTLS_PLATFORM_GMTIME_R_ALT.
  */
 #define MBEDTLS_HAVE_TIME_DATE
 
@@ -3098,22 +3098,22 @@
 
 /**
  * Uncomment the macro to let Mbed TLS use your alternate implementation of
- * mbedtls_platform_gmtime(). This replaces the default implementation in
+ * mbedtls_platform_gmtime_r(). This replaces the default implementation in
  * platform_util.c.
  *
  * gmtime() is not a thread safe function as defined in the C standard. The
  * library will try to use safer implementations of this function, such as
  * gmtime_r() when available. However, if Mbed TLS cannot identify the target
- * system, the implementation of mbedtls_platform_gmtime() will default to
+ * system, the implementation of mbedtls_platform_gmtime_r() will default to
  * using the standard gmtime(). In this case, calls from the library to
  * gmtime() will be guarded by the global mutex mbedtls_threading_gmtime_mutex
  * if MBEDTLS_THREADING_C is enable. It is advised that calls from outside the
  * library are also guarded with this mutex to avoid race conditions. However,
- * if the macro MBEDTLS_PLATFORM_GMTIME_ALT is defined, Mbed TLS will
- * unconditionally use the implementation for mbedtls_platform_time() supplied
- * at compile time.
+ * if the macro MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, Mbed TLS will
+ * unconditionally use the implementation for mbedtls_platform_gmtime_r()
+ * supplied at compile time.
  */
-//#define MBEDTLS_PLATFORM_GMTIME_ALT
+//#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
 /* \} name SECTION: Customisation configuration options */
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -149,9 +149,9 @@
  * when called behaves similarly to the gmtime() function from the C standard,
  * but is thread safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
- * POSIX and gmtime_s() for Windows). If this is not possible, then gmtime()
- * will be used. Refer to the documentation for mbedtls_platform_gmtime() for
- * more information.
+ * POSIX and gmtime_s() for Windows and IAR). If this is not possible, then
+ * gmtime() will be used. Refer to the documentation for
+ * mbedtls_platform_gmtime() for more information.
  *
  * \note It is possible to configure an implementation for
  * mbedtls_platform_gmtime() at compile-time by using the macro

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -147,7 +147,7 @@
  *
  * \note mbedtls_platform_gmtime_r() is an abstraction in platform_util.h that
  * behaves similarly to the gmtime() function from the C standard,
- * but is thread safe. Mbed TLS will try to identify the underlying platform
+ * but is thread-safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
  * POSIX and gmtime_s() for Windows). If this is not possible, then
  * gmtime() will be used. Refer to the documentation for
@@ -3101,7 +3101,7 @@
  * mbedtls_platform_gmtime_r(). This replaces the default implementation in
  * platform_util.c.
  *
- * gmtime() is not a thread safe function as defined in the C standard. The
+ * gmtime() is not a thread-safe function as defined in the C standard. The
  * library will try to use safer implementations of this function, such as
  * gmtime_r() when available. However, if Mbed TLS cannot identify the target
  * system, the implementation of mbedtls_platform_gmtime_r() will default to

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -146,7 +146,7 @@
  * Comment if your system does not have a correct clock.
  *
  * \note mbedtls_platform_gmtime() is an abstraction in platform_util.h that
- * when called behaves similar to the gmtime() function from the C standard,
+ * when called behaves similarly to the gmtime() function from the C standard,
  * but is thread safe. Mbed TLS will try to identify the underlying platform
  * and configure an appropriate underlying implementation (e.g. gmtime_r() for
  * POSIX and gmtime_s() for Windows). If this is not possible, then gmtime()

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -137,8 +137,8 @@
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
  *
- * System has time.h, time(), an implementation for mbedtls_platform_gmtime_r()
- * (see below), and the clock is correct.
+ * System has time.h, time(), and an implementation for
+ * mbedtls_platform_gmtime_r() (see below).
  * The time needs to be correct (not necesarily very accurate, but at least
  * the date should be correct). This is used to verify the validity period of
  * X.509 certificates.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -67,14 +67,13 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
- * \brief      Thread-safe implementation of gmtime()
+ * \brief      Platform-specific implementation of gmtime_r()
  *
- *             The function is an abstraction that when called behaves similar
- *             to the gmtime() function from the C standard, but is thread
- *             safe.
+ *             The function is a thread-safe abstraction that behaves
+ *             similar to the gmtime_r() function from the C standard.
  *
  *             Mbed TLS will try to identify the underlying platform and
- *             configure an appropriate underlying implementation (e.g.
+ *             make use of an appropriate underlying implementation (e.g.
  *             gmtime_r() for POSIX and gmtime_s() for Windows). If this is
  *             not possible, then gmtime() will be used. In this case, calls
  *             from the library to gmtime() will be guarded by the mutex

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -68,7 +68,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
- * \brief      Thread safe implementation of gmtime()
+ * \brief      Thread-safe implementation of gmtime()
  *
  *             The function is an abstraction that when called behaves similar
  *             to the gmtime() function from the C standard, but is thread

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -70,7 +70,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \brief      Platform-specific implementation of gmtime_r()
  *
  *             The function is a thread-safe abstraction that behaves
- *             similarly to the gmtime_r() function from the C standard.
+ *             similarly to the gmtime_r() function from Unix/POSIX.
  *
  *             Mbed TLS will try to identify the underlying platform and
  *             make use of an appropriate underlying implementation (e.g.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -31,10 +31,9 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#include "mbedtls/platform_time.h"
-
 #include <stddef.h>
 #if defined(MBEDTLS_HAVE_TIME_DATE)
+#include "mbedtls/platform_time.h"
 #include <time.h>
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -68,24 +68,24 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
- * \brief       Thread safe implementation of gmtime()
+ * \brief      Thread safe implementation of gmtime()
  *
- *              The function is an abstraction that when called behaves similar
- *              to the gmtime() function from the C standard, but is thread
- *              safe.
+ *             The function is an abstraction that when called behaves similar
+ *             to the gmtime() function from the C standard, but is thread
+ *             safe.
  *
- *              Mbed TLS will try to identify the underlying platform and
- *              configure an appropriate underlying implementation (e.g.
- *              gmtime_r() for POSIX and gmtime_s() for Windows). If this is
- *              not possible, then gmtime() will be used. In this case, calls
- *              from the library to gmtime() will be guarded by the mutex
- *              mbedtls_threading_gmtime_mutex if MBEDTLS_THREADING_C is
- *              enabled. It is recommended that calls from outside the library
- *              are also guarded by this mutex.
+ *             Mbed TLS will try to identify the underlying platform and
+ *             configure an appropriate underlying implementation (e.g.
+ *             gmtime_r() for POSIX and gmtime_s() for Windows). If this is
+ *             not possible, then gmtime() will be used. In this case, calls
+ *             from the library to gmtime() will be guarded by the mutex
+ *             mbedtls_threading_gmtime_mutex if MBEDTLS_THREADING_C is
+ *             enabled. It is recommended that calls from outside the library
+ *             are also guarded by this mutex.
  *
- *              If MBEDTLS_PLATFORM_GMTIME_ALT is defined, then Mbed TLS will
- *              unconditionally use the alternative implementation for
- *              mbedtls_platform_gmtime() supplied by the user at compile time
+ *             If MBEDTLS_PLATFORM_GMTIME_R_ALT is defined, then Mbed TLS will
+ *             unconditionally use the alternative implementation for
+ *             mbedtls_platform_gmtime_r() supplied by the user at compile time.
  *
  * \param tt     Pointer to an object containing time (in seconds) since the
  *               Epoc to be converted
@@ -94,8 +94,8 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \return      Pointer to an object of type struct tm on success, otherwise
  *              NULL
  */
-struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
-                                    struct tm *tm_buf );
+struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
+                                      struct tm *tm_buf );
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
 #ifdef __cplusplus

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -88,7 +88,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  *             mbedtls_platform_gmtime_r() supplied by the user at compile time.
  *
  * \param tt     Pointer to an object containing time (in seconds) since the
- *               Epoc to be converted
+ *               epoch to be converted
  * \param tm_buf Pointer to an object where the results will be stored
  *
  * \return      Pointer to an object of type struct tm on success, otherwise

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -70,7 +70,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \brief      Platform-specific implementation of gmtime_r()
  *
  *             The function is a thread-safe abstraction that behaves
- *             similar to the gmtime_r() function from the C standard.
+ *             similarly to the gmtime_r() function from the C standard.
  *
  *             Mbed TLS will try to identify the underlying platform and
  *             make use of an appropriate underlying implementation (e.g.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -25,7 +25,18 @@
 #ifndef MBEDTLS_PLATFORM_UTIL_H
 #define MBEDTLS_PLATFORM_UTIL_H
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include "mbedtls/platform_time.h"
+
 #include <stddef.h>
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+#include <time.h>
+#endif /* MBEDTLS_HAVE_TIME_DATE */
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,6 +65,38 @@ extern "C" {
  *
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
+
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+/**
+ * \brief       Thread safe implementation of gmtime()
+ *
+ *              The function is an abstraction that when called behaves similar
+ *              to the gmtime() function from the C standard, but is thread
+ *              safe.
+ *
+ *              Mbed TLS will try to identify the underlying platform and
+ *              configure an appropriate underlying implementation (e.g.
+ *              gmtime_r() for POSIX and gmtime_s() for Windows). If this is
+ *              not possible, then gmtime() will be used. In this case, calls
+ *              from the library to gmtime() will be guarded by the mutex
+ *              mbedtls_threading_gmtime_mutex if MBEDTLS_THREADING_C is
+ *              enabled. It is recommended that calls from outside the library
+ *              are also guarded by this mutex.
+ *
+ *              If MBEDTLS_PLATFORM_GMTIME_ALT is defined, then Mbed TLS will
+ *              unconditionally use the alternative implementation for
+ *              mbedtls_platform_gmtime() supplied by the user at compile time
+ *
+ * \param tt    Pointer to an object containing time (in seconds) since the
+ *              Epoc to be converted
+ * \param tm    Pointer to an object where the results will be stored
+ *
+ * \return      Pointer to an object of type struct tm on success, otherwise
+ *              NULL
+ */
+struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
+                                    struct tm *tm_buf );
+#endif /* MBEDTLS_HAVE_TIME_DATE */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -87,9 +87,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  *              unconditionally use the alternative implementation for
  *              mbedtls_platform_gmtime() supplied by the user at compile time
  *
- * \param tt    Pointer to an object containing time (in seconds) since the
- *              Epoc to be converted
- * \param tm    Pointer to an object where the results will be stored
+ * \param tt     Pointer to an object containing time (in seconds) since the
+ *               Epoc to be converted
+ * \param tm_buf Pointer to an object where the results will be stored
  *
  * \return      Pointer to an object of type struct tm on success, otherwise
  *              NULL

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -100,13 +100,18 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
 #if defined(MBEDTLS_HAVE_TIME_DATE)
-#if !defined(_WIN32) && (defined(__unix__) || \
-    (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
+    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
+/*
+ * The preprocessor conditions above are the same as in platform_utils.c and
+ * threading.c. Remember to update the code there when changing the conditions
+ * here
+ */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 #endif /* MBEDTLS_THREADING_C */
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -107,7 +107,7 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
-#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
@@ -122,7 +122,7 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
-#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_ALT */
+#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -124,7 +124,10 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
  * threading.c. Remember to update the code there when changing the conditions
  * here.
  */
+#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
+
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -24,6 +24,12 @@
 #ifndef MBEDTLS_THREADING_H
 #define MBEDTLS_THREADING_H
 
+/*
+ * Ensure gmtime_r is available even with -std=c99; must be included before
+ * config.h, which pulls in glibc's features.h. Harmless on other platforms.
+ */
+#define _POSIX_C_SOURCE 200112L
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "config.h"
 #else

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -108,7 +108,7 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
 #if defined(MBEDTLS_HAVE_TIME_DATE)
-#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+#if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
@@ -120,7 +120,7 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 #endif /* MBEDTLS_THREADING_C */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -114,7 +114,7 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
 /*
- * The preprocessor conditions above are the same as in platform_utils.c and
+ * The preprocessor conditions above are the same as in platform_util.c and
  * threading.c. Remember to update the code there when changing the conditions
  * here.
  */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -28,7 +28,9 @@
  * Ensure gmtime_r is available even with -std=c99; must be included before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
+#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
+#endif
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "config.h"

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -116,7 +116,7 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 /*
  * The preprocessor conditions above are the same as in platform_utils.c and
  * threading.c. Remember to update the code there when changing the conditions
- * here
+ * here.
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -108,10 +108,14 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
+
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
+
 #if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
        ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
          _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
@@ -124,8 +128,6 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
-#endif /* !_WIN32 && (unix || __unix || __unix__ ||
-        * (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 #endif /* MBEDTLS_THREADING_C */
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -99,6 +99,15 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
+#if defined(MBEDTLS_HAVE_TIME_DATE)
+#if !defined(_WIN32) && (defined(__unix__) || \
+    (defined(__APPLE__) && defined(__MACH__)))
+#include <unistd.h>
+#if !defined(_POSIX_VERSION)
+extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
+#endif /* !_POSIX_VERSION */
+#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+#endif /* MBEDTLS_HAVE_TIME_DATE */
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -24,14 +24,6 @@
 #ifndef MBEDTLS_THREADING_H
 #define MBEDTLS_THREADING_H
 
-/*
- * Ensure gmtime_r is available even with -std=c99; must be defined before
- * config.h, which pulls in glibc's features.h. Harmless on other platforms.
- */
-#if !defined(_POSIX_C_SOURCE)
-#define _POSIX_C_SOURCE 200112L
-#endif
-
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "config.h"
 #else
@@ -107,31 +99,17 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
+
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
-
-#if !defined(_WIN32) && (defined(unix) || \
-    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
-    defined(__MACH__)))
-#include <unistd.h>
-#endif /* !_WIN32 && (unix || __unix || __unix__ ||
-        * (__APPLE__ && __MACH__)) */
-
-#if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
-       ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
-/*
- * The preprocessor conditions above are the same as in platform_util.c and
- * threading.c. Remember to update the code there when changing the conditions
- * here.
- */
-#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
+/* This mutex may or may not be used in the default definition of
+ * mbedtls_platform_gmtime_r(), but in order to determine that,
+ * we need to check POSIX features, hence modify _POSIX_C_SOURCE.
+ * With the current approach, this declaration is orphaned, lacking
+ * an accompanying definition, in case mbedtls_platform_gmtime_r()
+ * doesn't need it, but that's not a problem. */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
-#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
-
-#endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
-             ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
+
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -107,7 +107,7 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 #if defined(MBEDTLS_FS_IO)
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
-#if defined(MBEDTLS_HAVE_TIME_DATE)
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
@@ -122,7 +122,7 @@ extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
-#endif /* MBEDTLS_HAVE_TIME_DATE */
+#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_ALT */
 #endif /* MBEDTLS_THREADING_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -103,9 +103,9 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #if !defined(_WIN32) && (defined(__unix__) || \
     (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
-#if !defined(_POSIX_VERSION)
+#if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
-#endif /* !_POSIX_VERSION */
+#endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 #endif /* MBEDTLS_THREADING_C */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -106,8 +106,9 @@ extern int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t *mutex );
 extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
 #endif
 #if defined(MBEDTLS_HAVE_TIME_DATE)
-#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
-    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
+    defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
 /*
@@ -117,7 +118,8 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 #endif /* MBEDTLS_THREADING_C */
 

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -112,14 +112,18 @@ extern mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex;
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
-#if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
+#if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+       ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
 /*
  * The preprocessor conditions above are the same as in platform_util.c and
  * threading.c. Remember to update the code there when changing the conditions
  * here.
  */
 extern mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex;
-#endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
+#endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+             ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -25,7 +25,7 @@
 #define MBEDTLS_THREADING_H
 
 /*
- * Ensure gmtime_r is available even with -std=c99; must be included before
+ * Ensure gmtime_r is available even with -std=c99; must be defined before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
 #if !defined(_POSIX_C_SOURCE)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -81,7 +81,10 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
-#if !defined(_POSIX_VERSION) || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS
+
+#if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+       ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
@@ -90,7 +93,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  * we keep it private by only defining it in this file
  */
 #define PLATFORM_UTIL_USE_GMTIME
-#endif /* !_POSIX_VERSION || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS */
+#endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+             ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -81,6 +81,8 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
 
 #if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
        ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
@@ -96,8 +98,6 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
-#endif /* !_WIN32 && (unix || __unix || __unix__ ||
-        * (__APPLE__ && __MACH__)) */
 
 struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -75,13 +75,20 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
 #include <time.h>
-#if !defined(_WIN32) && (defined(__unix__) || \
-    (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
+    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS
+/*
+ * This is a convenience shorthand macro to avoid checking the long
+ * preprocessor conditions above. Ideally, we could expose this macro in
+ * platform_utils.h and simply use it in platform_utils.c, threading.c and
+ * threading.h. However, this macro is not part of the Mbed TLS public API, so
+ * we keep it private by only definining it in this file
+ */
 #define PLATFORM_UTIL_USE_GMTIME
 #endif /* !_POSIX_VERSION || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
 
 struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
                                     struct tm *tm_buf )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -87,9 +87,9 @@ struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
                                     struct tm *tm_buf )
 {
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
-    return ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL;
+    return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
 #elif !defined(PLATFORM_UTIL_USE_GMTIME)
-    return gmtime_r( tt, tm_buf );
+    return( gmtime_r( tt, tm_buf ) );
 #else
     struct tm *lt;
 
@@ -110,7 +110,7 @@ struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
         return( NULL );
 #endif /* MBEDTLS_THREADING_C */
 
-    return ( lt == NULL ) ? NULL : tm_buf;
-#endif
+    return( ( lt == NULL ) ? NULL : tm_buf );
+#endif /* _WIN32 && !EFIX64 && !EFI32 */
 }
 #endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_ALT */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -85,7 +85,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
- * platform_utils.h and simply use it in platform_utils.c, threading.c and
+ * platform_util.h and simply use it in platform_util.c, threading.c and
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
  * we keep it private by only defining it in this file
  */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -75,7 +75,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
-#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
@@ -94,8 +94,8 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 
-struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
-                                    struct tm *tm_buf )
+struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
+                                      struct tm *tm_buf )
 {
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
     return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
@@ -124,4 +124,4 @@ struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
     return( ( lt == NULL ) ? NULL : tm_buf );
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 }
-#endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_ALT */
+#endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -75,8 +75,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
 #include <time.h>
-#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
-    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
+    defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS
 /*
@@ -88,7 +89,8 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  */
 #define PLATFORM_UTIL_USE_GMTIME
 #endif /* !_POSIX_VERSION || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
 
 struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
                                     struct tm *tm_buf )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  * preprocessor conditions above. Ideally, we could expose this macro in
  * platform_utils.h and simply use it in platform_utils.c, threading.c and
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
- * we keep it private by only definining it in this file
+ * we keep it private by only defining it in this file
  */
 #define PLATFORM_UTIL_USE_GMTIME
 #endif /* !_POSIX_VERSION || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,6 +88,8 @@ struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
 {
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
     return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
+#elif defined(__IAR_SYSTEMS_ICC__)
+    return( gmtime_s( tt, tm_buf ) );
 #elif !defined(PLATFORM_UTIL_USE_GMTIME)
     return( gmtime_r( tt, tm_buf ) );
 #else

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -94,7 +94,10 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
  * we keep it private by only defining it in this file
  */
+#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
 #define PLATFORM_UTIL_USE_GMTIME
+#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
+
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -77,7 +77,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
 #include <time.h>
-#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+#if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
@@ -91,7 +91,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
  */
 #define PLATFORM_UTIL_USE_GMTIME
 #endif /* !_POSIX_VERSION || _POSIX_C_SOURCE > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 
 struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
@@ -99,8 +99,6 @@ struct tm *mbedtls_platform_gmtime( const mbedtls_time_t *tt,
 {
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
     return( ( gmtime_s( tm_buf, tt ) == 0 ) ? tm_buf : NULL );
-#elif defined(__IAR_SYSTEMS_ICC__)
-    return( gmtime_s( tt, tm_buf ) );
 #elif !defined(PLATFORM_UTIL_USE_GMTIME)
     return( gmtime_r( tt, tm_buf ) );
 #else

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -24,7 +24,9 @@
  * Ensure gmtime_r is available even with -std=c99; must be included before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
+#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
+#endif
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -21,7 +21,7 @@
  */
 
 /*
- * Ensure gmtime_r is available even with -std=c99; must be included before
+ * Ensure gmtime_r is available even with -std=c99; must be defined before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
 #if !defined(_POSIX_C_SOURCE)

--- a/library/threading.c
+++ b/library/threading.c
@@ -23,7 +23,9 @@
  * Ensure gmtime_r is available even with -std=c99; must be included before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
+#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
+#endif
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/library/threading.c
+++ b/library/threading.c
@@ -38,10 +38,14 @@
 #include "mbedtls/threading.h"
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
+
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
+
 #if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
        ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
          _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
@@ -56,8 +60,7 @@
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
-#endif /* !_WIN32 && (unix || __unix || __unix__ ||
-        * (__APPLE__ && __MACH__)) */
+
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)

--- a/library/threading.c
+++ b/library/threading.c
@@ -42,7 +42,9 @@
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
-#if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
+#if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+       ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
@@ -51,7 +53,9 @@
  * we keep it private by only defining it in this file
  */
 #define THREADING_USE_GMTIME
-#endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
+#endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
+             ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */

--- a/library/threading.c
+++ b/library/threading.c
@@ -37,7 +37,7 @@
 
 #include "mbedtls/threading.h"
 
-#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+#if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
 #include <unistd.h>
@@ -51,7 +51,7 @@
  */
 #define THREADING_USE_GMTIME
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+#endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)

--- a/library/threading.c
+++ b/library/threading.c
@@ -29,6 +29,14 @@
 
 #include "mbedtls/threading.h"
 
+#if !defined(_WIN32) && (defined(__unix__) || \
+    (defined(__APPLE__) && defined(__MACH__)))
+#include <unistd.h>
+#if !defined(_POSIX_VERSION)
+#define MBEDTLS_THREADING_USE_GMTIME
+#endif /* !_POSIX_VERSION */
+#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )
 {
@@ -114,6 +122,9 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
 #endif
+#if defined(MBEDTLS_THREADING_USE_GMTIME)
+    mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
+#endif
 }
 
 /*
@@ -123,6 +134,9 @@ void mbedtls_threading_free_alt( void )
 {
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
+#endif
+#if defined(MBEDTLS_THREADING_USE_GMTIME)
+    mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
 #endif
 }
 #endif /* MBEDTLS_THREADING_ALT */
@@ -135,6 +149,9 @@ void mbedtls_threading_free_alt( void )
 #endif
 #if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
+#endif
+#if defined(MBEDTLS_THREADING_USE_GMTIME)
+mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
 #endif
 
 #endif /* MBEDTLS_THREADING_C */

--- a/library/threading.c
+++ b/library/threading.c
@@ -56,7 +56,11 @@
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
  * we keep it private by only defining it in this file
  */
+
+#if ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) )
 #define THREADING_USE_GMTIME
+#endif /* ! ( defined(_WIN32) && !defined(EFIX64) && !defined(EFI32) ) */
+
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */

--- a/library/threading.c
+++ b/library/threading.c
@@ -35,8 +35,9 @@
 
 #include "mbedtls/threading.h"
 
-#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
-    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && !defined(__IAR_SYSTEMS_ICC__) && (defined(unix) || \
+    defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
+    defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
 /*
@@ -48,7 +49,8 @@
  */
 #define THREADING_USE_GMTIME
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && !__IAR_SYSTEMS_ICC__ && (unix || __unix || __unix__ ||
+        * (__APPLE__ && __MACH__)) */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )

--- a/library/threading.c
+++ b/library/threading.c
@@ -32,9 +32,9 @@
 #if !defined(_WIN32) && (defined(__unix__) || \
     (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
-#if !defined(_POSIX_VERSION)
+#if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
 #define THREADING_USE_GMTIME
-#endif /* !_POSIX_VERSION */
+#endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)

--- a/library/threading.c
+++ b/library/threading.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Ensure gmtime_r is available even with -std=c99; must be included before
+ * Ensure gmtime_r is available even with -std=c99; must be defined before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
 #if !defined(_POSIX_C_SOURCE)

--- a/library/threading.c
+++ b/library/threading.c
@@ -37,7 +37,7 @@
 
 #include "mbedtls/threading.h"
 
-#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
@@ -54,7 +54,7 @@
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
-#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_ALT */
+#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )

--- a/library/threading.c
+++ b/library/threading.c
@@ -37,6 +37,7 @@
 
 #include "mbedtls/threading.h"
 
+#if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_ALT)
 #if !defined(_WIN32) && (defined(unix) || \
     defined(__unix) || defined(__unix__) || (defined(__APPLE__) && \
     defined(__MACH__)))
@@ -53,6 +54,7 @@
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
 #endif /* !_WIN32 && (unix || __unix || __unix__ ||
         * (__APPLE__ && __MACH__)) */
+#endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_ALT */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )

--- a/library/threading.c
+++ b/library/threading.c
@@ -33,7 +33,7 @@
     (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION)
-#define MBEDTLS_THREADING_USE_GMTIME
+#define THREADING_USE_GMTIME
 #endif /* !_POSIX_VERSION */
 #endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
 
@@ -122,7 +122,7 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_init( &mbedtls_threading_readdir_mutex );
 #endif
-#if defined(MBEDTLS_THREADING_USE_GMTIME)
+#if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_init( &mbedtls_threading_gmtime_mutex );
 #endif
 }
@@ -135,7 +135,7 @@ void mbedtls_threading_free_alt( void )
 #if defined(MBEDTLS_FS_IO)
     mbedtls_mutex_free( &mbedtls_threading_readdir_mutex );
 #endif
-#if defined(MBEDTLS_THREADING_USE_GMTIME)
+#if defined(THREADING_USE_GMTIME)
     mbedtls_mutex_free( &mbedtls_threading_gmtime_mutex );
 #endif
 }
@@ -150,7 +150,7 @@ void mbedtls_threading_free_alt( void )
 #if defined(MBEDTLS_FS_IO)
 mbedtls_threading_mutex_t mbedtls_threading_readdir_mutex MUTEX_INIT;
 #endif
-#if defined(MBEDTLS_THREADING_USE_GMTIME)
+#if defined(THREADING_USE_GMTIME)
 mbedtls_threading_mutex_t mbedtls_threading_gmtime_mutex MUTEX_INIT;
 #endif
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -19,6 +19,12 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+/*
+ * Ensure gmtime_r is available even with -std=c99; must be included before
+ * config.h, which pulls in glibc's features.h. Harmless on other platforms.
+ */
+#define _POSIX_C_SOURCE 200112L
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/library/threading.c
+++ b/library/threading.c
@@ -44,7 +44,7 @@
  * preprocessor conditions above. Ideally, we could expose this macro in
  * platform_utils.h and simply use it in platform_utils.c, threading.c and
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
- * we keep it private by only definining it in this file
+ * we keep it private by only defining it in this file
  */
 #define THREADING_USE_GMTIME
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */

--- a/library/threading.c
+++ b/library/threading.c
@@ -35,13 +35,20 @@
 
 #include "mbedtls/threading.h"
 
-#if !defined(_WIN32) && (defined(__unix__) || \
-    (defined(__APPLE__) && defined(__MACH__)))
+#if !defined(_WIN32) && (defined(unix) || defined(__unix) || \
+    defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION) || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS
+/*
+ * This is a convenience shorthand macro to avoid checking the long
+ * preprocessor conditions above. Ideally, we could expose this macro in
+ * platform_utils.h and simply use it in platform_utils.c, threading.c and
+ * threading.h. However, this macro is not part of the Mbed TLS public API, so
+ * we keep it private by only definining it in this file
+ */
 #define THREADING_USE_GMTIME
 #endif /* !_POSIX_VERSION || 200112L > _POSIX_THREAD_SAFE_FUNCTIONS */
-#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+#endif /* !_WIN32 && (unix || __unix || __unix__ || (__APPLE__ && __MACH__)) */
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 static void threading_mutex_init_pthread( mbedtls_threading_mutex_t *mutex )

--- a/library/threading.c
+++ b/library/threading.c
@@ -46,7 +46,7 @@
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
- * platform_utils.h and simply use it in platform_utils.c, threading.c and
+ * platform_util.h and simply use it in platform_util.c, threading.c and
  * threading.h. However, this macro is not part of the Mbed TLS public API, so
  * we keep it private by only defining it in this file
  */

--- a/library/x509.c
+++ b/library/x509.c
@@ -898,7 +898,7 @@ static int x509_get_current_time( mbedtls_x509_time *now )
     int ret = 0;
 
     tt = mbedtls_time( NULL );
-    lt = mbedtls_platform_gmtime( &tt, &tm_buf );
+    lt = mbedtls_platform_gmtime_r( &tt, &tm_buf );
 
     if( lt == NULL )
         ret = -1;

--- a/library/x509.c
+++ b/library/x509.c
@@ -894,7 +894,7 @@ int mbedtls_x509_key_size_helper( char *buf, size_t buf_size, const char *name )
     (defined(__APPLE__) && defined(__MACH__)))
 #include <unistd.h>
 #if !defined(_POSIX_VERSION)
-#define MBEDTLS_X509_USE_GMTIME
+#define X509_USE_GMTIME
 #endif /* !_POSIX_VERSION */
 #endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
 
@@ -910,10 +910,10 @@ static int x509_get_current_time( mbedtls_x509_time *now )
 
     (void)tm_buf;
 
-#if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_X509_USE_GMTIME)
+#if defined(MBEDTLS_THREADING_C) && defined(X509_USE_GMTIME)
     if( mbedtls_mutex_lock( &mbedtls_threading_gmtime_mutex ) != 0 )
         return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-#endif /* MBEDTLS_THREADING_C && MBEDTLS_X509_USE_GMTIME */
+#endif /* MBEDTLS_THREADING_C && X509_USE_GMTIME */
 
     tt = mbedtls_time( NULL );
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
@@ -936,10 +936,10 @@ static int x509_get_current_time( mbedtls_x509_time *now )
         now->sec  = lt->tm_sec;
     }
 
-#if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_X509_USE_GMTIME)
+#if defined(MBEDTLS_THREADING_C) && defined(X509_USE_GMTIME)
     if( mbedtls_mutex_unlock( &mbedtls_threading_gmtime_mutex ) != 0 )
         return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
-#endif /* MBEDTLS_THREADING_C && MBEDTLS_X509_USE_GMTIME */
+#endif /* MBEDTLS_THREADING_C && X509_USE_GMTIME */
 
     return( ret );
 }

--- a/library/x509.c
+++ b/library/x509.c
@@ -890,6 +890,14 @@ int mbedtls_x509_key_size_helper( char *buf, size_t buf_size, const char *name )
 }
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
+#if !defined(_WIN32) && (defined(__unix__) || \
+    (defined(__APPLE__) && defined(__MACH__)))
+#include <unistd.h>
+#if !defined(_POSIX_VERSION)
+#define MBEDTLS_X509_USE_GMTIME
+#endif /* !_POSIX_VERSION */
+#endif /* !_WIN32 && (__unix__ || (__APPLE__ && __MACH__)) */
+
 /*
  * Set the time structure to the current time.
  * Return 0 on success, non-zero on failure.
@@ -900,11 +908,20 @@ static int x509_get_current_time( mbedtls_x509_time *now )
     mbedtls_time_t tt;
     int ret = 0;
 
+    (void)tm_buf;
+
+#if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_X509_USE_GMTIME)
+    if( mbedtls_mutex_lock( &mbedtls_threading_gmtime_mutex ) != 0 )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+#endif /* MBEDTLS_THREADING_C && MBEDTLS_X509_USE_GMTIME */
+
     tt = mbedtls_time( NULL );
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
     lt = gmtime_s( &tm_buf, &tt ) == 0 ? &tm_buf : NULL;
-#else
+#elif defined(_POSIX_VERSION)
     lt = gmtime_r( &tt, &tm_buf );
+#else
+    lt = gmtime( &tt );
 #endif
 
     if( lt == NULL )
@@ -918,6 +935,11 @@ static int x509_get_current_time( mbedtls_x509_time *now )
         now->min  = lt->tm_min;
         now->sec  = lt->tm_sec;
     }
+
+#if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_X509_USE_GMTIME)
+    if( mbedtls_mutex_unlock( &mbedtls_threading_gmtime_mutex ) != 0 )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+#endif /* MBEDTLS_THREADING_C && MBEDTLS_X509_USE_GMTIME */
 
     return( ret );
 }

--- a/library/x509.c
+++ b/library/x509.c
@@ -897,8 +897,6 @@ static int x509_get_current_time( mbedtls_x509_time *now )
     mbedtls_time_t tt;
     int ret = 0;
 
-    (void)tm_buf;
-
     tt = mbedtls_time( NULL );
     lt = mbedtls_platform_gmtime( &tt, &tm_buf );
 


### PR DESCRIPTION
## Description
This patch is a first attempt at fixing https://github.com/ARMmbed/mbedtls/issues/1907. The build failure is caused by https://github.com/ARMmbed/mbedtls/pull/1198, which replaces the use of gmtime() with gmtime_r() (POSIX) and gmtime_s() (Windows). However, Mbed TLS is also used on platforms which are neither Windows nor POSIX, such as some targets in Mbed OS that only have gmtime().

The idea in this patch is to keep the majority of the changes from https://github.com/ARMmbed/mbedtls/pull/1198, but to fall back to using gmtime() if the target platform is neither POSIX nor Windows. Unfortunately, the code becomes slightly convoluted because we also need to use a mutex as gmtime() is not thread-safe and it is not particularly straight forward to check at compile-time if the target platform is POSIX.

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO