### PR TITLE
Add missing compile time guard around `derive_mpi()` in ecdsa.c

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
    * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+   * Add compile time guard around internal function derive_mpi() in
+     library/ecdsa.c to avoid unused function compiler warning configurations
+     where this function is not needed. Raised by HenrikRosenquistAnderson.
+     Fixes #1590.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -46,6 +46,9 @@
  * Derive a suitable integer for group grp from a buffer of length len
  * SEC1 4.1.3 step 5 aka SEC1 4.1.4 step 3
  */
+#if !defined(MBEDTLS_ECDSA_SIGN_ALT)        ||     \
+     defined(MBEDTLS_ECDSA_DETERMINISTIC)   ||     \
+    !defined(MBEDTLS_ECDSA_VERIFY_ALT)
 static int derive_mpi( const mbedtls_ecp_group *grp, mbedtls_mpi *x,
                        const unsigned char *buf, size_t blen )
 {
@@ -64,6 +67,9 @@ static int derive_mpi( const mbedtls_ecp_group *grp, mbedtls_mpi *x,
 cleanup:
     return( ret );
 }
+#endif /* !MBEDTLS_ECDSA_SIGN_ALT        ||
+           MBEDTLS_ECDSA_DETERMINISTIC   ||
+          !MBEDTLS_ECDSA_VERIFY_ALT     */
 
 #if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*


### PR DESCRIPTION
Fixes #1590.

__Backports:__ 2.7 only; 2.1 does not yet include `MBEDTLS_ECDSA_{SIGN,VERIFY}_ALT`.