### PR TITLE
bn_mul.h: require at least ARMv6 to enable the ARM DSP code

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -636,7 +636,8 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif (__ARM_ARCH >= 6) && \
+    defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 
 #define MULADDC_INIT                            \
     asm(


### PR DESCRIPTION
## Description
Commit 16b1bd89326e "bn_mul.h: add ARM DSP optimized MULADDC code"
added some ARM DSP instructions that was assumed to always be available
when __ARM_FEATURE_DSP is defined to 1. Unfortunately it appears that
the ARMv5TE architecture (GCC flag -march=armv5te) supports the DSP
instructions, but only in Thumb mode and not in ARM mode, despite
defining __ARM_FEATURE_DSP in both cases.

This patch fixes the build issue by requiring at least ARMv6 in addition
to the DSP feature.

## Status
READY

## Requires Backporting
NO, this is a bug fix for the development branch only, introduced by PR #1618.

## Steps to test or reproduce

Build mbedTLS with -march=armv5te -marm