### PR TITLE
Reduce Stack usage of hkdf test function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,7 @@ Bugfix
      replacements of standard calloc/free functions through the macros
      MBEDTLS_PLATFORM_CALLOC_MACRO and MBEDTLS_PLATFORM_FREE_MACRO.
      Reported by ole-de and ddhome2006. Fixes #882, #1642 and #1706.
+   * Reduce stack usage of hkdf tests. Fixes #2195.
 
 Changes
    * Removed support for Yotta as a build tool.

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -14,12 +14,12 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
 {
     int ret;
     size_t ikm_len, salt_len, info_len, okm_len;
-    unsigned char ikm[1024] = { '\0' };
-    unsigned char salt[1024] = { '\0' };
-    unsigned char info[1024] = { '\0' };
-    unsigned char expected_okm[1024] = { '\0' };
-    unsigned char okm[1024] = { '\0' };
-    unsigned char okm_string[1000] = { '\0' };
+    unsigned char ikm[128] = { '\0' };
+    unsigned char salt[128] = { '\0' };
+    unsigned char info[128] = { '\0' };
+    unsigned char expected_okm[256] = { '\0' };
+    unsigned char okm[256] = { '\0' };
+    unsigned char okm_string[200] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -17,9 +17,9 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     unsigned char ikm[128] = { '\0' };
     unsigned char salt[128] = { '\0' };
     unsigned char info[128] = { '\0' };
-    unsigned char expected_okm[256] = { '\0' };
-    unsigned char okm[256] = { '\0' };
-    unsigned char okm_string[200] = { '\0' };
+    unsigned char expected_okm[128] = { '\0' };
+    unsigned char okm[128] = { '\0' };
+    unsigned char okm_string[256] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -21,9 +21,9 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     unsigned char okm[128] = { '\0' };
     /*
      * okm_hex is the string representation of okm,
-     * so its size is twice the size of okm.
+     * so its size is twice the size of okm, and an extra null-termination.
      */
-    unsigned char okm_hex[256] = { '\0' };
+    unsigned char okm_hex[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -19,6 +19,10 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     unsigned char info[128] = { '\0' };
     unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
+    /*
+     * okm_string is the string representation of okm,
+     * so its size is twice as the size of okm.
+     */
     unsigned char okm_string[256] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -20,10 +20,10 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
     /*
-     * okm_string is the string representation of okm,
-     * so its size is twice as the size of okm.
+     * okm_hex is the string representation of okm,
+     * so its size is twice the size of okm.
      */
-    unsigned char okm_string[256] = { '\0' };
+    unsigned char okm_hex[256] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
@@ -38,8 +38,8 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     TEST_ASSERT( ret == 0 );
 
     // Run hexify on it so that it looks nicer if the assertion fails
-    hexify( okm_string, okm, okm_len );
-    TEST_ASSERT( !strcmp( (char *)okm_string, hex_okm_string ) );
+    hexify( okm_hex, okm, okm_len );
+    TEST_ASSERT( !strcmp( (char *)okm_hex, hex_okm_string ) );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

`test_hkdf` in the hkdf test suites consumed stack of ~6KB with
6 buffers of ~1KB each. This causes stack overflow on some platforms
with smaller stack. The buffer sizes were reduced. By testing, the sizes
can be reduced even further, as the largest seen size is 82 bytes(for okm).
Fixes #2195 
## Status
**READY**

## Requires Backporting

HKDF was introduced on version 2.11 , and no LTS branch was created since, so no need for backporting
[edited by mpg] 2.16 backport here: https://github.com/ARMmbed/mbedtls/pull/2364

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Run the hkdf test on platforms with stack size of < 6KB
