### PR TITLE
Fix build failure if MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO are set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
    * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+   * Fix compilation failure for configurations which use compile time
+     replacements of standard calloc/free functions through the macros
+     MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO.
+     Reported by ole-de and ddhome2006. Fixes #882, #1642 and #1706.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/platform.c
+++ b/library/platform.c
@@ -30,7 +30,14 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_util.h"
 
-#if defined(MBEDTLS_PLATFORM_MEMORY)
+/* The compile time configuration of memory allocation via the macros
+ * MBEDTLS_PLATFORM_{FREE/CALLOC}_MACRO takes precedence over the runtime
+ * configuration via mbedtls_platform_set_calloc_free(). So, omit everything
+ * related to the latter if MBEDTLS_PLATFORM_{FREE/CALLOC}_MACRO are defined. */
+#if defined(MBEDTLS_PLATFORM_MEMORY) &&                 \
+    !( defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&        \
+       defined(MBEDTLS_PLATFORM_FREE_MACRO) )
+
 #if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
 static void *platform_calloc_uninit( size_t n, size_t size )
 {
@@ -71,7 +78,9 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
     mbedtls_free_func = free_func;
     return( 0 );
 }
-#endif /* MBEDTLS_PLATFORM_MEMORY */
+#endif /* MBEDTLS_PLATFORM_MEMORY &&
+          !( defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&
+             defined(MBEDTLS_PLATFORM_FREE_MACRO) ) */
 
 #if defined(_WIN32)
 #include <stdarg.h>

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -736,6 +736,18 @@ make
 msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
 make test
 
+msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
+scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
+scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+make test
+
 msg "build: default config with AES_FEWER_TABLES enabled"
 cleanup
 cp "$CONFIG_H" "$CONFIG_BAK"


### PR DESCRIPTION
__Summary:__ This PR fixes #1642, the issue being a build failure in configurations that use the compile time configuration macros `MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO` to set custom `calloc()` and `free()` functions. If these macros are defined, the API for runtime configurations `mbedtls_platform_set_calloc_free()` should be omitted from `platform.c` (as in `platform.h`) but it's not. For the development branch, this leads to compilation warning (hence failure in some build modes) about function definition without prior declaration, while in the LTS branches Mbed TLS 2.1 and Mbed TLS 2.7, the compilation fails due to multiple function definitions (the reason for the different symptoms is commit https://github.com/ARMmbed/mbedtls/commit/7decfe8c1ed6a5da39fffb547a1b27ef0bb04ee1 was applied in between 2.7 and the development branch).

__Internal Reference:__ IOTSSL-2312, IOTSSL-2358.

Fixes #882 fixes #1642 fixes #1706.