### PR TITLE
Fix false positive result when on Target Tests should fail

### DIFF
--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -163,6 +163,7 @@ class MbedTlsTest(BaseHostTest):
         self.tests = []
         self.test_index = -1
         self.dep_index = 0
+        self.suite_passed = True
         self.error_str = dict()
         self.error_str[self.DEPENDENCY_SUPPORTED] = \
             'DEPENDENCY_SUPPORTED'
@@ -293,7 +294,7 @@ class MbedTlsTest(BaseHostTest):
             name, function_id, dependencies, args = self.tests[self.test_index]
             self.run_test(name, function_id, dependencies, args)
         else:
-            self.notify_complete(True)
+            self.notify_complete(self.suite_passed)
 
     def run_test(self, name, function_id, dependencies, args):
         """
@@ -353,6 +354,8 @@ class MbedTlsTest(BaseHostTest):
         self.log('{{__testcase_start;%s}}' % name)
         self.log('{{__testcase_finish;%s;%d;%d}}' % (name, int_val == 0,
                                                      int_val != 0))
+        if int_val != 0:
+            self.suite_passed = False
         self.run_next_test()
 
     @event_callback("F")


### PR DESCRIPTION
## Description
When specific tests fail in a test suite, the test suite would have still returned success in the on Target Tests, and the green tea would mark the test suite as succeeded. This fix adds a member for holding a failed result, and notify_complete with this member value, when finished.


## Status
**READY**

## Requires Backporting

NO  
The On Target Tests feature was not introduced on Any LTS branches

## Migrations
NO

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Run a test suite using the on Target Tests feature on Green Tea, and have a specific test return error. The whole test suite should be marked as failed
