### PR TITLE
Add ARIA and ChachaPoly to basic-build-test

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -93,6 +93,9 @@ OPENSSL_CMD="$OPENSSL_LEGACY"                                       \
     GNUTLS_SERV="$GNUTLS_LEGACY_SERV"                               \
     sh compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR' | \
     tee -a compat-test-$TEST_OUTPUT
+OPENSSL_CMD="$OPENSSL_NEXT"                     \
+    sh compat.sh -e '^$' -f 'ARIA\|CHACHA' |    \
+    tee -a compat-test-$TEST_OUTPUT
 echo
 
 # Step 3 - Process the coverage report


### PR DESCRIPTION
## Description

The invocation of `compat.sh` that runs those tests was added in all.sh but
not here, resulting in our reported coverage figures being slightly lower than
what we actually test. Fixing that omission change the figures reported from:
```
Lines Tested       : 19105 of 22623 84.4%
Functions Tested   : 1392 of 1460 95.3%
```
to:
```
Lines Tested       : 19126 of 22623 84.5%
Functions Tested   : 1399 of 1460 95.8%
```

It requires `$OPENSSL_NEXT` to be set and point to an OpenSSL version in the
1.1.1 line or later.


## Status
**READY**

## Requires Backporting

NO - the features are not present in maintained branches.

## Migrations

NO

## Steps to test or reproduce

Run `tests/basic-build-test.sh` before and after the PR.