### PR TITLE
conditionaly compile ECDH and ECDSA alt functions

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -108,6 +108,16 @@
 #error "MBEDTLS_ECJPAKE_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_ECP_RESTARTABLE)           && \
+    ( defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT) || \
+      defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)     || \
+      defined(MBEDTLS_ECDSA_SIGN_ALT)          || \
+      defined(MBEDTLS_ECDSA_VERIFY_ALT)        || \
+      defined(MBEDTLS_ECDSA_GENKEY_ALT)        || \
+      defined(MBEDTLS_ECP_ALT) )
+#error "MBEDTLS_ECP_RESTARTABLE defined, but it cannot coexist with an alternative ECP implementation"
+#endif
+
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC) && !defined(MBEDTLS_HMAC_DRBG_C)
 #error "MBEDTLS_ECDSA_DETERMINISTIC defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -697,7 +697,7 @@
  *
  * \note  This option only works with the default software implementation of
  *        elliptic curve functionality. It is incompatible with
- *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_xxx_ALT and MBEDTLS_ECDSA_xxx_ALT.
+ *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_XXX_ALT and MBEDTLS_ECDSA_XXX_ALT.
  */
 //#define MBEDTLS_ECP_RESTARTABLE
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -695,8 +695,9 @@
  *
  * Uncomment this macro to enable restartable ECC computations.
  *
- * \note  MBEDTLS_ECP_RESTARTABLE cannot be defined if there is an alternative
- *        implementation for one of the ECP, ECDSA or ECDH functions. *
+ * \note  This option only works with the default software implementation of
+ *        elliptic curve functionality. It is incompatible with
+ *        MBEDTLS_ECP_ALT, MBEDTLS_ECDH_xxx_ALT and MBEDTLS_ECDSA_xxx_ALT.
  */
 //#define MBEDTLS_ECP_RESTARTABLE
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -694,6 +694,9 @@
  * for too long on ECC (and, hence, X.509 or SSL/TLS) operations.
  *
  * Uncomment this macro to enable restartable ECC computations.
+ *
+ * \note  MBEDTLS_ECP_RESTARTABLE cannot be defined if there is an alternative
+ *        implementation for one of the ECP, ECDSA or ECDH functions. *
  */
 //#define MBEDTLS_ECP_RESTARTABLE
 

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -191,7 +191,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
 {
     int ret;
     size_t grp_len, pt_len;
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
@@ -286,7 +286,7 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
@@ -342,7 +342,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if !defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -191,14 +191,14 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
 {
     int ret;
     size_t grp_len, pt_len;
-#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -191,7 +191,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
 {
     int ret;
     size_t grp_len, pt_len;
-#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
@@ -204,15 +204,15 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
 #endif
 
 
-#if defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
-    if( ( ret = mbedtls_ecdh_gen_public( &ctx->grp, &ctx->d, &ctx->Q,
-                                         f_rng, p_rng ) ) != 0 )
-        return( ret );
-#else
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
                                              f_rng, p_rng, rs_ctx ) ) != 0 )
         return( ret );
-#endif /* !MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+#else
+    if( ( ret = mbedtls_ecdh_gen_public( &ctx->grp, &ctx->d, &ctx->Q,
+                                         f_rng, p_rng ) ) != 0 )
+        return( ret );
+#endif /* MBEDTLS_ECP_RESTARTABLE */
 
     if( ( ret = mbedtls_ecp_tls_write_group( &ctx->grp, &grp_len, buf, blen ) )
                 != 0 )
@@ -286,7 +286,7 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
@@ -298,15 +298,15 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
         rs_ctx = &ctx->rs;
 #endif
 
-#if defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
-    if( ( ret = mbedtls_ecdh_gen_public( &ctx->grp, &ctx->d, &ctx->Q,
-                                         f_rng, p_rng ) ) != 0 )
-        return( ret );
-#else
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
                     f_rng, p_rng, rs_ctx ) ) != 0 )
         return( ret );
-#endif /* MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+#else
+    if( ( ret = mbedtls_ecdh_gen_public( &ctx->grp, &ctx->d, &ctx->Q,
+                                         f_rng, p_rng ) ) != 0 )
+        return( ret );
+#endif /* MBEDTLS_ECP_RESTARTABLE */
 
     return mbedtls_ecp_tls_write_point( &ctx->grp, &ctx->Q, ctx->point_format,
                                 olen, buf, blen );
@@ -342,7 +342,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if !defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
@@ -354,19 +354,19 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
         rs_ctx = &ctx->rs;
 #endif
 
-#if defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
-    if( ( ret = mbedtls_ecdh_compute_shared( &ctx->grp, &ctx->z, &ctx->Qp,
-                                             &ctx->d, f_rng, p_rng ) ) != 0 )
-    {
-        return( ret );
-    }
-#else
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ( ret = ecdh_compute_shared_restartable( &ctx->grp,
                     &ctx->z, &ctx->Qp, &ctx->d, f_rng, p_rng, rs_ctx ) ) != 0 )
     {
         return( ret );
     }
-#endif /* MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
+#else
+    if( ( ret = mbedtls_ecdh_compute_shared( &ctx->grp, &ctx->z, &ctx->Qp,
+                                             &ctx->d, f_rng, p_rng ) ) != 0 )
+    {
+        return( ret );
+    }
+#endif /* MBEDTLS_ECP_RESTARTABLE */
 
     if( mbedtls_mpi_size( &ctx->z ) > blen )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -76,7 +76,7 @@ int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp
 {
     return( ecdh_gen_public_restartable( grp, d, Q, f_rng, p_rng, NULL ) );
 }
-#endif /* MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+#endif /* !MBEDTLS_ECDH_GEN_PUBLIC_ALT */
 
 #if !defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
 /*
@@ -122,7 +122,7 @@ int mbedtls_ecdh_compute_shared( mbedtls_ecp_group *grp, mbedtls_mpi *z,
     return( ecdh_compute_shared_restartable( grp, z, Q, d,
                                              f_rng, p_rng, NULL ) );
 }
-#endif /* MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
+#endif /* !MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
 
 /*
  * Initialize context
@@ -191,7 +191,9 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
 {
     int ret;
     size_t grp_len, pt_len;
+#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
+#endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
@@ -210,7 +212,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
                                              f_rng, p_rng, rs_ctx ) ) != 0 )
         return( ret );
-#endif
+#endif /* MBEDTLS_ECDH_GEN_PUBLIC_ALT */
 
     if( ( ret = mbedtls_ecp_tls_write_group( &ctx->grp, &grp_len, buf, blen ) )
                 != 0 )
@@ -284,7 +286,9 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
+#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
+#endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
@@ -302,7 +306,7 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
                     f_rng, p_rng, rs_ctx ) ) != 0 )
         return( ret );
-#endif
+#endif /* MBEDTLS_ECDH_GEN_PUBLIC_ALT */
 
     return mbedtls_ecp_tls_write_point( &ctx->grp, &ctx->Q, ctx->point_format,
                                 olen, buf, blen );
@@ -338,7 +342,9 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
+#if !defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
+#endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
@@ -360,7 +366,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
     {
         return( ret );
     }
-#endif
+#endif /* MBEDTLS_ECDH_COMPUTE_SHARED_ALT */
 
     if( mbedtls_mpi_size( &ctx->z ) > blen )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -198,7 +198,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif
@@ -293,7 +293,7 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif
@@ -349,7 +349,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE)
+#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -212,7 +212,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
     if( ( ret = ecdh_gen_public_restartable( &ctx->grp, &ctx->d, &ctx->Q,
                                              f_rng, p_rng, rs_ctx ) ) != 0 )
         return( ret );
-#endif /* MBEDTLS_ECDH_GEN_PUBLIC_ALT */
+#endif /* !MBEDTLS_ECDH_GEN_PUBLIC_ALT */
 
     if( ( ret = mbedtls_ecp_tls_write_group( &ctx->grp, &grp_len, buf, blen ) )
                 != 0 )
@@ -286,14 +286,14 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif
@@ -342,14 +342,14 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
                       void *p_rng )
 {
     int ret;
-#if !defined(MBEDTLS_ECDH_COMPUTE_SHARED_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     mbedtls_ecp_restart_ctx *rs_ctx = NULL;
 #endif
 
     if( ctx == NULL || ctx->grp.pbits == 0 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
-#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECDH_GEN_PUBLIC_ALT)
+#if defined(MBEDTLS_ECP_RESTARTABLE)
     if( ctx->restart_enabled )
         rs_ctx = &ctx->rs;
 #endif

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -237,6 +237,7 @@ cleanup:
     return( ret );
 }
 
+#if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message (SEC1 4.1.3)
  * Obviously, compared to SEC1 4.1.3, we skip step 4 (hash message)
@@ -369,7 +370,6 @@ cleanup:
     return( ret );
 }
 
-#if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message
  */
@@ -380,7 +380,7 @@ int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
     return( ecdsa_sign_restartable( grp, r, s, d, buf, blen,
                                     f_rng, p_rng, NULL ) );
 }
-#endif /* MBEDTLS_ECDSA_SIGN_ALT */
+#endif /* !MBEDTLS_ECDSA_SIGN_ALT */
 
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC)
 /*
@@ -438,7 +438,7 @@ sign:
 #else
     ret = ecdsa_sign_restartable( grp, r, s, d, buf, blen,
                       mbedtls_hmac_drbg_random, p_rng, rs_ctx );
-#endif
+#endif /* MBEDTLS_ECDSA_SIGN_ALT */
 
 cleanup:
     mbedtls_hmac_drbg_free( &rng_ctx );
@@ -460,6 +460,7 @@ int mbedtls_ecdsa_sign_det( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi 
 }
 #endif /* MBEDTLS_ECDSA_DETERMINISTIC */
 
+#if !defined(MBEDTLS_ECDSA_VERIFY_ALT)
 /*
  * Verify ECDSA signature of hashed message (SEC1 4.1.4)
  * Obviously, compared to SEC1 4.1.3, we skip step 2 (hash message)
@@ -569,7 +570,6 @@ cleanup:
     return( ret );
 }
 
-#if !defined(MBEDTLS_ECDSA_VERIFY_ALT)
 /*
  * Verify ECDSA signature of hashed message
  */
@@ -579,7 +579,7 @@ int mbedtls_ecdsa_verify( mbedtls_ecp_group *grp,
 {
     return( ecdsa_verify_restartable( grp, buf, blen, Q, r, s, NULL ) );
 }
-#endif /* MBEDTLS_ECDSA_VERIFY_ALT */
+#endif /* !MBEDTLS_ECDSA_VERIFY_ALT */
 
 /*
  * Convert a signature (given by context) to ASN.1
@@ -637,7 +637,7 @@ int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
 #else
     MBEDTLS_MPI_CHK( ecdsa_sign_restartable( &ctx->grp, &r, &s, &ctx->d,
                          hash, hlen, f_rng, p_rng, rs_ctx ) );
-#endif
+#endif /* MBEDTLS_ECDSA_SIGN_ALT */
 #endif
 
     MBEDTLS_MPI_CHK( ecdsa_signature_to_asn1( &r, &s, sig, slen ) );
@@ -730,7 +730,7 @@ int mbedtls_ecdsa_read_signature_restartable( mbedtls_ecdsa_context *ctx,
     if( ( ret = ecdsa_verify_restartable( &ctx->grp, hash, hlen,
                               &ctx->Q, &r, &s, rs_ctx ) ) != 0 )
         goto cleanup;
-#endif
+#endif /* MBEDTLS_ECDSA_VERIFY_ALT */
 
     /* At this point we know that the buffer starts with a valid signature.
      * Return 0 if the buffer just contains the signature, and a specific
@@ -755,7 +755,7 @@ int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
     return( mbedtls_ecp_group_load( &ctx->grp, gid ) ||
             mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d, &ctx->Q, f_rng, p_rng ) );
 }
-#endif /* MBEDTLS_ECDSA_GENKEY_ALT */
+#endif /* !MBEDTLS_ECDSA_GENKEY_ALT */
 
 /*
  * Set context from an mbedtls_ecp_keypair

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -638,7 +638,7 @@ int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
     MBEDTLS_MPI_CHK( ecdsa_sign_restartable( &ctx->grp, &r, &s, &ctx->d,
                          hash, hlen, f_rng, p_rng, rs_ctx ) );
 #endif /* MBEDTLS_ECDSA_SIGN_ALT */
-#endif
+#endif /* MBEDTLS_ECDSA_DETERMINISTIC */
 
     MBEDTLS_MPI_CHK( ecdsa_signature_to_asn1( &r, &s, sig, slen ) );
 
@@ -662,7 +662,7 @@ int mbedtls_ecdsa_write_signature( mbedtls_ecdsa_context *ctx, mbedtls_md_type_t
                 ctx, md_alg, hash, hlen, sig, slen, f_rng, p_rng, NULL ) );
 }
 
-#if ! defined(MBEDTLS_DEPRECATED_REMOVED) && \
+#if !defined(MBEDTLS_DEPRECATED_REMOVED) && \
     defined(MBEDTLS_ECDSA_DETERMINISTIC)
 int mbedtls_ecdsa_write_signature_det( mbedtls_ecdsa_context *ctx,
                                const unsigned char *hash, size_t hlen,

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -237,7 +237,6 @@ cleanup:
     return( ret );
 }
 
-#if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message (SEC1 4.1.3)
  * Obviously, compared to SEC1 4.1.3, we skip step 4 (hash message)
@@ -369,8 +368,8 @@ cleanup:
 
     return( ret );
 }
-#endif /* MBEDTLS_ECDSA_SIGN_ALT */
 
+#if !defined(MBEDTLS_ECDSA_SIGN_ALT)
 /*
  * Compute ECDSA signature of a hashed message
  */
@@ -381,6 +380,7 @@ int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
     return( ecdsa_sign_restartable( grp, r, s, d, buf, blen,
                                     f_rng, p_rng, NULL ) );
 }
+#endif /* MBEDTLS_ECDSA_SIGN_ALT */
 
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC)
 /*
@@ -432,8 +432,13 @@ static int ecdsa_sign_det_restartable( mbedtls_ecp_group *grp,
 
 sign:
 #endif
+#if defined(MBEDTLS_ECDSA_SIGN_ALT)
+    ret = mbedtls_ecdsa_sign( grp, r, s, d, buf, blen,
+                              mbedtls_hmac_drbg_random, p_rng );
+#else
     ret = ecdsa_sign_restartable( grp, r, s, d, buf, blen,
                       mbedtls_hmac_drbg_random, p_rng, rs_ctx );
+#endif
 
 cleanup:
     mbedtls_hmac_drbg_free( &rng_ctx );
@@ -455,7 +460,6 @@ int mbedtls_ecdsa_sign_det( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi 
 }
 #endif /* MBEDTLS_ECDSA_DETERMINISTIC */
 
-#if !defined(MBEDTLS_ECDSA_VERIFY_ALT)
 /*
  * Verify ECDSA signature of hashed message (SEC1 4.1.4)
  * Obviously, compared to SEC1 4.1.3, we skip step 2 (hash message)
@@ -564,8 +568,8 @@ cleanup:
 
     return( ret );
 }
-#endif /* MBEDTLS_ECDSA_VERIFY_ALT */
 
+#if !defined(MBEDTLS_ECDSA_VERIFY_ALT)
 /*
  * Verify ECDSA signature of hashed message
  */
@@ -575,6 +579,7 @@ int mbedtls_ecdsa_verify( mbedtls_ecp_group *grp,
 {
     return( ecdsa_verify_restartable( grp, buf, blen, Q, r, s, NULL ) );
 }
+#endif /* MBEDTLS_ECDSA_VERIFY_ALT */
 
 /*
  * Convert a signature (given by context) to ASN.1
@@ -626,8 +631,13 @@ int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
 #else
     (void) md_alg;
 
+#if defined(MBEDTLS_ECDSA_SIGN_ALT)
+    MBEDTLS_MPI_CHK( mbedtls_ecdsa_sign( &ctx->grp, &r, &s, &ctx->d,
+                         hash, hlen, f_rng, p_rng ) );
+#else
     MBEDTLS_MPI_CHK( ecdsa_sign_restartable( &ctx->grp, &r, &s, &ctx->d,
                          hash, hlen, f_rng, p_rng, rs_ctx ) );
+#endif
 #endif
 
     MBEDTLS_MPI_CHK( ecdsa_signature_to_asn1( &r, &s, sig, slen ) );
@@ -712,10 +722,15 @@ int mbedtls_ecdsa_read_signature_restartable( mbedtls_ecdsa_context *ctx,
         ret += MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
         goto cleanup;
     }
-
+#if defined(MBEDTLS_ECDSA_VERIFY_ALT)
+    if( ( ret = mbedtls_ecdsa_verify( &ctx->grp, hash, hlen,
+                                      &ctx->Q, &r, &s ) ) != 0 )
+        goto cleanup;
+#else
     if( ( ret = ecdsa_verify_restartable( &ctx->grp, hash, hlen,
                               &ctx->Q, &r, &s, rs_ctx ) ) != 0 )
         goto cleanup;
+#endif
 
     /* At this point we know that the buffer starts with a valid signature.
      * Return 0 if the buffer just contains the signature, and a specific


### PR DESCRIPTION


## Description
Return the condition compilation flags surrounding
`mbedtls_ecdh_compute_shared()`, `mbedtls_ecdh_gen_public()`,
`mbedtls_ecdsa_sign()` and `mbedtls_ecdsa_verify()` that were accidentally
removed in a previous merge.
Resolves #2163

## Status
**READY**

## Requires Backporting
 NO  
The bug was introduced on a recent PR, that is not in the LTS branches

## Migrations
 NO

## Additional comments
May be fixed in a simpler way, having a restartable and a non restartable path, when only the non-restartable path can be hw accelerated. Requires architectural discussion 


## Steps to test or reproduce
Compile the on target tests with the development branch with `NRF52840_DK` target
