### PR TITLE
Avoid stack-allocation of large memory buffers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,8 @@ Changes
      produced by some optimizing compilers, showing up as failures in
      e.g. RSA or ECC signature operations. Reported in #1722, fix suggested
      by Aurelien Jarno and submitted by Jeffrey Martin.
+   * Reduce the stack consumption of mbedtls_x509write_csr_der() which previously
+     could lead to stack overflow on constrained devices. Contributed by Doru Gucea.
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 


### PR DESCRIPTION
Using a stack-buffer with a size > 2K could easily produce a stack
overflow for an embedded device which has a limited stack size.

This commit dynamically allocates the large CSR buffer.