### PR TITLE
Fix fragility issues in all.sh

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -664,7 +664,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = ..
+INPUT                  = ../include input
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -696,7 +696,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../configs ../yotta/module
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -105,7 +105,7 @@ $(BINARIES): %$(EXEXT): %.c $(DEP)
 
 clean:
 ifndef WINDOWS
-	rm -rf $(APPS) *.c *.datax TESTS
+	rm -rf $(BINARIES) *.c *.datax TESTS
 else
 	del /Q /F *.c *.exe *.datax
 ifneq ($(wildcard TESTS/.*),)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -531,10 +531,10 @@ msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
 
 msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-tests/ssl-opt.sh -f RSA
+if_build_succeeded tests/ssl-opt.sh -f RSA
 
 msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-tests/compat.sh -t RSA
+if_build_succeeded tests/compat.sh -t RSA
 
 msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -436,25 +436,25 @@ OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
     ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
 
 msg "test: recursion.pl" # < 1s
-tests/scripts/recursion.pl library/*.c
+record_status tests/scripts/recursion.pl library/*.c
 
 msg "test: freshness of generated source files" # < 1s
-tests/scripts/check-generated-files.sh
+record_status tests/scripts/check-generated-files.sh
 
 msg "test: doxygen markup outside doxygen blocks" # < 1s
-tests/scripts/check-doxy-blocks.pl
+record_status tests/scripts/check-doxy-blocks.pl
 
 msg "test: check-files.py" # < 1s
 cleanup
-tests/scripts/check-files.py
+record_status tests/scripts/check-files.py
 
 msg "test/build: declared and exported names" # < 3s
 cleanup
-tests/scripts/check-names.sh
+record_status tests/scripts/check-names.sh
 
 msg "test: doxygen warnings" # ~ 3s
 cleanup
-tests/scripts/doxygen.sh
+record_status tests/scripts/doxygen.sh
 
 
 
@@ -1071,10 +1071,10 @@ for optimization_flag in -O2 -O3 -Ofast -Os; do
 done
 
 msg "Lint: Python scripts"
-tests/scripts/check-python-files.sh
+record_status tests/scripts/check-python-files.sh
 
 msg "uint test: generate_test_code.py"
-./tests/scripts/test_generate_test_code.py
+record_status ./tests/scripts/test_generate_test_code.py
 
 ################################################################
 #### Termination

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1063,7 +1063,6 @@ for optimization_flag in -O2 -O3 -Ofast -Os; do
         cleanup
         make programs CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag"
         if_build_succeeded gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx 2>&1 | tee test_zeroize.log
-        if_build_succeeded [ -s test_zeroize.log ]
         if_build_succeeded grep "The buffer was correctly zeroized" test_zeroize.log
         if_build_succeeded not grep -i "error" test_zeroize.log
         rm -f test_zeroize.log

--- a/tests/scripts/check-files.py
+++ b/tests/scripts/check-files.py
@@ -159,7 +159,6 @@ class IntegrityChecker(object):
         self.excluded_paths = list(map(os.path.normpath, [
             'cov-int',
             'examples',
-            'yotta/module'
         ]))
         self.issues_to_check = [
             PermissionIssueTracker(),

--- a/tests/scripts/test_zeroize.gdb
+++ b/tests/scripts/test_zeroize.gdb
@@ -41,6 +41,9 @@
 # number does not need to be updated often.
 
 set confirm off
+# We don't need to turn off ASLR, so don't try.
+set disable-randomization off
+
 file ./programs/test/zeroize
 break zeroize.c:100
 


### PR DESCRIPTION
Fix some issues that don't break `all.sh` on a pristine checkout, but make it fragile in a tree where you've been doing development.

* Fix `make WINDOWS_BUILD=1 clean` on non-Windows hosts.
* In keep-going mode, don't hard-fail on some auxiliary script or test.
* Fix #1691 fix #1713: `check-files.py` complaining about files in `.git` or in third-party subtrees.
* Fix `make apidoc` looking for files in unintended subdirectories.
* Don't fail on a spurious error if ASLR can't be disabled (not an issue on developer machines, but this would let us remove the don't-enforce-ASLR configuration from some CI jobs).

Backports: #2032 for 2.7, #2033 for 2.1.

Precursor to PSA.