### PR TITLE
Change ecdsa hash buf size to a valid hash length

### DIFF
--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -14,7 +14,7 @@ void ecdsa_prim_random( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     rnd_pseudo_info rnd_info;
-    unsigned char buf[66];
+    unsigned char buf[MBEDTLS_MD_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );


### PR DESCRIPTION
## Description
Change the size of `buf` to a valid hash size, in `ecdsa_prim_random()`
Tested on NRF52840_DK and on PC Linux

## Status
**READY**

## Requires Backporting
No, since the On Target Tests are not in the LTS branches


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Run the test_suite_ecdsa function in NRF62840_DK platform
