### PR TITLE
check-files: Don't check same-named files

### DIFF
--- a/tests/scripts/check-files.py
+++ b/tests/scripts/check-files.py
@@ -138,7 +138,9 @@ class TodoIssueTracker(IssueTracker):
         super().__init__()
         self.heading = "TODO present:"
         self.files_exemptions = [
-            __file__, "benchmark.c", "pull_request_template.md"
+            os.path.basename(__file__),
+            "benchmark.c",
+            "pull_request_template.md",
         ]
 
     def issue_with_line(self, line):


### PR DESCRIPTION
The check-files script contains the strings "TODO" and "todo" in order to
search for files that contain TODO items. So, any check-files script would
need to be excluded from the list of files that gets checked for "TODO".
Normally, the script excludes itself from checks, but with the addition of
the crypto submodule, there is another copy of the script present from the
project root. We must avoid checking check-files scripts for TODO items.
This also helps if you run check-files from another working tree in your
working tree.