### PR TITLE
Backport 2.1: Make mbedtls_ssl_send_alert_message() reentrant

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,10 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
+   * Fix bug in the alert sending function mbedtls_ssl_send_alert_message()
+     potentially leading to corrupted alert messages being sent in case
+     the function needs to be re-called after initially returning
+     MBEDTLS_SSL_WANT_WRITE.
 
 = mbed TLS 2.1.14 branch released 2018-07-25
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4245,6 +4245,9 @@ int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
     if( ssl == NULL || ssl->conf == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
+    if( ssl->out_left != 0 )
+        return( mbedtls_ssl_flush_output( ssl ) );
+
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> send alert message" ) );
 
     ssl->out_msgtype = MBEDTLS_SSL_MSG_ALERT;
@@ -7159,9 +7162,6 @@ int mbedtls_ssl_close_notify( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write close notify" ) );
-
-    if( ssl->out_left != 0 )
-        return( mbedtls_ssl_flush_output( ssl ) );
 
     if( ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER )
     {


### PR DESCRIPTION
Backport of #1946 to Mbed TLS 2.1, fixing #1916.

__Internal Reference:__ IOTSSL-2464