### PR TITLE
Typo fix in ecp.c

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -407,7 +407,7 @@ int mbedtls_ecp_is_zero( mbedtls_ecp_point *pt )
 }
 
 /*
- * Compare two points lazyly
+ * Compare two points lazily
  */
 int mbedtls_ecp_point_cmp( const mbedtls_ecp_point *P,
                            const mbedtls_ecp_point *Q )


### PR DESCRIPTION
Minor typo fix in ecp.c
lazyly 🠖 lazily