### PR TITLE
psa: Include PSA headers for tests and programs

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -16,6 +16,8 @@ LOCAL_LDFLAGS = -L../library 			\
 
 ifdef USE_CRYPTO_SUBMODULE
 LOCAL_LDFLAGS += -L../crypto/library
+LOCAL_CFLAGS += -I../crypto/include
+LOCAL_CXXFLAGS += -I../crypto/include
 endif
 
 ifndef SHARED

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,6 +14,7 @@ LOCAL_LDFLAGS = -L../library			\
 
 ifdef USE_CRYPTO_SUBMODULE
 LOCAL_LDFLAGS += -L../crypto/library
+LOCAL_CFLAGS += -I../crypto/include
 CRYPTO := ../crypto/library/
 else
 CRYPTO := ../library/


### PR DESCRIPTION
Programs and tests need to be able to use PSA header files when
USE_CRYPTO_SUBMODULE and MBEDTLS_USE_PSA_CRYPTO are set. Add the crypto
submodule include folder, which contains psa headers, after the main
include folder so that psa headers can be found and crypto submodule
headers don't take precedence over mbedtls headers.
