### PR TITLE
Backport 2.7: Add guards on CRL support to the SSL tests

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -558,8 +558,10 @@ void sni_free( sni_entry *head )
         mbedtls_x509_crt_free( cur->ca );
         mbedtls_free( cur->ca );
 
+#if defined(MBEDTLS_X509_CRL_PARSE_C)
         mbedtls_x509_crl_free( cur->crl );
         mbedtls_free( cur->crl );
+#endif /* MBEDTLS_X509_CRL_PARSE_C */
 
         next = cur->next;
         mbedtls_free( cur );
@@ -624,6 +626,7 @@ sni_entry *sni_parse( char *sni_string )
 
         if( strcmp( crl_file, "-" ) != 0 )
         {
+#if defined(MBEDTLS_X509_CRL_PARSE_C)
             if( ( new->crl = mbedtls_calloc( 1, sizeof( mbedtls_x509_crl ) ) ) == NULL )
                 goto error;
 
@@ -631,6 +634,9 @@ sni_entry *sni_parse( char *sni_string )
 
             if( mbedtls_x509_crl_parse_file( new->crl, crl_file ) != 0 )
                 goto error;
+#else
+            goto error;
+#endif /* MBEDTLS_X509_CRL_PARSE_C */
         }
 
         if( strcmp( auth_str, "-" ) != 0 )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2839,6 +2839,7 @@ run_test    "SNI: CA override" \
             -S "! The certificate is not correctly signed by the trusted CA" \
             -S "The certificate has been revoked (is on a CRL)"
 
+requires_config_enabled MBEDTLS_X509_CRL_PARSE_C
 run_test    "SNI: CA override with CRL" \
             "$P_SRV debug_level=3 auth_mode=optional \
              crt_file=data_files/server5.crt key_file=data_files/server5.key \
@@ -2975,6 +2976,7 @@ run_test    "SNI: DTLS, CA override" \
             -S "! The certificate is not correctly signed by the trusted CA" \
             -S "The certificate has been revoked (is on a CRL)"
 
+requires_config_enabled MBEDTLS_X509_CRL_PARSE_C
 run_test    "SNI: DTLS, CA override with CRL" \
             "$P_SRV debug_level=3 auth_mode=optional \
              crt_file=data_files/server5.crt key_file=data_files/server5.key dtls=1 \


### PR DESCRIPTION
Fix the build of `ssl_server2` and add missing dependencies in `ssl-opt.sh` so that the tests build and pass if `MBEDTLS_X509_CRT_PARSE_C` is defined but not `MBEDTLS_X509_CRL_PARSE_C`.

Backport of #2248.