### PR TITLE
Fix Wformat-overflow warning in ssl_mail_client.c

### DIFF
--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -356,9 +356,15 @@ int main( int argc, char *argv[] )
     int ret = 1, len;
     int exit_code = MBEDTLS_EXIT_FAILURE;
     mbedtls_net_context server_fd;
-    unsigned char buf[1024];
 #if defined(MBEDTLS_BASE64_C)
     unsigned char base[1024];
+    /* buf is used as the destination buffer for printing base with the format:
+     * "%s\r\n". Hence, the size of buf should be at least the size of base
+     * plus 2 bytes for the \r and \n characters.
+     */
+    unsigned char buf[sizeof( base ) + 2];
+#else
+    unsigned char buf[1024];
 #endif
     char hostname[32];
     const char *pers = "ssl_mail_client";


### PR DESCRIPTION
## Description
sprintf( (char *) buf, "%s\r\n", base );
 Above code generates Wformat-overflow warning since both buf and base
are of same size. buf should be sizeof( base ) + characters added in
the format. In this case format adds 2 bytes for "\r\n".


## Status
**READY**

## Requires Backporting
Yes

Which branch?
development

## Steps to test or reproduce
mingw32 build produces this warning.
