### PR TITLE
Don't use %d printf format string for size_t variables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ Bugfix
      invalidated keys of a lifetime of less than a 1s. Fixes #1968.
    * Fix failure in hmac_drbg in the benchmark sample application, when
      MBEDTLS_THREADING_C is defined. Found by TrinityTonic, #1095
+   * Remove usage of %d printf conversion specifier to print
+     values of type size_t. Fixes #1534.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -112,6 +112,11 @@ void mbedtls_debug_set_threshold( int threshold );
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
+#if defined(__GNUC__) || defined(__clang__)
+#if __has_attribute(format)
+__attribute__((format(__printf__, 5, 6)))
+#endif
+#endif
 void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
                               const char *file, int line,
                               const char *format, ... );

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -113,8 +113,10 @@ void mbedtls_debug_set_threshold( int threshold );
  *                  library only.
  */
 #if defined(__GNUC__) || defined(__clang__)
+#if defined(__has_attribute)
 #if __has_attribute(format)
 __attribute__((format(__printf__, 5, 6)))
+#endif
 #endif
 #endif
 void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -50,11 +50,15 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-/* The printf conversion specifier %zu for values of type size_t was
- * only introduced in C99, but we currently still promise to build with
- * C89 compilers. Until then, we use the %llu conversion specifier alongside
- * an explicit cast to unsigned long long whenever we want to print values
- * of type size_t.
+/* The printf conversion specifier %zu was officially introduced in C99
+ * but is not yet widely supported; for example, Visual Studio supports it
+ * from VS2013 onwards only.
+ * As a remedy, we fall back to using explicit casts to `unsigned long long`
+ * and the corresponding format specifier %llu, provided the presence of this
+ * type is indicated through ULLONG_MAX being defined (in theory, it could still
+ * be that `unsigned long long` is defined, but %llu isn't, but we assume this
+ * doesn't happen). If `unsigned long long` is not present, we fall back to
+ * using `unsigned long` and %lu.
  *
  * To allow changing and eventually removing this, we use dedicated
  * macros #FMTZU and #FMT_ZU_CAST for the conversion specifier and type cast.
@@ -63,8 +67,15 @@
  */
 /* #define FMT_ZU "%zu" */
 /* #define FMT_ZU_CAST( X ) X */
+
+#include <limits.h>
+#if defined(ULLONG_MAX)
 #define FMT_ZU "%llu"
 #define FMT_ZU_CAST( X ) (unsigned long long)( X )
+#else
+#define FMT_ZU "%lu"
+#define FMT_ZU_CAST( X ) (unsigned long)( X )
+#endif
 
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -50,6 +50,22 @@
 #include "mbedtls/platform_time.h"
 #endif
 
+/* The printf conversion specifier %zu for values of type size_t was
+ * only introduced in C99, but we currently still promise to build with
+ * C89 compilers. Until then, we use the %llu conversion specifier alongside
+ * an explicit cast to unsigned long long whenever we want to print values
+ * of type size_t.
+ *
+ * To allow changing and eventually removing this, we use dedicated
+ * macros #FMTZU and #FMT_ZU_CAST for the conversion specifier and type cast.
+ *
+ * Warning: These macros are internal and can be changed or removed at any time!
+ */
+/* #define FMT_ZU "%zu" */
+/* #define FMT_ZU_CAST( X ) X */
+#define FMT_ZU "%llu"
+#define FMT_ZU_CAST( X ) (unsigned long long)( X )
+
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
                                  const unsigned char *info,
@@ -524,7 +540,8 @@ static int ssl_parse_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* Remember the client asked us to send a new ticket */
     ssl->handshake->new_session_ticket = 1;
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket length: %d", len ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "ticket length: " FMT_ZU,
+                                FMT_ZU_CAST( len ) ) );
 
     if( len == 0 )
         return( 0 );
@@ -2457,7 +2474,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     *p++ = (unsigned char)( t >>  8 );
     *p++ = (unsigned char)( t       );
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, current time: %lu", t ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, current time: %llu",
+                                (unsigned long long) t ) );
 #else
     if( ( ret = ssl->conf->f_rng( ssl->conf->p_rng, p, 4 ) ) != 0 )
         return( ret );
@@ -2545,7 +2563,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     memcpy( p, ssl->session_negotiate->id, ssl->session_negotiate->id_len );
     p += ssl->session_negotiate->id_len;
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, session id len.: %d", n ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, session id len.: " FMT_ZU,
+                                FMT_ZU_CAST( n ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 3,   "server hello, session id", buf + 39, n );
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "%s session has been resumed",
                    ssl->handshake->resume ? "a" : "no" ) );
@@ -2616,7 +2635,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     ext_len += olen;
 #endif
 
-    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, total extension length: %d", ext_len ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, total extension length: " FMT_ZU,
+                                FMT_ZU_CAST( ext_len ) ) );
 
     if( ext_len > 0 )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -54,11 +54,15 @@
 #include "mbedtls/oid.h"
 #endif
 
-/* The printf conversion specifier %zu for values of type size_t was
- * only introduced in C99, but we currently still promise to build with
- * C89 compilers. Until then, we use the %llu conversion specifier alongside
- * an explicit cast to unsigned long long whenever we want to print values
- * of type size_t.
+/* The printf conversion specifier %zu was officially introduced in C99
+ * but is not yet widely supported; for example, Visual Studio supports it
+ * from VS2013 onwards only.
+ * As a remedy, we fall back to using explicit casts to `unsigned long long`
+ * and the corresponding format specifier %llu, provided the presence of this
+ * type is indicated through ULLONG_MAX being defined (in theory, it could still
+ * be that `unsigned long long` is defined, but %llu isn't, but we assume this
+ * doesn't happen). If `unsigned long long` is not present, we fall back to
+ * using `unsigned long` and %lu.
  *
  * To allow changing and eventually removing this, we use dedicated
  * macros #FMTZU and #FMT_ZU_CAST for the conversion specifier and type cast.
@@ -67,8 +71,15 @@
  */
 /* #define FMT_ZU "%zu" */
 /* #define FMT_ZU_CAST( X ) X */
+
+#include <limits.h>
+#if defined(ULLONG_MAX)
 #define FMT_ZU "%llu"
 #define FMT_ZU_CAST( X ) (unsigned long long)( X )
+#else
+#define FMT_ZU "%lu"
+#define FMT_ZU_CAST( X ) (unsigned long)( X )
+#endif
 
 static void ssl_reset_in_out_pointers( mbedtls_ssl_context *ssl );
 static uint32_t ssl_get_hs_total_len( mbedtls_ssl_context const *ssl );


### PR DESCRIPTION
__Summary:__ This PR fixes #1534. The problem is that we're using the `%d` conversion specifier to print values of type `size_t`, which may theoretically lead to wrong output or system crash. The straightforward solution of using the dedicated specifier `%zu` is not at our disposal because it is C99, leaving us with the option of using a C89 specifier alongside an explicit cast. In order to ease modification of the approach, in particular switching to `%zu` in the future, this PR introduces local macros `FMT_ZU` and `FMT_ZU_CAST` for the conversion specifier and cast, respectively, defaulting to `%llu` and `unsigned long long`.

NB: Initially I thought of using global macros defined in `debug.h`, but those would need to have the form `MBEDTLS_XXX`, making printf statements almost unreadable, and at the same time care would need to be taken to clarify that even though those macros are defined in a public header, they can be changed or removed any time. I therefore decided to instead replicate the definition of `FMT_ZU` and `FMT_ZU_CAST` in the three files `ssl_cli.c, ssl_srv.c, ssl_tls.c` that need them. The names `FMT_ZU / FMT_ZU_CAST` are not carved in stone, and I'm open for better suggestions, as long as they are short and expressive.

For more information, see #1534, the internal ticket IOTSSL-2204 and the commit message of 1e2c30d. 

__Internal Reference:__ IOTSSL-2204.