### PR TITLE
Backport 2.1: Reject properly authenticated but improperly padded records in CBC with EtM

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ Bugfix
       MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
     * Fix a bug in the update function for SSL ticket keys which previously
       invalidated keys of a lifetime of less than a 1s. Fixes #1968.
+    * Fix a bug in the record decryption routine ssl_decrypt_buf()
+      which lead to accepting properly authenticated but improperly
+      padded records in case of CBC ciphersuites using Encrypt-then-MAC.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2110,13 +2110,13 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
             correct = 0;
         }
         auth_done++;
-
-        /*
-         * Finally check the correct flag
-         */
-        if( correct == 0 )
-            return( MBEDTLS_ERR_SSL_INVALID_MAC );
     }
+
+    /*
+     * Finally check the correct flag
+     */
+    if( correct == 0 )
+        return( MBEDTLS_ERR_SSL_INVALID_MAC );
 #endif /* SSL_SOME_MODES_USE_MAC */
 
     /* Make extra sure authentication was performed, exactly once */


### PR DESCRIPTION
This is the backport to Mbed TLS 2.1 of #2111.