### PR TITLE
Backport 2.7: Fix bounds check in ssl_parse_certificate_request()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
+   * Fix overly strict bounds check in ssl_parse_certificate_request()
+     which could lead to valid CertificateRequest messages being rejected.
+     Fixes #1954.
 
 Changes
    * Improve compatibility with some alternative CCM implementations by using

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,9 +10,11 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
-   * Fix overly strict bounds check in ssl_parse_certificate_request()
-     which could lead to valid CertificateRequest messages being rejected.
-     Fixes #1954.
+   * Fix a bug that caused SSL/TLS clients to incorrectly abort the handshake
+     with TLS versions 1.1 and earlier when the server requested authentication
+     without providing a list of CAs. This was due to an overly strict bounds
+     check in parsing the CertificateRequest message,
+     introduced in Mbed TLS 2.12.0. Fixes #1954.
 
 Changes
    * Improve compatibility with some alternative CCM implementations by using

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2725,7 +2725,7 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
      * therefore the buffer length at this point must be greater than that
      * regardless of the actual code path.
      */
-    if( ssl->in_hslen <= mbedtls_ssl_hs_hdr_len( ssl ) + 3 + n )
+    if( ssl->in_hslen <= mbedtls_ssl_hs_hdr_len( ssl ) + 2 + n )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate request message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -782,6 +782,22 @@ run_test    "RC4: both enabled" \
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - The server has no ciphersuites in common"
 
+# Test empty CA list in CertificateRequest in TLS 1.1 and earlier
+
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_1
+run_test    "CertificateRequest with empty CA list, TLS 1.1 (GnuTLS server)" \
+            "$G_SRV"\
+            "$P_CLI force_version=tls1_1" \
+            0
+
+requires_gnutls
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1
+run_test    "CertificateRequest with empty CA list, TLS 1.0 (GnuTLS server)" \
+            "$G_SRV"\
+            "$P_CLI force_version=tls1" \
+            0
+
 # Tests for SHA-1 support
 
 requires_config_disabled MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES


### PR DESCRIPTION
Backport of #1955 to Mbed TLS 2.7, fixing #1954.