### PR TITLE
Backport 2.1: Reset session in/out pointers in mbedtls_ssl_session_reset()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
+   * Fix potential use-after-free in mbedtls_ssl_get_max_frag_len()
+     and mbedtls_ssl_get_record_expansion() after a session reset. Fixes #1941.
 
 = mbed TLS 2.1.14 branch released 2018-07-25
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5737,6 +5737,9 @@ static int ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl->transform_in = NULL;
     ssl->transform_out = NULL;
 
+    ssl->session_in = NULL;
+    ssl->session_out = NULL;
+
     memset( ssl->out_buf, 0, MBEDTLS_SSL_BUFFER_LEN );
     if( partial == 0 )
         memset( ssl->in_buf, 0, MBEDTLS_SSL_BUFFER_LEN );
@@ -6451,13 +6454,13 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
     size_t transform_expansion;
     const mbedtls_ssl_transform *transform = ssl->transform_out;
 
+    if( transform == NULL )
+        return( (int) mbedtls_ssl_hdr_len( ssl ) );
+
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->session_out->compression != MBEDTLS_SSL_COMPRESS_NULL )
         return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
 #endif
-
-    if( transform == NULL )
-        return( (int) mbedtls_ssl_hdr_len( ssl ) );
 
     switch( mbedtls_cipher_get_cipher_mode( &transform->cipher_ctx_enc ) )
     {


### PR DESCRIPTION
Backport of #1942 to Mbed TLS 2.1, fixing #1941.