### PR TITLE
Backport 2.7: Fix miscalculations of maximum record expansion in mbedtls_ssl_get_record_expansion()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
+   * Fix a miscalculation of the maximum record expansion in
+     mbedtls_ssl_get_record_expansion() in case of CBC ciphersuites
+     in (D)TLS versions 1.1 or higher. Fixes #1914.
 
 Changes
    * Improve compatibility with some alternative CCM implementations by using

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6684,7 +6684,7 @@ const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl )
 
 int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
 {
-    size_t transform_expansion;
+    size_t transform_expansion = 0;
     const mbedtls_ssl_transform *transform = ssl->transform_out;
     unsigned block_size;
 
@@ -6709,23 +6709,21 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
             block_size = mbedtls_cipher_get_block_size(
                 &transform->cipher_ctx_enc );
 
+            /* Expansion due to the addition of the MAC. */
+            transform_expansion += transform->maclen;
+
+            /* Expansion due to the addition of CBC padding;
+             * Theoretically up to 256 bytes, but we never use
+             * more than the block size of the underlying cipher. */
+            transform_expansion += block_size;
+
+            /* For TLS 1.1 or higher, an explicit IV is added
+             * after the record header. */
 #if defined(MBEDTLS_SSL_PROTO_TLS1_1) || defined(MBEDTLS_SSL_PROTO_TLS1_2)
             if( ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_2 )
-            {
-                /* Expansion due to addition of
-                 * - MAC
-                 * - CBC padding (theoretically up to 256 bytes, but
-                 *                we never use more than block_size)
-                 * - explicit IV
-                 */
-                transform_expansion = transform->maclen + 2 * block_size;
-            }
-            else
+                transform_expansion += block_size;
 #endif /* MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1_2 */
-            {
-                /* No explicit IV prior to TLS 1.1. */
-                transform_expansion = transform->maclen + block_size;
-            }
+
             break;
 
         default:

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6686,6 +6686,7 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
 {
     size_t transform_expansion;
     const mbedtls_ssl_transform *transform = ssl->transform_out;
+    unsigned block_size;
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->session_out->compression != MBEDTLS_SSL_COMPRESS_NULL )
@@ -6704,8 +6705,27 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl )
             break;
 
         case MBEDTLS_MODE_CBC:
-            transform_expansion = transform->maclen
-                      + mbedtls_cipher_get_block_size( &transform->cipher_ctx_enc );
+
+            block_size = mbedtls_cipher_get_block_size(
+                &transform->cipher_ctx_enc );
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_1) || defined(MBEDTLS_SSL_PROTO_TLS1_2)
+            if( ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_2 )
+            {
+                /* Expansion due to addition of
+                 * - MAC
+                 * - CBC padding (theoretically up to 256 bytes, but
+                 *                we never use more than block_size)
+                 * - explicit IV
+                 */
+                transform_expansion = transform->maclen + 2 * block_size;
+            }
+            else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_1 || MBEDTLS_SSL_PROTO_TLS1_2 */
+            {
+                /* No explicit IV prior to TLS 1.1. */
+                transform_expansion = transform->maclen + block_size;
+            }
             break;
 
         default:


### PR DESCRIPTION
This is the backport of #1915 to Mbed TLS 2.7, fixing #1914.