### PR TITLE
cmake: add proper target exporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,17 @@ else()
     project("mbed TLS" C)
 endif()
 
+include(CMakePackageConfigHelpers)
+
+set(CMAKE_EXPORT_DIR "lib/cmake/mbedtls")
+
+file(READ "${CMAKE_SOURCE_DIR}/include/mbedtls/version.h" MBEDTLS_VERSION_H)
+string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_MAJOR[\t ]+([0-9]+).*" "\\1" MBEDTLS_VERSION_MAJOR "${MBEDTLS_VERSION_H}")
+string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_MINOR[\t ]+([0-9]+).*" "\\1" MBEDTLS_VERSION_MINOR "${MBEDTLS_VERSION_H}")
+string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_PATCH[\t ]+([0-9]+).*" "\\1" MBEDTLS_VERSION_PATCH "${MBEDTLS_VERSION_H}")
+set(MBEDTLS_VERSION "${MBEDTLS_VERSION_MAJOR}.${MBEDTLS_VERSION_MINOR}.${MBEDTLS_VERSION_PATCH}")
+message(STATUS "mbed TLS version ${MBEDTLS_VERSION}")
+
 option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
 option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
 
@@ -215,3 +226,22 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DartConfiguration.tcl
                    ${CMAKE_CURRENT_BINARY_DIR}/DartConfiguration.tcl COPYONLY)
 endif()
+
+# installation
+
+export(PACKAGE mbedtls)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/mbedtls-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_EXPORT_DIR}")
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/mbedtls-config-version.cmake"
+    VERSION ${MBEDTLS_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+install(FILES
+    ${PROJECT_BINARY_DIR}/mbedtls-config.cmake
+    ${PROJECT_BINARY_DIR}/mbedtls-config-version.cmake
+    DESTINATION "${CMAKE_EXPORT_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
+# cmake export script installation directory
 set(CMAKE_EXPORT_DIR "lib/cmake/mbedtls")
 
 file(READ "${CMAKE_SOURCE_DIR}/include/mbedtls/version.h" MBEDTLS_VERSION_H)
@@ -14,7 +15,7 @@ string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_MAJOR[\t ]+([0-9]+).*" "\\1
 string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_MINOR[\t ]+([0-9]+).*" "\\1" MBEDTLS_VERSION_MINOR "${MBEDTLS_VERSION_H}")
 string(REGEX REPLACE ".*#define[\t ]+MBEDTLS_VERSION_PATCH[\t ]+([0-9]+).*" "\\1" MBEDTLS_VERSION_PATCH "${MBEDTLS_VERSION_H}")
 set(MBEDTLS_VERSION "${MBEDTLS_VERSION_MAJOR}.${MBEDTLS_VERSION_MINOR}.${MBEDTLS_VERSION_PATCH}")
-message(STATUS "mbed TLS version ${MBEDTLS_VERSION}")
+message(STATUS "Mbed TLS version ${MBEDTLS_VERSION}")
 
 option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
 option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -141,33 +141,48 @@ endif()
 
 if(USE_STATIC_MBEDTLS_LIBRARY)
     add_library(${mbedcrypto_static_target} STATIC ${src_crypto})
+    target_include_directories(${mbedcrypto_static_target} INTERFACE $<INSTALL_INTERFACE:include>)
     set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
     target_link_libraries(${mbedcrypto_static_target} ${libs})
 
     add_library(${mbedx509_static_target} STATIC ${src_x509})
+    target_include_directories(${mbedx509_static_target} INTERFACE $<INSTALL_INTERFACE:include>)
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
     target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
+    target_include_directories(${mbedtls_static_target} INTERFACE $<INSTALL_INTERFACE:include>)
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
 
     install(TARGETS ${mbedtls_static_target} ${mbedx509_static_target} ${mbedcrypto_static_target}
+            EXPORT mbedtls-target
             DESTINATION ${LIB_INSTALL_DIR}
             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+    export(TARGETS mbedtls
+        APPEND FILE ${PROJECT_BINARY_DIR}/mbedtls-target.cmake)
+
+    install(EXPORT mbedtls-target
+        FILE mbedtls-target.cmake
+        DESTINATION "${CMAKE_EXPORT_DIR}")
+        
 endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.13.1 SOVERSION 3)
+    target_include_directories(mbedcrypto INTERFACE $<INSTALL_INTERFACE:include>)
+    set_target_properties(mbedcrypto PROPERTIES VERSION ${MBEDTLS_VERSION} SOVERSION 3)
     target_link_libraries(mbedcrypto ${libs})
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.13.1 SOVERSION 0)
+    target_include_directories(mbedx509 INTERFACE $<INSTALL_INTERFACE:include>)
+    set_target_properties(mbedx509 PROPERTIES VERSION ${MBEDTLS_VERSION} SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.13.1 SOVERSION 12)
+    target_include_directories(mbedtls INTERFACE $<INSTALL_INTERFACE:include>)
+    set_target_properties(mbedtls PROPERTIES VERSION ${MBEDTLS_VERSION} SOVERSION 12)
     target_link_libraries(mbedtls ${libs} mbedx509)
 
     install(TARGETS mbedtls mbedx509 mbedcrypto

--- a/mbedtls-config.cmake.in
+++ b/mbedtls-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@ 
+
+include("${CMAKE_CURRENT_LIST_DIR}/mbedtls-target.cmake")
+


### PR DESCRIPTION
This pull request adds proper cmake target exporting, making it possible to build and install mbed TLS in a location from which it can be effortlessly imported by a separate cmake project. As a bonus, I added some cmake code to automatically extract the version number from version.h and therefore avoid potential issues where one can forget to manually update it in cmake. This was necessary because cmake exporting makes use of the version number.

Here is how it works. First, build and install mbed TLS to an installation prefix:

```
cmake -DCMAKE_INSTALL_PREFIX=/tmp/mbedtls .
make install
```

In a separate cmake project, importing looks like this:

```
find_package(mbedtls CONFIG REQUIRED)
add_executable(mbedtls-sample main.c)
target_link_libraries(mbedtls-sample mbedtls)
```

For the exported cmake package to be found, it needs to be added to CMAKE_PREFIX_PATH like this:
`cmake -DCMAKE_PREFIX_PATH=/tmp/mbedtls .`

That's it! the sample project will automatically link to the proper mbed TLS libraries and add the required include directories.

We have been using this method for Windows, macOS, Linux, Android and iOS for a while now and it works quite well.

This is my first pull request, I have read the contribution guidelines. I created an mbed account with the same email used for the commits in this PR and I accepted the contribution agreement.

Thank you!