### PR TITLE
Remove temporary stack-buffer from mbedtls_mpi_fill_random()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Reduce the stack consumption of mbedtls_mpi_fill_random() which could
+     previously lead to a stack overflow on constrained targets.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -741,14 +741,19 @@ static mbedtls_mpi_uint mpi_uint_bigendian_to_host( mbedtls_mpi_uint x )
 #if ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
 
 /* For GCC and Clang, have builtins for byte swapping. */
-#if( defined(__GNUC__) && defined(__GNUC_PREREQ) && __GNUC_PREREQ(4,3) )
-#define have_bswap
-#elif defined(__clang__)                &&               \
-      defined(__has_builtin)            &&               \
-      __has_builtin(__builtin_bswap32)  &&               \
-      __has_builtin(__builtin_bswap64)
+#if defined(__GNUC__) && defined(__GNUC_PREREQ)
+#if __GNUC_PREREQ(4,3)
 #define have_bswap
 #endif
+#endif
+
+#if defined(__clang__) && defined(__has_builtin)
+#if __has_builtin(__builtin_bswap32)  &&                 \
+    __has_builtin(__builtin_bswap64)
+#define have_bswap
+#endif
+#endif
+
 #if defined(have_bswap)
     /* The compiler is hopefully able to statically evaluate this! */
     switch( sizeof(mbedtls_mpi_uint) )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -823,10 +823,15 @@ int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf, size_t bu
     }
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    Xp = (unsigned char*) X->p;
-    memcpy( Xp + overhead, buf, buflen );
+    /* Avoid calling `memcpy` with NULL source argument,
+     * even if buflen is 0. */
+    if( buf != NULL )
+    {
+        Xp = (unsigned char*) X->p;
+        memcpy( Xp + overhead, buf, buflen );
 
-    mpi_bigendian_to_host( X->p, limbs );
+        mpi_bigendian_to_host( X->p, limbs );
+    }
 
 cleanup:
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -718,10 +718,8 @@ cleanup:
 
 /* Convert a big-endian byte array aligned to the size of mbedtls_mpi_uint
  * into the storage form used by mbedtls_mpi. */
-static int mpi_bigendian_to_host( unsigned char * const buf, size_t size )
+static void mpi_bigendian_to_host( mbedtls_mpi_uint * const p, size_t limbs )
 {
-    mbedtls_mpi_uint * const p = (mbedtls_mpi_uint *) buf;
-    size_t const limbs = size / ciL;
     size_t i;
 
     unsigned char *cur_byte_left;
@@ -732,8 +730,8 @@ static int mpi_bigendian_to_host( unsigned char * const buf, size_t size )
 
     mbedtls_mpi_uint tmp_left, tmp_right;
 
-    if( size % ciL != 0 || limbs == 0 )
-        return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
+    if( limbs == 0 )
+        return;
 
     /*
      * Traverse limbs and
@@ -767,7 +765,7 @@ static int mpi_bigendian_to_host( unsigned char * const buf, size_t size )
         *cur_limb_left  = tmp_right;
     }
 
-    return( 0 );
+    return;
 }
 
 /*
@@ -795,7 +793,7 @@ int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf, size_t bu
     Xp = (unsigned char*) X->p;
     memcpy( Xp + overhead, buf, buflen );
 
-    MBEDTLS_MPI_CHK( mpi_bigendian_to_host( Xp, limbs * ciL ) );
+    mpi_bigendian_to_host( X->p, limbs );
 
 cleanup:
 
@@ -2084,7 +2082,7 @@ int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
     Xp = (unsigned char*) X->p;
     f_rng( p_rng, Xp + overhead, size );
 
-    MBEDTLS_MPI_CHK( mpi_bigendian_to_host( Xp, limbs * ciL ) );
+    mpi_bigendian_to_host( X->p, limbs );
 
 cleanup:
     return( ret );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2091,7 +2091,7 @@ int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
                      void *p_rng )
 {
     int ret;
-    size_t const limbs CHARS_TO_LIMBS( size );
+    size_t const limbs = CHARS_TO_LIMBS( size );
     size_t const overhead = ( limbs * ciL ) - size;
     unsigned char *Xp;
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -741,7 +741,7 @@ static mbedtls_mpi_uint mpi_uint_bigendian_to_host( mbedtls_mpi_uint x )
 #if ( __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ )
 
 /* For GCC and Clang, have builtins for byte swapping. */
-#if( defined(__GNUC__) && __GNUC_PREREQ(4,3) )
+#if( defined(__GNUC__) && defined(__GNUC_PREREQ) && __GNUC_PREREQ(4,3) )
 #define have_bswap
 #elif defined(__clang__)                &&               \
       defined(__has_builtin)            &&               \


### PR DESCRIPTION
__Context:__ The function `mbedtls_mpi_fill_random()` uses a large temporary stack buffer to hold the random data before importing it into the target MPI.

__Problem:__ This is inefficient both computationally and memory-wise. Memory-wise, it may lead to a stack overflow on constrained devices with limited stack.

__Fix:__ This commit introduces the following changes to get rid of the temporary stack buffer entirely:

1. It modifies the call to the PRNG to output the random data directly into the target MPI's data buffer.

This alone, however, constitutes a change of observable behaviour: The previous implementation guaranteed to interpret the bytes emitted by the PRNG in a big-endian fashion, while rerouting the PRNG output into the target MPI's limb array leads to an interpretation that depends on the endianness of the host machine. As a remedy, the following change is applied, too:

2. Reorder bytes emitted from the PRNG in the target MPI's data buffer to ensure big-endian semantics.

Luckily, the byte reordering was essentially already implemented as part of `mbedtls_mpi_read_binary()`:

3. Extract bigendian-to-host byte reordering from `mbedtls_mpi_read_binary()` to a separate internal function `mpi_bigendian_to_host()` to be used by `mbedtls_mpi_read_binary()` and `mbedtls_mpi_fill_random()`.


__Internal Reference:__ IOTSSL-2316.