### PR TITLE
Backport 2.7: Add missing parentheses around parameter in MBEDTLS_X509_ID_FLAG

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Bugfix
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
    * Fix a bug in the update function for SSL ticket keys which previously
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+   * Add missing parentheses around parameters in the definition of the
+     public macro MBEDTLS_X509_ID_FLAG. This could lead to invalid evaluation
+     in case operators binding less strongly than subtraction were used
+     for the parameter.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -98,7 +98,7 @@ mbedtls_x509_crt;
  * Build flag from an algorithm/curve identifier (pk, md, ecp)
  * Since 0 is always XXX_NONE, ignore it.
  */
-#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( id - 1 ) )
+#define MBEDTLS_X509_ID_FLAG( id )   ( 1 << ( ( id ) - 1 ) )
 
 /**
  * Security profile for certificate verification.


### PR DESCRIPTION
__Summary:__ 
The `id` parameter of the public `MBEDTLS_X509_ID_FLAG` macro was used in a subtraction without being surrounded by parentheses. Since some operators bind less strongly than subtraction, this could lead to erroneous evaluation of `MBEDTLS_X509_ID_FLAG`. For example, `MBEDTLS_X509_ID_FLAG( 1 << 2 )` would evaluate evaluate to

  `1 << ( 1 << 2 - 1 ) == 1 << ( 1 << 1 ) == 4`

instead of the intended

  `1 << ( ( 1 << 2 ) - 1 ) == 1 << ( 4 - 1 ) == 8`.

This PR fixes this by adding parentheses about the `id` parameter in the definition of `MBEDTLS_X509_ID_FLAG`.

__Internal Reference:__ IOTSSL-1834

Partial backport of #2092 to Mbed TLS 2.7.