### PR TITLE
[2.14] all.sh: make it possible to run a subset of the components

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1045,18 +1045,6 @@ component_test_allow_sha1 () {
     if_build_succeeded tests/ssl-opt.sh -f SHA-1
 }
 
-component_test_rsa_no_crt () {
-    msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl set MBEDTLS_RSA_NO_CRT
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-
-    msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
-    make test
-}
-
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
     cleanup
@@ -1267,7 +1255,6 @@ run_component component_build_arm_none_eabi_gcc_no_udbl_division
 run_component component_build_arm_none_eabi_gcc_no_64bit_multiplication
 run_component component_build_armcc
 run_component component_test_allow_sha1
-run_component component_test_rsa_no_crt
 run_component component_build_mingw
 # MemSan currently only available on Linux 64 bits
 if uname -a | grep 'Linux.*x86_64' >/dev/null; then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -453,19 +453,16 @@ component_check_doxy_blocks () {
 
 component_check_files () {
     msg "test: check-files.py" # < 1s
-    cleanup
     record_status tests/scripts/check-files.py
 }
 
 component_check_names () {
     msg "test/build: declared and exported names" # < 3s
-    cleanup
     record_status tests/scripts/check-names.sh
 }
 
 component_check_doxygen_warnings () {
     msg "test: doxygen warnings" # ~ 3s
-    cleanup
     record_status tests/scripts/doxygen.sh
 }
 
@@ -477,7 +474,6 @@ component_check_doxygen_warnings () {
 
 component_test_default_cmake_gcc_asan () {
     msg "build: cmake, gcc, ASan" # ~ 1 min 50s
-    cleanup
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
@@ -499,7 +495,6 @@ component_test_default_cmake_gcc_asan () {
 
 component_test_sslv3 () {
     msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -518,7 +513,6 @@ component_test_sslv3 () {
 
 component_test_no_renegotiation () {
     msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -533,7 +527,6 @@ component_test_no_renegotiation () {
 
 component_test_rsa_no_crt () {
     msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_RSA_NO_CRT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -551,7 +544,6 @@ component_test_rsa_no_crt () {
 
 component_test_small_ssl_out_content_len () {
     msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
     scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
@@ -564,7 +556,6 @@ component_test_small_ssl_out_content_len () {
 
 component_test_small_ssl_in_content_len () {
     msg "build: small SSL_IN_CONTENT_LEN (ASan build)"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 4096
     scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 16384
@@ -577,7 +568,6 @@ component_test_small_ssl_in_content_len () {
 
 component_test_small_ssl_dtls_max_buffering () {
     msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 1000
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -589,7 +579,6 @@ component_test_small_ssl_dtls_max_buffering () {
 
 component_test_small_mbedtls_ssl_dtls_max_buffering () {
     msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 240
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -601,7 +590,6 @@ component_test_small_mbedtls_ssl_dtls_max_buffering () {
 
 component_test_full_cmake_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
@@ -623,7 +611,6 @@ component_test_full_cmake_clang () {
 
 component_build_deprecated () {
     msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
@@ -644,31 +631,26 @@ component_build_deprecated () {
 
 component_test_depends_curves () {
     msg "test/build: curves.pl (gcc)" # ~ 4 min
-    cleanup
     record_status tests/scripts/curves.pl
 }
 
 component_test_depends_hashes () {
     msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
-    cleanup
     record_status tests/scripts/depends-hashes.pl
 }
 
 component_test_depends_pkalgs () {
     msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
-    cleanup
     record_status tests/scripts/depends-pkalgs.pl
 }
 
 component_build_key_exchanges () {
     msg "test/build: key-exchanges (gcc)" # ~ 1 min
-    cleanup
     record_status tests/scripts/key-exchanges.pl
 }
 
 component_build_default_make_gcc_and_cxx () {
     msg "build: Unix make, -Os (gcc)" # ~ 30s
-    cleanup
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
 
     msg "test: verify header list in cpp_dummy_build.cpp"
@@ -683,7 +665,6 @@ component_test_no_platform () {
     # This should catch missing mbedtls_printf definitions, and by disabling file
     # IO, it should catch missing '#include <stdio.h>'
     msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_PLATFORM_C
@@ -706,7 +687,6 @@ component_test_no_platform () {
 component_build_no_std_function () {
     # catch compile bugs in _uninit functions
     msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
@@ -716,7 +696,6 @@ component_build_no_std_function () {
 
 component_build_no_ssl_srv () {
     msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_SRV_C
@@ -725,7 +704,6 @@ component_build_no_ssl_srv () {
 
 component_build_no_ssl_cli () {
     msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_CLI_C
@@ -736,7 +714,6 @@ component_build_no_sockets () {
     # Note, C99 compliance can also be tested with the sockets support disabled,
     # as that requires a POSIX platform (which isn't the same as C99).
     msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
@@ -747,7 +724,6 @@ component_build_no_sockets () {
 component_test_no_max_fragment_length () {
     # Run max fragment length tests with MFL disabled
     msg "build: default config except MFL extension (ASan build)" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -759,7 +735,6 @@ component_test_no_max_fragment_length () {
 
 component_test_no_max_fragment_length_small_ssl_out_content_len () {
     msg "build: no MFL extension, small SSL_OUT_CONTENT_LEN (ASan build)"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
@@ -773,7 +748,6 @@ component_test_no_max_fragment_length_small_ssl_out_content_len () {
 
 component_test_null_entropy () {
     msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
     scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
@@ -790,7 +764,6 @@ component_test_null_entropy () {
 
 component_test_platform_calloc_macro () {
     msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
     scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
@@ -804,7 +777,6 @@ component_test_platform_calloc_macro () {
 
 component_test_aes_fewer_tables () {
     msg "build: default config with AES_FEWER_TABLES enabled"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
     make CC=gcc CFLAGS='-Werror -Wall -Wextra'
@@ -815,7 +787,6 @@ component_test_aes_fewer_tables () {
 
 component_test_aes_rom_tables () {
     msg "build: default config with AES_ROM_TABLES enabled"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_ROM_TABLES
     make CC=gcc CFLAGS='-Werror -Wall -Wextra'
@@ -826,7 +797,6 @@ component_test_aes_rom_tables () {
 
 component_test_aes_fewer_tables_and_rom_tables () {
     msg "build: default config with AES_ROM_TABLES and AES_FEWER_TABLES enabled"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
     scripts/config.pl set MBEDTLS_AES_ROM_TABLES
@@ -838,14 +808,12 @@ component_test_aes_fewer_tables_and_rom_tables () {
 
 component_test_make_shared () {
     msg "build/test: make shared" # ~ 40s
-    cleanup
     make SHARED=1 all check
 }
 
 component_test_m32_o0 () {
     # Build once with -O0, to compile out the i386 specific inline assembly
     msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
@@ -857,7 +825,6 @@ component_test_m32_o0 () {
 component_test_m32_o1 () {
     # Build again with -O1, to compile in the i386 specific inline assembly
     msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
@@ -868,7 +835,6 @@ component_test_m32_o1 () {
 
 component_test_mx32 () {
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
@@ -879,7 +845,6 @@ component_test_mx32 () {
 
 component_test_have_int32 () {
     msg "build: gcc, force 32-bit bignum limbs"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
@@ -892,7 +857,6 @@ component_test_have_int32 () {
 
 component_test_have_int64 () {
     msg "build: gcc, force 64-bit bignum limbs"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
@@ -905,7 +869,6 @@ component_test_have_int64 () {
 
 component_test_no_udbl_division () {
     msg "build: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
@@ -918,7 +881,6 @@ component_test_no_udbl_division () {
 
 component_test_no_64bit_multiplication () {
     msg "build: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
@@ -931,7 +893,6 @@ component_test_no_64bit_multiplication () {
 
 component_build_arm_none_eabi_gcc () {
     msg "build: arm-none-eabi-gcc, make" # ~ 10s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
@@ -950,7 +911,6 @@ component_build_arm_none_eabi_gcc () {
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
@@ -972,7 +932,6 @@ component_build_arm_none_eabi_gcc_no_udbl_division () {
 
 component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
     msg "build: arm-none-eabi-gcc MBEDTLS_NO_64BIT_MULTIPLICATION, make" # ~ 10s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
@@ -994,7 +953,6 @@ component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
 
 component_build_armcc () {
     msg "build: ARM Compiler 5, make"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
@@ -1036,7 +994,6 @@ component_build_armcc () {
 
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
     make CFLAGS='-Werror -Wall -Wextra'
@@ -1047,7 +1004,6 @@ component_test_allow_sha1 () {
 
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
-    cleanup
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
 
     # note Make tests only builds the tests, but doesn't run them
@@ -1062,7 +1018,6 @@ component_build_mingw () {
 
 component_test_memsan () {
     msg "build: MSan (clang)" # ~ 1 min 20s
-    cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
@@ -1084,7 +1039,6 @@ component_test_memsan () {
 
 component_test_memcheck () {
     msg "build: Release (clang)"
-    cleanup
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
     make
 
@@ -1108,7 +1062,6 @@ component_test_memcheck () {
 
 component_test_cmake_out_of_source () {
     msg "build: cmake 'out-of-source' build"
-    cleanup
     MBEDTLS_ROOT_DIR="$PWD"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
@@ -1143,12 +1096,12 @@ component_test_zeroize () {
     for optimization_flag in -O2 -O3 -Ofast -Os; do
           for compiler in clang gcc; do
                 msg "test: $compiler $optimization_flag, mbedtls_platform_zeroize()"
-                cleanup
                 make programs CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag"
                 if_build_succeeded gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx 2>&1 | tee test_zeroize.log
                 if_build_succeeded grep "The buffer was correctly zeroized" test_zeroize.log
                 if_build_succeeded not grep -i "error" test_zeroize.log
                 rm -f test_zeroize.log
+                make clean
           done
     done
 }
@@ -1180,9 +1133,10 @@ post_report () {
 #### Run all the things
 ################################################################
 
-# Run one component. Currently trivial.
+# Run one component and clean up afterwards.
 run_component () {
     "$@"
+    cleanup
 }
 
 # Preliminary setup
@@ -1201,6 +1155,7 @@ fi
 pre_print_configuration
 pre_check_tools
 pre_print_tools
+cleanup
 
 # Small things
 run_component component_check_recursion

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -229,12 +229,16 @@ trap 'fatal_signal TERM' TERM
 
 msg()
 {
+    if [ -n "${current_component:-}" ]; then
+        current_section="${current_component#component_}: $1"
+    else
+        current_section="$1"
+    fi
     echo ""
     echo "******************************************************************"
-    echo "* $1 "
+    echo "* $current_section "
     printf "* "; date
     echo "******************************************************************"
-    current_section=$1
 }
 
 armc6_build_test()
@@ -1238,6 +1242,7 @@ run_component () {
     if [ $ALL_EXCEPT -ne 0 ] && component_is_excluded "$1"; then
         return
     fi
+    current_component="$1"
     "$@"
     cleanup
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -483,14 +483,14 @@ component_test_default_cmake_gcc_asan () {
     msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
     if_build_succeeded tests/ssl-opt.sh
 
-    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-    record_status tests/scripts/test-ref-configs.pl
-
-    msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
-    make
-
     msg "test: compat.sh (ASan build)" # ~ 6 min
     if_build_succeeded tests/compat.sh
+}
+
+component_test_ref_configs () {
+    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    record_status tests/scripts/test-ref-configs.pl
 }
 
 component_test_sslv3 () {
@@ -1167,6 +1167,7 @@ run_component component_check_doxygen_warnings
 
 # Test many different configurations
 run_component component_test_default_cmake_gcc_asan
+run_component component_test_ref_configs
 run_component component_test_sslv3
 run_component component_test_no_renegotiation
 run_component component_test_rsa_no_crt

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -529,7 +529,6 @@ component_test_ref_configs () {
 
 component_test_sslv3 () {
     msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -547,7 +546,6 @@ component_test_sslv3 () {
 
 component_test_no_renegotiation () {
     msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -561,7 +559,6 @@ component_test_no_renegotiation () {
 
 component_test_rsa_no_crt () {
     msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_RSA_NO_CRT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -578,7 +575,6 @@ component_test_rsa_no_crt () {
 
 component_test_small_ssl_out_content_len () {
     msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
     scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -590,7 +586,6 @@ component_test_small_ssl_out_content_len () {
 
 component_test_small_ssl_in_content_len () {
     msg "build: small SSL_IN_CONTENT_LEN (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 4096
     scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 16384
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
@@ -602,7 +597,6 @@ component_test_small_ssl_in_content_len () {
 
 component_test_small_ssl_dtls_max_buffering () {
     msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 1000
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -613,7 +607,6 @@ component_test_small_ssl_dtls_max_buffering () {
 
 component_test_small_mbedtls_ssl_dtls_max_buffering () {
     msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 240
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -624,7 +617,6 @@ component_test_small_mbedtls_ssl_dtls_max_buffering () {
 
 component_test_full_cmake_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
@@ -645,7 +637,6 @@ component_test_full_cmake_clang () {
 
 component_build_deprecated () {
     msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
     # Build with -O -Wextra to catch a maximum of issues.
@@ -699,7 +690,6 @@ component_test_no_platform () {
     # This should catch missing mbedtls_printf definitions, and by disabling file
     # IO, it should catch missing '#include <stdio.h>'
     msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_PLATFORM_C
     scripts/config.pl unset MBEDTLS_NET_C
@@ -721,7 +711,6 @@ component_test_no_platform () {
 component_build_no_std_function () {
     # catch compile bugs in _uninit functions
     msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
     scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
@@ -730,7 +719,6 @@ component_build_no_std_function () {
 
 component_build_no_ssl_srv () {
     msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_SRV_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
@@ -738,7 +726,6 @@ component_build_no_ssl_srv () {
 
 component_build_no_ssl_cli () {
     msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_CLI_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
@@ -748,7 +735,6 @@ component_build_no_sockets () {
     # Note, C99 compliance can also be tested with the sockets support disabled,
     # as that requires a POSIX platform (which isn't the same as C99).
     msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
     scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
@@ -758,7 +744,6 @@ component_build_no_sockets () {
 component_test_no_max_fragment_length () {
     # Run max fragment length tests with MFL disabled
     msg "build: default config except MFL extension (ASan build)" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -769,7 +754,6 @@ component_test_no_max_fragment_length () {
 
 component_test_no_max_fragment_length_small_ssl_out_content_len () {
     msg "build: no MFL extension, small SSL_OUT_CONTENT_LEN (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
     scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
@@ -782,7 +766,6 @@ component_test_no_max_fragment_length_small_ssl_out_content_len () {
 
 component_test_null_entropy () {
     msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
     scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
     scripts/config.pl set MBEDTLS_ENTROPY_C
@@ -798,7 +781,6 @@ component_test_null_entropy () {
 
 component_test_platform_calloc_macro () {
     msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
     scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
     scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
@@ -811,7 +793,6 @@ component_test_platform_calloc_macro () {
 
 component_test_aes_fewer_tables () {
     msg "build: default config with AES_FEWER_TABLES enabled"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
     make CC=gcc CFLAGS='-Werror -Wall -Wextra'
 
@@ -821,7 +802,6 @@ component_test_aes_fewer_tables () {
 
 component_test_aes_rom_tables () {
     msg "build: default config with AES_ROM_TABLES enabled"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_ROM_TABLES
     make CC=gcc CFLAGS='-Werror -Wall -Wextra'
 
@@ -831,7 +811,6 @@ component_test_aes_rom_tables () {
 
 component_test_aes_fewer_tables_and_rom_tables () {
     msg "build: default config with AES_ROM_TABLES and AES_FEWER_TABLES enabled"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
     scripts/config.pl set MBEDTLS_AES_ROM_TABLES
     make CC=gcc CFLAGS='-Werror -Wall -Wextra'
@@ -848,7 +827,6 @@ component_test_make_shared () {
 component_test_m32_o0 () {
     # Build once with -O0, to compile out the i386 specific inline assembly
     msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
 
@@ -859,7 +837,6 @@ component_test_m32_o0 () {
 component_test_m32_o1 () {
     # Build again with -O1, to compile in the i386 specific inline assembly
     msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
 
@@ -869,7 +846,6 @@ component_test_m32_o1 () {
 
 component_test_mx32 () {
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
 
@@ -879,7 +855,6 @@ component_test_mx32 () {
 
 component_test_have_int32 () {
     msg "build: gcc, force 32-bit bignum limbs"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
     scripts/config.pl unset MBEDTLS_PADLOCK_C
@@ -891,7 +866,6 @@ component_test_have_int32 () {
 
 component_test_have_int64 () {
     msg "build: gcc, force 64-bit bignum limbs"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
     scripts/config.pl unset MBEDTLS_PADLOCK_C
@@ -903,7 +877,6 @@ component_test_have_int64 () {
 
 component_test_no_udbl_division () {
     msg "build: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
@@ -915,7 +888,6 @@ component_test_no_udbl_division () {
 
 component_test_no_64bit_multiplication () {
     msg "build: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
@@ -927,7 +899,6 @@ component_test_no_64bit_multiplication () {
 
 component_build_arm_none_eabi_gcc () {
     msg "build: arm-none-eabi-gcc, make" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -945,7 +916,6 @@ component_build_arm_none_eabi_gcc () {
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -966,7 +936,6 @@ component_build_arm_none_eabi_gcc_no_udbl_division () {
 
 component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
     msg "build: arm-none-eabi-gcc MBEDTLS_NO_64BIT_MULTIPLICATION, make" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -987,7 +956,6 @@ component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
 
 component_build_armcc () {
     msg "build: ARM Compiler 5, make"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -1028,7 +996,6 @@ component_build_armcc () {
 
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
     make CFLAGS='-Werror -Wall -Wextra'
     msg "test: allow SHA1 in certificates by default"
@@ -1052,7 +1019,6 @@ component_build_mingw () {
 
 component_test_memsan () {
     msg "build: MSan (clang)" # ~ 1 min 20s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
     make
@@ -1242,6 +1208,9 @@ run_component () {
     if [ $ALL_EXCEPT -ne 0 ] && component_is_excluded "$1"; then
         return
     fi
+    # Back up the configuration in case the component modifies it.
+    # The cleanup function will restore it.
+    cp -p "$CONFIG_H" "$CONFIG_BAK"
     current_component="$1"
     "$@"
     cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -55,6 +55,16 @@
 # Notes for maintainers
 # ---------------------
 #
+# The bulk of the code is organized into functions that follow one of the
+# following naming conventions:
+#  * pre_XXX: things to do before running the tests, in order.
+#  * component_XXX: independent components. They can be run in any order.
+#      * component_check_XXX: quick tests that aren't worth parallelizing
+#      * component_build_XXX: build things but don't run them
+#      * component_test_XXX: build and test
+#  * post_XXX: things to do after running the tests.
+#  * other: miscellaneous support functions.
+#
 # The tests are roughly in order from fastest to slowest. This doesn't
 # have to be exact, but in general you should add slower tests towards
 # the end and fast checks near the beginning.
@@ -80,38 +90,42 @@
 # Abort on errors (and uninitialised variables)
 set -eu
 
-if [ "$( uname )" != "Linux" ]; then
-    echo "This script only works in Linux" >&2
-    exit 1
-elif [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from mbed TLS root" >&2
-    exit 1
-fi
+pre_check_environment () {
+    if [ "$( uname )" != "Linux" ]; then
+        echo "This script only works in Linux" >&2
+        exit 1
+    elif [ -d library -a -d include -a -d tests ]; then :; else
+        echo "Must be run from mbed TLS root" >&2
+        exit 1
+    fi
+}
 
-CONFIG_H='include/mbedtls/config.h'
-CONFIG_BAK="$CONFIG_H.bak"
+pre_initialize_variables () {
+    CONFIG_H='include/mbedtls/config.h'
+    CONFIG_BAK="$CONFIG_H.bak"
 
-MEMORY=0
-FORCE=0
-KEEP_GOING=0
-RUN_ARMCC=1
+    MEMORY=0
+    FORCE=0
+    KEEP_GOING=0
+    RUN_ARMCC=1
 
-# Default commands, can be overriden by the environment
-: ${OPENSSL:="openssl"}
-: ${OPENSSL_LEGACY:="$OPENSSL"}
-: ${OPENSSL_NEXT:="$OPENSSL"}
-: ${GNUTLS_CLI:="gnutls-cli"}
-: ${GNUTLS_SERV:="gnutls-serv"}
-: ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
-: ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
-: ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
-: ${ARMC5_BIN_DIR:=/usr/bin}
-: ${ARMC6_BIN_DIR:=/usr/bin}
+    # Default commands, can be overriden by the environment
+    : ${OPENSSL:="openssl"}
+    : ${OPENSSL_LEGACY:="$OPENSSL"}
+    : ${OPENSSL_NEXT:="$OPENSSL"}
+    : ${GNUTLS_CLI:="gnutls-cli"}
+    : ${GNUTLS_SERV:="gnutls-serv"}
+    : ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
+    : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
+    : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
+    : ${ARMC5_BIN_DIR:=/usr/bin}
+    : ${ARMC6_BIN_DIR:=/usr/bin}
 
-# if MAKEFLAGS is not set add the -j option to speed up invocations of make
-if [ -n "${MAKEFLAGS+set}" ]; then
-    export MAKEFLAGS="-j"
-fi
+    # if MAKEFLAGS is not set add the -j option to speed up invocations of make
+    if [ -n "${MAKEFLAGS+set}" ]; then
+        export MAKEFLAGS="-j"
+    fi
+}
 
 usage()
 {
@@ -197,17 +211,15 @@ msg()
     current_section=$1
 }
 
-if [ $RUN_ARMCC -ne 0 ]; then
-    armc6_build_test()
-    {
-        FLAGS="$1"
+armc6_build_test()
+{
+    FLAGS="$1"
 
-        msg "build: ARM Compiler 6 ($FLAGS), make"
-        ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
-                        WARNING_CFLAGS='-xc -std=c99' make lib
-        make clean
-    }
-fi
+    msg "build: ARM Compiler 6 ($FLAGS), make"
+    ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
+                    WARNING_CFLAGS='-xc -std=c99' make lib
+    make clean
+}
 
 err_msg()
 {
@@ -232,61 +244,64 @@ check_headers_in_cpp () {
     rm headers.txt
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --armcc) RUN_ARMCC=1;;
-        --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
-        --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
-        --force|-f) FORCE=1;;
-        --gnutls-cli) shift; GNUTLS_CLI="$1";;
-        --gnutls-legacy-cli) shift; GNUTLS_LEGACY_CLI="$1";;
-        --gnutls-legacy-serv) shift; GNUTLS_LEGACY_SERV="$1";;
-        --gnutls-serv) shift; GNUTLS_SERV="$1";;
-        --help|-h) usage; exit;;
-        --keep-going|-k) KEEP_GOING=1;;
-        --memory|-m) MEMORY=1;;
-        --no-armcc) RUN_ARMCC=0;;
-        --no-force) FORCE=0;;
-        --no-keep-going) KEEP_GOING=0;;
-        --no-memory) MEMORY=0;;
-        --openssl) shift; OPENSSL="$1";;
-        --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
-        --openssl-next) shift; OPENSSL_NEXT="$1";;
-        --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
-        --random-seed) unset SEED;;
-        --release-test|-r) SEED=1;;
-        --seed|-s) shift; SEED="$1";;
-        *)
-            echo >&2 "Unknown option: $1"
-            echo >&2 "Run $0 --help for usage."
-            exit 120
-            ;;
-    esac
-    shift
-done
+pre_parse_command_line () {
+    while [ $# -gt 0 ]; do
+          case "$1" in
+              --armcc) RUN_ARMCC=1;;
+              --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
+              --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
+              --force|-f) FORCE=1;;
+              --gnutls-cli) shift; GNUTLS_CLI="$1";;
+              --gnutls-legacy-cli) shift; GNUTLS_LEGACY_CLI="$1";;
+              --gnutls-legacy-serv) shift; GNUTLS_LEGACY_SERV="$1";;
+              --gnutls-serv) shift; GNUTLS_SERV="$1";;
+              --help|-h) usage; exit;;
+              --keep-going|-k) KEEP_GOING=1;;
+              --memory|-m) MEMORY=1;;
+              --no-armcc) RUN_ARMCC=0;;
+              --no-force) FORCE=0;;
+              --no-keep-going) KEEP_GOING=0;;
+              --no-memory) MEMORY=0;;
+              --openssl) shift; OPENSSL="$1";;
+              --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
+              --openssl-next) shift; OPENSSL_NEXT="$1";;
+              --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
+              --random-seed) unset SEED;;
+              --release-test|-r) SEED=1;;
+              --seed|-s) shift; SEED="$1";;
+              *)
+                  echo >&2 "Unknown option: $1"
+                  echo >&2 "Run $0 --help for usage."
+                  exit 120
+                  ;;
+          esac
+          shift
+    done
+}
 
-if [ $FORCE -eq 1 ]; then
-    git checkout-index -f -q $CONFIG_H
-    cleanup
-else
+pre_check_git () {
+    if [ $FORCE -eq 1 ]; then
+        git checkout-index -f -q $CONFIG_H
+        cleanup
+    else
 
-    if [ -d "$OUT_OF_SOURCE_DIR" ]; then
-        echo "Warning - there is an existing directory at '$OUT_OF_SOURCE_DIR'" >&2
-        echo "You can either delete this directory manually, or force the test by rerunning"
-        echo "the script as: $0 --force --out-of-source-dir $OUT_OF_SOURCE_DIR"
-        exit 1
+        if [ -d "$OUT_OF_SOURCE_DIR" ]; then
+            echo "Warning - there is an existing directory at '$OUT_OF_SOURCE_DIR'" >&2
+            echo "You can either delete this directory manually, or force the test by rerunning"
+            echo "the script as: $0 --force --out-of-source-dir $OUT_OF_SOURCE_DIR"
+            exit 1
+        fi
+
+        if ! git diff-files --quiet include/mbedtls/config.h; then
+            err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
+            echo "You can either delete or preserve your work, or force the test by rerunning the"
+            echo "script as: $0 --force"
+            exit 1
+        fi
     fi
+}
 
-    if ! git diff-files --quiet include/mbedtls/config.h; then
-        err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
-        echo "You can either delete or preserve your work, or force the test by rerunning the"
-        echo "script as: $0 --force"
-        exit 1
-    fi
-fi
-
-build_status=0
-if [ $KEEP_GOING -eq 1 ]; then
+pre_setup_keep_going () {
     failure_summary=
     failure_count=0
     start_red=
@@ -340,11 +355,8 @@ $text"
             echo "Killed by SIG$1."
         fi
     }
-else
-    record_status () {
-        "$@"
-    }
-fi
+}
+
 if_build_succeeded () {
     if [ $build_status -eq 0 ]; then
         record_status "$@"
@@ -357,45 +369,48 @@ not() {
     ! "$@"
 }
 
-msg "info: $0 configuration"
-echo "MEMORY: $MEMORY"
-echo "FORCE: $FORCE"
-echo "SEED: ${SEED-"UNSET"}"
-echo "OPENSSL: $OPENSSL"
-echo "OPENSSL_LEGACY: $OPENSSL_LEGACY"
-echo "OPENSSL_NEXT: $OPENSSL_NEXT"
-echo "GNUTLS_CLI: $GNUTLS_CLI"
-echo "GNUTLS_SERV: $GNUTLS_SERV"
-echo "GNUTLS_LEGACY_CLI: $GNUTLS_LEGACY_CLI"
-echo "GNUTLS_LEGACY_SERV: $GNUTLS_LEGACY_SERV"
-echo "ARMC5_BIN_DIR: $ARMC5_BIN_DIR"
-echo "ARMC6_BIN_DIR: $ARMC6_BIN_DIR"
+pre_print_configuration () {
+    msg "info: $0 configuration"
+    echo "MEMORY: $MEMORY"
+    echo "FORCE: $FORCE"
+    echo "SEED: ${SEED-"UNSET"}"
+    echo "OPENSSL: $OPENSSL"
+    echo "OPENSSL_LEGACY: $OPENSSL_LEGACY"
+    echo "OPENSSL_NEXT: $OPENSSL_NEXT"
+    echo "GNUTLS_CLI: $GNUTLS_CLI"
+    echo "GNUTLS_SERV: $GNUTLS_SERV"
+    echo "GNUTLS_LEGACY_CLI: $GNUTLS_LEGACY_CLI"
+    echo "GNUTLS_LEGACY_SERV: $GNUTLS_LEGACY_SERV"
+    echo "ARMC5_BIN_DIR: $ARMC5_BIN_DIR"
+    echo "ARMC6_BIN_DIR: $ARMC6_BIN_DIR"
+}
 
-ARMC5_CC="$ARMC5_BIN_DIR/armcc"
-ARMC5_AR="$ARMC5_BIN_DIR/armar"
-ARMC6_CC="$ARMC6_BIN_DIR/armclang"
-ARMC6_AR="$ARMC6_BIN_DIR/armar"
+pre_check_tools () {
+    ARMC5_CC="$ARMC5_BIN_DIR/armcc"
+    ARMC5_AR="$ARMC5_BIN_DIR/armar"
+    ARMC6_CC="$ARMC6_BIN_DIR/armclang"
+    ARMC6_AR="$ARMC6_BIN_DIR/armar"
 
-# To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
-# we just export the variables they require
-export OPENSSL_CMD="$OPENSSL"
-export GNUTLS_CLI="$GNUTLS_CLI"
-export GNUTLS_SERV="$GNUTLS_SERV"
+    # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
+    # we just export the variables they require
+    export OPENSSL_CMD="$OPENSSL"
+    export GNUTLS_CLI="$GNUTLS_CLI"
+    export GNUTLS_SERV="$GNUTLS_SERV"
 
-# Avoid passing --seed flag in every call to ssl-opt.sh
-if [ -n "${SEED-}" ]; then
-  export SEED
-fi
+    # Avoid passing --seed flag in every call to ssl-opt.sh
+    if [ -n "${SEED-}" ]; then
+        export SEED
+    fi
 
-# Make sure the tools we need are available.
-check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$OPENSSL_NEXT" \
-            "$GNUTLS_CLI" "$GNUTLS_SERV" \
-            "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-            "arm-none-eabi-gcc" "i686-w64-mingw32-gcc" "gdb"
-if [ $RUN_ARMCC -ne 0 ]; then
-    check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
-fi
-
+    # Make sure the tools we need are available.
+    check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$OPENSSL_NEXT" \
+                "$GNUTLS_CLI" "$GNUTLS_SERV" \
+                "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
+                "arm-none-eabi-gcc" "i686-w64-mingw32-gcc" "gdb"
+    if [ $RUN_ARMCC -ne 0 ]; then
+        check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
+    fi
+}
 
 
 ################################################################
@@ -413,32 +428,46 @@ fi
 #
 # Indicative running times are given for reference.
 
-msg "info: output_env.sh"
-OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
-    GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
-    GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
-    ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
+pre_print_tools () {
+    msg "info: output_env.sh"
+    OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
+           GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
+           GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
+           ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
+}
 
-msg "test: recursion.pl" # < 1s
-record_status tests/scripts/recursion.pl library/*.c
+component_check_recursion () {
+    msg "test: recursion.pl" # < 1s
+    record_status tests/scripts/recursion.pl library/*.c
+}
 
-msg "test: freshness of generated source files" # < 1s
-record_status tests/scripts/check-generated-files.sh
+component_check_generated_files () {
+    msg "test: freshness of generated source files" # < 1s
+    record_status tests/scripts/check-generated-files.sh
+}
 
-msg "test: doxygen markup outside doxygen blocks" # < 1s
-record_status tests/scripts/check-doxy-blocks.pl
+component_check_doxy_blocks () {
+    msg "test: doxygen markup outside doxygen blocks" # < 1s
+    record_status tests/scripts/check-doxy-blocks.pl
+}
 
-msg "test: check-files.py" # < 1s
-cleanup
-record_status tests/scripts/check-files.py
+component_check_files () {
+    msg "test: check-files.py" # < 1s
+    cleanup
+    record_status tests/scripts/check-files.py
+}
 
-msg "test/build: declared and exported names" # < 3s
-cleanup
-record_status tests/scripts/check-names.sh
+component_check_names () {
+    msg "test/build: declared and exported names" # < 3s
+    cleanup
+    record_status tests/scripts/check-names.sh
+}
 
-msg "test: doxygen warnings" # ~ 3s
-cleanup
-record_status tests/scripts/doxygen.sh
+component_check_doxygen_warnings () {
+    msg "test: doxygen warnings" # ~ 3s
+    cleanup
+    record_status tests/scripts/doxygen.sh
+}
 
 
 
@@ -446,319 +475,374 @@ record_status tests/scripts/doxygen.sh
 #### Build and test many configurations and targets
 ################################################################
 
-msg "build: cmake, gcc, ASan" # ~ 1 min 50s
-cleanup
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_default_cmake_gcc_asan () {
+    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
+    cleanup
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
+    msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
 
-msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
-if_build_succeeded tests/ssl-opt.sh
+    msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
+    if_build_succeeded tests/ssl-opt.sh
 
-msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-record_status tests/scripts/test-ref-configs.pl
+    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+    record_status tests/scripts/test-ref-configs.pl
 
-msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
-make
+    msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
+    make
 
-msg "test: compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh
+    msg "test: compat.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/compat.sh
+}
 
-msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_sslv3 () {
+    msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
+    msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
 
-msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
+    msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
+    if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
 
-msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
+    msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/ssl-opt.sh
+}
 
-msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_no_renegotiation () {
+    msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
+    msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
 
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
+    msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/ssl-opt.sh
+}
 
-msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_rsa_no_crt () {
+    msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_RSA_NO_CRT
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
+    msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
 
-msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-if_build_succeeded tests/ssl-opt.sh -f RSA
+    msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
+    if_build_succeeded tests/ssl-opt.sh -f RSA
 
-msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-if_build_succeeded tests/compat.sh -t RSA
+    msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
+    if_build_succeeded tests/compat.sh -t RSA
+}
 
-msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
-scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_small_ssl_out_content_len () {
+    msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
+    scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: small SSL_OUT_CONTENT_LEN - ssl-opt.sh MFL and large packet tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment\|Large packet"
+    msg "test: small SSL_OUT_CONTENT_LEN - ssl-opt.sh MFL and large packet tests"
+    if_build_succeeded tests/ssl-opt.sh -f "Max fragment\|Large packet"
+}
 
-msg "build: small SSL_IN_CONTENT_LEN (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 4096
-scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 16384
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_small_ssl_in_content_len () {
+    msg "build: small SSL_IN_CONTENT_LEN (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 4096
+    scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 16384
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: small SSL_IN_CONTENT_LEN - ssl-opt.sh MFL tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment"
+    msg "test: small SSL_IN_CONTENT_LEN - ssl-opt.sh MFL tests"
+    if_build_succeeded tests/ssl-opt.sh -f "Max fragment"
+}
 
-msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 1000
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_small_ssl_dtls_max_buffering () {
+    msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 1000
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0 - ssl-opt.sh specific reordering test"
-if_build_succeeded tests/ssl-opt.sh -f "DTLS reordering: Buffer out-of-order hs msg before reassembling next, free buffered msg"
+    msg "test: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #0 - ssl-opt.sh specific reordering test"
+    if_build_succeeded tests/ssl-opt.sh -f "DTLS reordering: Buffer out-of-order hs msg before reassembling next, free buffered msg"
+}
 
-msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 240
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_test_small_mbedtls_ssl_dtls_max_buffering () {
+    msg "build: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_DTLS_MAX_BUFFERING 240
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1 - ssl-opt.sh specific reordering test"
-if_build_succeeded tests/ssl-opt.sh -f "DTLS reordering: Buffer encrypted Finished message, drop for fragmented NewSessionTicket"
+    msg "test: small MBEDTLS_SSL_DTLS_MAX_BUFFERING #1 - ssl-opt.sh specific reordering test"
+    if_build_succeeded tests/ssl-opt.sh -f "DTLS reordering: Buffer encrypted Finished message, drop for fragmented NewSessionTicket"
+}
 
-msg "build: cmake, full config, clang" # ~ 50s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
-make
+component_test_full_cmake_clang () {
+    msg "build: cmake, full config, clang" # ~ 50s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
+    make
 
-msg "test: main suites (full config)" # ~ 5s
-make test
+    msg "test: main suites (full config)" # ~ 5s
+    make test
 
-msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
+    msg "test: ssl-opt.sh default, ECJPAKE, SSL async (full config)" # ~ 1s
+    if_build_succeeded tests/ssl-opt.sh -f 'Default\|ECJPAKE\|SSL async private'
 
-msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
+    msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
+    if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
 
-msg "test: compat.sh ARIA + ChachaPoly"
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
+    msg "test: compat.sh ARIA + ChachaPoly"
+    if_build_succeeded env OPENSSL_CMD="$OPENSSL_NEXT" tests/compat.sh -e '^$' -f 'ARIA\|CHACHA'
+}
 
-msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
-# Build with -O -Wextra to catch a maximum of issues.
-make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
-make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+component_build_deprecated () {
+    msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+    # Build with -O -Wextra to catch a maximum of issues.
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
 
-msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
-# No cleanup, just tweak the configuration and rebuild
-make clean
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
-# Build with -O -Wextra to catch a maximum of issues.
-make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
-make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+    msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
+    # No cleanup, just tweak the configuration and rebuild
+    make clean
+    scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
+    scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
+    # Build with -O -Wextra to catch a maximum of issues.
+    make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
+    make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+}
 
-msg "test/build: curves.pl (gcc)" # ~ 4 min
-cleanup
-record_status tests/scripts/curves.pl
 
-msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
-cleanup
-record_status tests/scripts/depends-hashes.pl
+component_test_depends_curves () {
+    msg "test/build: curves.pl (gcc)" # ~ 4 min
+    cleanup
+    record_status tests/scripts/curves.pl
+}
 
-msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
-cleanup
-record_status tests/scripts/depends-pkalgs.pl
+component_test_depends_hashes () {
+    msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
+    cleanup
+    record_status tests/scripts/depends-hashes.pl
+}
 
-msg "test/build: key-exchanges (gcc)" # ~ 1 min
-cleanup
-record_status tests/scripts/key-exchanges.pl
+component_test_depends_pkalgs () {
+    msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
+    cleanup
+    record_status tests/scripts/depends-pkalgs.pl
+}
 
-msg "build: Unix make, -Os (gcc)" # ~ 30s
-cleanup
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
+component_build_key_exchanges () {
+    msg "test/build: key-exchanges (gcc)" # ~ 1 min
+    cleanup
+    record_status tests/scripts/key-exchanges.pl
+}
 
-msg "test: verify header list in cpp_dummy_build.cpp"
-record_status check_headers_in_cpp
+component_build_default_make_gcc_and_cxx () {
+    msg "build: Unix make, -Os (gcc)" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
 
-msg "build: Unix make, incremental g++"
-make TEST_CPP=1
+    msg "test: verify header list in cpp_dummy_build.cpp"
+    record_status check_headers_in_cpp
 
-# Full configuration build, without platform support, file IO and net sockets.
-# This should catch missing mbedtls_printf definitions, and by disabling file
-# IO, it should catch missing '#include <stdio.h>'
-msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_PLATFORM_C
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_PLATFORM_MEMORY
-scripts/config.pl unset MBEDTLS_PLATFORM_PRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_FPRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_SNPRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_EXIT_ALT
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
-scripts/config.pl unset MBEDTLS_FS_IO
-# Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
-# to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
+    msg "build: Unix make, incremental g++"
+    make TEST_CPP=1
+}
 
-# catch compile bugs in _uninit functions
-msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+component_test_no_platform () {
+    # Full configuration build, without platform support, file IO and net sockets.
+    # This should catch missing mbedtls_printf definitions, and by disabling file
+    # IO, it should catch missing '#include <stdio.h>'
+    msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_PLATFORM_C
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_PLATFORM_MEMORY
+    scripts/config.pl unset MBEDTLS_PLATFORM_PRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_FPRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_SNPRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_EXIT_ALT
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
+    # to re-enable platform integration features otherwise disabled in C99 builds
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
+}
 
-msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_SRV_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+component_build_no_std_function () {
+    # catch compile bugs in _uninit functions
+    msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+}
 
-msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_CLI_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+component_build_no_ssl_srv () {
+    msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_SSL_SRV_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+}
 
-# Note, C99 compliance can also be tested with the sockets support disabled,
-# as that requires a POSIX platform (which isn't the same as C99).
-msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0 -std=c99 -pedantic' lib
+component_build_no_ssl_cli () {
+    msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_SSL_CLI_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+}
 
-# Run max fragment length tests with MFL disabled
-msg "build: default config except MFL extension (ASan build)" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+component_build_no_sockets () {
+    # Note, C99 compliance can also be tested with the sockets support disabled,
+    # as that requires a POSIX platform (which isn't the same as C99).
+    msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0 -std=c99 -pedantic' lib
+}
 
-msg "test: ssl-opt.sh, MFL-related tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
+component_test_no_max_fragment_length () {
+    # Run max fragment length tests with MFL disabled
+    msg "build: default config except MFL extension (ASan build)" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "build: no MFL extension, small SSL_OUT_CONTENT_LEN (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
-scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+    msg "test: ssl-opt.sh, MFL-related tests"
+    if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
+}
 
-msg "test: MFL tests (disabled MFL extension case) & large packet tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment length\|Large buffer"
+component_test_no_max_fragment_length_small_ssl_out_content_len () {
+    msg "build: no MFL extension, small SSL_OUT_CONTENT_LEN (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+    scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384
+    scripts/config.pl set MBEDTLS_SSL_OUT_CONTENT_LEN 4096
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
-scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
-scripts/config.pl set MBEDTLS_ENTROPY_C
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_ENTROPY_HARDWARE_ALT
-scripts/config.pl unset MBEDTLS_HAVEGE_C
-CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
-make
+    msg "test: MFL tests (disabled MFL extension case) & large packet tests"
+    if_build_succeeded tests/ssl-opt.sh -f "Max fragment length\|Large buffer"
+}
 
-msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
-make test
+component_test_null_entropy () {
+    msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
+    scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+    scripts/config.pl set MBEDTLS_ENTROPY_C
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_ENTROPY_HARDWARE_ALT
+    scripts/config.pl unset MBEDTLS_HAVEGE_C
+    CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
+    make
 
-msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
-scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
-scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+    msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
+    make test
+}
 
-msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-make test
+component_test_platform_calloc_macro () {
+    msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
+    scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
+    scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "build: default config with AES_FEWER_TABLES enabled"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
-make CC=gcc CFLAGS='-Werror -Wall -Wextra'
+    msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+    make test
+}
 
-msg "test: AES_FEWER_TABLES"
-make test
+component_test_aes_fewer_tables () {
+    msg "build: default config with AES_FEWER_TABLES enabled"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra'
 
-msg "build: default config with AES_ROM_TABLES enabled"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_AES_ROM_TABLES
-make CC=gcc CFLAGS='-Werror -Wall -Wextra'
+    msg "test: AES_FEWER_TABLES"
+    make test
+}
 
-msg "test: AES_ROM_TABLES"
-make test
+component_test_aes_rom_tables () {
+    msg "build: default config with AES_ROM_TABLES enabled"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_AES_ROM_TABLES
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra'
 
-msg "build: default config with AES_ROM_TABLES and AES_FEWER_TABLES enabled"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
-scripts/config.pl set MBEDTLS_AES_ROM_TABLES
-make CC=gcc CFLAGS='-Werror -Wall -Wextra'
+    msg "test: AES_ROM_TABLES"
+    make test
+}
 
-msg "test: AES_FEWER_TABLES + AES_ROM_TABLES"
-make test
+component_test_aes_fewer_tables_and_rom_tables () {
+    msg "build: default config with AES_ROM_TABLES and AES_FEWER_TABLES enabled"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_AES_FEWER_TABLES
+    scripts/config.pl set MBEDTLS_AES_ROM_TABLES
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra'
 
-if uname -a | grep -F Linux >/dev/null; then
+    msg "test: AES_FEWER_TABLES + AES_ROM_TABLES"
+    make test
+}
+
+component_test_make_shared () {
     msg "build/test: make shared" # ~ 40s
     cleanup
     make SHARED=1 all check
-fi
+}
 
-if uname -a | grep -F x86_64 >/dev/null; then
+component_test_m32_o0 () {
     # Build once with -O0, to compile out the i386 specific inline assembly
     msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
     cleanup
@@ -768,7 +852,9 @@ if uname -a | grep -F x86_64 >/dev/null; then
 
     msg "test: i386, make, gcc -O0 (ASan build)"
     make test
+}
 
+component_test_m32_o1 () {
     # Build again with -O1, to compile in the i386 specific inline assembly
     msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
     cleanup
@@ -778,7 +864,9 @@ if uname -a | grep -F x86_64 >/dev/null; then
 
     msg "test: i386, make, gcc -O1 (ASan build)"
     make test
+}
 
+component_test_mx32 () {
     msg "build: 64-bit ILP32, make, gcc" # ~ 30s
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
@@ -787,187 +875,204 @@ if uname -a | grep -F x86_64 >/dev/null; then
 
     msg "test: 64-bit ILP32, make, gcc"
     make test
-fi # x86_64
+}
 
-msg "build: gcc, force 32-bit bignum limbs"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
+component_test_have_int32 () {
+    msg "build: gcc, force 32-bit bignum limbs"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
 
-msg "test: gcc, force 32-bit bignum limbs"
-make test
+    msg "test: gcc, force 32-bit bignum limbs"
+    make test
+}
 
-msg "build: gcc, force 64-bit bignum limbs"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
+component_test_have_int64 () {
+    msg "build: gcc, force 64-bit bignum limbs"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
 
-msg "test: gcc, force 64-bit bignum limbs"
-make test
+    msg "test: gcc, force 64-bit bignum limbs"
+    make test
+}
 
+component_test_no_udbl_division () {
+    msg "build: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
+    scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
+    make CFLAGS='-Werror -O1'
 
-msg "build: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-make CFLAGS='-Werror -O1'
+    msg "test: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
+    make test
+}
 
-msg "test: MBEDTLS_NO_UDBL_DIVISION native" # ~ 10s
-make test
+component_test_no_64bit_multiplication () {
+    msg "build: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
+    scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
+    make CFLAGS='-Werror -O1'
 
+    msg "test: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
+    make test
+}
 
-msg "build: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
-make CFLAGS='-Werror -O1'
+component_build_arm_none_eabi_gcc () {
+    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+}
 
-msg "test: MBEDTLS_NO_64BIT_MULTIPLICATION native" # ~ 10s
-make test
+component_build_arm_none_eabi_gcc_no_udbl_division () {
+    msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+    echo "Checking that software 64-bit division is not required"
+    if_build_succeeded not grep __aeabi_uldiv library/*.o
+}
 
+component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
+    msg "build: arm-none-eabi-gcc MBEDTLS_NO_64BIT_MULTIPLICATION, make" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1 -march=armv6-m -mthumb' lib
+    echo "Checking that software 64-bit multiplication is not required"
+    if_build_succeeded not grep __aeabi_lmul library/*.o
+}
 
-msg "build: arm-none-eabi-gcc, make" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+component_build_armcc () {
+    msg "build: ARM Compiler 5, make"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_HAVE_TIME
+    scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
 
-msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
-echo "Checking that software 64-bit division is not required"
-if_build_succeeded not grep __aeabi_uldiv library/*.o
+    if [ $RUN_ARMCC -ne 0 ]; then
+        make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+        make clean
 
-msg "build: arm-none-eabi-gcc MBEDTLS_NO_64BIT_MULTIPLICATION, make" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1 -march=armv6-m -mthumb' lib
-echo "Checking that software 64-bit multiplication is not required"
-if_build_succeeded not grep __aeabi_lmul library/*.o
+        # ARM Compiler 6 - Target ARMv7-A
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
 
-msg "build: ARM Compiler 5, make"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_HAVE_TIME
-scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
+        # ARM Compiler 6 - Target ARMv7-M
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
 
-if [ $RUN_ARMCC -ne 0 ]; then
-    make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
-    make clean
+        # ARM Compiler 6 - Target ARMv8-A - AArch32
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
 
-    # ARM Compiler 6 - Target ARMv7-A
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
+        # ARM Compiler 6 - Target ARMv8-M
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
 
-    # ARM Compiler 6 - Target ARMv7-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
+        # ARM Compiler 6 - Target ARMv8-A - AArch64
+        armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
+    fi
+}
 
-    # ARM Compiler 6 - Target ARMv8-A - AArch32
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
+component_test_allow_sha1 () {
+    msg "build: allow SHA1 in certificates by default"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
+    make CFLAGS='-Werror -Wall -Wextra'
+    msg "test: allow SHA1 in certificates by default"
+    make test
+    if_build_succeeded tests/ssl-opt.sh -f SHA-1
+}
 
-    # ARM Compiler 6 - Target ARMv8-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
+component_test_rsa_no_crt () {
+    msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_RSA_NO_CRT
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-    # ARM Compiler 6 - Target ARMv8-A - AArch64
-    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
-fi
+    msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
+    make test
+}
 
-msg "build: allow SHA1 in certificates by default"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
-make CFLAGS='-Werror -Wall -Wextra'
-msg "test: allow SHA1 in certificates by default"
-make test
-if_build_succeeded tests/ssl-opt.sh -f SHA-1
+component_build_mingw () {
+    msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+    cleanup
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
 
-msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
+    # note Make tests only builds the tests, but doesn't run them
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
+    make WINDOWS_BUILD=1 clean
 
-msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
-make test
+    msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
+    make WINDOWS_BUILD=1 clean
+}
 
-msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
-cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
-
-# note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
-make WINDOWS_BUILD=1 clean
-
-msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
-make WINDOWS_BUILD=1 clean
-
-# MemSan currently only available on Linux 64 bits
-if uname -a | grep 'Linux.*x86_64' >/dev/null; then
-
+component_test_memsan () {
     msg "build: MSan (clang)" # ~ 1 min 20s
     cleanup
     cp "$CONFIG_H" "$CONFIG_BAK"
@@ -987,9 +1092,9 @@ if uname -a | grep 'Linux.*x86_64' >/dev/null; then
         msg "test: compat.sh (MSan)" # ~ 6 min 20s
         if_build_succeeded tests/compat.sh
     fi
+}
 
-else # no MemSan
-
+component_test_memcheck () {
     msg "build: Release (clang)"
     cleanup
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
@@ -1011,63 +1116,171 @@ else # no MemSan
         msg "test: compat.sh --memcheck (Release)"
         if_build_succeeded tests/compat.sh --memcheck
     fi
+}
 
-fi # MemSan
+component_test_cmake_out_of_source () {
+    msg "build: cmake 'out-of-source' build"
+    cleanup
+    MBEDTLS_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+    cmake "$MBEDTLS_ROOT_DIR"
+    make
 
-msg "build: cmake 'out-of-source' build"
-cleanup
-MBEDTLS_ROOT_DIR="$PWD"
-mkdir "$OUT_OF_SOURCE_DIR"
-cd "$OUT_OF_SOURCE_DIR"
-cmake "$MBEDTLS_ROOT_DIR"
-make
+    msg "test: cmake 'out-of-source' build"
+    make test
+    # Test an SSL option that requires an auxiliary script in test/scripts/.
+    # Also ensure that there are no error messages such as
+    # "No such file or directory", which would indicate that some required
+    # file is missing (ssl-opt.sh tolerates the absence of some files so
+    # may exit with status 0 but emit errors).
+    if_build_succeeded ./tests/ssl-opt.sh -f 'Fallback SCSV: beginning of list' 2>ssl-opt.err
+    if [ -s ssl-opt.err ]; then
+        cat ssl-opt.err >&2
+        record_status [ ! -s ssl-opt.err ]
+        rm ssl-opt.err
+    fi
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    unset MBEDTLS_ROOT_DIR
+}
 
-msg "test: cmake 'out-of-source' build"
-make test
-# Test an SSL option that requires an auxiliary script in test/scripts/.
-# Also ensure that there are no error messages such as
-# "No such file or directory", which would indicate that some required
-# file is missing (ssl-opt.sh tolerates the absence of some files so
-# may exit with status 0 but emit errors).
-if_build_succeeded ./tests/ssl-opt.sh -f 'Fallback SCSV: beginning of list' 2>ssl-opt.err
-if [ -s ssl-opt.err ]; then
-  cat ssl-opt.err >&2
-  record_status [ ! -s ssl-opt.err ]
-  rm ssl-opt.err
-fi
-cd "$MBEDTLS_ROOT_DIR"
-rm -rf "$OUT_OF_SOURCE_DIR"
-unset MBEDTLS_ROOT_DIR
-
-# Test that the function mbedtls_platform_zeroize() is not optimized away by
-# different combinations of compilers and optimization flags by using an
-# auxiliary GDB script. Unfortunately, GDB does not return error values to the
-# system in all cases that the script fails, so we must manually search the
-# output to check whether the pass string is present and no failure strings
-# were printed.
-for optimization_flag in -O2 -O3 -Ofast -Os; do
-    for compiler in clang gcc; do
-        msg "test: $compiler $optimization_flag, mbedtls_platform_zeroize()"
-        cleanup
-        make programs CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag"
-        if_build_succeeded gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx 2>&1 | tee test_zeroize.log
-        if_build_succeeded grep "The buffer was correctly zeroized" test_zeroize.log
-        if_build_succeeded not grep -i "error" test_zeroize.log
-        rm -f test_zeroize.log
+component_test_zeroize () {
+    # Test that the function mbedtls_platform_zeroize() is not optimized away by
+    # different combinations of compilers and optimization flags by using an
+    # auxiliary GDB script. Unfortunately, GDB does not return error values to the
+    # system in all cases that the script fails, so we must manually search the
+    # output to check whether the pass string is present and no failure strings
+    # were printed.
+    for optimization_flag in -O2 -O3 -Ofast -Os; do
+          for compiler in clang gcc; do
+                msg "test: $compiler $optimization_flag, mbedtls_platform_zeroize()"
+                cleanup
+                make programs CC="$compiler" DEBUG=1 CFLAGS="$optimization_flag"
+                if_build_succeeded gdb -x tests/scripts/test_zeroize.gdb -nw -batch -nx 2>&1 | tee test_zeroize.log
+                if_build_succeeded grep "The buffer was correctly zeroized" test_zeroize.log
+                if_build_succeeded not grep -i "error" test_zeroize.log
+                rm -f test_zeroize.log
+          done
     done
-done
+}
 
-msg "Lint: Python scripts"
-record_status tests/scripts/check-python-files.sh
+component_check_python_files () {
+    msg "Lint: Python scripts"
+    record_status tests/scripts/check-python-files.sh
+}
 
-msg "uint test: generate_test_code.py"
-record_status ./tests/scripts/test_generate_test_code.py
+component_check_generate_test_code () {
+    msg "uint test: generate_test_code.py"
+    record_status ./tests/scripts/test_generate_test_code.py
+}
 
 ################################################################
 #### Termination
 ################################################################
 
-msg "Done, cleaning up"
-cleanup
+post_report () {
+    msg "Done, cleaning up"
+    cleanup
 
-final_report
+    final_report
+}
+
+
+
+################################################################
+#### Run all the things
+################################################################
+
+# Run one component. Currently trivial.
+run_component () {
+    "$@"
+}
+
+# Preliminary setup
+pre_check_environment
+pre_initialize_variables
+pre_parse_command_line "$@"
+pre_check_git
+build_status=0
+if [ $KEEP_GOING -eq 1 ]; then
+    pre_setup_keep_going
+else
+    record_status () {
+        "$@"
+    }
+fi
+pre_print_configuration
+pre_check_tools
+pre_print_tools
+
+# Small things
+run_component component_check_recursion
+run_component component_check_generated_files
+run_component component_check_doxy_blocks
+run_component component_check_files
+run_component component_check_names
+run_component component_check_doxygen_warnings
+
+# Test many different configurations
+run_component component_test_default_cmake_gcc_asan
+run_component component_test_sslv3
+run_component component_test_no_renegotiation
+run_component component_test_rsa_no_crt
+run_component component_test_small_ssl_out_content_len
+run_component component_test_small_ssl_in_content_len
+run_component component_test_small_ssl_dtls_max_buffering
+run_component component_test_small_mbedtls_ssl_dtls_max_buffering
+run_component component_test_full_cmake_clang
+run_component component_build_deprecated
+run_component component_test_depends_curves
+run_component component_test_depends_hashes
+run_component component_test_depends_pkalgs
+run_component component_build_key_exchanges
+run_component component_build_default_make_gcc_and_cxx
+run_component component_test_no_platform
+run_component component_build_no_std_function
+run_component component_build_no_ssl_srv
+run_component component_build_no_ssl_cli
+run_component component_build_no_sockets
+run_component component_test_no_max_fragment_length
+run_component component_test_no_max_fragment_length_small_ssl_out_content_len
+run_component component_test_null_entropy
+run_component component_test_platform_calloc_macro
+run_component component_test_aes_fewer_tables
+run_component component_test_aes_rom_tables
+run_component component_test_aes_fewer_tables_and_rom_tables
+if uname -a | grep -F Linux >/dev/null; then
+    run_component component_test_make_shared
+fi
+if uname -a | grep -F x86_64 >/dev/null; then
+    run_component component_test_m32_o0
+    run_component component_test_m32_o1
+    run_component component_test_mx32
+fi
+run_component component_test_have_int32
+run_component component_test_have_int64
+run_component component_test_no_udbl_division
+run_component component_test_no_64bit_multiplication
+run_component component_build_arm_none_eabi_gcc
+run_component component_build_arm_none_eabi_gcc_no_udbl_division
+run_component component_build_arm_none_eabi_gcc_no_64bit_multiplication
+run_component component_build_armcc
+run_component component_test_allow_sha1
+run_component component_test_rsa_no_crt
+run_component component_build_mingw
+# MemSan currently only available on Linux 64 bits
+if uname -a | grep 'Linux.*x86_64' >/dev/null; then
+    run_component component_test_memsan
+else # no MemSan
+    run_component component_test_memcheck
+fi
+run_component component_test_cmake_out_of_source
+
+# More small things
+run_component component_test_zeroize
+run_component component_check_python_files
+run_component component_check_generate_test_code
+
+# We're done.
+post_report


### PR DESCRIPTION
Break up `all.sh` into components and make it possible to run a subset of the components by listing them on the command line.

To this effect:

1. Reorganize `all.sh` into functions.
2. A very minimal amount of tidying up. I did remove one redundant component.
3. All components back up `config.h` systematically.
4. If you pass component names on the command line, `all.sh` only executes these components. With `--except`, `all.sh` runs all the components except the ones named on the command line. With no non-option argument, `all.sh` executes all the components. Run `all.sh --list-components` to list available components.

Apart from some minor differences in the lead-in and clean-up to each component and some minor component reorganization, the result and reporting of `all.sh` should be the same as before.

Potential follow-ups, which are explicitly out of scope in this PR:

* Simplify keep-going mode: if a component fails in the middle, just move on to the next component.
* Make the reporting fit the component model better: report the names of failing components, report the number of passing components...
* Self-checks to ensure that when someone adds a component, they don't forget to add it to the default list.
* Aids to parallelization. The primary goal of this PR is to pave the way for parallelization, not to achieve parallelization.
