### PR TITLE
Add missing brackets around macro parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,10 @@ Bugfix
      in X.509 module. Fixes #2212.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Add missing parentheses around parameters in the definition of the
+     public macro MBEDTLS_X509_ID_FLAG. This could lead to invalid evaluation
+     in case operators binding less strongly than subtraction were used
+     for the parameter.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -33,11 +33,12 @@
 #include "asn1.h"
 
 #define MBEDTLS_ASN1_CHK_ADD(g, f)                      \
-    do {                                                \
-        if( ( ret = f ) < 0 )                           \
+    do                                                  \
+    {                                                   \
+        if( ( ret = (f) ) < 0 )                         \
             return( ret );                              \
         else                                            \
-            g += ret;                                   \
+            (g) += ret;                                 \
     } while( 0 )
 
 #ifdef __cplusplus

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -46,7 +46,12 @@
 #define MBEDTLS_ERR_MPI_NOT_ACCEPTABLE                    -0x000E  /**< The input arguments are not acceptable. */
 #define MBEDTLS_ERR_MPI_ALLOC_FAILED                      -0x0010  /**< Memory allocation failed. */
 
-#define MBEDTLS_MPI_CHK(f) do { if( ( ret = f ) != 0 ) goto cleanup; } while( 0 )
+#define MBEDTLS_MPI_CHK(f)       \
+    do                           \
+    {                            \
+        if( ( ret = (f) ) != 0 ) \
+            goto cleanup;        \
+    } while( 0 )
 
 /*
  * Maximum size MPIs are allowed to grow to in number of limbs.

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -59,7 +59,7 @@
 #define MBEDTLS_PADLOCK_PHE 0x0C00
 #define MBEDTLS_PADLOCK_PMM 0x3000
 
-#define MBEDTLS_PADLOCK_ALIGN16(x) (uint32_t *) (16 + ((int32_t) x & ~15))
+#define MBEDTLS_PADLOCK_ALIGN16(x) (uint32_t *) (16 + ((int32_t) (x) & ~15))
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -98,7 +98,7 @@ mbedtls_x509_crt;
  * Build flag from an algorithm/curve identifier (pk, md, ecp)
  * Since 0 is always XXX_NONE, ignore it.
  */
-#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( id - 1 ) )
+#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( (id) - 1 ) )
 
 /**
  * Security profile for certificate verification.

--- a/library/aes.c
+++ b/library/aes.c
@@ -395,9 +395,9 @@ static uint32_t RCON[10];
 /*
  * Tables generation code
  */
-#define ROTL8(x) ( ( x << 8 ) & 0xFFFFFFFF ) | ( x >> 24 )
-#define XTIME(x) ( ( x << 1 ) ^ ( ( x & 0x80 ) ? 0x1B : 0x00 ) )
-#define MUL(x,y) ( ( x && y ) ? pow[(log[x]+log[y]) % 255] : 0 )
+#define ROTL8(x) ( ( (x) << 8 ) & 0xFFFFFFFF ) | ( (x) >> 24 )
+#define XTIME(x) ( ( (x) << 1 ) ^ ( ( (x) & 0x80 ) ? 0x1B : 0x00 ) )
+#define MUL(x,y) ( ( (x) && (y) ) ? pow[(log[x]+log[y]) % 255] : 0 )
 
 static int aes_init_done = 0;
 
@@ -815,51 +815,53 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
 
 #endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
 
-#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)         \
-{                                                   \
-    X0 = *RK++ ^ AES_FT0( ( Y0       ) & 0xFF ) ^   \
-                 AES_FT1( ( Y1 >>  8 ) & 0xFF ) ^   \
-                 AES_FT2( ( Y2 >> 16 ) & 0xFF ) ^   \
-                 AES_FT3( ( Y3 >> 24 ) & 0xFF );    \
-                                                    \
-    X1 = *RK++ ^ AES_FT0( ( Y1       ) & 0xFF ) ^   \
-                 AES_FT1( ( Y2 >>  8 ) & 0xFF ) ^   \
-                 AES_FT2( ( Y3 >> 16 ) & 0xFF ) ^   \
-                 AES_FT3( ( Y0 >> 24 ) & 0xFF );    \
-                                                    \
-    X2 = *RK++ ^ AES_FT0( ( Y2       ) & 0xFF ) ^   \
-                 AES_FT1( ( Y3 >>  8 ) & 0xFF ) ^   \
-                 AES_FT2( ( Y0 >> 16 ) & 0xFF ) ^   \
-                 AES_FT3( ( Y1 >> 24 ) & 0xFF );    \
-                                                    \
-    X3 = *RK++ ^ AES_FT0( ( Y3       ) & 0xFF ) ^   \
-                 AES_FT1( ( Y0 >>  8 ) & 0xFF ) ^   \
-                 AES_FT2( ( Y1 >> 16 ) & 0xFF ) ^   \
-                 AES_FT3( ( Y2 >> 24 ) & 0xFF );    \
-}
+#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                     \
+    do                                                          \
+    {                                                           \
+        (X0) = *RK++ ^ AES_FT0( ( (Y0)       ) & 0xFF ) ^       \
+                       AES_FT1( ( (Y1) >>  8 ) & 0xFF ) ^       \
+                       AES_FT2( ( (Y2) >> 16 ) & 0xFF ) ^       \
+                       AES_FT3( ( (Y3) >> 24 ) & 0xFF );        \
+                                                                \
+        (X1) = *RK++ ^ AES_FT0( ( (Y1)       ) & 0xFF ) ^       \
+                       AES_FT1( ( (Y2) >>  8 ) & 0xFF ) ^       \
+                       AES_FT2( ( (Y3) >> 16 ) & 0xFF ) ^       \
+                       AES_FT3( ( (Y0) >> 24 ) & 0xFF );        \
+                                                                \
+        (X2) = *RK++ ^ AES_FT0( ( (Y2)       ) & 0xFF ) ^       \
+                       AES_FT1( ( (Y3) >>  8 ) & 0xFF ) ^       \
+                       AES_FT2( ( (Y0) >> 16 ) & 0xFF ) ^       \
+                       AES_FT3( ( (Y1) >> 24 ) & 0xFF );        \
+                                                                \
+        (X3) = *RK++ ^ AES_FT0( ( (Y3)       ) & 0xFF ) ^       \
+                       AES_FT1( ( (Y0) >>  8 ) & 0xFF ) ^       \
+                       AES_FT2( ( (Y1) >> 16 ) & 0xFF ) ^       \
+                       AES_FT3( ( (Y2) >> 24 ) & 0xFF );        \
+    } while( 0 )
 
-#define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)         \
-{                                                   \
-    X0 = *RK++ ^ AES_RT0( ( Y0       ) & 0xFF ) ^   \
-                 AES_RT1( ( Y3 >>  8 ) & 0xFF ) ^   \
-                 AES_RT2( ( Y2 >> 16 ) & 0xFF ) ^   \
-                 AES_RT3( ( Y1 >> 24 ) & 0xFF );    \
-                                                    \
-    X1 = *RK++ ^ AES_RT0( ( Y1       ) & 0xFF ) ^   \
-                 AES_RT1( ( Y0 >>  8 ) & 0xFF ) ^   \
-                 AES_RT2( ( Y3 >> 16 ) & 0xFF ) ^   \
-                 AES_RT3( ( Y2 >> 24 ) & 0xFF );    \
-                                                    \
-    X2 = *RK++ ^ AES_RT0( ( Y2       ) & 0xFF ) ^   \
-                 AES_RT1( ( Y1 >>  8 ) & 0xFF ) ^   \
-                 AES_RT2( ( Y0 >> 16 ) & 0xFF ) ^   \
-                 AES_RT3( ( Y3 >> 24 ) & 0xFF );    \
-                                                    \
-    X3 = *RK++ ^ AES_RT0( ( Y3       ) & 0xFF ) ^   \
-                 AES_RT1( ( Y2 >>  8 ) & 0xFF ) ^   \
-                 AES_RT2( ( Y1 >> 16 ) & 0xFF ) ^   \
-                 AES_RT3( ( Y0 >> 24 ) & 0xFF );    \
-}
+#define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                 \
+    do                                                      \
+    {                                                       \
+        (X0) = *RK++ ^ AES_RT0( ( (Y0)       ) & 0xFF ) ^   \
+                       AES_RT1( ( (Y3) >>  8 ) & 0xFF ) ^   \
+                       AES_RT2( ( (Y2) >> 16 ) & 0xFF ) ^   \
+                       AES_RT3( ( (Y1) >> 24 ) & 0xFF );    \
+                                                            \
+        (X1) = *RK++ ^ AES_RT0( ( (Y1)       ) & 0xFF ) ^   \
+                       AES_RT1( ( (Y0) >>  8 ) & 0xFF ) ^   \
+                       AES_RT2( ( (Y3) >> 16 ) & 0xFF ) ^   \
+                       AES_RT3( ( (Y2) >> 24 ) & 0xFF );    \
+                                                            \
+        (X2) = *RK++ ^ AES_RT0( ( (Y2)       ) & 0xFF ) ^   \
+                       AES_RT1( ( (Y1) >>  8 ) & 0xFF ) ^   \
+                       AES_RT2( ( (Y0) >> 16 ) & 0xFF ) ^   \
+                       AES_RT3( ( (Y3) >> 24 ) & 0xFF );    \
+                                                            \
+        (X3) = *RK++ ^ AES_RT0( ( (Y3)       ) & 0xFF ) ^   \
+                       AES_RT1( ( (Y2) >>  8 ) & 0xFF ) ^   \
+                       AES_RT2( ( (Y1) >> 16 ) & 0xFF ) ^   \
+                       AES_RT3( ( (Y0) >> 24 ) & 0xFF );    \
+    } while( 0 )
 
 /*
  * AES-ECB block encryption

--- a/library/aes.c
+++ b/library/aes.c
@@ -397,7 +397,7 @@ static uint32_t RCON[10];
  */
 #define ROTL8(x) ( ( (x) << 8 ) & 0xFFFFFFFF ) | ( (x) >> 24 )
 #define XTIME(x) ( ( (x) << 1 ) ^ ( ( (x) & 0x80 ) ? 0x1B : 0x00 ) )
-#define MUL(x,y) ( ( (x) && (y) ) ? pow[(log[x]+log[y]) % 255] : 0 )
+#define MUL(x,y) ( ( (x) && (y) ) ? pow[(log[(x)]+log[(y)]) % 255] : 0 )
 
 static int aes_init_done = 0;
 

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -134,11 +134,17 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
  * This avoids allocating one more 16 bytes buffer while allowing src == dst.
  */
 #define CTR_CRYPT( dst, src, len  )                                            \
-    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctr, 16, b, &olen ) ) != 0 )  \
-        return( ret );                                                         \
-                                                                               \
-    for( i = 0; i < len; i++ )                                                 \
-        dst[i] = src[i] ^ b[i];
+    do                                                                  \
+    {                                                                   \
+        if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctr,       \
+                                           16, b, &olen ) ) != 0 )      \
+        {                                                               \
+            return( ret );                                              \
+        }                                                               \
+                                                                        \
+        for( i = 0; i < (len); i++ )                                    \
+            (dst)[i] = (src)[i] ^ b[i];                                 \
+    } while( 0 )
 
 /*
  * Authenticated encryption or decryption

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -60,14 +60,14 @@
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
 #define BYTES_TO_U32_LE( data, offset )                           \
-    ( (uint32_t) data[offset]                                     \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 1] << 8 )   \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 2] << 16 )  \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 3] << 24 )  \
+    ( (uint32_t) (data)[offset]                                   \
+      | (uint32_t) ( (uint32_t) (data)[( offset ) + 1] << 8 )     \
+      | (uint32_t) ( (uint32_t) (data)[( offset ) + 2] << 16 )    \
+      | (uint32_t) ( (uint32_t) (data)[( offset ) + 3] << 24 )    \
     )
 
 #define ROTL32( value, amount ) \
-        ( (uint32_t) ( value << amount ) | ( value >> ( 32 - amount ) ) )
+    ( (uint32_t) ( (value) << (amount) ) | ( (value) >> ( 32 - (amount) ) ) )
 
 #define CHACHA20_CTR_INDEX ( 12U )
 

--- a/library/des.c
+++ b/library/des.c
@@ -257,50 +257,57 @@ static const uint32_t RHs[16] =
 /*
  * Initial Permutation macro
  */
-#define DES_IP(X,Y)                                             \
-{                                                               \
-    T = ((X >>  4) ^ Y) & 0x0F0F0F0F; Y ^= T; X ^= (T <<  4);   \
-    T = ((X >> 16) ^ Y) & 0x0000FFFF; Y ^= T; X ^= (T << 16);   \
-    T = ((Y >>  2) ^ X) & 0x33333333; X ^= T; Y ^= (T <<  2);   \
-    T = ((Y >>  8) ^ X) & 0x00FF00FF; X ^= T; Y ^= (T <<  8);   \
-    Y = ((Y << 1) | (Y >> 31)) & 0xFFFFFFFF;                    \
-    T = (X ^ Y) & 0xAAAAAAAA; Y ^= T; X ^= T;                   \
-    X = ((X << 1) | (X >> 31)) & 0xFFFFFFFF;                    \
-}
+#define DES_IP(X,Y)                                                       \
+    do                                                                    \
+    {                                                                     \
+        T = (((X) >>  4) ^ (Y)) & 0x0F0F0F0F; (Y) ^= T; (X) ^= (T <<  4); \
+        T = (((X) >> 16) ^ (Y)) & 0x0000FFFF; (Y) ^= T; (X) ^= (T << 16); \
+        T = (((Y) >>  2) ^ (X)) & 0x33333333; (X) ^= T; (Y) ^= (T <<  2); \
+        T = (((Y) >>  8) ^ (X)) & 0x00FF00FF; (X) ^= T; (Y) ^= (T <<  8); \
+        (Y) = (((Y) << 1) | ((Y) >> 31)) & 0xFFFFFFFF;                    \
+        T = ((X) ^ (Y)) & 0xAAAAAAAA; (Y) ^= T; (X) ^= T;                 \
+        (X) = (((X) << 1) | ((X) >> 31)) & 0xFFFFFFFF;                    \
+    } while( 0 )
 
 /*
  * Final Permutation macro
  */
-#define DES_FP(X,Y)                                             \
-{                                                               \
-    X = ((X << 31) | (X >> 1)) & 0xFFFFFFFF;                    \
-    T = (X ^ Y) & 0xAAAAAAAA; X ^= T; Y ^= T;                   \
-    Y = ((Y << 31) | (Y >> 1)) & 0xFFFFFFFF;                    \
-    T = ((Y >>  8) ^ X) & 0x00FF00FF; X ^= T; Y ^= (T <<  8);   \
-    T = ((Y >>  2) ^ X) & 0x33333333; X ^= T; Y ^= (T <<  2);   \
-    T = ((X >> 16) ^ Y) & 0x0000FFFF; Y ^= T; X ^= (T << 16);   \
-    T = ((X >>  4) ^ Y) & 0x0F0F0F0F; Y ^= T; X ^= (T <<  4);   \
-}
+#define DES_FP(X,Y)                                                       \
+    do                                                                    \
+    {                                                                     \
+        (X) = (((X) << 31) | ((X) >> 1)) & 0xFFFFFFFF;                    \
+        T = ((X) ^ (Y)) & 0xAAAAAAAA; (X) ^= T; (Y) ^= T;                 \
+        (Y) = (((Y) << 31) | ((Y) >> 1)) & 0xFFFFFFFF;                    \
+        T = (((Y) >>  8) ^ (X)) & 0x00FF00FF; (X) ^= T; (Y) ^= (T <<  8); \
+        T = (((Y) >>  2) ^ (X)) & 0x33333333; (X) ^= T; (Y) ^= (T <<  2); \
+        T = (((X) >> 16) ^ (Y)) & 0x0000FFFF; (Y) ^= T; (X) ^= (T << 16); \
+        T = (((X) >>  4) ^ (Y)) & 0x0F0F0F0F; (Y) ^= T; (X) ^= (T <<  4); \
+    } while( 0 )
 
 /*
  * DES round macro
  */
-#define DES_ROUND(X,Y)                          \
-{                                               \
-    T = *SK++ ^ X;                              \
-    Y ^= SB8[ (T      ) & 0x3F ] ^              \
-         SB6[ (T >>  8) & 0x3F ] ^              \
-         SB4[ (T >> 16) & 0x3F ] ^              \
-         SB2[ (T >> 24) & 0x3F ];               \
-                                                \
-    T = *SK++ ^ ((X << 28) | (X >> 4));         \
-    Y ^= SB7[ (T      ) & 0x3F ] ^              \
-         SB5[ (T >>  8) & 0x3F ] ^              \
-         SB3[ (T >> 16) & 0x3F ] ^              \
-         SB1[ (T >> 24) & 0x3F ];               \
-}
+#define DES_ROUND(X,Y)                              \
+    do                                              \
+    {                                               \
+        T = *SK++ ^ (X);                            \
+        (Y) ^= SB8[ (T      ) & 0x3F ] ^            \
+               SB6[ (T >>  8) & 0x3F ] ^            \
+               SB4[ (T >> 16) & 0x3F ] ^            \
+               SB2[ (T >> 24) & 0x3F ];             \
+                                                    \
+        T = *SK++ ^ (((X) << 28) | ((X) >> 4));     \
+        (Y) ^= SB7[ (T      ) & 0x3F ] ^            \
+               SB5[ (T >>  8) & 0x3F ] ^            \
+               SB3[ (T >> 16) & 0x3F ] ^            \
+               SB1[ (T >> 24) & 0x3F ];             \
+    } while( 0 )
 
-#define SWAP(a,b) { uint32_t t = a; a = b; b = t; t = 0; }
+#define SWAP(a,b)                                       \
+    do                                                  \
+    {                                                   \
+        uint32_t t = (a); (a) = (b); (b) = t; t = 0;    \
+    } while( 0 )
 
 void mbedtls_des_init( mbedtls_des_context *ctx )
 {

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1046,25 +1046,29 @@ cleanup:
 #define INC_MUL_COUNT
 #endif
 
-#define MOD_MUL( N )    do { MBEDTLS_MPI_CHK( ecp_modp( &N, grp ) ); INC_MUL_COUNT } \
-                        while( 0 )
+#define MOD_MUL( N )                                                    \
+    do                                                                  \
+    {                                                                   \
+        MBEDTLS_MPI_CHK( ecp_modp( &(N), grp ) );                       \
+        INC_MUL_COUNT                                                   \
+    } while( 0 )
 
 /*
  * Reduce a mbedtls_mpi mod p in-place, to use after mbedtls_mpi_sub_mpi
  * N->s < 0 is a very fast test, which fails only if N is 0
  */
-#define MOD_SUB( N )                                \
-    while( N.s < 0 && mbedtls_mpi_cmp_int( &N, 0 ) != 0 )   \
-        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &N, &N, &grp->P ) )
+#define MOD_SUB( N )                                                    \
+    while( (N).s < 0 && mbedtls_mpi_cmp_int( &(N), 0 ) != 0 )           \
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &(N), &(N), &grp->P ) )
 
 /*
  * Reduce a mbedtls_mpi mod p in-place, to use after mbedtls_mpi_add_mpi and mbedtls_mpi_mul_int.
  * We known P, N and the result are positive, so sub_abs is correct, and
  * a bit faster.
  */
-#define MOD_ADD( N )                                \
-    while( mbedtls_mpi_cmp_mpi( &N, &grp->P ) >= 0 )        \
-        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( &N, &N, &grp->P ) )
+#define MOD_ADD( N )                                                    \
+    while( mbedtls_mpi_cmp_mpi( &(N), &grp->P ) >= 0 )                  \
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_abs( &(N), &(N), &grp->P ) )
 
 #if defined(ECP_SHORTWEIERSTRASS)
 /*

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -51,11 +51,11 @@
  */
 #if defined(MBEDTLS_HAVE_INT32)
 
-#define BYTES_TO_T_UINT_4( a, b, c, d )             \
-    ( (mbedtls_mpi_uint) a <<  0 ) |                          \
-    ( (mbedtls_mpi_uint) b <<  8 ) |                          \
-    ( (mbedtls_mpi_uint) c << 16 ) |                          \
-    ( (mbedtls_mpi_uint) d << 24 )
+#define BYTES_TO_T_UINT_4( a, b, c, d )                       \
+    ( (mbedtls_mpi_uint) (a) <<  0 ) |                        \
+    ( (mbedtls_mpi_uint) (b) <<  8 ) |                        \
+    ( (mbedtls_mpi_uint) (c) << 16 ) |                        \
+    ( (mbedtls_mpi_uint) (d) << 24 )
 
 #define BYTES_TO_T_UINT_2( a, b )                   \
     BYTES_TO_T_UINT_4( a, b, 0, 0 )
@@ -67,14 +67,14 @@
 #else /* 64-bits */
 
 #define BYTES_TO_T_UINT_8( a, b, c, d, e, f, g, h ) \
-    ( (mbedtls_mpi_uint) a <<  0 ) |                          \
-    ( (mbedtls_mpi_uint) b <<  8 ) |                          \
-    ( (mbedtls_mpi_uint) c << 16 ) |                          \
-    ( (mbedtls_mpi_uint) d << 24 ) |                          \
-    ( (mbedtls_mpi_uint) e << 32 ) |                          \
-    ( (mbedtls_mpi_uint) f << 40 ) |                          \
-    ( (mbedtls_mpi_uint) g << 48 ) |                          \
-    ( (mbedtls_mpi_uint) h << 56 )
+    ( (mbedtls_mpi_uint) (a) <<  0 ) |                        \
+    ( (mbedtls_mpi_uint) (b) <<  8 ) |                        \
+    ( (mbedtls_mpi_uint) (c) << 16 ) |                        \
+    ( (mbedtls_mpi_uint) (d) << 24 ) |                        \
+    ( (mbedtls_mpi_uint) (e) << 32 ) |                        \
+    ( (mbedtls_mpi_uint) (f) << 40 ) |                        \
+    ( (mbedtls_mpi_uint) (g) << 48 ) |                        \
+    ( (mbedtls_mpi_uint) (h) << 56 )
 
 #define BYTES_TO_T_UINT_4( a, b, c, d )             \
     BYTES_TO_T_UINT_8( a, b, c, d, 0, 0, 0, 0 )
@@ -890,7 +890,7 @@ static inline void carry64( mbedtls_mpi_uint *dst, mbedtls_mpi_uint *carry )
 }
 
 #define WIDTH       8 / sizeof( mbedtls_mpi_uint )
-#define A( i )      N->p + i * WIDTH
+#define A( i )      N->p + (i) * WIDTH
 #define ADD( i )    add64( p, A( i ), &c )
 #define NEXT        p += WIDTH; carry64( p, &c )
 #define LAST        p += WIDTH; *p = c; while( ++p < end ) *p = 0
@@ -955,7 +955,8 @@ cleanup:
 #else                               /* 64-bit */
 
 #define MAX32       N->n * 2
-#define A( j ) j % 2 ? (uint32_t)( N->p[j/2] >> 32 ) : (uint32_t)( N->p[j/2] )
+#define A( j ) (j) % 2 ? (uint32_t)( N->p[(j)/2] >> 32 ) : \
+                         (uint32_t)( N->p[(j)/2] )
 #define STORE32                                   \
     if( i % 2 ) {                                 \
         N->p[i/2] &= 0x00000000FFFFFFFF;          \
@@ -989,20 +990,21 @@ static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
  * Helpers for the main 'loop'
  * (see fix_negative for the motivation of C)
  */
-#define INIT( b )                                           \
-    int ret;                                                \
-    signed char c = 0, cc;                                  \
-    uint32_t cur;                                           \
-    size_t i = 0, bits = b;                                 \
-    mbedtls_mpi C;                                                  \
-    mbedtls_mpi_uint Cp[ b / 8 / sizeof( mbedtls_mpi_uint) + 1 ];               \
-                                                            \
-    C.s = 1;                                                \
-    C.n = b / 8 / sizeof( mbedtls_mpi_uint) + 1;                      \
-    C.p = Cp;                                               \
-    memset( Cp, 0, C.n * sizeof( mbedtls_mpi_uint ) );                \
-                                                            \
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( N, b * 2 / 8 / sizeof( mbedtls_mpi_uint ) ) ); \
+#define INIT( b )                                                       \
+    int ret;                                                            \
+    signed char c = 0, cc;                                              \
+    uint32_t cur;                                                       \
+    size_t i = 0, bits = (b);                                           \
+    mbedtls_mpi C;                                                      \
+    mbedtls_mpi_uint Cp[ (b) / 8 / sizeof( mbedtls_mpi_uint) + 1 ];     \
+                                                                        \
+    C.s = 1;                                                            \
+    C.n = (b) / 8 / sizeof( mbedtls_mpi_uint) + 1;                      \
+    C.p = Cp;                                                           \
+    memset( Cp, 0, C.n * sizeof( mbedtls_mpi_uint ) );                  \
+                                                                        \
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( N, (b) * 2 / 8 /                 \
+                                       sizeof( mbedtls_mpi_uint ) ) );  \
     LOAD32;
 
 #define NEXT                    \

--- a/library/havege.c
+++ b/library/havege.c
@@ -54,7 +54,7 @@
  * ------------------------------------------------------------------------
  */
 
-#define SWAP(X,Y) { int *T = X; X = Y; Y = T; }
+#define SWAP(X,Y) { int *T = (X); (X) = (Y); (Y) = T; }
 
 #define TST1_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;
 #define TST2_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;

--- a/library/md4.c
+++ b/library/md4.c
@@ -148,8 +148,8 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 #define P(a,b,c,d,x,s)         \
     do                         \
     {                          \
-        (a) += F(b,c,d) + (x); \
-        (a) = S(a,s);          \
+        (a) += F((b),(c),(d)) + (x);             \
+        (a) = S((a),(s));                        \
     } while( 0 )
 
 

--- a/library/md4.c
+++ b/library/md4.c
@@ -145,9 +145,9 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
     D = ctx->state[3];
 
 #define F(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
-#define P(a,b,c,d,x,s)         \
-    do                         \
-    {                          \
+#define P(a,b,c,d,x,s)                           \
+    do                                           \
+    {                                            \
         (a) += F((b),(c),(d)) + (x);             \
         (a) = S((a),(s));                        \
     } while( 0 )
@@ -177,8 +177,8 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 #define P(a,b,c,d,x,s)                          \
     do                                          \
     {                                           \
-        (a) += F(b,c,d) + (x) + 0x5A827999;     \
-        (a) = S(a,s);                           \
+        (a) += F((b),(c),(d)) + (x) + 0x5A827999;       \
+        (a) = S((a),(s));                               \
     } while( 0 )
 
     P( A, B, C, D, X[ 0],  3 );
@@ -202,11 +202,11 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 #undef F
 
 #define F(x,y,z) ((x) ^ (y) ^ (z))
-#define P(a,b,c,d,x,s)                      \
-    do                                      \
-    {                                       \
-        (a) += F(b,c,d) + (x) + 0x6ED9EBA1; \
-        (a) = S(a,s);                       \
+#define P(a,b,c,d,x,s)                                  \
+    do                                                  \
+    {                                                   \
+        (a) += F((b),(c),(d)) + (x) + 0x6ED9EBA1;       \
+        (a) = S((a),(s));                               \
     } while( 0 )
 
     P( A, B, C, D, X[ 0],  3 );

--- a/library/md4.c
+++ b/library/md4.c
@@ -137,15 +137,21 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
     GET_UINT32_LE( X[14], data, 56 );
     GET_UINT32_LE( X[15], data, 60 );
 
-#define S(x,n) ((x << n) | ((x & 0xFFFFFFFF) >> (32 - n)))
+#define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
     A = ctx->state[0];
     B = ctx->state[1];
     C = ctx->state[2];
     D = ctx->state[3];
 
-#define F(x, y, z) ((x & y) | ((~x) & z))
-#define P(a,b,c,d,x,s) { a += F(b,c,d) + x; a = S(a,s); }
+#define F(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
+#define P(a,b,c,d,x,s)         \
+    do                         \
+    {                          \
+        (a) += F(b,c,d) + (x); \
+        (a) = S(a,s);          \
+    } while( 0 )
+
 
     P( A, B, C, D, X[ 0],  3 );
     P( D, A, B, C, X[ 1],  7 );
@@ -167,8 +173,13 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 #undef P
 #undef F
 
-#define F(x,y,z) ((x & y) | (x & z) | (y & z))
-#define P(a,b,c,d,x,s) { a += F(b,c,d) + x + 0x5A827999; a = S(a,s); }
+#define F(x,y,z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
+#define P(a,b,c,d,x,s)                          \
+    do                                          \
+    {                                           \
+        (a) += F(b,c,d) + (x) + 0x5A827999;     \
+        (a) = S(a,s);                           \
+    } while( 0 )
 
     P( A, B, C, D, X[ 0],  3 );
     P( D, A, B, C, X[ 4],  5 );
@@ -190,8 +201,13 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 #undef P
 #undef F
 
-#define F(x,y,z) (x ^ y ^ z)
-#define P(a,b,c,d,x,s) { a += F(b,c,d) + x + 0x6ED9EBA1; a = S(a,s); }
+#define F(x,y,z) ((x) ^ (y) ^ (z))
+#define P(a,b,c,d,x,s)                      \
+    do                                      \
+    {                                       \
+        (a) += F(b,c,d) + (x) + 0x6ED9EBA1; \
+        (a) = S(a,s);                       \
+    } while( 0 )
 
     P( A, B, C, D, X[ 0],  3 );
     P( D, A, B, C, X[ 8],  9 );

--- a/library/md5.c
+++ b/library/md5.c
@@ -136,19 +136,22 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
     GET_UINT32_LE( X[14], data, 56 );
     GET_UINT32_LE( X[15], data, 60 );
 
-#define S(x,n) ((x << n) | ((x & 0xFFFFFFFF) >> (32 - n)))
+#define S(x,n)                                                          \
+    ( ( (x) << (n) ) | ( ( (x) & 0xFFFFFFFF) >> ( 32 - (n) ) ) )
 
-#define P(a,b,c,d,k,s,t)                                \
-{                                                       \
-    a += F(b,c,d) + X[k] + t; a = S(a,s) + b;           \
-}
+#define P(a,b,c,d,k,s,t)                                        \
+    do                                                          \
+    {                                                           \
+        (a) += F((b),(c),(d)) + X[k] + (t);                     \
+        (a) = S((a),(s)) + (b);                                 \
+    } while( 0 )
 
     A = ctx->state[0];
     B = ctx->state[1];
     C = ctx->state[2];
     D = ctx->state[3];
 
-#define F(x,y,z) (z ^ (x & (y ^ z)))
+#define F(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 
     P( A, B, C, D,  0,  7, 0xD76AA478 );
     P( D, A, B, C,  1, 12, 0xE8C7B756 );
@@ -169,7 +172,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 
 #undef F
 
-#define F(x,y,z) (y ^ (z & (x ^ y)))
+#define F(x,y,z) ((y) ^ ((z) & ((x) ^ (y))))
 
     P( A, B, C, D,  1,  5, 0xF61E2562 );
     P( D, A, B, C,  6,  9, 0xC040B340 );
@@ -190,7 +193,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 
 #undef F
 
-#define F(x,y,z) (x ^ y ^ z)
+#define F(x,y,z) ((x) ^ (y) ^ (z))
 
     P( A, B, C, D,  5,  4, 0xFFFA3942 );
     P( D, A, B, C,  8, 11, 0x8771F681 );
@@ -211,7 +214,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 
 #undef F
 
-#define F(x,y,z) (y ^ (x | ~z))
+#define F(x,y,z) ((y) ^ ((x) | ~(z)))
 
     P( A, B, C, D,  0,  6, 0xF4292244 );
     P( D, A, B, C,  7, 10, 0x432AFF97 );

--- a/library/md5.c
+++ b/library/md5.c
@@ -142,7 +142,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 #define P(a,b,c,d,k,s,t)                                        \
     do                                                          \
     {                                                           \
-        (a) += F((b),(c),(d)) + X[k] + (t);                     \
+        (a) += F((b),(c),(d)) + X[(k)] + (t);                   \
         (a) = S((a),(s)) + (b);                                 \
     } while( 0 )
 

--- a/library/oid.c
+++ b/library/oid.c
@@ -54,22 +54,24 @@
  * Macro to generate an internal function for oid_XXX_from_asn1() (used by
  * the other functions)
  */
-#define FN_OID_TYPED_FROM_ASN1( TYPE_T, NAME, LIST )                        \
-static const TYPE_T * oid_ ## NAME ## _from_asn1( const mbedtls_asn1_buf *oid )     \
-{                                                                           \
-    const TYPE_T *p = LIST;                                                 \
-    const mbedtls_oid_descriptor_t *cur = (const mbedtls_oid_descriptor_t *) p;             \
-    if( p == NULL || oid == NULL ) return( NULL );                          \
-    while( cur->asn1 != NULL ) {                                            \
-        if( cur->asn1_len == oid->len &&                                    \
-            memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {                  \
-            return( p );                                                    \
-        }                                                                   \
-        p++;                                                                \
-        cur = (const mbedtls_oid_descriptor_t *) p;                                 \
-    }                                                                       \
-    return( NULL );                                                         \
-}
+#define FN_OID_TYPED_FROM_ASN1( TYPE_T, NAME, LIST )                    \
+    static const TYPE_T * oid_ ## NAME ## _from_asn1(                   \
+                                      const mbedtls_asn1_buf *oid )     \
+    {                                                                   \
+        const TYPE_T *p = (LIST);                                       \
+        const mbedtls_oid_descriptor_t *cur =                           \
+            (const mbedtls_oid_descriptor_t *) p;                       \
+        if( p == NULL || oid == NULL ) return( NULL );                  \
+        while( cur->asn1 != NULL ) {                                    \
+            if( cur->asn1_len == oid->len &&                            \
+                memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {          \
+                return( p );                                            \
+            }                                                           \
+            p++;                                                        \
+            cur = (const mbedtls_oid_descriptor_t *) p;                 \
+        }                                                               \
+        return( NULL );                                                 \
+    }
 
 /*
  * Macro to generate a function for retrieving a single attribute from the
@@ -103,12 +105,13 @@ int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1 )                  
  */
 #define FN_OID_GET_ATTR2(FN_NAME, TYPE_T, TYPE_NAME, ATTR1_TYPE, ATTR1,     \
                          ATTR2_TYPE, ATTR2)                                 \
-int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1, ATTR2_TYPE * ATTR2 )  \
+int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1,               \
+                                          ATTR2_TYPE * ATTR2 )              \
 {                                                                           \
     const TYPE_T *data = oid_ ## TYPE_NAME ## _from_asn1( oid );            \
-    if( data == NULL ) return( MBEDTLS_ERR_OID_NOT_FOUND );                \
-    *ATTR1 = data->ATTR1;                                                   \
-    *ATTR2 = data->ATTR2;                                                   \
+    if( data == NULL ) return( MBEDTLS_ERR_OID_NOT_FOUND );                 \
+    *(ATTR1) = data->ATTR1;                                                 \
+    *(ATTR2) = data->ATTR2;                                                 \
     return( 0 );                                                            \
 }
 
@@ -119,16 +122,16 @@ int FN_NAME( const mbedtls_asn1_buf *oid, ATTR1_TYPE * ATTR1, ATTR2_TYPE * ATTR2
 #define FN_OID_GET_OID_BY_ATTR1(FN_NAME, TYPE_T, LIST, ATTR1_TYPE, ATTR1)   \
 int FN_NAME( ATTR1_TYPE ATTR1, const char **oid, size_t *olen )             \
 {                                                                           \
-    const TYPE_T *cur = LIST;                                               \
+    const TYPE_T *cur = (LIST);                                             \
     while( cur->descriptor.asn1 != NULL ) {                                 \
-        if( cur->ATTR1 == ATTR1 ) {                                         \
+        if( cur->ATTR1 == (ATTR1) ) {                                       \
             *oid = cur->descriptor.asn1;                                    \
             *olen = cur->descriptor.asn1_len;                               \
             return( 0 );                                                    \
         }                                                                   \
         cur++;                                                              \
     }                                                                       \
-    return( MBEDTLS_ERR_OID_NOT_FOUND );                                   \
+    return( MBEDTLS_ERR_OID_NOT_FOUND );                                    \
 }
 
 /*
@@ -140,9 +143,9 @@ int FN_NAME( ATTR1_TYPE ATTR1, const char **oid, size_t *olen )             \
 int FN_NAME( ATTR1_TYPE ATTR1, ATTR2_TYPE ATTR2, const char **oid ,         \
              size_t *olen )                                                 \
 {                                                                           \
-    const TYPE_T *cur = LIST;                                               \
+    const TYPE_T *cur = (LIST);                                             \
     while( cur->descriptor.asn1 != NULL ) {                                 \
-        if( cur->ATTR1 == ATTR1 && cur->ATTR2 == ATTR2 ) {                  \
+        if( cur->ATTR1 == (ATTR1) && cur->ATTR2 == (ATTR2) ) {              \
             *oid = cur->descriptor.asn1;                                    \
             *olen = cur->descriptor.asn1_len;                               \
             return( 0 );                                                    \

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -58,10 +58,10 @@
 #define POLY1305_BLOCK_SIZE_BYTES ( 16U )
 
 #define BYTES_TO_U32_LE( data, offset )                           \
-    ( (uint32_t) data[offset]                                     \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 1] << 8 )   \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 2] << 16 )  \
-          | (uint32_t) ( (uint32_t) data[( offset ) + 3] << 24 )  \
+    ( (uint32_t) (data)[offset]                                     \
+          | (uint32_t) ( (uint32_t) (data)[( offset ) + 1] << 8 )   \
+          | (uint32_t) ( (uint32_t) (data)[( offset ) + 2] << 16 )  \
+          | (uint32_t) ( (uint32_t) (data)[( offset ) + 3] << 24 )  \
     )
 
 /*

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -147,22 +147,29 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
     D = Dp = ctx->state[3];
     E = Ep = ctx->state[4];
 
-#define F1( x, y, z )   ( x ^ y ^ z )
-#define F2( x, y, z )   ( ( x & y ) | ( ~x & z ) )
-#define F3( x, y, z )   ( ( x | ~y ) ^ z )
-#define F4( x, y, z )   ( ( x & z ) | ( y & ~z ) )
-#define F5( x, y, z )   ( x ^ ( y | ~z ) )
+#define F1( x, y, z )   ( (x) ^ (y) ^ (z) )
+#define F2( x, y, z )   ( ( (x) & (y) ) | ( ~(x) & (z) ) )
+#define F3( x, y, z )   ( ( (x) | ~(y) ) ^ (z) )
+#define F4( x, y, z )   ( ( (x) & (z) ) | ( (y) & ~(z) ) )
+#define F5( x, y, z )   ( (x) ^ ( (y) | ~(z) ) )
 
-#define S( x, n ) ( ( x << n ) | ( x >> (32 - n) ) )
+#define S( x, n ) ( ( (x) << (n) ) | ( (x) >> (32 - (n)) ) )
 
-#define P( a, b, c, d, e, r, s, f, k )      \
-    a += f( b, c, d ) + X[r] + k;           \
-    a = S( a, s ) + e;                      \
-    c = S( c, 10 );
+#define P( a, b, c, d, e, r, s, f, k )                \
+    do                                                \
+    {                                                 \
+        (a) += f( (b), (c), (d) ) + X[r] + (k);       \
+        (a) = S( (a), (s) ) + (e);                    \
+        (c) = S( (c), 10 );                           \
+    } while( 0 )
 
-#define P2( a, b, c, d, e, r, s, rp, sp )   \
-    P( a, b, c, d, e, r, s, F, K );         \
-    P( a ## p, b ## p, c ## p, d ## p, e ## p, rp, sp, Fp, Kp );
+#define P2( a, b, c, d, e, r, s, rp, sp )                               \
+    do                                                                  \
+    {                                                                   \
+        P( (a), (b), (c), (d), (e), (r), (s), F, K );                   \
+        P( a ## p, b ## p, c ## p, d ## p, e ## p,                      \
+           (rp), (sp), Fp, Kp );                                        \
+    } while( 0 )
 
 #define F   F1
 #define K   0x00000000

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -164,8 +164,8 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 #define P(a,b,c,d,e,x)                                          \
     do                                                          \
     {                                                           \
-        (e) += S(a,5) + F(b,c,d) + K + (x);                     \
-        (b) = S(b,30);                                          \
+        (e) += S((a),5) + F((b),(c),(d)) + K + (x);             \
+        (b) = S((b),30);                                        \
     } while( 0 )
 
     A = ctx->state[0];

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -152,19 +152,21 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     GET_UINT32_BE( W[14], data, 56 );
     GET_UINT32_BE( W[15], data, 60 );
 
-#define S(x,n) ((x << n) | ((x & 0xFFFFFFFF) >> (32 - n)))
+#define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
-#define R(t)                                            \
-(                                                       \
-    temp = W[( t -  3 ) & 0x0F] ^ W[( t - 8 ) & 0x0F] ^ \
-           W[( t - 14 ) & 0x0F] ^ W[  t       & 0x0F],  \
-    ( W[t & 0x0F] = S(temp,1) )                         \
-)
+#define R(t)                                                    \
+    (                                                           \
+        temp = W[( (t) -  3 ) & 0x0F] ^ W[( (t) - 8 ) & 0x0F] ^ \
+               W[( (t) - 14 ) & 0x0F] ^ W[  (t)       & 0x0F],  \
+        ( W[(t) & 0x0F] = S(temp,1) )                           \
+    )
 
-#define P(a,b,c,d,e,x)                                  \
-{                                                       \
-    e += S(a,5) + F(b,c,d) + K + x; b = S(b,30);        \
-}
+#define P(a,b,c,d,e,x)                                          \
+    do                                                          \
+    {                                                           \
+        (e) += S(a,5) + F(b,c,d) + K + (x);                     \
+        (b) = S(b,30);                                          \
+    } while( 0 )
 
     A = ctx->state[0];
     B = ctx->state[1];
@@ -172,7 +174,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     D = ctx->state[3];
     E = ctx->state[4];
 
-#define F(x,y,z) (z ^ (x & (y ^ z)))
+#define F(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 #define K 0x5A827999
 
     P( A, B, C, D, E, W[0]  );
@@ -199,7 +201,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 #undef K
 #undef F
 
-#define F(x,y,z) (x ^ y ^ z)
+#define F(x,y,z) ((x) ^ (y) ^ (z))
 #define K 0x6ED9EBA1
 
     P( A, B, C, D, E, R(20) );
@@ -226,7 +228,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 #undef K
 #undef F
 
-#define F(x,y,z) ((x & y) | (z & (x | y)))
+#define F(x,y,z) (((x) & (y)) | ((z) & ((x) | (y))))
 #define K 0x8F1BBCDC
 
     P( A, B, C, D, E, R(40) );
@@ -253,7 +255,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 #undef K
 #undef F
 
-#define F(x,y,z) (x ^ y ^ z)
+#define F(x,y,z) ((x) ^ (y) ^ (z))
 #define K 0xCA62C1D6
 
     P( A, B, C, D, E, R(60) );

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -193,8 +193,8 @@ static const uint32_t K[] =
 #define P(a,b,c,d,e,f,g,h,x,K)                          \
     do                                                  \
     {                                                   \
-        temp1 = (h) + S3(e) + F1(e,f,g) + (K) + (x);    \
-        temp2 = S2(a) + F0(a,b,c);                      \
+        temp1 = (h) + S3(e) + F1((e),(f),(g)) + (K) + (x);      \
+        temp2 = S2(a) + F0((a),(b),(c));                        \
         (d) += temp1; (h) = temp1 + temp2;              \
     } while( 0 )
 

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -172,8 +172,8 @@ static const uint32_t K[] =
     0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2,
 };
 
-#define  SHR(x,n) ((x & 0xFFFFFFFF) >> n)
-#define ROTR(x,n) (SHR(x,n) | (x << (32 - n)))
+#define  SHR(x,n) (((x) & 0xFFFFFFFF) >> (n))
+#define ROTR(x,n) (SHR(x,n) | ((x) << (32 - (n))))
 
 #define S0(x) (ROTR(x, 7) ^ ROTR(x,18) ^  SHR(x, 3))
 #define S1(x) (ROTR(x,17) ^ ROTR(x,19) ^  SHR(x,10))
@@ -181,21 +181,22 @@ static const uint32_t K[] =
 #define S2(x) (ROTR(x, 2) ^ ROTR(x,13) ^ ROTR(x,22))
 #define S3(x) (ROTR(x, 6) ^ ROTR(x,11) ^ ROTR(x,25))
 
-#define F0(x,y,z) ((x & y) | (z & (x | y)))
-#define F1(x,y,z) (z ^ (x & (y ^ z)))
+#define F0(x,y,z) (((x) & (y)) | ((z) & ((x) | (y))))
+#define F1(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 
 #define R(t)                                    \
-(                                               \
-    W[t] = S1(W[t -  2]) + W[t -  7] +          \
-           S0(W[t - 15]) + W[t - 16]            \
-)
+    (                                           \
+        W[t] = S1(W[(t) -  2]) + W[(t) -  7] +  \
+               S0(W[(t) - 15]) + W[(t) - 16]    \
+    )
 
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
-}
+#define P(a,b,c,d,e,f,g,h,x,K)                          \
+    do                                                  \
+    {                                                   \
+        temp1 = (h) + S3(e) + F1(e,f,g) + (K) + (x);    \
+        temp2 = S2(a) + F0(a,b,c);                      \
+        (d) += temp1; (h) = temp1 + temp2;              \
+    } while( 0 )
 
 int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                 const unsigned char data[64] )

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -239,8 +239,8 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 #define P(a,b,c,d,e,f,g,h,x,K)                          \
     do                                                  \
     {                                                   \
-        temp1 = (h) + S3(e) + F1(e,f,g) + (K) + (x);    \
-        temp2 = S2(a) + F0(a,b,c);                      \
+        temp1 = (h) + S3(e) + F1((e),(f),(g)) + (K) + (x);      \
+        temp2 = S2(a) + F0((a),(b),(c));                        \
         (d) += temp1; (h) = temp1 + temp2;              \
     } while( 0 )
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -225,7 +225,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     SHA512_VALIDATE_RET( (const unsigned char *)data != NULL );
 
 #define  SHR(x,n) ((x) >> (n))
-#define ROTR(x,n) (SHR(x,n) | ((x) << (64 - (n))))
+#define ROTR(x,n) (SHR((x),(n)) | ((x) << (64 - (n))))
 
 #define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
 #define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
@@ -236,12 +236,12 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 #define F0(x,y,z) (((x) & (y)) | ((z) & ((x) | (y))))
 #define F1(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 
-#define P(a,b,c,d,e,f,g,h,x,K)                          \
-    do                                                  \
-    {                                                   \
+#define P(a,b,c,d,e,f,g,h,x,K)                                  \
+    do                                                          \
+    {                                                           \
         temp1 = (h) + S3(e) + F1((e),(f),(g)) + (K) + (x);      \
         temp2 = S2(a) + F0((a),(b),(c));                        \
-        (d) += temp1; (h) = temp1 + temp2;              \
+        (d) += temp1; (h) = temp1 + temp2;                      \
     } while( 0 )
 
     for( i = 0; i < 16; i++ )

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -224,8 +224,8 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     SHA512_VALIDATE_RET( ctx != NULL );
     SHA512_VALIDATE_RET( (const unsigned char *)data != NULL );
 
-#define  SHR(x,n) (x >> n)
-#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
+#define  SHR(x,n) ((x) >> (n))
+#define ROTR(x,n) (SHR(x,n) | ((x) << (64 - (n))))
 
 #define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
 #define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
@@ -233,15 +233,16 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 #define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
 #define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
 
-#define F0(x,y,z) ((x & y) | (z & (x | y)))
-#define F1(x,y,z) (z ^ (x & (y ^ z)))
+#define F0(x,y,z) (((x) & (y)) | ((z) & ((x) | (y))))
+#define F1(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
-}
+#define P(a,b,c,d,e,f,g,h,x,K)                          \
+    do                                                  \
+    {                                                   \
+        temp1 = (h) + S3(e) + F1(e,f,g) + (K) + (x);    \
+        temp2 = S2(a) + F0(a,b,c);                      \
+        (d) += temp1; (h) = temp1 + temp2;              \
+    } while( 0 )
 
     for( i = 0; i < 16; i++ )
     {

--- a/library/x509.c
+++ b/library/x509.c
@@ -67,8 +67,15 @@
 #include <time.h>
 #endif
 
-#define CHECK(code) if( ( ret = code ) != 0 ){ return( ret ); }
-#define CHECK_RANGE(min, max, val) if( val < min || val > max ){ return( ret ); }
+#define CHECK(code) if( ( ret = ( code ) ) != 0 ){ return( ret ); }
+#define CHECK_RANGE(min, max, val)                      \
+    do                                                  \
+    {                                                   \
+        if( ( val ) < ( min ) || ( val ) > ( max ) )    \
+        {                                               \
+            return( ret );                              \
+        }                                               \
+    } while( 0 )
 
 /*
  *  CertificateSerialNumber  ::=  INTEGER

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1444,7 +1444,7 @@ static int x509_info_subject_alt_name( char **buf, size_t *size,
     }
 
 #define CERT_TYPE(type,name)                    \
-    if( ns_cert_type & type )                   \
+    if( ns_cert_type & (type) )                 \
         PRINT_ITEM( name );
 
 static int x509_info_cert_type( char **buf, size_t *size,
@@ -1471,7 +1471,7 @@ static int x509_info_cert_type( char **buf, size_t *size,
 }
 
 #define KEY_USAGE(code,name)    \
-    if( key_usage & code )      \
+    if( key_usage & (code) )    \
         PRINT_ITEM( name );
 
 static int x509_info_key_usage( char **buf, size_t *size,

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -615,11 +615,14 @@ static int get_auth_mode( const char *s )
  * Used by sni_parse and psk_parse to handle coma-separated lists
  */
 #define GET_ITEM( dst )         \
-    dst = p;                    \
-    while( *p != ',' )          \
-        if( ++p > end )         \
-            goto error;         \
-    *p++ = '\0';
+    do                          \
+    {                           \
+        (dst) = p;              \
+        while( *p != ',' )      \
+            if( ++p > end )     \
+                goto error;     \
+        *p++ = '\0';            \
+    } while( 0 )
 
 #if defined(SNI_OPTION)
 typedef struct _sni_entry sni_entry;
@@ -776,15 +779,18 @@ int sni_callback( void *p_info, mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
-#define HEX2NUM( c )                    \
-        if( c >= '0' && c <= '9' )      \
-            c -= '0';                   \
-        else if( c >= 'a' && c <= 'f' ) \
-            c -= 'a' - 10;              \
-        else if( c >= 'A' && c <= 'F' ) \
-            c -= 'A' - 10;              \
-        else                            \
-            return( -1 );
+#define HEX2NUM( c )                        \
+    do                                      \
+    {                                       \
+        if( (c) >= '0' && (c) <= '9' )      \
+            (c) -= '0';                     \
+        else if( (c) >= 'a' && (c) <= 'f' ) \
+            (c) -= 'a' - 10;                \
+        else if( (c) >= 'A' && (c) <= 'F' ) \
+            (c) -= 'A' - 10;                \
+        else                                \
+            return( -1 );                   \
+    } while( 0 )
 
 /*
  * Convert a hex string to bytes.

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -163,7 +163,7 @@ do {                                                                    \
 
 #define MEMORY_MEASURE_PRINT( title_len )                               \
     mbedtls_memory_buffer_alloc_max_get( &max_used, &max_blocks );      \
-    for( ii = 12 - title_len; ii != 0; ii-- ) mbedtls_printf( " " );    \
+    for( ii = 12 - (title_len); ii != 0; ii-- ) mbedtls_printf( " " );  \
     max_used -= prv_used;                                               \
     max_blocks -= prv_blocks;                                           \
     max_bytes = max_used + MEM_BLOCK_OVERHEAD * max_blocks;             \


### PR DESCRIPTION
__Summary:__ This PR improves hygiene and formatting of macro definitions throughout the library. Specifically:
- It adds brackets around parameters to avoid unintended interpretation of arguments, e.g. due to operator precedence.
- It adds uses of the `do { ... } while( 0 )` idiom for macros that can be used as commands.

__Internal Reference:__ IOTSSL-1834.

__Backports:__ Backported missing parentheses is public, documented macro `MBEDTLS_X509_ID_FLAG` in #2094 and #2093.