### PR TITLE
Backport 2.7: Add explicit integer to enumeration casts to gen_key example program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,9 @@ Bugfix
    * Zeroize memory used for reassembling handshake messages after use.
    * Use `mbedtls_zeroize()` instead of `memset()` for zeroization of
      sensitive data in the example programs aescrypt2 and crypt_and_hash.
+   * Add explicit integer to enumeration type casts to example program
+     programs/pkey/gen_key which previously led to compilation failure
+     on some toolchains. Reported by phoenixmcallister. Fixes #2170.
 
 Changes
    * Add tests for session resumption in DTLS.

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -322,7 +322,8 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "\n  . Generating the private key ..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_pk_setup( &key, mbedtls_pk_info_from_type( opt.type ) ) ) != 0 )
+    if( ( ret = mbedtls_pk_setup( &key,
+            mbedtls_pk_info_from_type( (mbedtls_pk_type_t) opt.type ) ) ) != 0 )
     {
         mbedtls_printf( " failed\n  !  mbedtls_pk_setup returned -0x%04x", -ret );
         goto exit;
@@ -344,7 +345,8 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_ECP_C)
     if( opt.type == MBEDTLS_PK_ECKEY )
     {
-        ret = mbedtls_ecp_gen_key( opt.ec_curve, mbedtls_pk_ec( key ),
+        ret = mbedtls_ecp_gen_key( (mbedtls_ecp_group_id) opt.ec_curve,
+                                   mbedtls_pk_ec( key ),
                                    mbedtls_ctr_drbg_random, &ctr_drbg );
         if( ret != 0 )
         {


### PR DESCRIPTION
This is the backport to Mbed TLS 2.7 of #2175, fixing #2170.