### PR TITLE
Correct typo in documentation of MBEDTLS_SSL_RENEGOTIATION

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1288,7 +1288,7 @@
 /**
  * \def MBEDTLS_SSL_RENEGOTIATION
  *
- * Disable support for TLS renegotiation.
+ * Enable support for TLS renegotiation.
  *
  * The two main uses of renegotiation are (1) refresh keys on long-lived
  * connections and (2) client authentication after the initial handshake.


### PR DESCRIPTION
__Summary:__ The configuration option `MBEDTLS_SSL_RENEGOTIATION` is a 'positive' option in the sense that setting it _enables_ the feature of renegotiation. However, the macro was previously documented as 'Disable support for TLS renegotiation'. This PR fixes this.