### PR TITLE
ssl-opt.sh: Preserve proxy log if --preserve-logs is specified

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -632,6 +632,9 @@ run_test() {
     if [ "$PRESERVE_LOGS" -gt 0 ]; then
         mv $SRV_OUT o-srv-${TESTS}.log
         mv $CLI_OUT o-cli-${TESTS}.log
+        if [ -n "$PXY_CMD" ]; then
+            mv $PXY_OUT o-pxy-${TESTS}.log
+        fi
     fi
 
     rm -f $SRV_OUT $CLI_OUT $PXY_OUT


### PR DESCRIPTION
__Summary:__ `ssl-opt.sh` allows the option `--preserve-logs` to keep log files on test successes. However, the option currently only applies to the client and server logs, but not to the UDP proxy log.  This PR adapts `ssl-opt.sh` to also keep the proxy log if `--preserve-logs` is specified.