### PR TITLE
key_app_writer writes invalid private key DER file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix private key DER output in the key_app_writer example. File contents
+     were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
+     Christian Walther in #2239.
+
 = mbed TLS 2.14.0 branch released 2018-11-19
 
 Security

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -173,7 +173,7 @@ static int write_private_key( mbedtls_pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof(output_buf) - len;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )


### PR DESCRIPTION
## Description
The same bug as reported in #1257 and fixed in #1258 for public key output also exists in the private key output: When writing the private key in DER format, the contents of the file are shifted by one byte, which makes it an invalid DER file.

## Status
**READY**

## Requires Backporting
Yes: mbedtls-2.1, mbedtls-2.7

## Migrations
NO

## Todos
- [x] Changelog updated
- [x] Backported: #2400 and #2401


## Steps to test or reproduce
```
programs/pkey/gen_key
programs/pkey/key_app_writer mode=private filename=keyfile.key output_mode=private output_file=keyfile.der output_format=der
programs/pkey/key_app mode=private filename=keyfile.der 
```

Expected result:

```
  . Loading the private key ... ok
  . Key information    ...
...
```

Actual result:

```
  . Loading the private key ... failed
  !  mbedtls_pk_parse_keyfile returned -0x3d00
  !  Last error was: PK - Invalid key tag or value
```