### PR TITLE
Backport 2.7: Fix fragility issues in all.sh

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -664,7 +664,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = ..
+INPUT                  = ../include input
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -696,7 +696,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../configs ../yotta/module
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -511,10 +511,10 @@ msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
 
 msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-tests/ssl-opt.sh -f RSA
+if_build_succeeded tests/ssl-opt.sh -f RSA
 
 msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-tests/compat.sh -t RSA
+if_build_succeeded tests/compat.sh -t RSA
 
 msg "build: cmake, full config, clang" # ~ 50s
 cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -416,25 +416,25 @@ OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
     ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
 
 msg "test: recursion.pl" # < 1s
-tests/scripts/recursion.pl library/*.c
+record_status tests/scripts/recursion.pl library/*.c
 
 msg "test: freshness of generated source files" # < 1s
-tests/scripts/check-generated-files.sh
+record_status tests/scripts/check-generated-files.sh
 
 msg "test: doxygen markup outside doxygen blocks" # < 1s
-tests/scripts/check-doxy-blocks.pl
+record_status tests/scripts/check-doxy-blocks.pl
 
 msg "test: check-files.py" # < 1s
 cleanup
-tests/scripts/check-files.py
+record_status tests/scripts/check-files.py
 
 msg "test/build: declared and exported names" # < 3s
 cleanup
-tests/scripts/check-names.sh
+record_status tests/scripts/check-names.sh
 
 msg "test: doxygen warnings" # ~ 3s
 cleanup
-tests/scripts/doxygen.sh
+record_status tests/scripts/doxygen.sh
 
 
 


### PR DESCRIPTION
Fix some issues that don't break `all.sh` on a pristine checkout, but make it fragile in a tree where you've been doing development.

* In keep-going mode, don't hard-fail on some auxiliary script or test.
* Fix #1691 #1713: `check-files.py` complaining about files in `.git` or in third-party subtrees.
* Fix `make apidoc` looking for files in unintended subdirectories.

Backport of #2031. Differences with the original:

* “Fix `make WINDOWS_BUILD=1 clean` on non-Windows hosts.” is not applicable since it fixes an issue introduced by #930. It should be fixed in the backport of #930.
* The ALSR issue does not apply since we don't use gdb in the 2.7 tests.
