### PR TITLE
Make inclusion of stdio.h conditional in x509_crt.c

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -43,7 +43,6 @@
 #include "mbedtls/oid.h"
 #include "mbedtls/platform_util.h"
 
-#include <stdio.h>
 #include <string.h>
 
 #if defined(MBEDTLS_PEM_PARSE_C)
@@ -53,6 +52,7 @@
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
+#include <stdio.h>
 #include <stdlib.h>
 #define mbedtls_free       free
 #define mbedtls_calloc    calloc


### PR DESCRIPTION
## Description
`stdio.h` was being included both conditionally if `MBEDTLS_FS_IO` was defined, and also unconditionally, which made at least one of them redundant.

This change removes the unconditional inclusion of stdio.h and makes it conditional on `MBEDTLS_PLATFORM_C`.

## Status
**READY**

## Requires Backporting
Yes
Which branch?
`mbedtls-2.7` and `mbedtls-2.1`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
