### PR TITLE
Backport 2.1: Fix build failure if MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO are set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
       MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
     * Fix a bug in the update function for SSL ticket keys which previously
       invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+    * Fix compilation failure for configurations which use compile time
+      replacements of standard calloc/free functions through the macros
+      MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO.
+      Reported by ole-de and ddhome2006. Fixes #882, #1642 and #1706.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/platform.c
+++ b/library/platform.c
@@ -29,7 +29,14 @@
 
 #include "mbedtls/platform.h"
 
-#if defined(MBEDTLS_PLATFORM_MEMORY)
+/* The compile time configuration of memory allocation via the macros
+ * MBEDTLS_PLATFORM_{FREE/CALLOC}_MACRO takes precedence over the runtime
+ * configuration via mbedtls_platform_set_calloc_free(). So, omit everything
+ * related to the latter if MBEDTLS_PLATFORM_{FREE/CALLOC}_MACRO are defined. */
+#if defined(MBEDTLS_PLATFORM_MEMORY) &&                 \
+    !( defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&        \
+       defined(MBEDTLS_PLATFORM_FREE_MACRO) )
+
 #if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
 static void *platform_calloc_uninit( size_t n, size_t size )
 {
@@ -60,7 +67,9 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
     mbedtls_free = free_func;
     return( 0 );
 }
-#endif /* MBEDTLS_PLATFORM_MEMORY */
+#endif /* MBEDTLS_PLATFORM_MEMORY &&
+          !( defined(MBEDTLS_PLATFORM_CALLOC_MACRO) &&
+             defined(MBEDTLS_PLATFORM_FREE_MACRO) ) */
 
 #if defined(_WIN32)
 #include <stdarg.h>

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -591,6 +591,18 @@ scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
 scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
 make CC=gcc CFLAGS='-Werror -O0 -std=c99 -pedantic' lib
 
+msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+cleanup
+cp "$CONFIG_H" "$CONFIG_BAK"
+scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
+scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
+scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
+CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+make
+
+msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+make test
+
 if uname -a | grep -F Linux >/dev/null; then
     msg "build/test: make shared" # ~ 40s
     cleanup


### PR DESCRIPTION
This is the backport of #2079 to Mbed TLS 2.1, fixing #1642 and #1706.