### PR TITLE
Feature unavailable unified error support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -392,6 +392,10 @@ API Changes
      report errors whereas the old functions return void. We recommend that
      applications use the new functions.
 
+Changes
+   * Skip test and benchmark application in case the returned error is
+     MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED.
+
 = mbed TLS 2.14.0 branch released 2018-11-19
 
 Security

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -85,27 +85,28 @@
  * \{
  */
 /* Reminder: update x509_crt_verify_strings[] in library/x509_crt.c */
-#define MBEDTLS_X509_BADCERT_EXPIRED             0x01  /**< The certificate validity has expired. */
-#define MBEDTLS_X509_BADCERT_REVOKED             0x02  /**< The certificate has been revoked (is on a CRL). */
-#define MBEDTLS_X509_BADCERT_CN_MISMATCH         0x04  /**< The certificate Common Name (CN) does not match with the expected CN. */
-#define MBEDTLS_X509_BADCERT_NOT_TRUSTED         0x08  /**< The certificate is not correctly signed by the trusted CA. */
-#define MBEDTLS_X509_BADCRL_NOT_TRUSTED          0x10  /**< The CRL is not correctly signed by the trusted CA. */
-#define MBEDTLS_X509_BADCRL_EXPIRED              0x20  /**< The CRL is expired. */
-#define MBEDTLS_X509_BADCERT_MISSING             0x40  /**< Certificate was missing. */
-#define MBEDTLS_X509_BADCERT_SKIP_VERIFY         0x80  /**< Certificate verification was skipped. */
-#define MBEDTLS_X509_BADCERT_OTHER             0x0100  /**< Other reason (can be used by verify callback) */
-#define MBEDTLS_X509_BADCERT_FUTURE            0x0200  /**< The certificate validity starts in the future. */
-#define MBEDTLS_X509_BADCRL_FUTURE             0x0400  /**< The CRL is from the future */
-#define MBEDTLS_X509_BADCERT_KEY_USAGE         0x0800  /**< Usage does not match the keyUsage extension. */
-#define MBEDTLS_X509_BADCERT_EXT_KEY_USAGE     0x1000  /**< Usage does not match the extendedKeyUsage extension. */
-#define MBEDTLS_X509_BADCERT_NS_CERT_TYPE      0x2000  /**< Usage does not match the nsCertType extension. */
-#define MBEDTLS_X509_BADCERT_BAD_MD            0x4000  /**< The certificate is signed with an unacceptable hash. */
-#define MBEDTLS_X509_BADCERT_BAD_PK            0x8000  /**< The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
-#define MBEDTLS_X509_BADCERT_BAD_KEY         0x010000  /**< The certificate is signed with an unacceptable key (eg bad curve, RSA too short). */
-#define MBEDTLS_X509_BADCRL_BAD_MD           0x020000  /**< The CRL is signed with an unacceptable hash. */
-#define MBEDTLS_X509_BADCRL_BAD_PK           0x040000  /**< The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
-#define MBEDTLS_X509_BADCRL_BAD_KEY          0x080000  /**< The CRL is signed with an unacceptable key (eg bad curve, RSA too short). */
-
+#define MBEDTLS_X509_BADCERT_EXPIRED               0x01  /**< The certificate validity has expired. */
+#define MBEDTLS_X509_BADCERT_REVOKED               0x02  /**< The certificate has been revoked (is on a CRL). */
+#define MBEDTLS_X509_BADCERT_CN_MISMATCH           0x04  /**< The certificate Common Name (CN) does not match with the expected CN. */
+#define MBEDTLS_X509_BADCERT_NOT_TRUSTED           0x08  /**< The certificate is not correctly signed by the trusted CA. */
+#define MBEDTLS_X509_BADCRL_NOT_TRUSTED            0x10  /**< The CRL is not correctly signed by the trusted CA. */
+#define MBEDTLS_X509_BADCRL_EXPIRED                0x20  /**< The CRL is expired. */
+#define MBEDTLS_X509_BADCERT_MISSING               0x40  /**< Certificate was missing. */
+#define MBEDTLS_X509_BADCERT_SKIP_VERIFY           0x80  /**< Certificate verification was skipped. */
+#define MBEDTLS_X509_BADCERT_OTHER               0x0100  /**< Other reason (can be used by verify callback) */
+#define MBEDTLS_X509_BADCERT_FUTURE              0x0200  /**< The certificate validity starts in the future. */
+#define MBEDTLS_X509_BADCRL_FUTURE               0x0400  /**< The CRL is from the future */
+#define MBEDTLS_X509_BADCERT_KEY_USAGE           0x0800  /**< Usage does not match the keyUsage extension. */
+#define MBEDTLS_X509_BADCERT_EXT_KEY_USAGE       0x1000  /**< Usage does not match the extendedKeyUsage extension. */
+#define MBEDTLS_X509_BADCERT_NS_CERT_TYPE        0x2000  /**< Usage does not match the nsCertType extension. */
+#define MBEDTLS_X509_BADCERT_BAD_MD              0x4000  /**< The certificate is signed with an unacceptable hash. */
+#define MBEDTLS_X509_BADCERT_BAD_PK              0x8000  /**< The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
+#define MBEDTLS_X509_BADCERT_BAD_KEY           0x010000  /**< The certificate is signed with an unacceptable key (eg bad curve, RSA too short). */
+#define MBEDTLS_X509_BADCRL_BAD_MD             0x020000  /**< The CRL is signed with an unacceptable hash. */
+#define MBEDTLS_X509_BADCRL_BAD_PK             0x040000  /**< The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
+#define MBEDTLS_X509_BADCRL_BAD_KEY            0x080000  /**< The CRL is signed with an unacceptable key (eg bad curve, RSA too short). */
+#define MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED  0x100000 /**< The CRL is signed with an algorithm not supported by the hardware accelerator */
+#define MBEDTLS_X509_BADCERT_ALG_NOT_SUPPORTED 0x200000 /**< The certificate is signed with an algorithm not supported by the hardware accelerator */
 /* \} name */
 /* \} addtogroup x509_module */
 

--- a/library/x509.c
+++ b/library/x509.c
@@ -48,15 +48,13 @@
 #include "mbedtls/pem.h"
 #endif
 
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdio.h>
 #include <stdlib.h>
 #define mbedtls_free      free
 #define mbedtls_calloc    calloc
 #define mbedtls_printf    printf
-#define mbedtls_snprintf  snprintf
 #endif
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/x509.c
+++ b/library/x509.c
@@ -1025,7 +1025,14 @@ int mbedtls_x509_self_test( int verbose )
 
     ret = mbedtls_x509_crt_parse( &clicert, (const unsigned char *) mbedtls_test_cli_crt,
                            mbedtls_test_cli_crt_len );
-    if( ret != 0 )
+    if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "skipped\n" );
+        ret = 0;
+        goto cleanup;
+    }
+    else if( ret != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );
@@ -1035,7 +1042,14 @@ int mbedtls_x509_self_test( int verbose )
 
     ret = mbedtls_x509_crt_parse( &cacert, (const unsigned char *) mbedtls_test_ca_crt,
                           mbedtls_test_ca_crt_len );
-    if( ret != 0 )
+    if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "skipped\n" );
+        ret = 0;
+        goto cleanup;
+    }
+    else if( ret != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );
@@ -1047,7 +1061,15 @@ int mbedtls_x509_self_test( int verbose )
         mbedtls_printf( "passed\n  X.509 signature verify: ");
 
     ret = mbedtls_x509_crt_verify( &clicert, &cacert, NULL, NULL, &flags, NULL, NULL );
-    if( ret != 0 )
+    if( flags & ( MBEDTLS_X509_BADCERT_ALG_NOT_SUPPORTED |
+                  MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED ) )
+    {
+        if( verbose != 0 )
+            mbedtls_printf( "skipped\n" );
+        ret = 0;
+        goto cleanup;
+    }
+    else if( ret != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );
@@ -1061,6 +1083,7 @@ int mbedtls_x509_self_test( int verbose )
 cleanup:
     mbedtls_x509_crt_free( &cacert  );
     mbedtls_x509_crt_free( &clicert );
+
 #else
     ((void) verbose);
 #endif /* MBEDTLS_CERTS_C && MBEDTLS_SHA1_C */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -54,14 +54,12 @@
 #include "mbedtls/psa_util.h"
 #endif
 
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdio.h>
 #include <stdlib.h>
 #define mbedtls_free       free
 #define mbedtls_calloc    calloc
-#define mbedtls_snprintf   snprintf
 #endif
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1472,6 +1472,11 @@ int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain,
                  */
                 if( ret == MBEDTLS_ERR_X509_ALLOC_FAILED )
                     return( ret );
+                /*
+                 * Quit parsing on a feature not suppoprted by HW error.
+                 */
+                if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+                    return( ret );
 
                 if( first_error == 0 )
                     first_error = ret;
@@ -1565,7 +1570,15 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
         }
 
         w_ret = mbedtls_x509_crt_parse_file( chain, filename );
-        if( w_ret < 0 )
+        /*
+         * Quit parsing on a feature not suppoprted by HW error.
+         */
+        if( w_ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+        {
+            ret = w_ret;
+            goto cleanup;
+        }
+        else if( w_ret < 0 )
             ret++;
         else
             ret += w_ret;
@@ -1618,7 +1631,15 @@ cleanup:
         // Ignore parse errors
         //
         t_ret = mbedtls_x509_crt_parse_file( chain, entry_name );
-        if( t_ret < 0 )
+        /*
+         * Quit parsing on a feature not suppoprted by HW error.
+         */
+        if( t_ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+        {
+            ret = t_ret;
+            goto cleanup;
+        }
+        else if( t_ret < 0 )
             ret++;
         else
             ret += t_ret;
@@ -2311,6 +2332,8 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
     int flags = 0;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     const mbedtls_md_info_t *md_info;
+    int ret = 0;
+
 
     if( ca == NULL )
         return( flags );
@@ -2346,9 +2369,18 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
             flags |= MBEDTLS_X509_BADCRL_BAD_PK;
 
         md_info = mbedtls_md_info_from_type( crl_list->sig_md );
-        if( mbedtls_md( md_info, crl_list->tbs.p, crl_list->tbs.len, hash ) != 0 )
+        if( ( ret = mbedtls_md( md_info, crl_list->tbs.p,
+                                crl_list->tbs.len, hash ) ) != 0 )
         {
-            /* Note: this can't happen except after an internal error */
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            {
+                flags |= MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED;
+            }
+            /*
+             * Add the MBEDTLS_X509_BADCRL_NOT_TRUSTED flag because the CRL
+             * couldn't be verified.Otherwise, this can't happen except after an
+             * internal error
+             */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
             break;
         }
@@ -2356,10 +2388,18 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
         if( x509_profile_check_key( profile, &ca->pk ) != 0 )
             flags |= MBEDTLS_X509_BADCERT_BAD_KEY;
 
-        if( mbedtls_pk_verify_ext( crl_list->sig_pk, crl_list->sig_opts, &ca->pk,
+        if( ( ret = mbedtls_pk_verify_ext( crl_list->sig_pk, crl_list->sig_opts, &ca->pk,
                            crl_list->sig_md, hash, mbedtls_md_get_size( md_info ),
-                           crl_list->sig.p, crl_list->sig.len ) != 0 )
+                           crl_list->sig.p, crl_list->sig.len ) ) != 0 )
         {
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            {
+                flags |= MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED;
+            }
+            /*
+             * Add the MBEDTLS_X509_BADCRL_NOT_TRUSTED flag because the CRL
+             * couldn't be verified.
+             */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
             break;
         }
@@ -2580,6 +2620,9 @@ check_signature:
 #endif
         ret = x509_crt_check_signature( child, parent, rs_ctx );
 
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            return( ret );
+
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
         if( rs_ctx != NULL && ret == MBEDTLS_ERR_ECP_IN_PROGRESS )
         {
@@ -2679,6 +2722,8 @@ static int x509_crt_find_parent(
                                        parent, signature_is_good,
                                        *parent_is_trusted,
                                        path_cnt, self_cnt, rs_ctx );
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            return( ret );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
         if( rs_ctx != NULL && ret == MBEDTLS_ERR_ECP_IN_PROGRESS )
@@ -2888,6 +2933,8 @@ find_parent:
         ret = x509_crt_find_parent( child, cur_trust_ca, &parent,
                                        &parent_is_trusted, &signature_is_good,
                                        ver_chain->len - 1, self_cnt, rs_ctx );
+        if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            *flags |= MBEDTLS_X509_BADCERT_ALG_NOT_SUPPORTED;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
         if( rs_ctx != NULL && ret == MBEDTLS_ERR_ECP_IN_PROGRESS )
@@ -2902,10 +2949,13 @@ find_parent:
 #else
         (void) ret;
 #endif
-
         /* No parent? We're done here */
         if( parent == NULL )
         {
+            /*
+             * Add the MBEDTLS_X509_BADCERT_NOT_TRUSTED flag because
+             * the certificate couldn't be verified.
+             */
             *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED;
             return( 0 );
         }

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1571,7 +1571,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
 
         w_ret = mbedtls_x509_crt_parse_file( chain, filename );
         /*
-         * Quit parsing on a feature not suppoprted by HW error.
+         * Quit parsing if some feature is not supported by the hardware.
          */
         if( w_ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
         {
@@ -2377,9 +2377,9 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                 flags |= MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED;
             }
             /*
-             * Add the MBEDTLS_X509_BADCRL_NOT_TRUSTED flag because the CRL
-             * couldn't be verified.Otherwise, this can't happen except after an
-             * internal error
+             * The CRL couldn't be verified, so it isn't trusted.
+             * Apart from the case of an unsupported feature handled
+             * just above, this can only happen after an internal error.
              */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
             break;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1473,7 +1473,7 @@ int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain,
                 if( ret == MBEDTLS_ERR_X509_ALLOC_FAILED )
                     return( ret );
                 /*
-                 * Quit parsing on a feature not suppoprted by HW error.
+                 * Quit parsing on a feature not supported by HW error.
                  */
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                     return( ret );
@@ -1632,7 +1632,7 @@ cleanup:
         //
         t_ret = mbedtls_x509_crt_parse_file( chain, entry_name );
         /*
-         * Quit parsing on a feature not suppoprted by HW error.
+         * Quit parsing on a feature not supported by HW error.
          */
         if( t_ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
         {

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -223,7 +223,11 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
         return( MBEDTLS_ERR_X509_FATAL_ERROR );
     }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
-    mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    if( ( ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ),
+                            c, len, hash ) ) != 0 )
+    {
+        return( ret );
+    }
 #endif
     if( ( ret = mbedtls_pk_sign( ctx->key, ctx->md_alg, hash, 0, sig, &sig_len,
                                  f_rng, p_rng ) ) != 0 )

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -530,7 +530,11 @@ int main( int argc, char *argv[] )
         /*
          * Write the final block of data
          */
-        mbedtls_cipher_finish( &cipher_ctx, output, &olen );
+        if( mbedtls_cipher_finish( &cipher_ctx, output, &olen ) != 0)
+        {
+            mbedtls_fprintf( stderr,"mbedtls_cipher_finish() returned error\n");
+            goto exit;
+        }
 
         if( fwrite( output, 1, olen, fout ) != olen )
         {

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -610,7 +610,6 @@ int main( int argc, char *argv[] )
                 continue;
             }
 
-
             TIME_AND_TSC( title,
                     mbedtls_ccm_encrypt_and_tag( &ccm, BUFSIZE, tmp,
                         12, NULL, 0, buf, buf, tmp, 16 ) );
@@ -940,7 +939,6 @@ int main( int argc, char *argv[] )
             if( mbedtls_mpi_copy( &dhm.GY, &dhm.GX ) != 0 )
                 mbedtls_exit( 1 );
 
-
             TIME_PUBLIC( title, "handshake",
                     ret |= mbedtls_dhm_make_public( &dhm, (int) dhm.len, buf, dhm.len,
                                             myrand, NULL );
@@ -1087,7 +1085,6 @@ int main( int argc, char *argv[] )
                                                     myrand, NULL ) );
             CHECK_AND_CONTINUE( mbedtls_ecp_copy( &ecdh.Qp, &ecdh.Q ) );
             ecp_clear_precomputed( &ecdh.grp );
-
 
             TIME_PUBLIC( title, "handshake",
                     CHECK_AND_CONTINUE( mbedtls_ecdh_make_public( &ecdh, &olen, buf, sizeof( buf),

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #define mbedtls_exit       exit
 #define mbedtls_printf     printf
-#define mbedtls_snprintf   snprintf
 #define mbedtls_free       free
 #endif
 

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -136,7 +136,7 @@ do {                                                                    \
                                                                         \
     if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )               \
     {                                                                   \
-        mbedtls_printf( "Feature Not Supported. Skipping.\n" );         \
+        mbedtls_printf( "Feature not supported. Skipping.\n" );         \
         ret = 0;                                                        \
     }                                                                   \
     else if( ret != 0 )                                                 \
@@ -204,6 +204,23 @@ do {                                                                    \
         mbedtls_printf( "\n" );                                         \
     }                                                                   \
 } while( 0 )
+
+#define SET_KEY_ENC( MODULE, CTX, KEYSIZE )                             \
+        ret = mbedtls_##MODULE##_setkey_enc( CTX, tmp, KEYSIZE );       \
+        if( ret != 0 )                                                  \
+        {                                                               \
+            mbedtls_printf( HEADER_FORMAT, title );                     \
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )       \
+            {                                                           \
+                mbedtls_printf( "Feature not supported. Skipping.\n" ); \
+                ret = 0;                                                \
+            }                                                           \
+            else                                                        \
+            {                                                           \
+                PRINT_ERROR;                                            \
+            }                                                           \
+            continue;                                                   \
+        }                                                               \
 
 static int myrand( void *rng_state, unsigned char *output, size_t len )
 {
@@ -413,9 +430,27 @@ int main( int argc, char *argv[] )
     {
         mbedtls_des3_context des3;
         mbedtls_des3_init( &des3 );
-        mbedtls_des3_set3key_enc( &des3, tmp );
-        TIME_AND_TSC( "3DES",
-                mbedtls_des3_crypt_cbc( &des3, MBEDTLS_DES_ENCRYPT, BUFSIZE, tmp, buf, buf ) );
+        mbedtls_snprintf( title, sizeof( title ), "3DES" );
+        ret = mbedtls_des3_set3key_enc( &des3, tmp );
+        if( ret != 0 )
+        {
+            mbedtls_printf( HEADER_FORMAT, title );
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            {
+                mbedtls_printf( "Feature not supported. Skipping.\n" );
+                ret = 0;
+            }
+            else
+            {
+                PRINT_ERROR;
+            }
+        }
+        else
+        {
+            TIME_AND_TSC( title,
+                    mbedtls_des3_crypt_cbc( &des3, MBEDTLS_DES_ENCRYPT, BUFSIZE,
+                                            tmp, buf, buf ) );
+        }
         mbedtls_des3_free( &des3 );
     }
 
@@ -423,9 +458,26 @@ int main( int argc, char *argv[] )
     {
         mbedtls_des_context des;
         mbedtls_des_init( &des );
-        mbedtls_des_setkey_enc( &des, tmp );
-        TIME_AND_TSC( "DES",
-                mbedtls_des_crypt_cbc( &des, MBEDTLS_DES_ENCRYPT, BUFSIZE, tmp, buf, buf ) );
+        mbedtls_snprintf( title, sizeof( title ), "DES" );
+        ret = mbedtls_des_setkey_enc( &des, tmp );
+        if( ret != 0 )
+        {
+            mbedtls_printf( HEADER_FORMAT, title );
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+            {
+                mbedtls_printf( "Feature not supported. Skipping.\n" );
+                ret = 0;
+            }
+            else
+            {
+                 PRINT_ERROR;
+            }
+        }
+        else
+        {
+            TIME_AND_TSC( title,
+                    mbedtls_des_crypt_cbc( &des, MBEDTLS_DES_ENCRYPT, BUFSIZE, tmp, buf, buf ) );
+        }
         mbedtls_des_free( &des );
     }
 
@@ -461,21 +513,7 @@ int main( int argc, char *argv[] )
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
-            ret = mbedtls_aes_setkey_enc( &aes, tmp, keysize );
-            if( ret != 0 )
-            {
-                mbedtls_printf( HEADER_FORMAT, title );
-                if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
-                {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
-                    ret = 0;
-                }
-                else
-                {
-                    PRINT_ERROR;
-                }
-                continue;
-            }
+            SET_KEY_ENC( aes, &aes, keysize );
 
             TIME_AND_TSC( title,
                 mbedtls_aes_crypt_cbc( &aes, MBEDTLS_AES_ENCRYPT, BUFSIZE, tmp, buf, buf ) );
@@ -496,21 +534,7 @@ int main( int argc, char *argv[] )
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
-            ret = mbedtls_aes_xts_setkey_enc( &ctx, tmp, keysize * 2 );
-            if( ret != 0 )
-            {
-                mbedtls_printf( HEADER_FORMAT, title );
-                if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
-                {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
-                    ret = 0;
-                }
-                else
-                {
-                    PRINT_ERROR;
-                }
-                continue;
-            }
+            SET_KEY_ENC( aes_xts, &ctx, keysize * 2 );
 
             TIME_AND_TSC( title,
                     mbedtls_aes_crypt_xts( &ctx, MBEDTLS_AES_ENCRYPT, BUFSIZE,
@@ -539,7 +563,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                 }
                 else
@@ -576,7 +600,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                 }
                 else
@@ -612,7 +636,7 @@ int main( int argc, char *argv[] )
             mbedtls_printf( HEADER_FORMAT, title );
             if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
             {
-                mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                mbedtls_printf( "Feature not supported. Skipping.\n" );
                 ret = 0;
             }
             else
@@ -675,21 +699,7 @@ int main( int argc, char *argv[] )
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
-            ret = mbedtls_aria_setkey_enc( &aria, tmp, keysize );
-            if( ret != 0 )
-            {
-                mbedtls_printf( HEADER_FORMAT, title );
-                if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
-                {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
-                    ret = 0;
-                }
-                else
-                {
-                    PRINT_ERROR;
-                }
-                continue;
-            }
+            SET_KEY_ENC( aria, &aria, keysize );
 
             TIME_AND_TSC( title,
                     mbedtls_aria_crypt_cbc( &aria, MBEDTLS_ARIA_ENCRYPT,
@@ -711,21 +721,7 @@ int main( int argc, char *argv[] )
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
-            ret = mbedtls_camellia_setkey_enc( &camellia, tmp, keysize );
-            if( ret != 0 )
-            {
-                mbedtls_printf( HEADER_FORMAT, title );
-                if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
-                {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
-                    ret = 0;
-                }
-                else
-                {
-                    PRINT_ERROR;
-                }
-                continue;
-            }
+            SET_KEY_ENC( camellia, &camellia, keysize );
 
             TIME_AND_TSC( title,
                     mbedtls_camellia_crypt_cbc( &camellia, MBEDTLS_CAMELLIA_ENCRYPT,
@@ -768,7 +764,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                 }
                 else
@@ -931,7 +927,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                     continue;
                 }
@@ -984,7 +980,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                     continue;
                 }
@@ -1020,7 +1016,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                     continue;
                 }
@@ -1037,7 +1033,7 @@ int main( int argc, char *argv[] )
                 mbedtls_printf( HEADER_FORMAT, title );
                 if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
                 {
-                    mbedtls_printf( "Feature Not Supported. Skipping.\n" );
+                    mbedtls_printf( "Feature not supported. Skipping.\n" );
                     ret = 0;
                     continue;
                 }
@@ -1158,6 +1154,8 @@ int main( int argc, char *argv[] )
             mbedtls_ecdh_init( &ecdh );
             mbedtls_mpi_init( &z );
 
+            mbedtls_snprintf( title, sizeof(title), "ECDH-%s",
+                              curve_info->name );
             CHECK_AND_CONTINUE( mbedtls_ecp_group_load( &ecdh.grp, curve_info->grp_id ) );
             CHECK_AND_CONTINUE( mbedtls_ecdh_gen_public( &ecdh.grp, &ecdh.d, &ecdh.Qp,
                                  myrand, NULL ) );

--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -154,6 +154,7 @@ class MbedTlsTest(BaseHostTest):
     DISPATCH_TEST_FN_NOT_FOUND = -3     # Test function not found.
     DISPATCH_INVALID_TEST_DATA = -4     # Invalid parameter type.
     DISPATCH_UNSUPPORTED_SUITE = -5     # Test suite not supported/enabled.
+    FEATURE_UNSUPPORTED        = -6     # Feture not supported by the platform.
 
     def __init__(self):
         """
@@ -177,6 +178,8 @@ class MbedTlsTest(BaseHostTest):
             'DISPATCH_INVALID_TEST_DATA'
         self.error_str[self.DISPATCH_UNSUPPORTED_SUITE] = \
             'DISPATCH_UNSUPPORTED_SUITE'
+        self.error_str[self.FEATURE_UNSUPPORTED] = \
+            'FEATURE_UNSUPPORTED'
 
     def setup(self):
         """

--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -154,7 +154,7 @@ class MbedTlsTest(BaseHostTest):
     DISPATCH_TEST_FN_NOT_FOUND = -3     # Test function not found.
     DISPATCH_INVALID_TEST_DATA = -4     # Invalid parameter type.
     DISPATCH_UNSUPPORTED_SUITE = -5     # Test suite not supported/enabled.
-    FEATURE_UNSUPPORTED        = -6     # Feture not supported by the platform.
+    FEATURE_UNSUPPORTED        = -6     # Feature not supported by the platform.
 
     def __init__(self):
         """

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -114,6 +114,7 @@ typedef enum
           test_fail( #TEST, __LINE__, __FILE__ );           \
           goto exit;                                        \
        }                                                    \
+    } while( 0 )
 
 #define TEST_ASSERT_RET( TEST, EXP_RET )                          \
     do {                                                          \
@@ -339,6 +340,7 @@ void test_skip( const char *test, int line_no, const char* filename )
     test_info.test = test;
     test_info.line_no = line_no;
     test_info.filename = filename;
+    test_info.skipped = 1;
 }
 
 static int platform_setup()
@@ -670,23 +672,6 @@ int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
     return( 0 );
 }
 
-static void test_skip( const char *test, int line_no, const char* filename )
-{
-    test_info.failed = 0;
-    test_info.test = test;
-    test_info.line_no = line_no;
-    test_info.filename = filename;
-    test_info.skipped = 1;
-}
-
-static void test_fail( const char *test, int line_no, const char* filename )
-{
-    test_info.failed = 1;
-    test_info.test = test;
-    test_info.line_no = line_no;
-    test_info.filename = filename;
-    test_info.skipped = 0;
-}
 
 int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
 {

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -109,30 +109,31 @@ typedef enum
  *
  * \param   TEST    The test expression to be tested.
  */
-#define TEST_ASSERT( TEST )                                 \
-    do {                                                    \
-       if( ! (TEST) )                                       \
-       {                                                    \
-          test_fail( #TEST, __LINE__, __FILE__ );           \
-          goto exit;                                        \
-       }                                                    \
+
+#define TEST_ASSERT( TEST )                                       \
+    do {                                                          \
+        if( ! (TEST) )                                            \
+        {                                                         \
+            set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );\
+            goto exit;                                            \
+        }                                                         \
     } while( 0 )
 
-#define TEST_ASSERT_RET( TEST, EXP_RET )                                              \
-    do {                                                                              \
-        int ret = (TEST);                                                             \
-        if( ret != ( EXP_RET ) )                                                      \
-        {                                                                             \
-            if( ( -ret & ~0xFF80 ) == -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) ) \
-            {                                                                         \
-                test_skip( #TEST, __LINE__, __FILE__ );                               \
-            }                                                                         \
-            else                                                                      \
-            {                                                                         \
-                test_fail( #TEST, __LINE__, __FILE__ );                               \
-            }                                                                         \
-            goto exit;                                                                \
-        }                                                                             \
+#define TEST_ASSERT_RET( TEST, EXP_RET )                                                              \
+    do {                                                                                              \
+        int TEST_ASSERT_RET_ret = (TEST);                                                             \
+        if( TEST_ASSERT_RET_ret != ( EXP_RET ) )                                                      \
+        {                                                                                             \
+            if( ( -TEST_ASSERT_RET_ret & ~0xFF80 ) == -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) ) \
+            {                                                                                         \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_SKIPPED );                    \
+            }                                                                                         \
+            else                                                                                      \
+            {                                                                                         \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );                     \
+            }                                                                                         \
+            goto exit;                                                                                \
+        }                                                                                             \
     } while( 0 )
 
 /**
@@ -177,7 +178,7 @@ typedef enum
         if( (TEST) != (PARAM_ERR_VALUE) ||                                  \
             test_info.paramfail_test_state != PARAMFAIL_TESTSTATE_CALLED )  \
         {                                                                   \
-            test_fail( #TEST, __LINE__, __FILE__ );                         \
+            set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );\
             goto exit;                                                      \
         }                                                                   \
    } while( 0 )
@@ -208,7 +209,7 @@ typedef enum
         if( setjmp( param_fail_jmp ) == 0 )                                 \
         {                                                                   \
             TEST;                                                           \
-            test_fail( #TEST, __LINE__, __FILE__ );                         \
+            set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );\
             goto exit;                                                      \
         }                                                                   \
         memcpy(param_fail_jmp, jmp_tmp, sizeof(jmp_buf));                   \
@@ -297,7 +298,6 @@ static struct
     const char *test;
     const char *filename;
     int line_no;
-    int skipped;
 }
 test_info;
 
@@ -328,21 +328,13 @@ jmp_buf jmp_tmp;
 /*----------------------------------------------------------------------------*/
 /* Helper Functions */
 
-void test_fail( const char *test, int line_no, const char* filename )
+static void set_test_result( const char *test, int line_no,
+                             const char* filename, test_result_t test_result )
 {
-    test_info.result = TEST_RESULT_FAILED;
+    test_info.result = test_result;
     test_info.test = test;
     test_info.line_no = line_no;
     test_info.filename = filename;
-}
-
-void test_skip( const char *test, int line_no, const char* filename )
-{
-    test_info.result = TEST_RESULT_SKIPPED;
-    test_info.test = test;
-    test_info.line_no = line_no;
-    test_info.filename = filename;
-    test_info.skipped = 1;
 }
 
 static int platform_setup()
@@ -377,7 +369,7 @@ void mbedtls_param_failed( const char *failure_condition,
 
         /* Record the location of the failure, but not as a failure yet, in case
          * it was part of the test */
-        test_fail( failure_condition, line, file );
+        set_test_result( failure_condition, line, file, TEST_RESULT_FAILED );
         test_info.result = TEST_RESULT_SUCCESS;
 
         longjmp( param_fail_jmp, 1 );

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -119,21 +119,45 @@ typedef enum
         }                                                         \
     } while( 0 )
 
-#define TEST_ASSERT_RET( TEST, EXP_RET )                                                              \
-    do {                                                                                              \
-        int TEST_ASSERT_RET_ret = (TEST);                                                             \
-        if( TEST_ASSERT_RET_ret != ( EXP_RET ) )                                                      \
-        {                                                                                             \
-            if( ( -TEST_ASSERT_RET_ret & ~0xFF80 ) == -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) ) \
-            {                                                                                         \
-                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_SKIPPED );                    \
-            }                                                                                         \
-            else                                                                                      \
-            {                                                                                         \
-                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );                     \
-            }                                                                                         \
-            goto exit;                                                                                \
-        }                                                                                             \
+/**
+ * \brief   This macro tests the expression passed to it as a test step or
+ *          individual test in a test case, comparing result to an expected
+ *          result given as parameter, and skips the test in case the underlying
+ *          alternative implementation doesn't support the feature.
+ *
+ *          It allows a library function to return a value and return an error
+ *          code that can be tested.
+ *          It receives an expected return code and:
+ *          - If the underlying alternative implementation does not support the feature,
+ *          by returning MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED, the test is skipped.
+ *          - If and fails in case the expression
+ *          results different.
+ *
+ *          When MBEDTLS_CHECK_PARAMS is enabled, calls to the parameter failure
+ *          callback, MBEDTLS_PARAM_FAILED(), will be assumed to be a test
+ *          failure.
+ *
+ *          This macro is not suitable for negative parameter validation tests,
+ *          as it assumes the test step will not create an error.
+ *
+ * \param   TEST    The test expression to be tested.
+ */
+#define TEST_ASSERT_RET( TEST, EXP_RET )                                \
+    do {                                                                \
+        int TEST_ASSERT_RET_ret = (TEST);                               \
+        if( TEST_ASSERT_RET_ret != ( EXP_RET ) )                        \
+        {                                                               \
+            if( ( -TEST_ASSERT_RET_ret & ~0xFF80 ) ==                   \
+                -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) )         \
+            {                                                           \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_SKIPPED );\
+            }                                                           \
+            else                                                        \
+            {                                                           \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED ); \
+            }                                                           \
+            goto exit;                                                  \
+        }                                                               \
     } while( 0 )
 
 /**
@@ -174,12 +198,21 @@ typedef enum
  */
 #define TEST_INVALID_PARAM_RET( PARAM_ERR_VALUE, TEST )                     \
     do {                                                                    \
+        int TEST_INVALID_PARAM_RET_ret;                                     \
         test_info.paramfail_test_state = PARAMFAIL_TESTSTATE_PENDING;       \
-        if( (TEST) != (PARAM_ERR_VALUE) ||                                  \
+        TEST_INVALID_PARAM_RET_ret = (TEST);                                \
+        if( TEST_INVALID_PARAM_RET_ret != (PARAM_ERR_VALUE) ||              \
             test_info.paramfail_test_state != PARAMFAIL_TESTSTATE_CALLED )  \
         {                                                                   \
-            set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );\
-            goto exit;                                                      \
+            if( ( -TEST_INVALID_PARAM_RET_ret & ~0xFF80 ) ==                \
+                -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) )             \
+            {                                                               \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_SKIPPED );\
+            }                                                               \
+            else                                                            \
+            {                                                               \
+                set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_FAILED );\
+            }                                                               \
         }                                                                   \
    } while( 0 )
 
@@ -369,8 +402,7 @@ void mbedtls_param_failed( const char *failure_condition,
 
         /* Record the location of the failure, but not as a failure yet, in case
          * it was part of the test */
-        set_test_result( failure_condition, line, file, TEST_RESULT_FAILED );
-        test_info.result = TEST_RESULT_SUCCESS;
+        set_test_result( failure_condition, line, file, TEST_RESULT_SUCCESS );
 
         longjmp( param_fail_jmp, 1 );
     }
@@ -665,7 +697,6 @@ int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
 
     return( 0 );
 }
-
 
 int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
 {

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -114,6 +114,22 @@ typedef enum
           test_fail( #TEST, __LINE__, __FILE__ );           \
           goto exit;                                        \
        }                                                    \
+
+#define TEST_ASSERT_RET( TEST, EXP_RET )                          \
+    do {                                                          \
+        int ret = (TEST);                                         \
+        if( ret != EXP_RET )                                      \
+        {                                                         \
+            if( ret & MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )  \
+            {                                                     \
+                test_skip( #TEST, __LINE__, __FILE__ );           \
+            }                                                     \
+            else                                                  \
+            {                                                     \
+                test_fail( #TEST, __LINE__, __FILE__ );           \
+            }                                                     \
+            goto exit;                                            \
+        }                                                         \
     } while( 0 )
 
 /**
@@ -278,6 +294,7 @@ static struct
     const char *test;
     const char *filename;
     int line_no;
+    int skipped;
 }
 test_info;
 
@@ -651,6 +668,24 @@ int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
     }
 
     return( 0 );
+}
+
+static void test_skip( const char *test, int line_no, const char* filename )
+{
+    test_info.failed = 0;
+    test_info.test = test;
+    test_info.line_no = line_no;
+    test_info.filename = filename;
+    test_info.skipped = 1;
+}
+
+static void test_fail( const char *test, int line_no, const char* filename )
+{
+    test_info.failed = 1;
+    test_info.test = test;
+    test_info.line_no = line_no;
+    test_info.filename = filename;
+    test_info.skipped = 0;
 }
 
 int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -4,19 +4,15 @@
 
 #include <stdlib.h>
 
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdio.h>
 #define mbedtls_fprintf    fprintf
-#define mbedtls_snprintf   snprintf
 #define mbedtls_calloc     calloc
 #define mbedtls_free       free
 #define mbedtls_exit       exit
 #define mbedtls_time       time
 #define mbedtls_time_t     time_t
-#define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
-#define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -69,6 +69,8 @@ typedef struct data_tag
                                                allowed */
 #define DISPATCH_UNSUPPORTED_SUITE      -5  /* Test suite not supported by the
                                                build */
+#define FEATURE_UNSUPPORTED             -6  /* Feature not supported by the
+                                               platform */
 
 typedef enum
 {
@@ -116,21 +118,21 @@ typedef enum
        }                                                    \
     } while( 0 )
 
-#define TEST_ASSERT_RET( TEST, EXP_RET )                          \
-    do {                                                          \
-        int ret = (TEST);                                         \
-        if( ret != EXP_RET )                                      \
-        {                                                         \
-            if( ret & MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )  \
-            {                                                     \
-                test_skip( #TEST, __LINE__, __FILE__ );           \
-            }                                                     \
-            else                                                  \
-            {                                                     \
-                test_fail( #TEST, __LINE__, __FILE__ );           \
-            }                                                     \
-            goto exit;                                            \
-        }                                                         \
+#define TEST_ASSERT_RET( TEST, EXP_RET )                                              \
+    do {                                                                              \
+        int ret = (TEST);                                                             \
+        if( ret != ( EXP_RET ) )                                                      \
+        {                                                                             \
+            if( ( -ret & ~0xFF80 ) == -( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ) ) \
+            {                                                                         \
+                test_skip( #TEST, __LINE__, __FILE__ );                               \
+            }                                                                         \
+            else                                                                      \
+            {                                                                         \
+                test_fail( #TEST, __LINE__, __FILE__ );                               \
+            }                                                                         \
+            goto exit;                                                                \
+        }                                                                             \
     } while( 0 )
 
 /**

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -548,6 +548,7 @@ int execute_tests( int argc , const char ** argv )
             {
                 test_info.result = TEST_RESULT_SUCCESS;
                 test_info.paramfail_test_state = PARAMFAIL_TESTSTATE_IDLE;
+                test_info.skipped = 0;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
                 /* Suppress all output from the library unless we're verbose
@@ -613,7 +614,21 @@ int execute_tests( int argc , const char ** argv )
             {
                 if( test_info.result == TEST_RESULT_SUCCESS )
                 {
-                    mbedtls_fprintf( stdout, "PASS\n" );
+                    if( test_info.skipped == 1 )
+                    {
+                        total_skipped++;
+                        mbedtls_fprintf( stdout, "----\n" );
+                        if( 1 == option_verbose )
+                        {
+                            mbedtls_fprintf( stdout, "  %s\n  Feature not supported by the platform at line %d, %s\n",
+                                             test_info.test, test_info.line_no,
+                                             test_info.filename );
+                        }
+                    }
+                    else
+                    {
+                        mbedtls_fprintf( stdout, "PASS\n" );
+                    }
                 }
                 else if( test_info.result == TEST_RESULT_SKIPPED )
                 {

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -548,7 +548,6 @@ int execute_tests( int argc , const char ** argv )
             {
                 test_info.result = TEST_RESULT_SUCCESS;
                 test_info.paramfail_test_state = PARAMFAIL_TESTSTATE_IDLE;
-                test_info.skipped = 0;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
                 /* Suppress all output from the library unless we're verbose
@@ -612,9 +611,9 @@ int execute_tests( int argc , const char ** argv )
             }
             else if( ret == DISPATCH_TEST_SUCCESS )
             {
-                if( test_info.result == TEST_RESULT_SUCCESS )
+                if( test_info.result != TEST_RESULT_FAILED )
                 {
-                    if( test_info.skipped == 1 )
+                    if( test_info.result == TEST_RESULT_SKIPPED )
                     {
                         total_skipped++;
                         mbedtls_fprintf( stdout, "----\n" );
@@ -629,11 +628,6 @@ int execute_tests( int argc , const char ** argv )
                     {
                         mbedtls_fprintf( stdout, "PASS\n" );
                     }
-                }
-                else if( test_info.result == TEST_RESULT_SKIPPED )
-                {
-                    mbedtls_fprintf( stdout, "----\n" );
-                    total_skipped++;
                 }
                 else
                 {

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -374,8 +374,7 @@ int execute_tests( int args, const char ** argv )
     while ( 1 )
     {
         ret = 0;
-        test_info.failed = 0;
-        test_info.skipped = 0;
+        test_info.result = TEST_RESULT_SUCCESS;
         data_len = 0;
 
         data = receive_data( &data_len );
@@ -432,10 +431,10 @@ int execute_tests( int args, const char ** argv )
 
         if ( ret )
             send_failure( ret );
-        else if ( test_info.skipped == 1)
+        else if ( test_info.result == TEST_RESULT_SKIPPED )
             send_failure( FEATURE_UNSUPPORTED );
         else
-            send_status( test_info.failed );
+            send_status( test_info.result );
     }
     return( 0 );
 }

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -90,18 +90,19 @@ uint8_t receive_byte()
 uint32_t receive_uint32()
 {
     uint32_t value;
-    const uint8_t c[9] = { greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           greentea_getc(),
-                           '\0'
-                         };
-    TEST_HELPER_ASSERT( unhexify( &value, c ) != 8 );
-    return( (uint32_t)value );
+    uint8_t c_be[8] = { greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc(),
+                        greentea_getc()
+                      };
+    const uint8_t c[9] = { c_be[6], c_be[7], c_be[4], c_be[5], c_be[2],
+                           c_be[3], c_be[0], c_be[1], '\0' };
+    TEST_HELPER_ASSERT( unhexify( (uint8_t*)&value, c ) != 8 );
+    return( value );
 }
 
 /**

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -75,7 +75,7 @@ uint8_t receive_byte()
     c[1] = greentea_getc();
     c[2] = '\0';
 
-    assert( unhexify( &byte, c ) != 2 );
+    TEST_HELPER_ASSERT( unhexify( &byte, c ) != 2 );
     return( byte );
 }
 
@@ -100,7 +100,7 @@ uint32_t receive_uint32()
                            greentea_getc(),
                            '\0'
                          };
-    assert( unhexify( &value, c ) != 8 );
+    TEST_HELPER_ASSERT( unhexify( &value, c ) != 8 );
     return( (uint32_t)value );
 }
 

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -375,6 +375,7 @@ int execute_tests( int args, const char ** argv )
     {
         ret = 0;
         test_info.failed = 0;
+        test_info.skipped = 0;
         data_len = 0;
 
         data = receive_data( &data_len );
@@ -431,6 +432,8 @@ int execute_tests( int args, const char ** argv )
 
         if ( ret )
             send_failure( ret );
+        else if ( test_info.skipped == 1)
+            send_failure( FEATURE_UNSUPPORTED );
         else
             send_status( test_info.failed );
     }

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -150,7 +150,7 @@ void mbedtls_debug_print_crt( char * crt_file, char * file, int line,
 
     mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
     mbedtls_debug_print_crt( &ssl, 0, file, line, prefix, &crt);
 
     TEST_ASSERT( strcmp( buffer.buf, result_str ) == 0 );

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -207,7 +207,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD2_C:MBEDTLS_RSA_C
 mbedtls_x509_crl_info:"data_files/crl_md2.pem":"CRL version   \: 1\nissuer name   \: C=NL, O=PolarSSL, CN=PolarSSL Test CA\nthis update   \: 2009-07-19 19\:56\:37\nnext update   \: 2009-09-17 19\:56\:37\nRevoked certificates\:\nserial number\: 01 revocation date\: 2009-02-09 21\:12\:36\nserial number\: 03 revocation date\: 2009-02-09 21\:12\:36\nsigned using  \: RSA with MD2\n"
 
 X509 CRL Information MD4 Digest
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD4_C
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD4_C:MBEDTLS_RSA_C
 mbedtls_x509_crl_info:"data_files/crl_md4.pem":"CRL version   \: 1\nissuer name   \: C=NL, O=PolarSSL, CN=PolarSSL Test CA\nthis update   \: 2011-02-12 14\:44\:07\nnext update   \: 2011-04-13 14\:44\:07\nRevoked certificates\:\nserial number\: 01 revocation date\: 2011-02-12 14\:44\:07\nserial number\: 03 revocation date\: 2011-02-12 14\:44\:07\nsigned using  \: RSA with MD4\n"
 
 X509 CRL Information MD5 Digest

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -24,6 +24,17 @@ const mbedtls_x509_crt_profile profile_all =
     1024,
 };
 
+#define TEST_ASSERT_FLAGS( TEST )                                 \
+    do {                                                          \
+        res = (TEST);                                             \
+        if( flags & ( MBEDTLS_X509_BADCERT_ALG_NOT_SUPPORTED |    \
+                      MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED ) )   \
+        {                                                         \
+            test_skip( #TEST, __LINE__, __FILE__ );               \
+            goto exit;                                            \
+        }                                                         \
+    } while( 0 )
+
 /* Profile for backward compatibility. Allows SHA-1, unlike the default
    profile. */
 const mbedtls_x509_crt_profile compat_profile =
@@ -359,7 +370,7 @@ void x509_cert_info( char * crt_file, char * result_str )
     mbedtls_x509_crt_init( &crt );
     memset( buf, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
     res = mbedtls_x509_crt_info( buf, 2000, "", &crt );
 
     TEST_ASSERT( res != -1 );
@@ -382,7 +393,7 @@ void mbedtls_x509_crl_info( char * crl_file, char * result_str )
     mbedtls_x509_crl_init( &crl );
     memset( buf, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crl_parse_file( &crl, crl_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crl_parse_file( &crl, crl_file ), 0 );
     res = mbedtls_x509_crl_info( buf, 2000, "", &crl );
 
     TEST_ASSERT( res != -1 );
@@ -404,7 +415,7 @@ void mbedtls_x509_crl_parse( char * crl_file, int result )
     mbedtls_x509_crl_init( &crl );
     memset( buf, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crl_parse_file( &crl, crl_file ) == result );
+    TEST_ASSERT_RET( mbedtls_x509_crl_parse_file( &crl, crl_file ), result );
 
 exit:
     mbedtls_x509_crl_free( &crl );
@@ -421,7 +432,7 @@ void mbedtls_x509_csr_info( char * csr_file, char * result_str )
     mbedtls_x509_csr_init( &csr );
     memset( buf, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_csr_parse_file( &csr, csr_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_csr_parse_file( &csr, csr_file ), 0 );
     res = mbedtls_x509_csr_info( buf, 2000, "", &csr );
 
     TEST_ASSERT( res != -1 );
@@ -442,7 +453,8 @@ void x509_verify_info( int flags, char * prefix, char * result_str )
 
     memset( buf, 0, sizeof( buf ) );
 
-    res = mbedtls_x509_crt_verify_info( buf, sizeof( buf ), prefix, flags );
+    TEST_ASSERT_FLAGS( mbedtls_x509_crt_verify_info( buf, sizeof( buf ),
+                                                     prefix, flags ) );
 
     TEST_ASSERT( res >= 0 );
 
@@ -554,13 +566,14 @@ void x509_verify( char *crt_file, char *ca_file, char *crl_file,
     else
         TEST_ASSERT( "No known verify callback selected" == 0 );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &ca, ca_file ) == 0 );
-    TEST_ASSERT( mbedtls_x509_crl_parse_file( &crl, crl_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &ca, ca_file ), 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crl_parse_file( &crl, crl_file ), 0 );
 
-    res = mbedtls_x509_crt_verify_with_profile( &crt, &ca, &crl, profile, cn_name, &flags, f_vrfy, NULL );
-
-    TEST_ASSERT( res == ( result ) );
+    TEST_ASSERT_FLAGS( mbedtls_x509_crt_verify_with_profile( &crt, &ca, &crl,
+                                                             profile, cn_name,
+                                                             &flags, f_vrfy, NULL ) );
+    TEST_ASSERT( res == result );
     TEST_ASSERT( flags == (uint32_t)( flags_result ) );
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
@@ -617,7 +630,7 @@ exit:
 void x509_verify_callback( char *crt_file, char *ca_file, char *name,
                            int exp_ret, char *exp_vrfy_out )
 {
-    int ret;
+    int res;
     mbedtls_x509_crt crt;
     mbedtls_x509_crt ca;
     uint32_t flags = 0;
@@ -631,18 +644,18 @@ void x509_verify_callback( char *crt_file, char *ca_file, char *name,
     mbedtls_x509_crt_init( &ca );
     verify_print_init( &vrfy_ctx );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &ca, ca_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &ca, ca_file ), 0 );
 
     if( strcmp( name, "NULL" ) == 0 )
         name = NULL;
 
-    ret = mbedtls_x509_crt_verify_with_profile( &crt, &ca, NULL,
-                                                &compat_profile,
-                                                name, &flags,
-                                                verify_print, &vrfy_ctx );
-
-    TEST_ASSERT( ret == exp_ret );
+    TEST_ASSERT_FLAGS( mbedtls_x509_crt_verify_with_profile( &crt, &ca, NULL,
+                                                             &compat_profile,
+                                                             name, &flags,
+                                                             verify_print,
+                                                             &vrfy_ctx ) );
+    TEST_ASSERT( res == exp_ret );
     TEST_ASSERT( strcmp( vrfy_ctx.buf, exp_vrfy_out ) == 0 );
 
 exit:
@@ -661,7 +674,7 @@ void mbedtls_x509_dn_gets( char * crt_file, char * entity, char * result_str )
     mbedtls_x509_crt_init( &crt );
     memset( buf, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
     if( strcmp( entity, "subject" ) == 0 )
         res =  mbedtls_x509_dn_gets( buf, 2000, &crt.subject );
     else if( strcmp( entity, "issuer" ) == 0 )
@@ -686,12 +699,12 @@ void mbedtls_x509_time_is_past( char * crt_file, char * entity, int result )
 
     mbedtls_x509_crt_init( &crt );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
 
     if( strcmp( entity, "valid_from" ) == 0 )
-        TEST_ASSERT( mbedtls_x509_time_is_past( &crt.valid_from ) == result );
+        TEST_ASSERT_RET( mbedtls_x509_time_is_past( &crt.valid_from ), result );
     else if( strcmp( entity, "valid_to" ) == 0 )
-        TEST_ASSERT( mbedtls_x509_time_is_past( &crt.valid_to ) == result );
+        TEST_ASSERT_RET( mbedtls_x509_time_is_past( &crt.valid_to ), result );
     else
         TEST_ASSERT( "Unknown entity" == 0 );
 
@@ -707,12 +720,12 @@ void mbedtls_x509_time_is_future( char * crt_file, char * entity, int result )
 
     mbedtls_x509_crt_init( &crt );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
 
     if( strcmp( entity, "valid_from" ) == 0 )
-        TEST_ASSERT( mbedtls_x509_time_is_future( &crt.valid_from ) == result );
+        TEST_ASSERT_RET( mbedtls_x509_time_is_future( &crt.valid_from ), result );
     else if( strcmp( entity, "valid_to" ) == 0 )
-        TEST_ASSERT( mbedtls_x509_time_is_future( &crt.valid_to ) == result );
+        TEST_ASSERT_RET( mbedtls_x509_time_is_future( &crt.valid_to ), result );
     else
         TEST_ASSERT( "Unknown entity" == 0 );
 
@@ -728,7 +741,7 @@ void x509parse_crt_file( char * crt_file, int result )
 
     mbedtls_x509_crt_init( &crt );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == result );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), result );
 
 exit:
     mbedtls_x509_crt_free( &crt );
@@ -745,7 +758,7 @@ void x509parse_crt( data_t * buf, char * result_str, int result )
     mbedtls_x509_crt_init( &crt );
     memset( output, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_der( &crt, buf->x, buf->len ) == ( result ) );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_der( &crt, buf->x, buf->len ), ( result ) );
     if( ( result ) == 0 )
     {
         res = mbedtls_x509_crt_info( (char *) output, 2000, "", &crt );
@@ -760,7 +773,8 @@ void x509parse_crt( data_t * buf, char * result_str, int result )
     mbedtls_x509_crt_init( &crt );
     memset( output, 0, 2000 );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_der_nocopy( &crt, buf->x, buf->len ) == ( result ) );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_der_nocopy( &crt, buf->x, buf->len ), ( result ) );
+
     if( ( result ) == 0 )
     {
         res = mbedtls_x509_crt_info( (char *) output, 2000, "", &crt );
@@ -787,7 +801,7 @@ void x509parse_crl( data_t * buf, char * result_str, int result )
     memset( output, 0, 2000 );
 
 
-    TEST_ASSERT( mbedtls_x509_crl_parse( &crl, buf->x, buf->len ) == ( result ) );
+    TEST_ASSERT_RET( mbedtls_x509_crl_parse( &crl, buf->x, buf->len ), result );
     if( ( result ) == 0 )
     {
         res = mbedtls_x509_crl_info( (char *) output, 2000, "", &crl );
@@ -808,14 +822,12 @@ void mbedtls_x509_csr_parse( data_t * csr_der, char * ref_out, int ref_ret )
 {
     mbedtls_x509_csr csr;
     char my_out[1000];
-    int my_ret;
 
     mbedtls_x509_csr_init( &csr );
     memset( my_out, 0, sizeof( my_out ) );
 
-    my_ret = mbedtls_x509_csr_parse_der( &csr, csr_der->x, csr_der->len );
-    TEST_ASSERT( my_ret == ref_ret );
-
+    TEST_ASSERT_RET( mbedtls_x509_csr_parse_der( &csr, csr_der->x, csr_der->len ),
+                                                 ref_ret );
     if( ref_ret == 0 )
     {
         size_t my_out_len = mbedtls_x509_csr_info( my_out, sizeof( my_out ), "", &csr );
@@ -829,14 +841,14 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C */
-void mbedtls_x509_crt_parse_path( char * crt_path, int ret, int nb_crt )
+void mbedtls_x509_crt_parse_path( char * crt_path, int res, int nb_crt )
 {
     mbedtls_x509_crt chain, *cur;
     int i;
 
     mbedtls_x509_crt_init( &chain );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_path( &chain, crt_path ) == ret );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_path( &chain, crt_path ), res );
 
     /* Check how many certs we got */
     for( i = 0, cur = &chain; cur != NULL; cur = cur->next )
@@ -855,8 +867,8 @@ void mbedtls_x509_crt_verify_max( char *ca_file, char *chain_dir, int nb_int,
                                   int ret_chk, int flags_chk )
 {
     char file_buf[128];
-    int ret;
     uint32_t flags;
+    int res;
     mbedtls_x509_crt trusted, chain;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -872,19 +884,19 @@ void mbedtls_x509_crt_verify_max( char *ca_file, char *chain_dir, int nb_int,
     mbedtls_x509_crt_init( &chain );
 
     /* Load trusted root */
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &trusted, ca_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &trusted, ca_file ), 0 );
 
     /* Load a chain with nb_int intermediates (from 01 to nb_int),
      * plus one "end-entity" cert (nb_int + 1) */
-    ret = mbedtls_snprintf( file_buf, sizeof file_buf, "%s/c%02d.pem", chain_dir,
+    res = mbedtls_snprintf( file_buf, sizeof file_buf, "%s/c%02d.pem", chain_dir,
                                                             nb_int + 1 );
-    TEST_ASSERT( ret > 0 && (size_t) ret < sizeof file_buf );
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &chain, file_buf ) == 0 );
+    TEST_ASSERT( res > 0 && (size_t) res < sizeof file_buf );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &chain, file_buf ), 0 );
 
     /* Try to verify that chain */
-    ret = mbedtls_x509_crt_verify( &chain, &trusted, NULL, NULL, &flags,
-                                   NULL, NULL );
-    TEST_ASSERT( ret == ret_chk );
+    TEST_ASSERT_FLAGS( mbedtls_x509_crt_verify( &chain, &trusted, NULL, NULL,
+                                                &flags, NULL, NULL ) );
+    TEST_ASSERT( res == ret_chk );
     TEST_ASSERT( flags == (uint32_t) flags_chk );
 
 exit:
@@ -912,8 +924,10 @@ void mbedtls_x509_crt_verify_chain(  char *chain_paths, char *trusted_ca,
     mbedtls_x509_crt_init( &trusted );
 
     while( ( act = mystrsep( &chain_paths, " " ) ) != NULL )
-        TEST_ASSERT( mbedtls_x509_crt_parse_file( &chain, act ) == 0 );
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &trusted, trusted_ca ) == 0 );
+    {
+        TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &chain, act ), 0 );
+    }
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &trusted, trusted_ca ), 0 );
 
     if( strcmp( profile_name, "" ) == 0 )
         profile = &mbedtls_x509_crt_profile_default;
@@ -926,10 +940,10 @@ void mbedtls_x509_crt_verify_chain(  char *chain_paths, char *trusted_ca,
     else if( strcmp( profile_name, "sha512" ) == 0 )
         profile = &profile_sha512;
 
-    res = mbedtls_x509_crt_verify_with_profile( &chain, &trusted, NULL, profile,
-            NULL, &flags, verify_fatal, &vrfy_fatal_lvls );
+    TEST_ASSERT_FLAGS( mbedtls_x509_crt_verify_with_profile( &chain, &trusted, NULL, profile,
+                                                NULL, &flags, verify_fatal, &vrfy_fatal_lvls ) );
 
-    TEST_ASSERT( res == ( result ) );
+    TEST_ASSERT( res == result );
     TEST_ASSERT( flags == (uint32_t)( flags_result ) );
 
 exit:
@@ -991,15 +1005,15 @@ void x509_oid_numstr( data_t * oid_buf, char * numstr, int blen, int ret )
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_X509_CHECK_KEY_USAGE */
-void x509_check_key_usage( char * crt_file, int usage, int ret )
+void x509_check_key_usage( char * crt_file, int usage, int res )
 {
     mbedtls_x509_crt crt;
 
     mbedtls_x509_crt_init( &crt );
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
 
-    TEST_ASSERT( mbedtls_x509_crt_check_key_usage( &crt, usage ) == ret );
+    TEST_ASSERT_RET( mbedtls_x509_crt_check_key_usage( &crt, usage ), res );
 
 exit:
     mbedtls_x509_crt_free( &crt );
@@ -1007,7 +1021,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE */
-void x509_check_extended_key_usage( char * crt_file, data_t * oid, int ret
+void x509_check_extended_key_usage( char * crt_file, data_t * oid, int exp_ret
                                     )
 {
     mbedtls_x509_crt crt;
@@ -1015,9 +1029,9 @@ void x509_check_extended_key_usage( char * crt_file, data_t * oid, int ret
     mbedtls_x509_crt_init( &crt );
 
 
-    TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509_crt_parse_file( &crt, crt_file ), 0 );
 
-    TEST_ASSERT( mbedtls_x509_crt_check_extended_key_usage( &crt, (const char *)oid->x, oid->len ) == ret );
+    TEST_ASSERT_RET( mbedtls_x509_crt_check_extended_key_usage( &crt, (const char *)oid->x, oid->len ), exp_ret );
 
 exit:
     mbedtls_x509_crt_free( &crt );
@@ -1025,7 +1039,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C */
-void x509_get_time( int tag, char * time_str, int ret, int year, int mon,
+void x509_get_time( int tag, char * time_str, int exp_ret, int year, int mon,
                     int day, int hour, int min, int sec )
 {
     mbedtls_x509_time time;
@@ -1041,8 +1055,8 @@ void x509_get_time( int tag, char * time_str, int ret, int year, int mon,
     memcpy( end, time_str, (size_t)*(end - 1) );
     end += *(end - 1);
 
-    TEST_ASSERT( mbedtls_x509_get_time( &start, end, &time ) == ret );
-    if( ret == 0 )
+    TEST_ASSERT_RET( mbedtls_x509_get_time( &start, end, &time ), exp_ret );
+    if( exp_ret == 0 )
     {
         TEST_ASSERT( year == time.year );
         TEST_ASSERT( mon  == time.mon  );
@@ -1059,7 +1073,6 @@ void x509_parse_rsassa_pss_params( data_t * hex_params, int params_tag,
                                    int ref_msg_md, int ref_mgf_md,
                                    int ref_salt_len, int ref_ret )
 {
-    int my_ret;
     mbedtls_x509_buf params;
     mbedtls_md_type_t my_msg_md, my_mgf_md;
     int my_salt_len;
@@ -1068,10 +1081,8 @@ void x509_parse_rsassa_pss_params( data_t * hex_params, int params_tag,
     params.len = hex_params->len;
     params.tag = params_tag;
 
-    my_ret = mbedtls_x509_get_rsassa_pss_params( &params, &my_msg_md, &my_mgf_md,
-                                         &my_salt_len );
-
-    TEST_ASSERT( my_ret == ref_ret );
+    TEST_ASSERT_RET( mbedtls_x509_get_rsassa_pss_params( &params, &my_msg_md, &my_mgf_md,
+                                         &my_salt_len ), ref_ret );
 
     if( ref_ret == 0 )
     {

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -30,7 +30,7 @@ const mbedtls_x509_crt_profile profile_all =
         if( flags & ( MBEDTLS_X509_BADCERT_ALG_NOT_SUPPORTED |    \
                       MBEDTLS_X509_BADCRL_ALG_NOT_SUPPORTED ) )   \
         {                                                         \
-            test_skip( #TEST, __LINE__, __FILE__ );               \
+            set_test_result( #TEST, __LINE__, __FILE__, TEST_RESULT_SKIPPED );\
             goto exit;                                            \
         }                                                         \
     } while( 0 )

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -88,7 +88,6 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     mbedtls_x509write_csr req;
     unsigned char buf[4096];
     unsigned char check_buf[4000];
-    int ret;
     size_t olen = 0, pem_len = 0;
     int der_len = -1;
     FILE *f;
@@ -98,20 +97,19 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     memset( &rnd_info, 0x2a, sizeof( rnd_pseudo_info ) );
 
     mbedtls_pk_init( &key );
-    TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL ) == 0 );
+    TEST_ASSERT_RET( mbedtls_pk_parse_keyfile( &key, key_file, NULL ), 0 );
 
     mbedtls_x509write_csr_init( &req );
     mbedtls_x509write_csr_set_md_alg( &req, md_type );
     mbedtls_x509write_csr_set_key( &req, &key );
-    TEST_ASSERT( mbedtls_x509write_csr_set_subject_name( &req, subject_name ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_csr_set_subject_name( &req, subject_name ), 0 );
     if( set_key_usage != 0 )
-        TEST_ASSERT( mbedtls_x509write_csr_set_key_usage( &req, key_usage ) == 0 );
+        TEST_ASSERT_RET( mbedtls_x509write_csr_set_key_usage( &req, key_usage ), 0 );
     if( set_cert_type != 0 )
-        TEST_ASSERT( mbedtls_x509write_csr_set_ns_cert_type( &req, cert_type ) == 0 );
+        TEST_ASSERT_RET( mbedtls_x509write_csr_set_ns_cert_type( &req, cert_type ), 0 );
 
-    ret = mbedtls_x509write_csr_pem( &req, buf, sizeof( buf ),
-                             rnd_pseudo_rand, &rnd_info );
-    TEST_ASSERT( ret == 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_csr_pem( &req, buf, sizeof( buf ),
+                                                rnd_pseudo_rand, &rnd_info ), 0 );
 
     pem_len = strlen( (char *) buf );
 
@@ -130,9 +128,9 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     if( der_len == 0 )
         goto exit;
 
-    ret = mbedtls_x509write_csr_der( &req, buf, (size_t)( der_len - 1 ),
-                            rnd_pseudo_rand, &rnd_info );
-    TEST_ASSERT( ret == MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+    TEST_ASSERT_RET( mbedtls_x509write_csr_der( &req, buf, (size_t)( der_len - 1 ),
+                                                rnd_pseudo_rand, &rnd_info ),
+                                                MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
 exit:
     mbedtls_x509write_csr_free( &req );
@@ -203,7 +201,6 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     unsigned char buf[4096];
     unsigned char check_buf[5000];
     mbedtls_mpi serial;
-    int ret;
     size_t olen = 0, pem_len = 0;
     int der_len = -1;
     FILE *f;
@@ -218,21 +215,21 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
 
     mbedtls_x509write_crt_init( &crt );
 
-    TEST_ASSERT( mbedtls_pk_parse_keyfile( &subject_key, subject_key_file,
-                                         subject_pwd ) == 0 );
+    TEST_ASSERT_RET( mbedtls_pk_parse_keyfile( &subject_key, subject_key_file,
+                                         subject_pwd ), 0 );
 
-    TEST_ASSERT( mbedtls_pk_parse_keyfile( &issuer_key, issuer_key_file,
-                                         issuer_pwd ) == 0 );
+    TEST_ASSERT_RET( mbedtls_pk_parse_keyfile( &issuer_key, issuer_key_file,
+                                         issuer_pwd ), 0 );
 
 #if defined(MBEDTLS_RSA_C)
     /* For RSA PK contexts, create a copy as an alternative RSA context. */
     if( rsa_alt == 1 && mbedtls_pk_get_type( &issuer_key ) == MBEDTLS_PK_RSA )
     {
-        TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &issuer_key_alt,
-                                            mbedtls_pk_rsa( issuer_key ),
-                                            mbedtls_rsa_decrypt_func,
-                                            mbedtls_rsa_sign_func,
-                                            mbedtls_rsa_key_len_func ) == 0 );
+        TEST_ASSERT_RET( mbedtls_pk_setup_rsa_alt( &issuer_key_alt,
+                                                   mbedtls_pk_rsa( issuer_key ),
+                                                   mbedtls_rsa_decrypt_func,
+                                                   mbedtls_rsa_sign_func,
+                                                   mbedtls_rsa_key_len_func ), 0 );
 
         key = &issuer_key_alt;
     }
@@ -240,36 +237,35 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     (void) rsa_alt;
 #endif
 
-    TEST_ASSERT( mbedtls_mpi_read_string( &serial, 10, serial_str ) == 0 );
+    TEST_ASSERT_RET( mbedtls_mpi_read_string( &serial, 10, serial_str ), 0 );
 
     if( ver != -1 )
         mbedtls_x509write_crt_set_version( &crt, ver );
 
-    TEST_ASSERT( mbedtls_x509write_crt_set_serial( &crt, &serial ) == 0 );
-    TEST_ASSERT( mbedtls_x509write_crt_set_validity( &crt, not_before,
-                                                     not_after ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_set_serial( &crt, &serial ), 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_set_validity( &crt, not_before,
+                                                         not_after ), 0 );
     mbedtls_x509write_crt_set_md_alg( &crt, md_type );
-    TEST_ASSERT( mbedtls_x509write_crt_set_issuer_name( &crt, issuer_name ) == 0 );
-    TEST_ASSERT( mbedtls_x509write_crt_set_subject_name( &crt, subject_name ) == 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_set_issuer_name( &crt, issuer_name ), 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_set_subject_name( &crt, subject_name ), 0 );
     mbedtls_x509write_crt_set_subject_key( &crt, &subject_key );
 
     mbedtls_x509write_crt_set_issuer_key( &crt, key );
 
     if( crt.version >= MBEDTLS_X509_CRT_VERSION_3 )
     {
-        TEST_ASSERT( mbedtls_x509write_crt_set_basic_constraints( &crt, 0, 0 ) == 0 );
-        TEST_ASSERT( mbedtls_x509write_crt_set_subject_key_identifier( &crt ) == 0 );
+        TEST_ASSERT_RET( mbedtls_x509write_crt_set_basic_constraints( &crt, 0, 0 ), 0 );
+        TEST_ASSERT_RET( mbedtls_x509write_crt_set_subject_key_identifier( &crt ), 0 );
         if( auth_ident )
-            TEST_ASSERT( mbedtls_x509write_crt_set_authority_key_identifier( &crt ) == 0 );
+            TEST_ASSERT_RET( mbedtls_x509write_crt_set_authority_key_identifier( &crt ), 0 );
         if( set_key_usage != 0 )
-            TEST_ASSERT( mbedtls_x509write_crt_set_key_usage( &crt, key_usage ) == 0 );
+            TEST_ASSERT_RET( mbedtls_x509write_crt_set_key_usage( &crt, key_usage ), 0 );
         if( set_cert_type != 0 )
-            TEST_ASSERT( mbedtls_x509write_crt_set_ns_cert_type( &crt, cert_type ) == 0 );
+            TEST_ASSERT_RET( mbedtls_x509write_crt_set_ns_cert_type( &crt, cert_type ), 0 );
     }
 
-    ret = mbedtls_x509write_crt_pem( &crt, buf, sizeof( buf ),
-                                     rnd_pseudo_rand, &rnd_info );
-    TEST_ASSERT( ret == 0 );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_pem( &crt, buf, sizeof( buf ),
+                                                rnd_pseudo_rand, &rnd_info ), 0 );
 
     pem_len = strlen( (char *) buf );
 
@@ -284,14 +280,17 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
 
     der_len = mbedtls_x509write_crt_der( &crt, buf, sizeof( buf ),
                                          rnd_pseudo_rand, &rnd_info );
-    TEST_ASSERT( der_len >= 0 );
+    if( der_len == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED )
+    {
+        goto exit;
+    }
 
     if( der_len == 0 )
         goto exit;
 
-    ret = mbedtls_x509write_crt_der( &crt, buf, (size_t)( der_len - 1 ),
-                                     rnd_pseudo_rand, &rnd_info );
-    TEST_ASSERT( ret == MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+    TEST_ASSERT_RET( mbedtls_x509write_crt_der( &crt, buf, (size_t)( der_len - 1 ),
+                                                rnd_pseudo_rand, &rnd_info ),
+                                                MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
 exit:
     mbedtls_x509write_crt_free( &crt );


### PR DESCRIPTION
## Description
This PR adds support for `MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED` introduced in #2054 
Tests that receive this error, skip to the next step, as the underlying HW accelerator does not support that specific feature.
Exception are the entropy, when the SHA function returns such an error, as the specific entropy source is dependent on the SHA function, and not configurable, and the ctr_drbg, when the specific AES functionality is not supported, as it is dependent on it to work. Skipping the tests may result in security issue, if developer assumes the test passes.
Second PR that supersedes #1716
## Status
**READY**

## Requires Backporting
NO  


## Migrations
~Error codes have been removed, so we may consider this as an API change~

## Additional comments

ctr_drbg requires `MBEDTLS_CTR_DRBG_USE_128_BIT_KEY` to be defined, in case AES 256 is not supported by the HW, ~once PR #1902 will be merged.~

~Note: Once #2054 will be merged, I will rebase to have the support for the on target testing to run, but this PR can start the review~

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported

