### PR TITLE
Backport 2.1: Replace Windows API threading with CRT functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ Changes
    * Close a test gap in (D)TLS between the client side and the server side:
      test the handling of large packets and small packets on the client side
      in the same way as on the server side.
+   * Change the use of Windows threading to use Microsoft Visual C++ runtime
+     calls, rather than Win32 API calls directly. This is necessary to avoid
+     conflict with C runtime usage. Found and fixed by irwir.
 
 = mbed TLS 2.1.15 branch released 2018-08-31
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -264,7 +264,7 @@ static DWORD alarmMs;
 
 static void TimerProc( void *TimerContext )
 {
-    (void)TimerContext;
+    (void) TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
     // Implicit call of _endthread() is better (see MS online docs)
@@ -282,7 +282,7 @@ void mbedtls_set_alarm( int seconds )
 
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
-    (void)_beginthread( TimerProc, 0, NULL );
+    (void) _beginthread( TimerProc, 0, NULL );
 }
 
 #else /* _WIN32 && !EFIX64 && !EFI32 */

--- a/library/timing.c
+++ b/library/timing.c
@@ -267,7 +267,8 @@ static void TimerProc( void *TimerContext )
     (void) TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
-    // Implicit call of _endthread() is better (see MS online docs)
+    /* _endthread will be called implicitly on return
+     * That ensures execution of thread funcition's epilogue */
 }
 
 void mbedtls_set_alarm( int seconds )

--- a/library/timing.c
+++ b/library/timing.c
@@ -46,6 +46,7 @@
 
 #include <windows.h>
 #include <winbase.h>
+#include <process.h>
 
 struct _hr_time
 {
@@ -261,18 +262,16 @@ unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int 
 /* It's OK to use a global because alarm() is supposed to be global anyway */
 static DWORD alarmMs;
 
-static DWORD WINAPI TimerProc( LPVOID TimerContext )
+static void TimerProc( void *TimerContext )
 {
-    ((void) TimerContext);
+    (void)TimerContext;
     Sleep( alarmMs );
     mbedtls_timing_alarmed = 1;
-    return( TRUE );
+    // Implicit call of _endthread() is better (see MS online docs)
 }
 
 void mbedtls_set_alarm( int seconds )
 {
-    DWORD ThreadId;
-
     if( seconds == 0 )
     {
         /* No need to create a thread for this simple case.
@@ -283,7 +282,7 @@ void mbedtls_set_alarm( int seconds )
 
     mbedtls_timing_alarmed = 0;
     alarmMs = seconds * 1000;
-    CloseHandle( CreateThread( NULL, 0, TimerProc, NULL, 0, &ThreadId ) );
+    (void)_beginthread( TimerProc, 0, NULL );
 }
 
 #else /* _WIN32 && !EFIX64 && !EFI32 */


### PR DESCRIPTION
## Description
Backport of #1777.

In Visual C/C++ programs that use CRT library, should do threading with _beginthread, _beginthreadex and _endthread, _endthreadex functions instead of Windows API functions CreateThread, ExitThread and CloseHandle.

Otherwise some CRT funtions could fail, and memory leaks are possible.

Timer tests in selftest.c with the new code were successful.

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
