### PR TITLE
Remove redundant `else` statement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@ Bugfix
    * Add ecc extensions only if an ecc based ciphersuite is used.
      This improves compliance to RFC 4492, and as a result, solves
      interoperability issues with BouncyCastle. Raised by milenamil in #1157.
+   * Remove redundant else statement, which is not readable, and the positive
+     path in the if statement results in exiting the funciton. Raised by irwir
+     in #1776.
 
 Changes
    * Copy headers preserving timestamps when doing a "make install".

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1897,7 +1897,6 @@ int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp, const mbedtls_mpi *
             mbedtls_mpi_get_bit( d, 1 ) != 0 ||
             mbedtls_mpi_bitlen( d ) - 1 != grp->nbits ) /* mbedtls_mpi_bitlen is one-based! */
             return( MBEDTLS_ERR_ECP_INVALID_KEY );
-        else
 
         /* see [Curve25519] page 5 */
         if( grp->nbits == 254 && mbedtls_mpi_get_bit( d, 2 ) != 0 )


### PR DESCRIPTION
## Description
Remove `else` statement, as it is redundant. resolves #1776


## Status
**READY**

## Requires Backporting

No
~~~Yes~~~
~~~Although it is a trivial fix, I would backport it.~~~

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


