### PR TITLE
Backport 2.1: Fix memory leak in ssl_server2 when buffer allocator and backtracing enabled

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2495,6 +2495,8 @@ exit:
     mbedtls_ssl_cookie_free( &cookie_ctx );
 #endif
 
+    mbedtls_free( buf );
+
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #if defined(MBEDTLS_MEMORY_DEBUG)
     mbedtls_memory_buffer_alloc_status();
@@ -2502,7 +2504,6 @@ exit:
     mbedtls_memory_buffer_alloc_free();
 #endif
 
-    mbedtls_free( buf );
     mbedtls_printf( " done.\n" );
 
 #if defined(_WIN32)


### PR DESCRIPTION
Backport of #2070 to Mbed TLS 2.1, fixing #2069.