### PR TITLE
Change data file suffix for ott

### DIFF
--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -185,7 +185,7 @@ class MbedTlsTest(BaseHostTest):
         binary_path = self.get_config_item('image_path')
         script_dir = os.path.split(os.path.abspath(__file__))[0]
         suite_name = os.path.splitext(os.path.basename(binary_path))[0]
-        data_file = ".".join((suite_name, 'data'))
+        data_file = ".".join((suite_name, 'datax'))
         data_file = os.path.join(script_dir, '..', 'mbedtls',
                                  suite_name, data_file)
         if os.path.exists(data_file):


### PR DESCRIPTION


## Description
Change the suffix of the data files searched in `mbedtls_test.py`
to `datax` as the generated files have this suffix.

[`generate_test_code`](https://github.com/ARMmbed/mbedtls/blob/development/tests/scripts/generate_test_code.py#L1115) creates the data files with `.datax` suffix, but the [`mbedtl_test.py`](https://github.com/ARMmbed/mbedtls/blob/development/tests/scripts/mbedtls_test.py#L188) script searches for data files with suffix `.data`
Without this fix, the On Target Tests don't work


## Status
**READY**

## Requires Backporting

NO  
The On Target Tests was not backported

## Migrations
NO
