### PR TITLE
Change file scoping of test helper functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix to allow test-ref-config.pl to build with Clang. Fixes #1628.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix to allow test-ref-config.pl to build with Clang. Fixes #1628.
+   * Fix to allow building test suites with any warning that detects unused
+     functions. Fixes #1628.
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 CFLAGS	?= -O2
-WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -Wno-unused-function -Wno-unused-value
+WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -Wunused
 LDFLAGS ?=
 
 LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -278,7 +278,7 @@ jmp_buf jmp_tmp;
 /*----------------------------------------------------------------------------*/
 /* Helper Functions */
 
-static void test_fail( const char *test, int line_no, const char* filename )
+void test_fail( const char *test, int line_no, const char* filename )
 {
     test_info.failed = 1;
     test_info.test = test;
@@ -368,7 +368,7 @@ static void close_output( FILE* out_stream )
 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
-static int unhexify( unsigned char *obuf, const char *ibuf )
+int unhexify( unsigned char *obuf, const char *ibuf )
 {
     unsigned char c, c2;
     int len = strlen( ibuf ) / 2;
@@ -402,7 +402,7 @@ static int unhexify( unsigned char *obuf, const char *ibuf )
     return len;
 }
 
-static void hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
+void hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
 {
     unsigned char l, h;
 
@@ -456,7 +456,7 @@ static unsigned char *zero_alloc( size_t len )
  *
  * For convenience, dies if allocation fails.
  */
-static unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
+unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
 {
     unsigned char *obuf;
 
@@ -507,7 +507,7 @@ static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len )
  *
  * rng_state shall be NULL.
  */
-static int rnd_zero_rand( void *rng_state, unsigned char *output, size_t len )
+int rnd_zero_rand( void *rng_state, unsigned char *output, size_t len )
 {
     if( rng_state != NULL )
         rng_state  = NULL;
@@ -534,7 +534,7 @@ typedef struct
  *
  * After the buffer is empty it will return rand();
  */
-static int rnd_buffer_rand( void *rng_state, unsigned char *output, size_t len )
+int rnd_buffer_rand( void *rng_state, unsigned char *output, size_t len )
 {
     rnd_buf_info *info = (rnd_buf_info *) rng_state;
     size_t use_len;
@@ -580,7 +580,7 @@ typedef struct
  *
  * rng_state shall be a pointer to a rnd_pseudo_info structure.
  */
-static int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
+int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
 {
     rnd_pseudo_info *info = (rnd_pseudo_info *) rng_state;
     uint32_t i, *k, sum, delta=0x9E3779B9;


### PR DESCRIPTION
## Description
Dependent on configured options, not all of the helper functions were being used, which was leading to warning of unused functions with Clang.

To avoid any complex compile time options, or adding more logic to `generate_test_code.py` to screen out unused functions, those functions which were provoking the warning were changed to remove static, remove them from file scope, and expose them to the linker.

Fixes #2051.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported
