### PR TITLE
Fix incomplete assertion in `ssl_write_handshake_msg()`

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3200,8 +3200,10 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
         }
     }
 
-    if( ssl->out_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
-        hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST &&
+    /* Whenever we send anything different from a
+     * HelloRequest we should be in a handshake - double check. */
+    if( ! ( ssl->out_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
+            hs_type          == MBEDTLS_SSL_HS_HELLO_REQUEST ) &&
         ssl->handshake == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
@@ -3295,8 +3297,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
     /* Either send now, or just save to be sent (and resent) later */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM &&
-        ( ssl->out_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ||
-          hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST ) )
+        ! ( ssl->out_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
+            hs_type          == MBEDTLS_SSL_HS_HELLO_REQUEST ) )
     {
         if( ( ret = ssl_flight_append( ssl ) ) != 0 )
         {


### PR DESCRIPTION
__Issue:__ `ssl_write_handshake_msg()` asserts that `ssl->handshake != NULL` for a record which is
   (a) a handshake record, but NOT
(b) a `HelloRequest`.
However, it later calls `ssl_append_flight()` for any record different from a `HelloRequest` handshake record, that is, for any record satisfying `!(a) || !(b)`, instead of `(a) && !(b)` as covered by the assertion; concretely, it is also called for CCS and Alert records, for which the assertion is void.

Since `ssl_append_flight()` assumes `ssl->handshake != NULL`, this triggers static analyzer warnings.

This PR expands the scope of the assertion to check that `ssl->handshake != NULL` for any record which is not a `HelloRequest`, hopefully making the analyzer happy.

__Note:__ There is no vulnerability here, because the assertion is a safe-guard only and always holds to the best of our knowledge. However, as it stands, it is an incomplete safe-guard.

__Internal Reference:__ IOTSSL-2493

__Backports:__ No, this was introduced in Mbed TLS 2.13 only.