### PR TITLE
Add support for test coverage test thresholds

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -42,6 +42,7 @@ fi
 : ${GNUTLS_SERV:="gnutls-serv"}
 : ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
 : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
+: ${SEED:=1}
 
 # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
 # we just export the variables they require
@@ -62,6 +63,7 @@ print_usage() {
     printf "  -h|--help\tPrint this help.\n"
     printf "     --line-cov-threshold\tLine coverage test threshold (default 0)\n"
     printf "     --fn-cov-threshold\tLine coverage test threshold (default 0)\n"
+    printf "     --seed\tInteger seed value to use for this test run (default 1)\n"
 }
 
 get_options() {
@@ -72,6 +74,9 @@ get_options() {
                 ;;
             --fn-cov-threshold)
                 shift; FN_COV_THRESHOLD=$1
+                ;;
+            --seed)
+                shift; SEED="$1"
                 ;;
             -h|--help)
                 print_usage
@@ -120,7 +125,7 @@ perl scripts/run-test-suites.pl -v |tee unit-test-$TEST_OUTPUT
 echo
 
 # Step 2b - System Tests
-sh ssl-opt.sh |tee sys-test-$TEST_OUTPUT
+sh ssl-opt.sh --seed $SEED |tee sys-test-$TEST_OUTPUT
 echo
 
 # Step 2c - Compatibility tests

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -230,6 +230,11 @@ echo "Total exec'd tests : $TOTAL_EXED"
 echo "Total avail tests  : $TOTAL_AVAIL"
 echo
 
+# Set exitcode if any tests failed
+if [ $(echo "$TOTAL_FAIL > 0" | bc) = "1" ]; then
+    EXITCODE=1
+fi
+
 
 # Step 4e - Coverage
 echo "Coverage"


### PR DESCRIPTION
## Description
Adds support for a test threshold for line and function coverage in the test script `basic-build-test.sh`, which will also cause the script to report an error if the threshold falls short, and to exit with an error code.

The idea is this can be used in the CI to indicate an error if the line or function coverage falls beneath a set threshold.

## Status
**READY**

## Requires Backporting
Yes  
Which branch?
`mbedtls-2.7` but not 2.1, as the script doesn't already exist there

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported