### PR TITLE
Create a block list for Travis CI and fix the Coverity email address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ compiler:
 - gcc
 sudo: false
 cache: ccache
+
+# blocklist
+branches:
+  except:
+  - development-psa
+  - coverity_scan
+
 script:
 - tests/scripts/recursion.pl library/*.c
 - tests/scripts/check-generated-files.sh
@@ -34,7 +41,7 @@ addons:
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"
-    notification_email: p.j.bakker@polarssl.org
+    notification_email: simon.butcher@arm.com
     build_command_prepend:
     build_command: make
     branch_pattern: coverity_scan


### PR DESCRIPTION
## Description
This PR creates a list of branches for Travis CI to ignore, including `coverity_scan` and `development-psa`.

It also fixes the Coverity notification email address to be myself.

## Status
**READY**

## Requires Backporting
Yes

Which branch?
This should be merged with `development` and `development-psa`. This PR can be used to merge both, and no backport is necessary.

## Migrations
NO
