### PR TITLE
Backport 2.7: Make inclusion of stdio.h conditional in x509_crt.c

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -40,7 +40,6 @@
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/oid.h"
 
-#include <stdio.h>
 #include <string.h>
 
 #if defined(MBEDTLS_PEM_PARSE_C)
@@ -50,6 +49,7 @@
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
+#include <stdio.h>
 #include <stdlib.h>
 #define mbedtls_free       free
 #define mbedtls_calloc    calloc


### PR DESCRIPTION
## Description
`stdio.h` was being included both conditionally if `MBEDTLS_FS_IO` was defined, and also unconditionally, which made at least one of them redundant.

This change removes the unconditional inclusion of stdio.h and makes it conditional on `MBEDTLS_PLATFORM_C`.

This is a backport of #2052.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
