### PR TITLE
Update the Mbed TLS Library version to 2.15.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
-= mbed TLS x.xx.x branch released xxxx-xx-xx
+= mbed TLS 2.15.0 branch released 2018-11-23
 
 Features
    * Add an experimental build option, USE_CRYPTO_SUBMODULE, to enable use of

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.14.0 source code documentation
+ * @mainpage mbed TLS v2.15.0 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.14.0"
+PROJECT_NAME           = "mbed TLS v2.15.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  14
+#define MBEDTLS_VERSION_MINOR  15
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x020E0000
-#define MBEDTLS_VERSION_STRING         "2.14.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.14.0"
+#define MBEDTLS_VERSION_NUMBER         0x020F0000
+#define MBEDTLS_VERSION_STRING         "2.15.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.15.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -176,20 +176,20 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 if(USE_SHARED_MBEDTLS_LIBRARY)
     if(NOT USE_CRYPTO_SUBMODULE)
         add_library(mbedcrypto SHARED ${src_crypto})
-        set_target_properties(mbedcrypto PROPERTIES VERSION 2.14.0 SOVERSION 3)
+        set_target_properties(mbedcrypto PROPERTIES VERSION 2.15.0 SOVERSION 3)
         target_link_libraries(mbedcrypto ${libs})
         target_include_directories(mbedcrypto PUBLIC ${CMAKE_SOURCE_DIR}/include/)
     endif()
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.14.0 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.15.0 SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${CMAKE_SOURCE_DIR}/include/
         PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.14.0 SOVERSION 12)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.15.0 SOVERSION 12)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${CMAKE_SOURCE_DIR}/include/

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.14.0"
+check_compiletime_version:"2.15.0"
 
 Check runtime library version
-check_runtime_version:"2.14.0"
+check_runtime_version:"2.15.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
## Description
Updates the Mbed TLS library version to 2.15.0.

## Status
**READY**

## Requires Backporting
NO  
