### PR TITLE
Fix test md api violation

### DIFF
--- a/ChangeLog.d/add-mbedtls_md_starts-to-mbedtls_md_process-test.txt
+++ b/ChangeLog.d/add-mbedtls_md_starts-to-mbedtls_md_process-test.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix API violation in mbedtls_md_process() test by adding a call to
+     mbedtls_md_starts(). Fixes #2227.

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -31,6 +31,7 @@ void mbedtls_md_process(  )
         info = mbedtls_md_info_from_type( *md_type_ptr );
         TEST_ASSERT( info != NULL );
         TEST_ASSERT( mbedtls_md_setup( &ctx, info, 0 ) == 0 );
+        TEST_ASSERT( mbedtls_md_starts( &ctx ) == 0 );
         TEST_ASSERT( mbedtls_md_process( &ctx, buf ) == 0 );
         mbedtls_md_free( &ctx );
     }


### PR DESCRIPTION
## Description
Add a call to `mbedtls_md_starts()` in the `mbedtls_md_process()`
test, as it violates the API usage. Fixes #2227.


## Status
**READY**

## Requires Backporting
Yes 
Which branch?
`mbedtls-2.28`

## Additional comments
This was discovered by running the test suite on NRF52840_DK target

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported

