### PR TITLE
Add missing return value check in ECDSA test suite

### DIFF
--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -117,7 +117,8 @@ void ecdsa_det_test_vectors( int id, char * d_str, int md_alg, char * msg,
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
     hlen = mbedtls_md_get_size( md_info );
-    mbedtls_md( md_info, (const unsigned char *) msg, strlen( msg ), hash );
+    TEST_ASSERT( mbedtls_md( md_info, (const unsigned char *) msg,
+                 strlen( msg ), hash ) == 0 );
 
     TEST_ASSERT( mbedtls_ecdsa_sign_det( &grp, &r, &s, &d, hash, hlen, md_alg ) == 0 );
 


### PR DESCRIPTION
__Summary:__ The test case `ecdsa_det_test_vectors` from the ECDSA test suite called `mbedtls_md()` without checking its return value. This PR fixes this.

__Internal Reference:__ IOTSSL-2492.