### PR TITLE
Backport 2.7: Correct typo in documentation of MBEDTLS_SSL_RENEGOTIATION

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1188,7 +1188,7 @@
 /**
  * \def MBEDTLS_SSL_RENEGOTIATION
  *
- * Disable support for TLS renegotiation.
+ * Enable support for TLS renegotiation.
  *
  * The two main uses of renegotiation are (1) refresh keys on long-lived
  * connections and (2) client authentication after the initial handshake.


### PR DESCRIPTION
This is the backport to Mbed TLS 2.7 of #2140.