### PR TITLE
Backport 2.1: Clarify documentation of ssl_set_own_cert()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,8 @@ Bugfix
      program programs/x509/cert_write. Fixes #1422.
    * Ignore iv in mbedtls_cipher_set_iv() when the cipher mode is MBEDTLS_MODE_ECB
      Fix for #1091 raised by ezdevelop
+   * Clarify documentation of mbedtls_ssl_set_own_cert() regarding the absence
+     of check for certificate/key matching. Reported by Attila Molnar, #507.
 
 Changes
    * "make apidoc" now generates the documentation for the current

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1408,6 +1408,14 @@ void mbedtls_ssl_conf_ca_chain( mbedtls_ssl_config *conf,
  *
  * \note           On client, only the first call has any effect.
  *
+ * \note           The provided \p pk_key needs to match the public key in the
+ *                 first certificate in \p own_cert, or all handshakes using
+ *                 that certificate will fail. It is your responsibility
+ *                 to ensure that; this function will not perform any check.
+ *                 You may use mbedtls_pk_check_pair() in order to perform
+ *                 this check yourself, but be aware that this function can
+ *                 be computationally expensive on some key types.
+ *
  * \param conf     SSL configuration
  * \param own_cert own public certificate chain
  * \param pk_key   own private key


### PR DESCRIPTION
Backport of #2134 to 2.1