### PR TITLE
Test AD too long only when CCM_ALT not defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Run the AD too long test only if MBEDTLS_CCM_ALT is not defined.
+     Raised as a comment in #1996.
+
 = mbed TLS 2.14.0 branch released 2018-11-19
 
 Security

--- a/tests/suites/test_suite_ccm.data
+++ b/tests/suites/test_suite_ccm.data
@@ -36,6 +36,7 @@ CCM lengths #6 tag length not even
 ccm_lengths:5:10:5:7:MBEDTLS_ERR_CCM_BAD_INPUT
 
 CCM lenghts #7 AD too long (2^16 - 2^8 + 1)
+depends_on:!MBEDTLS_CCM_ALT
 ccm_lengths:5:10:65281:8:MBEDTLS_ERR_CCM_BAD_INPUT
 
 CCM lengths #8 msg too long for this IV length (2^16, q = 2)


### PR DESCRIPTION
## Description
As described in https://github.com/ARMmbed/mbedtls/issues/1996#issuecomment-441077715 , The test for AD too long should run only when `MBEDTLS_CCM_ALT` is not defined, as this is a limitation in Mbed TLS.

## Status
**READY**

## Requires Backporting
Perhaps.
Although the On Target Tests haven't been ontroduced until version 2.13, We may consider backporting this fix

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
