### PR TITLE
Backport 2.1: Fix fragility issues in all.sh

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -384,21 +384,21 @@ fi
 # Indicative running times are given for reference.
 
 msg "test: recursion.pl" # < 1s
-tests/scripts/recursion.pl library/*.c
+record_status tests/scripts/recursion.pl library/*.c
 
 msg "test: freshness of generated source files" # < 1s
-tests/scripts/check-generated-files.sh
+record_status tests/scripts/check-generated-files.sh
 
 msg "test: doxygen markup outside doxygen blocks" # < 1s
-tests/scripts/check-doxy-blocks.pl
+record_status tests/scripts/check-doxy-blocks.pl
 
 msg "test: check-files.py" # < 1s
 cleanup
-tests/scripts/check-files.py
+record_status tests/scripts/check-files.py
 
 msg "test/build: declared and exported names" # < 3s
 cleanup
-tests/scripts/check-names.sh
+record_status tests/scripts/check-names.sh
 
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -440,7 +440,7 @@ CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
 make
 
 msg "test: ssl-opt.sh, MFL-related tests"
-tests/ssl-opt.sh -f "Max fragment length"
+if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
 
 msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
 cleanup
@@ -484,10 +484,10 @@ msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
 make test
 
 msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-tests/ssl-opt.sh -f RSA
+if_build_succeeded tests/ssl-opt.sh -f RSA
 
 msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-tests/compat.sh -t RSA
+if_build_succeeded tests/compat.sh -t RSA
 
 
 msg "build: cmake, full config, clang" # ~ 50s


### PR DESCRIPTION
Fix some issues that don't break `all.sh` on a pristine checkout, but make it fragile in a tree where you've been doing development.

* In keep-going mode, don't hard-fail on some auxiliary script or test.
* Fix #1691 #1713: `check-files.py` complaining about files in `.git` or in third-party subtrees.

Backport of #2031. Differences with the original:

* “Fix `make WINDOWS_BUILD=1 clean` on non-Windows hosts.” is not applicable since it fixes an issue introduced by #930. It should be fixed in the backport of #930.
* “Fix `make apidoc`” interacts with #2011 and I'll handle it there instead of here.
* The ALSR issue does not apply since we don't use gdb in the 2.1 tests.
