### PR TITLE
Add the python files check for prepush script

### DIFF
--- a/tests/git-scripts/README.md
+++ b/tests/git-scripts/README.md
@@ -6,6 +6,11 @@ for more information, see the [git documentation](https://git-scm.com/docs/githo
 
 The mbed TLS git hooks are located in `<mbed TLS root>/tests/git-scripts` directory, and one must create a soft link from `<mbed TLS root>/.git/hooks` to `<mbed TLS root>/tesst/git-scripts`, in order to make the hook scripts successfully work.
 
+Prerequisites for running the scripts:
+* python
+* perl
+* pylint (installed with `pip install pylint`)
+
 Example:
 
 Execute the following command to create a link on linux from the mbed TLS `.git/hooks` directory:  

--- a/tests/git-scripts/README.md
+++ b/tests/git-scripts/README.md
@@ -10,6 +10,7 @@ Prerequisites for running the scripts:
 * python
 * perl
 * pylint (installed with `pip install pylint`)
+* doxygen
 
 Example:
 

--- a/tests/git-scripts/pre-push.sh
+++ b/tests/git-scripts/pre-push.sh
@@ -47,3 +47,4 @@ run_test ./tests/scripts/check-names.sh
 run_test ./tests/scripts/check-generated-files.sh
 run_test ./tests/scripts/check-files.py
 run_test ./tests/scripts/doxygen.sh
+run_test ./tests/scripts/check-python-files.sh


### PR DESCRIPTION
## Description
Add the `check-python-files.sh` test to the prepush git script.
This should avoid errors in the python scripts, prior to making the PR.


## Status
**READY**

## Requires Backporting
NO  


## Additional comments
Requires `pylint` to be installed, using `pip install pylint`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
