### PR TITLE
PSA: support: Disable test that trigger bug in old GnuTLS

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7306,6 +7306,11 @@ run_test    "DTLS proxy: 3d, gnutls server" \
             -s "Extra-header:" \
             -c "Extra-header:"
 
+# The next two test are disabled because they tend to trigger a bug in the
+# version of GnuTLS that's currently installed on our CI. The bug occurs when
+# different fragments of the same handshake message are received out-of-order
+# by GnuTLS and results in a timeout. It's been fixed in GnuTLS 3.5.2.
+skip_next_test
 requires_gnutls
 client_needs_more_time 8
 not_with_valgrind # risk of non-mbedtls peer timing out
@@ -7317,6 +7322,7 @@ run_test    "DTLS proxy: 3d, gnutls server, fragmentation" \
             -s "Extra-header:" \
             -c "Extra-header:"
 
+skip_next_test
 requires_gnutls
 client_needs_more_time 8
 not_with_valgrind # risk of non-mbedtls peer timing out


### PR DESCRIPTION
This is a continuation of what was done in #1990 and #1988 but we missed those two at the time: even though the underlying bug was known, we didn't notice at that time that those test could trigger it too.

Whether the bug is triggered or not depends not only on the seed used, but also on subtle timing differences, so using a fixed seed is not enough.

This is temporary until we fix the GnuTLS version available in our CI.

While not strictly related to PSA, it supports it in that, at least on my machine, the random failure seems to happen more often in the builds used to test the submodule PR in `all.sh` (perhaps because they're debug which slightly influences the timing). It has been confirmed that those more frequent failures are indeed occurence of the known old-GnuTLS bug, and nothing introduce by PSA.

So this supports PSA in avoiding some false positives in `all.sh`.

## Status
**READY**

## Requires Backporting

No: only present since 2.13.0, so not present in any LTS branch.