### PR TITLE
Backport 2.7: Adds a filter to run-test-suites.pl to exclude source code and data files

### DIFF
--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -35,8 +35,9 @@ if ( defined($switch) && ( $switch eq "-v" || $switch eq "--verbose" ) ) {
 
 # All test suites = executable files, excluding source files, debug
 # and profiling information, etc. We can't just grep {! /\./} because
-#some of our test cases' base names contain a dot.
+# some of our test cases' base names contain a dot.
 my @suites = grep { -x $_ || /\.exe$/ } glob 'test_suite_*';
+@suites = grep { !/\.c$/ && !/\.data$/ } @suites;
 die "$0: no test suite found\n" unless @suites;
 
 # in case test suites are linked dynamically

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -37,7 +37,7 @@ if ( defined($switch) && ( $switch eq "-v" || $switch eq "--verbose" ) ) {
 # and profiling information, etc. We can't just grep {! /\./} because
 # some of our test cases' base names contain a dot.
 my @suites = grep { -x $_ || /\.exe$/ } glob 'test_suite_*';
-@suites = grep { !/\.c$/ && !/\.data$/ } @suites;
+@suites = grep { !/\.c$/ && !/\.data$/ && -f } @suites;
 die "$0: no test suite found\n" unless @suites;
 
 # in case test suites are linked dynamically


### PR DESCRIPTION
## Description

This is a backport of #1806.

The run-test-suites.pl script was executing all files of the form `test_suite*` which were either executable or ended with a `.exe` extension.

On some filesystems, such as through network shares or VMs, which are abstracting one set of file permissions to Unix permissions, the executable permission on files could be set, whether they're executable or not.

That was leading to the `run-test-suites.pl` script to attempt to execute the `.c` intermediate files because they followed the form `test_suite_*.c`. This change now excludes them, just in case they accidentally have execute permissions.

This is a trivial PR, for a minor issue which is really a corner case, that annoyed me, and doesn't deserve any priority.

## Status
**READY**

## Migrations
NO