### PR TITLE
Enhance nist_kw with some NULL buffers tests

### DIFF
--- a/tests/suites/test_suite_nist_kw.data
+++ b/tests/suites/test_suite_nist_kw.data
@@ -69,6 +69,27 @@ nist_kw_ciphertext_lengths:32:16:MBEDTLS_KW_MODE_KW:MBEDTLS_ERR_CIPHER_BAD_INPUT
 NIST KW lengths #16 KWP unwrapping output buffer too short
 nist_kw_ciphertext_lengths:24:12:MBEDTLS_KW_MODE_KWP:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
+NIST KW lengths #17 KW plaintext NULL (2 to 2^54 - 1 semiblocks)
+nist_kw_plaintext_lengths:0:8:MBEDTLS_KW_MODE_KW:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #18 KW wrapping output NULL
+nist_kw_plaintext_lengths:8:0:MBEDTLS_KW_MODE_KW:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #19 KWP wrapping output NULL
+nist_kw_plaintext_lengths:8:0:MBEDTLS_KW_MODE_KWP:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #20 KW ciphertext NULL
+nist_kw_ciphertext_lengths:0:8:MBEDTLS_KW_MODE_KW:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #21 KWP ciphertext NULL
+nist_kw_ciphertext_lengths:0:8:MBEDTLS_KW_MODE_KWP:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #15 KW unwrapping output NULL
+nist_kw_ciphertext_lengths:32:0:MBEDTLS_KW_MODE_KW:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
+NIST KW lengths #16 KWP unwrapping output NULL
+nist_kw_ciphertext_lengths:24:0:MBEDTLS_KW_MODE_KWP:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+
 NIST KW wrap AES-128 CAVS 17.4 PLAINTEXT LENGTH = 128 count 7
 depends_on:MBEDTLS_AES_C
 mbedtls_nist_kw_wrap:MBEDTLS_CIPHER_ID_AES:MBEDTLS_KW_MODE_KW:"095e293f31e317ba6861114b95c90792":"64349d506ae85ecd84459c7a5c423f55":"97de4425572274bd7fb2d6688d5afd4454d992348d42a643"

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -167,7 +167,7 @@ void nist_kw_plaintext_lengths( int in_len, int out_len, int mode, int res )
     if( out_len != 0 )
     {
         ciphertext = mbedtls_calloc( 1, output_len );
-    TEST_ASSERT( ciphertext != NULL );
+        TEST_ASSERT( ciphertext != NULL );
     }
 
     memset( plaintext, 0, in_len );

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -161,14 +161,14 @@ void nist_kw_plaintext_lengths( int in_len, int out_len, int mode, int res )
     if( in_len != 0 )
     {
         plaintext = mbedtls_calloc( 1, in_len );
+        TEST_ASSERT( plaintext != NULL );
     }
-    TEST_ASSERT( in_len == 0 || plaintext != NULL );
 
     if( out_len != 0 )
     {
         ciphertext = mbedtls_calloc( 1, output_len );
+    TEST_ASSERT( ciphertext != NULL );
     }
-    TEST_ASSERT( out_len == 0 || ciphertext != NULL );
 
     memset( plaintext, 0, in_len );
     memset( ciphertext, 0, output_len );
@@ -217,13 +217,13 @@ void nist_kw_ciphertext_lengths( int in_len, int out_len, int mode, int res )
     if( out_len != 0 )
     {
         plaintext = mbedtls_calloc( 1, output_len );
+        TEST_ASSERT( plaintext != NULL );
     }
-    TEST_ASSERT( out_len == 0 || plaintext != NULL );
     if( in_len != 0 )
     {
         ciphertext = mbedtls_calloc( 1, in_len );
+        TEST_ASSERT( ciphertext != NULL );
     }
-    TEST_ASSERT( in_len == 0 || ciphertext != NULL );
 
     memset( plaintext, 0, output_len );
     memset( ciphertext, 0, in_len );

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -158,19 +158,17 @@ void nist_kw_plaintext_lengths( int in_len, int out_len, int mode, int res )
 
     memset( key, 0, sizeof( key ) );
 
-    if (in_len == 0)
-    {
-        /* mbedtls_calloc can return NULL for zero-length buffers. Make sure we
-         * always have a plaintext buffer, even if the length is 0. */
-        plaintext = mbedtls_calloc( 1, 1 );
-    }
-    else
+    if( in_len != 0 )
     {
         plaintext = mbedtls_calloc( 1, in_len );
     }
-    TEST_ASSERT( plaintext != NULL );
-    ciphertext = mbedtls_calloc( 1, output_len );
-    TEST_ASSERT( ciphertext != NULL );
+    TEST_ASSERT( in_len == 0 || plaintext != NULL );
+
+    if( out_len != 0 )
+    {
+        ciphertext = mbedtls_calloc( 1, output_len );
+    }
+    TEST_ASSERT( out_len == 0 || ciphertext != NULL );
 
     memset( plaintext, 0, in_len );
     memset( ciphertext, 0, output_len );
@@ -216,10 +214,16 @@ void nist_kw_ciphertext_lengths( int in_len, int out_len, int mode, int res )
 
     memset( key, 0, sizeof( key ) );
 
-    plaintext = mbedtls_calloc( 1, output_len );
-    TEST_ASSERT( plaintext != NULL );
-    ciphertext = mbedtls_calloc( 1, in_len );
-    TEST_ASSERT( ciphertext != NULL );
+    if( out_len != 0 )
+    {
+        plaintext = mbedtls_calloc( 1, output_len );
+    }
+    TEST_ASSERT( out_len == 0 || plaintext != NULL );
+    if( in_len != 0 )
+    {
+        ciphertext = mbedtls_calloc( 1, in_len );
+    }
+    TEST_ASSERT( in_len == 0 || ciphertext != NULL );
 
     memset( plaintext, 0, output_len );
     memset( ciphertext, 0, in_len );


### PR DESCRIPTION
## Description
Enhance the nist_kw test suite, with setting zero length input\output
buffers. Resolves #1882.
Increasing test coverage, by testing NULL pointers with zero length

## Status
**READY**

## Requires Backporting

 NO  


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
