### PR TITLE
Backport 2.1: Add a facility to skip running some test suites

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,13 @@ if(NOT PERL_FOUND)
     message(FATAL_ERROR "Cannot build test suites without Perl")
 endif()
 
+# Test suites caught by SKIP_TEST_SUITES are built but not executed.
+# "foo" as a skip pattern skips "test_suite_foo" and "test_suite_foo.bar"
+# but not "test_suite_foobar".
+string(REGEX REPLACE "[ ,;]" "|" SKIP_TEST_SUITES_REGEX "${SKIP_TEST_SUITES}")
+string(REPLACE "." "\\." SKIP_TEST_SUITES_REGEX "${SKIP_TEST_SUITES_REGEX}")
+set(SKIP_TEST_SUITES_REGEX "^(${SKIP_TEST_SUITES_REGEX})(\$|\\.)")
+
 function(add_test_suite suite_name)
     if(ARGV1)
         set(data_name ${ARGV1})
@@ -31,7 +38,11 @@ function(add_test_suite suite_name)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     add_executable(test_suite_${data_name} test_suite_${data_name}.c)
     target_link_libraries(test_suite_${data_name} ${libs})
-    add_test(${data_name}-suite test_suite_${data_name} --verbose)
+    if(${data_name} MATCHES ${SKIP_TEST_SUITES_REGEX})
+        message(STATUS "The test suite ${data_name} will not be executed.")
+    else()
+        add_test(${data_name}-suite test_suite_${data_name} --verbose)
+    endif()
 endfunction(add_test_suite)
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -431,7 +431,8 @@ else
 	del /Q /F *.c *.exe
 endif
 
+# Test suites caught by SKIP_TEST_SUITES are built but not executed.
 check: $(APPS)
-	perl scripts/run-test-suites.pl
+	perl scripts/run-test-suites.pl --skip=$(SKIP_TEST_SUITES)
 
 test: check

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -3,8 +3,18 @@
 use warnings;
 use strict;
 
+use Getopt::Long;
+
 use utf8;
 use open qw(:std utf8);
+
+# The --verbose option is recognized for compatibility with other branches,
+# but it does nothing in Mbed TLS 2.1.
+my $verbose;
+
+GetOptions(
+    'verbose|v' => \$verbose,
+) or die "Command line option not recognized";
 
 my @suites = grep { ! /\.(?:c|gcno)$/ } glob 'test_suite_*';
 die "$0: no test suite found\n" unless @suites;

--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -1,9 +1,29 @@
 #!/usr/bin/env perl
 
+# run-test-suites.pl
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2015-2018, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# Executes all the available test suites, and provides a basic summary of the
+# results.
+#
+# Usage: run-test-suites.pl [-v] [--skip=SUITE,...]
+#
+# Options :
+#   -v|--verbose    - Ignored for compatibility with other branches.
+#   --skip=SUITE[,SUITE...]
+#                   - Skip the specified SUITE(s). This option can be used
+#                     multiple times.
+#
+
 use warnings;
 use strict;
 
-use Getopt::Long;
+use Getopt::Long qw(:config gnu_compat);
 
 use utf8;
 use open qw(:std utf8);
@@ -11,13 +31,26 @@ use open qw(:std utf8);
 # The --verbose option is recognized for compatibility with other branches,
 # but it does nothing in Mbed TLS 2.1.
 my $verbose;
+my @skip_patterns;
 
 GetOptions(
+    'skip=s' => \@skip_patterns,
     'verbose|v' => \$verbose,
 ) or die "Command line option not recognized";
 
 my @suites = grep { ! /\.(?:c|gcno)$/ } glob 'test_suite_*';
 die "$0: no test suite found\n" unless @suites;
+
+# "foo" as a skip pattern skips "test_suite_foo" and "test_suite_foo.bar"
+# but not "test_suite_foobar".
+my $skip_re =
+    ( '\Atest_suite_(' .
+      join('|', map {
+          s/[ ,;]/|/g; # allow any of " ,;|" as separators
+          s/\./\./g; # "." in the input means ".", not "any character"
+          $_
+      } @skip_patterns) .
+      ')(\z|\.)' );
 
 # in case test suites are linked dynamically
 $ENV{'LD_LIBRARY_PATH'} = '../library';
@@ -26,9 +59,18 @@ $ENV{'DYLD_LIBRARY_PATH'} = '../library';
 my $prefix = $^O eq "MSWin32" ? '' : './';
 
 my ($failed_suites, $total_tests_run);
+my $suites_skipped = 0;
+
 for my $suite (@suites)
 {
     print "$suite ", "." x ( 72 - length($suite) - 2 - 4 ), " ";
+
+    if( $suite =~ /$skip_re/o ) {
+        print "SKIP\n";
+        ++$suites_skipped;
+        next;
+    }
+
     my $result = `$prefix$suite`;
     if( $result =~ /PASSED/ ) {
         print "PASS\n";
@@ -42,5 +84,8 @@ for my $suite (@suites)
 
 print "-" x 72, "\n";
 print $failed_suites ? "FAILED" : "PASSED";
-printf " (%d suites, %d tests run)\n", scalar @suites, $total_tests_run;
+printf( " (%d suites, %d tests run%s)\n",
+        scalar(@suites) - $suites_skipped,
+        $total_tests_run,
+        $suites_skipped ? ", $suites_skipped suites skipped" : "" );
 exit( $failed_suites ? 1 : 0 );


### PR DESCRIPTION
Backport of #2293. The changes to `run-test-suites.pl` are different from 2.7 and 2.14 because that script was very different in 2.1.

In 2.1, the list of test suites in `tests/CMakeLists.txt` is fine.
