### PR TITLE
Add limits.h inclusion to ssl_tls.c and udp_proxy.c

### DIFF
--- a/3rdparty/everest/library/Hacl_Curve25519_joined.c
+++ b/3rdparty/everest/library/Hacl_Curve25519_joined.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED)
 

--- a/3rdparty/everest/library/everest.c
+++ b/3rdparty/everest/library/everest.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #include <string.h>
 

--- a/3rdparty/everest/library/x25519.c
+++ b/3rdparty/everest/library/x25519.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECDH_C) && defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,9 @@ Bugfix
      a warning with some compilers. Fix contributed by irwir in #2856.
    * Fix a function name in a debug message. Contributed by Ercan Ozturk in
      #3013.
+   * Add missing limits.h standard C library header to ssl_tls.c and udp_proxy.c
+     which was only including it via check_config.h previously, which may not be
+     included in custom configuration files. Fixes #1803
 
 Changes
    * Mbed Crypto is no longer a Git submodule. The crypto part of the library

--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -83,6 +83,4 @@
  */
 #define MBEDTLS_SSL_MAX_CONTENT_LEN             1024
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-mini-tls1_1.h
+++ b/configs/config-mini-tls1_1.h
@@ -73,6 +73,4 @@
 /* For testing with compat.sh */
 #define MBEDTLS_FS_IO
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -87,6 +87,4 @@
 /* Miscellaneous options */
 #define MBEDTLS_AES_ROM_TABLES
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -112,6 +112,4 @@
  */
 #define MBEDTLS_SSL_MAX_CONTENT_LEN             1024
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -89,6 +89,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3688,6 +3688,4 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_H */

--- a/library/aes.c
+++ b/library/aes.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_AES_C)
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_AESNI_C)
 

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ARC4_C)
 

--- a/library/aria.c
+++ b/library/aria.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ARIA_C)
 

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ASN1_WRITE_C)
 

--- a/library/base64.c
+++ b/library/base64.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_BASE64_C)
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -40,6 +40,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_BIGNUM_C)
 

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_BLOWFISH_C)
 

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CAMELLIA_C)
 

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -33,6 +33,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CCM_C)
 

--- a/library/certs.c
+++ b/library/certs.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #include "mbedtls/certs.h"
 

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CHACHA20_C)
 

--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -25,6 +25,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CHACHAPOLY_C)
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CIPHER_C)
 

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CIPHER_C)
 

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -45,6 +45,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CMAC_C)
 

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_CTR_DRBG_C)
 

--- a/library/debug.c
+++ b/library/debug.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_DEBUG_C)
 

--- a/library/des.c
+++ b/library/des.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_DES_C)
 

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -32,6 +32,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_DHM_C)
 

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -31,6 +31,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECDH_C)
 

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECDSA_C)
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECJPAKE_C)
 

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -46,6 +46,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 /**
  * \brief Function level alternative implementation.

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ECP_C)
 

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ENTROPY_C)
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #include <string.h>
 

--- a/library/error.c
+++ b/library/error.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
 #include <string.h>

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_GCM_C)
 

--- a/library/havege.c
+++ b/library/havege.c
@@ -31,6 +31,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_HAVEGE_C)
 

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -23,6 +23,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_HKDF_C)
 

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_HMAC_DRBG_C)
 

--- a/library/md.c
+++ b/library/md.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_MD_C)
 

--- a/library/md2.c
+++ b/library/md2.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_MD2_C)
 

--- a/library/md4.c
+++ b/library/md4.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_MD4_C)
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_MD5_C)
 

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #include "mbedtls/memory_buffer_alloc.h"

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_NET_C)
 

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_NIST_KW_C)
 

--- a/library/oid.c
+++ b/library/oid.c
@@ -26,6 +26,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_OID_C)
 

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PADLOCK_C)
 

--- a/library/pem.c
+++ b/library/pem.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PK_C)
 #include "mbedtls/pk.h"

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PK_C)
 #include "mbedtls/pk_internal.h"

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -22,10 +22,15 @@
  *
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
-
-#include "mbedtls/pkcs11.h"
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PKCS11_C)
+#include "mbedtls/pkcs11.h"
 
 #include "mbedtls/md.h"
 #include "mbedtls/oid.h"

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PKCS12_C)
 

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PKCS5_C)
 

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PK_PARSE_C)
 

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PK_WRITE_C)
 

--- a/library/platform.c
+++ b/library/platform.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -33,6 +33,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #include "mbedtls/platform_util.h"
 #include "mbedtls/platform.h"

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -25,6 +25,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_POLY1305_C)
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 

--- a/library/psa_crypto_se.c
+++ b/library/psa_crypto_se.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -24,6 +24,7 @@
 #else
 #include "mbedtls/config.h"
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -24,6 +24,7 @@
 #else
 #include "mbedtls/config.h"
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_PSA_ITS_FILE_C)
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_RIPEMD160_C)
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -42,6 +42,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_RSA_C)
 

--- a/library/rsa_internal.c
+++ b/library/rsa_internal.c
@@ -25,6 +25,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_RSA_C)
 

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SHA1_C)
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SHA256_C)
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SHA512_C)
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_CACHE_C)
 

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -26,6 +26,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_TLS_C)
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_CLI_C)
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -28,6 +28,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_COOKIE_C)
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -51,6 +51,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/version.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_SRV_C)
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_TICKET_C)
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -50,6 +50,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/version.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -32,6 +32,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SSL_TLS_C)
 

--- a/library/threading.c
+++ b/library/threading.c
@@ -32,6 +32,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_THREADING_C)
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/library/version.c
+++ b/library/version.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_USE_C)
 

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CREATE_C)
 

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CRL_PARSE_C)
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -36,6 +36,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -34,6 +34,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CSR_PARSE_C)
 

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -30,6 +30,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CRT_WRITE_C)
 

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -29,6 +29,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_X509_CSR_WRITE_C)
 

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_XTEA_C)
 

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -1,5 +1,6 @@
 #include "common.h"
 #include <stdio.h>
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include "mbedtls/ctr_drbg.h"

--- a/programs/test/cpp_dummy_build.cpp
+++ b/programs/test/cpp_dummy_build.cpp
@@ -25,6 +25,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #include "mbedtls/aes.h"
 #include "mbedtls/aesni.h"
@@ -41,7 +42,6 @@
 #include "mbedtls/certs.h"
 #include "mbedtls/chacha20.h"
 #include "mbedtls/chachapoly.h"
-#include "mbedtls/check_config.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/cipher_internal.h"
 #include "mbedtls/cmac.h"

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -60,6 +60,7 @@ int main( void )
 #include "mbedtls/ssl.h"
 #include "mbedtls/timing.h"
 
+#include <limits.h>
 #include <string.h>
 
 /* For select() */

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
 #include <string.h>

--- a/scripts/data_files/version_features.fmt
+++ b/scripts/data_files/version_features.fmt
@@ -24,6 +24,7 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+#include "mbedtls/check_config.h"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1,6 +1,8 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ecp.h"
 
+#include <limits.h>
+
 #define ECP_PF_UNKNOWN     -1
 
 #define ECP_PT_RESET( x )           \

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1,5 +1,6 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
+#include <limits.h>
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/asn1write.h"

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal_mocks.function
@@ -1,4 +1,6 @@
 /* BEGIN_HEADER */
+#include <limits.h>
+
 #include "psa_crypto_helpers.h"
 #include "psa/crypto_se_driver.h"
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -7,6 +7,8 @@
 #include <mbedtls/timing.h>
 #include <mbedtls/debug.h>
 
+#include <limits.h>
+
 typedef struct log_pattern
 {
     const char *pattern;


### PR DESCRIPTION
## Description
The standard C library header limits.h was only being included by `check_config.h` so was being missing if users provided their own config.h that didn't include `check_config.h`.

This fixes #1803.

## Status
**READY**

## Requires Backporting
Yes
Which branch?
[edited by mpg] `mbedtls-2.16` and `mbedtls-2.7`
[quoting redtangent] I've provided backports with PR #2445 and PR #2446 to `mbedtls-2.16` and `mbedtls-2.7`.

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Backported
