### PR TITLE
Remove unnecessary branch in x509_crt.c

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2180,7 +2180,7 @@ static int x509_crt_find_parent(
     }
 
     /* extra precaution against mistakes in the caller */
-    if( parent == NULL )
+    if( *parent == NULL )
     {
         *parent_is_trusted = 0;
         *signature_is_good = 0;


### PR DESCRIPTION
## Description

A conditional zeroing of two flags was present in the
`x509_crt_find_parent` function, that only happened upon the pointer
`parent` was NULL. However, the pointer is already dereferenced prior to
the aforementioned code, therefore, it is either unnecessary, or an
additional test is missing beforehand.

Nevertheless, this issue is going to be taken care of in the process of
introducing the unified parameter validation across the library. For now
the branch should be removed as it triggers static analysis tools to
signal a false positive.

## Status
READY

## Requires Backporting
NO (unless SA complains in those branches as well)

## Migrations
NO

## Additional comments
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
None
