### PR TITLE
Reject properly authenticated but improperly padded records in CBC with EtM

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ Bugfix
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
    * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+   * Fix a bug in the record decryption routine ssl_decrypt_buf()
+     which lead to accepting properly authenticated but improperly
+     padded records in case of CBC ciphersuites using Encrypt-then-MAC.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2304,13 +2304,13 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
             correct = 0;
         }
         auth_done++;
-
-        /*
-         * Finally check the correct flag
-         */
-        if( correct == 0 )
-            return( MBEDTLS_ERR_SSL_INVALID_MAC );
     }
+
+    /*
+     * Finally check the correct flag
+     */
+    if( correct == 0 )
+        return( MBEDTLS_ERR_SSL_INVALID_MAC );
 #endif /* SSL_SOME_MODES_USE_MAC */
 
     /* Make extra sure authentication was performed, exactly once */


### PR DESCRIPTION
__Summary:__ This PR changes the behavior of the record decryption routine `ssl_decrypt_buf()` in the following situation:
1. A CBC ciphersuite with Encrypt-then-MAC is used.
2. A record with valid MAC but invalid CBC padding is received.

In this situation, the previous code would not raise and error but instead forward the decrypted packet, including the wrong padding, to the user.

This PR changes this behaviour to return the error `MBEDTLS_ERR_SSL_INVALID_MAC` instead.

__Note:__ While erroneous, the previous behaviour does not constitute a security flaw since it can only happen for properly authenticated records.

__Internal Reference:__ IOTSSL-1919