### PR TITLE
Remove integer conversion warning in non-blocking ECC

### DIFF
--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -233,7 +233,9 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
                               unsigned ops );
 
 /* Utility macro for checking and updating ops budget */
-#define MBEDTLS_ECP_BUDGET( ops )   MBEDTLS_MPI_CHK( mbedtls_ecp_check_budget( grp, rs_ctx, ops ) );
+#define MBEDTLS_ECP_BUDGET( ops )   \
+    MBEDTLS_MPI_CHK( mbedtls_ecp_check_budget( grp, rs_ctx, \
+                                               (unsigned) (ops) ) );
 
 #else /* MBEDTLS_ECP_RESTARTABLE */
 

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -248,9 +248,16 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
         else if( grp->pbits >= 384 )
             ops *= 2;
 
-        /* avoid infinite loops: always allow first step */
-        if( rs_ctx->ops_done != 0 && rs_ctx->ops_done + ops > ecp_max_ops )
+        /* Avoid infinite loops: always allow first step.
+         * Because of that, however, it's not generally true
+         * that ops_done <= ecp_max_ops, so the check
+         * ops_done > ecp_max_ops below is mandatory. */
+        if( ( rs_ctx->ops_done != 0 ) &&
+            ( rs_ctx->ops_done > ecp_max_ops ||
+              ops > ecp_max_ops - rs_ctx->ops_done ) )
+        {
             return( MBEDTLS_ERR_ECP_IN_PROGRESS );
+        }
 
         /* update running count */
         rs_ctx->ops_done += ops;


### PR DESCRIPTION
__Context:__ The macro `MBEDTLS_ECP_BUDGET()` is called before performing a number of potentially time-consuming ECC operations. If restartable ECC is enabled, it wraps a call to `mbedtls_ecp_check_budget()` which in turn checks if the requested number of operations can be performed without exceeding the maximum number of consecutive ECC operations.

__Issue:__ The function `mbedtls_ecp_check_budget()` expects the number of requested operations to be given as a value of type `unsigned`, while some calls of the wrapper macro `MBEDTLS_ECP_BUDGET()` use
expressions of type `size_t`. This rightfully leads to warnings about implicit truncation from `size_t` to `unsigned` on some compilers, and was reported in #2141.

__Fix:__ Commit abdf67e makes the truncation explicit by adding an explicit cast to `unsigned` in the expansion of the `MBEDTLS_ECP_BUDGET()` macro.

__Justification:__ Functionally, the new version if equivalent to the previous code. The warning about truncation can be discarded because, as can be inferred from `ecp.h`, the number of requested operations is never larger than `~1000`. The _total_ number of operations since the last interruption can be larger, though, and commit b10c660 makes sure that `mbedtls_ecp_check_budget()` behaves correctly even if the requested number of operations would overflow the operation counter.

Fixes #2141. 