### PR TITLE
Backport 2.7: Fix memory leak in ssl_server2 when buffer allocator and backtracing enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
    * Fix a bug in the update function for SSL ticket keys which previously
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+   * Fix wrong order of freeing in programs/ssl/ssl_server2 example
+     application leading to a memory leak in case both
+     MBEDTLS_MEMORY_BUFFER_ALLOC_C and MBEDTLS_MEMORY_BACKTRACE are set.
+     Fixes #2069.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2538,6 +2538,8 @@ exit:
     mbedtls_ssl_cookie_free( &cookie_ctx );
 #endif
 
+    mbedtls_free( buf );
+
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #if defined(MBEDTLS_MEMORY_DEBUG)
     mbedtls_memory_buffer_alloc_status();
@@ -2545,7 +2547,6 @@ exit:
     mbedtls_memory_buffer_alloc_free();
 #endif
 
-    mbedtls_free( buf );
     mbedtls_printf( " done.\n" );
 
 #if defined(_WIN32)


### PR DESCRIPTION
Backport of #2070 to Mbed TLS 2.7, fixing #2069.