### PR TITLE
Backport 2.7: Fix memory leak in cert_write example program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ Bugfix
       MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
     * Fix a bug in the update function for SSL ticket keys which previously
       invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+   * Fix memory leak and freeing without initialization in the example
+     program programs/x509/cert_write. Fixes #1422.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -238,6 +238,7 @@ int main( int argc, char *argv[] )
     mbedtls_pk_init( &loaded_subject_key );
     mbedtls_mpi_init( &serial );
     mbedtls_ctr_drbg_init( &ctr_drbg );
+    mbedtls_entropy_init( &entropy );
 #if defined(MBEDTLS_X509_CSR_PARSE_C)
     mbedtls_x509_csr_init( &csr );
 #endif
@@ -472,7 +473,6 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Seeding the random number generator..." );
     fflush( stdout );
 
-    mbedtls_entropy_init( &entropy );
     if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
@@ -789,6 +789,10 @@ int main( int argc, char *argv[] )
     mbedtls_printf( " ok\n" );
 
 exit:
+#if defined(MBEDTLS_X509_CSR_PARSE_C)
+    mbedtls_x509_csr_free( &csr );
+#endif /* MBEDTLS_X509_CSR_PARSE_C */
+    mbedtls_x509_crt_free( &issuer_crt );
     mbedtls_x509write_crt_free( &crt );
     mbedtls_pk_free( &loaded_subject_key );
     mbedtls_pk_free( &loaded_issuer_key );


### PR DESCRIPTION
Backport of #2056 to Mbed TLS 2.1, fixing #1422.