### PR TITLE
Add pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,3 +215,9 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DartConfiguration.tcl
                    ${CMAKE_CURRENT_BINARY_DIR}/DartConfiguration.tcl COPYONLY)
 endif()
+
+# Install hint file for programs using pkg-config
+set(PKGCONFIGDIR "${LIB_INSTALL_DIR}/pkgconfig")
+
+configure_file(mbedtls.pc.in mbedtls.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mbedtls.pc" DESTINATION "${PKGCONFIGDIR}")

--- a/mbedtls.pc.in
+++ b/mbedtls.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: mbedtls
+Description: mbed TLS open source SSL libary
+Version: 2.12.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmbedtls -lmbedx509 -lmbedcrypto

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -72,6 +72,10 @@ fi
 sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < library/CMakeLists.txt > tmp
 mv tmp library/CMakeLists.txt
 
+[ $VERBOSE ] && echo "Bumping VERSION in mbedtls.pc.in"
+sed -e "s/Version: [0-9.]\{1,\}/Version: $VERSION/g" < mbedtls.pc.in > tmp
+mv tmp mbedtls.pc.in
+
 if [ "X" != "X$SO_CRYPTO" ];
 then
   [ $VERBOSE ] && echo "Bumping SOVERSION for libmbedcrypto in library/CMakeLists.txt"


### PR DESCRIPTION
pkg-config is a well-known method on Unix systems to find library
headers and linker parameters to link against a library.

So to make it easier for programs to use/link against mbedtls,
provide such a hint file.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
