### PR TITLE
Backport 2.7: Fix missing or improper zeroization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ Bugfix
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
    * Fix a bug in the update function for SSL ticket keys which previously
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+   * Zeroize memory used for reassembling handshake messages after use.
+   * Use `mbedtls_zeroize()` instead of `memset()` for zeroization of
+     sensitive data in the example programs aescrypt2 and crypt_and_hash.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3235,6 +3235,7 @@ static int ssl_reassemble_dtls_handshake( mbedtls_ssl_context *ssl )
 
     memcpy( ssl->in_msg, ssl->handshake->hs_msg, ssl->in_hslen );
 
+    mbedtls_zeroize( ssl->handshake->hs_msg, ssl->in_hslen );
     mbedtls_free( ssl->handshake->hs_msg );
     ssl->handshake->hs_msg = NULL;
 

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -72,6 +72,12 @@ int main( void )
     return( 0 );
 }
 #else
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
 int main( int argc, char *argv[] )
 {
     int ret = 0;
@@ -445,13 +451,13 @@ exit:
        the case when the user has missed or reordered some,
        in which case the key might not be in argv[4]. */
     for( i = 0; i < (unsigned int) argc; i++ )
-        memset( argv[i], 0, strlen( argv[i] ) );
+        mbedtls_zeroize( argv[i], strlen( argv[i] ) );
 
-    memset( IV,     0, sizeof( IV ) );
-    memset( key,    0, sizeof( key ) );
-    memset( tmp,    0, sizeof( tmp ) );
-    memset( buffer, 0, sizeof( buffer ) );
-    memset( digest, 0, sizeof( digest ) );
+    mbedtls_zeroize( IV,     sizeof( IV ) );
+    mbedtls_zeroize( key,    sizeof( key ) );
+    mbedtls_zeroize( tmp,    sizeof( tmp ) );
+    mbedtls_zeroize( buffer, sizeof( buffer ) );
+    mbedtls_zeroize( digest, sizeof( digest ) );
 
     mbedtls_aes_free( &aes_ctx );
     mbedtls_md_free( &sha_ctx );

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -74,6 +74,12 @@ int main( void )
     return( 0 );
 }
 #else
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
 int main( int argc, char *argv[] )
 {
     int ret = 1, i, n;
@@ -542,13 +548,13 @@ exit:
        the case when the user has missed or reordered some,
        in which case the key might not be in argv[6]. */
     for( i = 0; i < argc; i++ )
-        memset( argv[i], 0, strlen( argv[i] ) );
+        mbedtls_zeroize( argv[i], strlen( argv[i] ) );
 
-    memset( IV,     0, sizeof( IV ) );
-    memset( key,    0, sizeof( key ) );
-    memset( buffer, 0, sizeof( buffer ) );
-    memset( output, 0, sizeof( output ) );
-    memset( digest, 0, sizeof( digest ) );
+    mbedtls_zeroize( IV,     sizeof( IV ) );
+    mbedtls_zeroize( key,    sizeof( key ) );
+    mbedtls_zeroize( buffer, sizeof( buffer ) );
+    mbedtls_zeroize( output, sizeof( output ) );
+    mbedtls_zeroize( digest, sizeof( digest ) );
 
     mbedtls_cipher_free( &cipher_ctx );
     mbedtls_md_free( &md_ctx );


### PR DESCRIPTION
This is the backport of #2095 to Mbed TLS 2.7.