### PR TITLE
Backport 2.7: Fix resource leak of file desc in test code

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -144,6 +144,7 @@ static int redirect_output( FILE** out_stream, const char* path )
 
     if( *out_stream == NULL )
     {
+        close( stdout_fd );
         return -1;
     }
 


### PR DESCRIPTION
## Description
Fix leak of file descriptor in test code on failure (found by coverity).

This is a backport of https://github.com/ARMmbed/mbedtls/pull/2232

## Status
**READY**