### PR TITLE
Backport 2.1: Change the default IP addresses for DTLS samples

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Changes
    * Close a test gap in (D)TLS between the client side and the server side:
      test the handling of large packets and small packets on the client side
      in the same way as on the server side.
+   * Change the dtls_client and dtls_server samples to work by default over
+     IPv6 and optionally by a build option over IPv4.
 
 = mbed TLS 2.1.15 branch released 2018-08-31
 

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -60,9 +60,18 @@ int main( void )
 #include "mbedtls/certs.h"
 #include "mbedtls/timing.h"
 
+/* Uncomment out the following line to default to IPv4 and disable IPv6 */
+//#define FORCE_IPV4
+
 #define SERVER_PORT "4433"
 #define SERVER_NAME "localhost"
-#define SERVER_ADDR "127.0.0.1" /* forces IPv4 */
+
+#ifdef FORCE_IPV4
+#define SERVER_ADDR "127.0.0.1"     /* Forces IPv4 */
+#else
+#define SERVER_ADDR "::1"
+#endif
+
 #define MESSAGE     "Echo this"
 
 #define READ_TIMEOUT_MS 1000

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -33,6 +33,15 @@
 #define mbedtls_fprintf    fprintf
 #endif
 
+/* Uncomment out the following line to default to IPv4 and disable IPv6 */
+//#define FORCE_IPV4
+
+#ifdef FORCE_IPV4
+#define BIND_IP     "0.0.0.0"     /* Forces IPv4 */
+#else
+#define BIND_IP     "::"
+#endif
+
 #if !defined(MBEDTLS_SSL_SRV_C) || !defined(MBEDTLS_SSL_PROTO_DTLS) ||    \
     !defined(MBEDTLS_SSL_COOKIE_C) || !defined(MBEDTLS_NET_C) ||          \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) ||        \
@@ -169,7 +178,7 @@ int main( void )
     printf( "  . Bind on udp/*/4433 ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_net_bind( &listen_fd, NULL, "4433", MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+    if( ( ret = mbedtls_net_bind( &listen_fd, BIND_IP, "4433", MBEDTLS_NET_PROTO_UDP ) ) != 0 )
     {
         printf( " failed\n  ! mbedtls_net_bind returned %d\n\n", ret );
         goto exit;


### PR DESCRIPTION
## Description
This is a backport of #1627 to `mbedtls-2.1`.

Changes the IP address to bind to for dtls_server.c to be "::" or optionally "0.0.0.0" if the preprocessor symbol FORCE_IPV4 is defined.

Also changes the destinaton IP address for dtls_client.c to be "::1" or if FORCE_IPV4 symbol is defined "127.0.0.1".

This change allows `dtls_server.c` and `dtls_client.c` to be configured to use either IPv4 or IPv6 at build time, so out of the box they will work together.

Previously `dtls_server.c` might bind to IPv6 and `dtls_client.c` connect over IPv4, leading to a failure.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
