### PR TITLE
Add guards on CRL support to the SSL tests

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -595,8 +595,10 @@ void sni_free( sni_entry *head )
         mbedtls_x509_crt_free( cur->ca );
         mbedtls_free( cur->ca );
 
+#if defined(MBEDTLS_X509_CRL_PARSE_C)
         mbedtls_x509_crl_free( cur->crl );
         mbedtls_free( cur->crl );
+#endif /* MBEDTLS_X509_CRL_PARSE_C */
 
         next = cur->next;
         mbedtls_free( cur );
@@ -659,6 +661,7 @@ sni_entry *sni_parse( char *sni_string )
                 goto error;
         }
 
+#if defined(MBEDTLS_X509_CRL_PARSE_C)
         if( strcmp( crl_file, "-" ) != 0 )
         {
             if( ( new->crl = mbedtls_calloc( 1, sizeof( mbedtls_x509_crl ) ) ) == NULL )
@@ -669,6 +672,10 @@ sni_entry *sni_parse( char *sni_string )
             if( mbedtls_x509_crl_parse_file( new->crl, crl_file ) != 0 )
                 goto error;
         }
+#else
+        (void) crl_file;
+        new->crl = NULL;
+#endif /* MBEDTLS_X509_CRL_PARSE_C */
 
         if( strcmp( auth_str, "-" ) != 0 )
         {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -3000,6 +3000,7 @@ run_test    "SNI: CA override" \
             -S "! The certificate is not correctly signed by the trusted CA" \
             -S "The certificate has been revoked (is on a CRL)"
 
+requires_config_enabled MBEDTLS_X509_CRL_PARSE_C
 run_test    "SNI: CA override with CRL" \
             "$P_SRV debug_level=3 auth_mode=optional \
              crt_file=data_files/server5.crt key_file=data_files/server5.key \
@@ -3136,6 +3137,7 @@ run_test    "SNI: DTLS, CA override" \
             -S "! The certificate is not correctly signed by the trusted CA" \
             -S "The certificate has been revoked (is on a CRL)"
 
+requires_config_enabled MBEDTLS_X509_CRL_PARSE_C
 run_test    "SNI: DTLS, CA override with CRL" \
             "$P_SRV debug_level=3 auth_mode=optional \
              crt_file=data_files/server5.crt key_file=data_files/server5.key dtls=1 \


### PR DESCRIPTION
Fix the build of `ssl_server2` and add missing dependencies in `ssl-opt.sh` so that the tests build and pass if `MBEDTLS_X509_CRT_PARSE_C` is defined but not `MBEDTLS_X509_CRL_PARSE_C`.

Fix #2247.
