### PR TITLE
Backport 2.1: Fix documentation of allowed_pks field in mbedtls_x509_crt_profile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
       MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
     * Fix a bug in the update function for SSL ticket keys which previously
       invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+    * Fix incorrect documentation of mbedtls_x509_crt_profile. The previous
+      documentation stated that the `allowed_pks` field applies to signatures
+      only, but in fact it does apply to the public key type of the end entity
+      certificate, too. Fixes #1992.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -107,7 +107,9 @@ mbedtls_x509_crt;
 typedef struct
 {
     uint32_t allowed_mds;       /**< MDs for signatures         */
-    uint32_t allowed_pks;       /**< PK algs for signatures     */
+    uint32_t allowed_pks;       /**< PK algs for public keys;
+                                 *   this applies to any CRT
+                                 *   in the provided chain.     */
     uint32_t allowed_curves;    /**< Elliptic curves for ECDSA  */
     uint32_t rsa_min_bitlen;    /**< Minimum size for RSA keys  */
 }


### PR DESCRIPTION
This is the backport to Mbed TLS 2.1 of #2082, fixing #1992.