### PR TITLE
Deprecate feature MBEDTLS_PKCS11_C

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS X.X.X branch released XXXX-XX-XX
 
+New deprecations
+   * Deprecate MBEDTLS_PKCS11_C that enables the wrapper for PKCS#11 smartcard
+     support.
+
 Bugfix
    * Allow loading symlinked certificates. Fixes #3005. Reported and fixed
      by Jonathan Bennett <JBennett@incomsystems.biz> via #3008.

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,8 +3,9 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS X.X.X branch released XXXX-XX-XX
 
 New deprecations
-   * Deprecate MBEDTLS_PKCS11_C that enables the wrapper for PKCS#11 smartcard
-     support.
+   * Deprecate for MBEDTLS_PKCS11_C, the wrapper around the pkcs11-helper
+     library which allows TLS authentication to use keys stored in a
+     PKCS#11 token such as a smartcard.
 
 Bugfix
    * Allow loading symlinked certificates. Fixes #3005. Reported and fixed

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -342,6 +342,14 @@
 #error "MBEDTLS_PKCS11_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_PKCS11_C)
+#if defined(MBEDTLS_DEPRECATED_REMOVED)
+#error "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
+#elif defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
+#endif
+#endif /* MBEDTLS_PKCS11_C */
+
 #if defined(MBEDTLS_PLATFORM_EXIT_ALT) && !defined(MBEDTLS_PLATFORM_C)
 #error "MBEDTLS_PLATFORM_EXIT_ALT defined, but not all prerequisites"
 #endif
@@ -773,14 +781,6 @@
     defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
-
-#if defined(MBEDTLS_PKCS11_C)
-#if defined(MBEDTLS_DEPRECATED_REMOVED)
-#error "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
-#elif defined(MBEDTLS_DEPRECATED_WARNING)
-#warning "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
-#endif
-#endif /* MBEDTLS_PKCS11_C */
 
 /*
  * Avoid warning from -pedantic. This is a convenient place for this

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -776,9 +776,9 @@
 
 #if defined(MBEDTLS_PKCS11_C)
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
-#error "MBEDTLS_PKCS11_C is deprecated and will likely be removed in a future version of Mbed TLS"
+#error "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
 #elif defined(MBEDTLS_DEPRECATED_WARNING)
-#warning "MBEDTLS_PKCS11_C is deprecated and will likely be removed in a future version of Mbed TLS"
+#warning "MBEDTLS_PKCS11_C is deprecated and will be removed in a future version of Mbed TLS"
 #endif
 #endif /* MBEDTLS_PKCS11_C */
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -774,6 +774,14 @@
 #error "MBEDTLS_HAVE_INT32/MBEDTLS_HAVE_INT64 and MBEDTLS_HAVE_ASM cannot be defined simultaneously"
 #endif /* (MBEDTLS_HAVE_INT32 || MBEDTLS_HAVE_INT64) && MBEDTLS_HAVE_ASM */
 
+#if defined(MBEDTLS_PKCS11_C)
+#if defined(MBEDTLS_DEPRECATED_REMOVED)
+#error "MBEDTLS_PKCS11_C is deprecated and will likely be removed in a future version of Mbed TLS"
+#elif defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "MBEDTLS_PKCS11_C is deprecated and will likely be removed in a future version of Mbed TLS"
+#endif
+#endif /* MBEDTLS_PKCS11_C */
+
 /*
  * Avoid warning from -pedantic. This is a convenient place for this
  * workaround since this is included by every single file before the

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2814,6 +2814,9 @@
  *
  * Enable wrapper for PKCS#11 smartcard support.
  *
+ * \deprecated This option is deprecated and will likely be removed in a
+ *             future version of Mbed TLS.
+ *
  * Module:  library/pkcs11.c
  * Caller:  library/pk.c
  *

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2814,8 +2814,8 @@
  *
  * Enable wrapper for PKCS#11 smartcard support.
  *
- * \deprecated This option is deprecated and will likely be removed in a
- *             future version of Mbed TLS.
+ * \deprecated This option is deprecated and will be removed in a future
+ *             version of Mbed TLS.
  *
  * Module:  library/pkcs11.c
  * Caller:  library/pk.c

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2812,7 +2812,7 @@
 /**
  * \def MBEDTLS_PKCS11_C
  *
- * Enable wrapper for PKCS#11 smartcard support.
+ * Enable wrapper for PKCS#11 smartcard support via the pkcs11-helper library.
  *
  * \deprecated This option is deprecated and will be removed in a future
  *             version of Mbed TLS.

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -56,46 +56,80 @@ typedef struct mbedtls_pkcs11_context
         int len;
 } mbedtls_pkcs11_context;
 
+/*
+ * NOTE: It is not necessary to enclose the definitions with
+ * MBEDTLS_DEPRECATED_REMOVED because we already have a check for the full
+ * MBEDTLS_PKCS11_C feature that makes compilation fail even before we get
+ * here.
+ */
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
 /**
  * Initialize a mbedtls_pkcs11_context.
  * (Just making memory references valid.)
+ *
+ * \deprecated          It is deprecated and discouraged to call this function
+ *                      as future versions of the library are likely to remove
+ *                      it.
  */
-void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
+MBEDTLS_DEPRECATED void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
 
 /**
  * Fill in a mbed TLS certificate, based on the given PKCS11 helper certificate.
+ *
+ * \deprecated          It is deprecated and discouraged to call this function
+ *                      as future versions of the library are likely to remove
+ *                      it.
  *
  * \param cert          X.509 certificate to fill
  * \param pkcs11h_cert  PKCS #11 helper certificate
  *
  * \return              0 on success.
  */
-int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert, pkcs11h_certificate_t pkcs11h_cert );
+MBEDTLS_DEPRECATED int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert,
+                                        pkcs11h_certificate_t pkcs11h_cert );
 
 /**
  * Set up a mbedtls_pkcs11_context storing the given certificate. Note that the
  * mbedtls_pkcs11_context will take over control of the certificate, freeing it when
  * done.
  *
+ * \deprecated          It is deprecated and discouraged to call this function
+ *                      as future versions of the library are likely to remove
+ *                      it.
+ *
  * \param priv_key      Private key structure to fill.
  * \param pkcs11_cert   PKCS #11 helper certificate
  *
  * \return              0 on success
  */
-int mbedtls_pkcs11_priv_key_bind( mbedtls_pkcs11_context *priv_key,
-        pkcs11h_certificate_t pkcs11_cert );
+MBEDTLS_DEPRECATED int mbedtls_pkcs11_priv_key_bind(
+                                        mbedtls_pkcs11_context *priv_key,
+                                        pkcs11h_certificate_t pkcs11_cert );
 
 /**
  * Free the contents of the given private key context. Note that the structure
  * itself is not freed.
  *
+ * \deprecated          It is deprecated and discouraged to call this function
+ *                      as future versions of the library are likely to remove
+ *                      it.
+ *
  * \param priv_key      Private key structure to cleanup
  */
-void mbedtls_pkcs11_priv_key_free( mbedtls_pkcs11_context *priv_key );
+MBEDTLS_DEPRECATED void mbedtls_pkcs11_priv_key_free(
+                                            mbedtls_pkcs11_context *priv_key );
 
 /**
  * \brief          Do an RSA private key decrypt, then remove the message
  *                 padding
+ *
+ * \deprecated     It is deprecated and discouraged to call this function as
+ *                 future versions of the library are likely to remove it.
  *
  * \param ctx      PKCS #11 context
  * \param mode     must be MBEDTLS_RSA_PRIVATE, for compatibility with rsa.c's signature
@@ -110,14 +144,17 @@ void mbedtls_pkcs11_priv_key_free( mbedtls_pkcs11_context *priv_key );
  *                 of ctx->N (eg. 128 bytes if RSA-1024 is used) otherwise
  *                 an error is thrown.
  */
-int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
-                       int mode, size_t *olen,
-                       const unsigned char *input,
-                       unsigned char *output,
-                       size_t output_max_len );
+MBEDTLS_DEPRECATED int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
+                                               int mode, size_t *olen,
+                                               const unsigned char *input,
+                                               unsigned char *output,
+                                               size_t output_max_len );
 
 /**
  * \brief          Do a private RSA to sign a message digest
+ *
+ * \deprecated     It is deprecated and discouraged to call this function as
+ *                 future versions of the library are likely to remove it.
  *
  * \param ctx      PKCS #11 context
  * \param mode     must be MBEDTLS_RSA_PRIVATE, for compatibility with rsa.c's signature
@@ -132,28 +169,32 @@ int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
  * \note           The "sig" buffer must be as large as the size
  *                 of ctx->N (eg. 128 bytes if RSA-1024 is used).
  */
-int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
-                    int mode,
-                    mbedtls_md_type_t md_alg,
-                    unsigned int hashlen,
-                    const unsigned char *hash,
-                    unsigned char *sig );
+MBEDTLS_DEPRECATED int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
+                                            int mode,
+                                            mbedtls_md_type_t md_alg,
+                                            unsigned int hashlen,
+                                            const unsigned char *hash,
+                                            unsigned char *sig );
 
 /**
  * SSL/TLS wrappers for PKCS#11 functions
+ *
+ * \deprecated     It is deprecated and discouraged to call these functions as
+ *                 future versions of the library are likely to remove them.
  */
-static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx, int mode, size_t *olen,
-                        const unsigned char *input, unsigned char *output,
-                        size_t output_max_len )
+MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx,
+                            int mode, size_t *olen,
+                            const unsigned char *input, unsigned char *output,
+                            size_t output_max_len )
 {
     return mbedtls_pkcs11_decrypt( (mbedtls_pkcs11_context *) ctx, mode, olen, input, output,
                            output_max_len );
 }
 
-static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
-                     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-                     int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
-                     const unsigned char *hash, unsigned char *sig )
+MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
+                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+                    int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
+                    const unsigned char *hash, unsigned char *sig )
 {
     ((void) f_rng);
     ((void) p_rng);
@@ -161,10 +202,12 @@ static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
                         hashlen, hash, sig );
 }
 
-static inline size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
+MBEDTLS_DEPRECATED static inline size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
 {
     return ( (mbedtls_pkcs11_context *) ctx )->len;
 }
+
+#undef MBEDTLS_DEPRECATED
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -206,7 +206,7 @@ MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx,
  * \return         A non-zero error code on failure.
  *
  * \note           The \p sig buffer must be as large as the size of
- *                 <code>ctx->N<code>. For example, 128 bytes if RSA-1024 is
+ *                 <code>ctx->N</code>. For example, 128 bytes if RSA-1024 is
  *                 used.
  */
 MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_sign( void *ctx,

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -183,6 +183,32 @@ MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx,
                            output_max_len );
 }
 
+/**
+ * \brief          This function signs a message digest using RSA.
+ *
+ * \deprecated     This function is deprecated and will be removed in a future
+ *                 version of the library.
+ *
+ * \param ctx      The PKCS #11 context.
+ * \param f_rng    The RNG function. This parameter is unused.
+ * \param p_rng    The RNG context. This parameter is unused.
+ * \param mode     The operation to run. This must be set to
+ *                 MBEDTLS_RSA_PRIVATE, for compatibility with rsa.c's
+ *                 signature.
+ * \param md_alg   The message digest algorithm. One of the MBEDTLS_MD_XXX
+ *                 must be passed to this function and MBEDTLS_MD_NONE can be
+ *                 used for signing raw data.
+ * \param hashlen  The message digest length (for MBEDTLS_MD_NONE only).
+ * \param hash     The buffer holding the message digest.
+ * \param sig      The buffer that will hold the ciphertext.
+ *
+ * \return         \c 0 if the signing operation was successful.
+ * \return         A non-zero error code on failure.
+ *
+ * \note           The \p sig buffer must be as large as the size of
+ *                 <code>ctx->N<code>. For example, 128 bytes if RSA-1024 is
+ *                 used.
+ */
 MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
                     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
                     int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
@@ -194,6 +220,16 @@ MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_sign( void *ctx,
                         hashlen, hash, sig );
 }
 
+/**
+ * This function gets the length of the private key.
+ *
+ * \deprecated     This function is deprecated and will be removed in a future
+ *                 version of the library.
+ *
+ * \param ctx      The PKCS #11 context.
+ *
+ * \return         The length of the private key.
+ */
 MBEDTLS_DEPRECATED static inline size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
 {
     return ( (mbedtls_pkcs11_context *) ctx )->len;

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -72,18 +72,16 @@ typedef struct mbedtls_pkcs11_context
  * Initialize a mbedtls_pkcs11_context.
  * (Just making memory references valid.)
  *
- * \deprecated          It is deprecated and discouraged to call this function
- *                      as future versions of the library are likely to remove
- *                      it.
+ * \deprecated          This function is deprecated and will be removed in a
+ *                      future version of the library.
  */
 MBEDTLS_DEPRECATED void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
 
 /**
  * Fill in a mbed TLS certificate, based on the given PKCS11 helper certificate.
  *
- * \deprecated          It is deprecated and discouraged to call this function
- *                      as future versions of the library are likely to remove
- *                      it.
+ * \deprecated          This function is deprecated and will be removed in a
+ *                      future version of the library.
  *
  * \param cert          X.509 certificate to fill
  * \param pkcs11h_cert  PKCS #11 helper certificate
@@ -98,9 +96,8 @@ MBEDTLS_DEPRECATED int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert,
  * mbedtls_pkcs11_context will take over control of the certificate, freeing it when
  * done.
  *
- * \deprecated          It is deprecated and discouraged to call this function
- *                      as future versions of the library are likely to remove
- *                      it.
+ * \deprecated          This function is deprecated and will be removed in a
+ *                      future version of the library.
  *
  * \param priv_key      Private key structure to fill.
  * \param pkcs11_cert   PKCS #11 helper certificate
@@ -115,9 +112,8 @@ MBEDTLS_DEPRECATED int mbedtls_pkcs11_priv_key_bind(
  * Free the contents of the given private key context. Note that the structure
  * itself is not freed.
  *
- * \deprecated          It is deprecated and discouraged to call this function
- *                      as future versions of the library are likely to remove
- *                      it.
+ * \deprecated          This function is deprecated and will be removed in a
+ *                      future version of the library.
  *
  * \param priv_key      Private key structure to cleanup
  */
@@ -128,8 +124,8 @@ MBEDTLS_DEPRECATED void mbedtls_pkcs11_priv_key_free(
  * \brief          Do an RSA private key decrypt, then remove the message
  *                 padding
  *
- * \deprecated     It is deprecated and discouraged to call this function as
- *                 future versions of the library are likely to remove it.
+ * \deprecated     This function is deprecated and will be removed in a future
+ *                 version of the library.
  *
  * \param ctx      PKCS #11 context
  * \param mode     must be MBEDTLS_RSA_PRIVATE, for compatibility with rsa.c's signature
@@ -153,8 +149,8 @@ MBEDTLS_DEPRECATED int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
 /**
  * \brief          Do a private RSA to sign a message digest
  *
- * \deprecated     It is deprecated and discouraged to call this function as
- *                 future versions of the library are likely to remove it.
+ * \deprecated     This function is deprecated and will be removed in a future
+ *                 version of the library.
  *
  * \param ctx      PKCS #11 context
  * \param mode     must be MBEDTLS_RSA_PRIVATE, for compatibility with rsa.c's signature
@@ -179,8 +175,8 @@ MBEDTLS_DEPRECATED int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
 /**
  * SSL/TLS wrappers for PKCS#11 functions
  *
- * \deprecated     It is deprecated and discouraged to call these functions as
- *                 future versions of the library are likely to remove them.
+ * \deprecated     This function is deprecated and will be removed in a future
+ *                 version of the library.
  */
 MBEDTLS_DEPRECATED static inline int mbedtls_ssl_pkcs11_decrypt( void *ctx,
                             int mode, size_t *olen,

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -47,6 +47,8 @@
 extern "C" {
 #endif
 
+#if defined(MBEDTLS_DEPRECATED_REMOVED)
+
 /**
  * Context for PKCS #11 private keys.
  */
@@ -56,12 +58,6 @@ typedef struct mbedtls_pkcs11_context
         int len;
 } mbedtls_pkcs11_context;
 
-/*
- * NOTE: It is not necessary to enclose the definitions with
- * MBEDTLS_DEPRECATED_REMOVED because we already have a check for the full
- * MBEDTLS_PKCS11_C feature that makes compilation fail even before we get
- * here.
- */
 #if defined(MBEDTLS_DEPRECATED_WARNING)
 #define MBEDTLS_DEPRECATED      __attribute__((deprecated))
 #else
@@ -204,6 +200,8 @@ MBEDTLS_DEPRECATED static inline size_t mbedtls_ssl_pkcs11_key_len( void *ctx )
 }
 
 #undef MBEDTLS_DEPRECATED
+
+#endif /* MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description
This PR deprecates the feature MBEDTLS_PKCS11_C (and its associated functions).

## Status
**READY**

## Requires Backporting
NO  

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Comments
There are no hard/functional dependencies on other changes, but the use of the macros MBEDTLS_DEPRECATED_REMOVED and MBEDTLS_DEPRECATED_WARNING is according to the documentation changes in https://github.com/ARMmbed/mbedtls/pull/2236. Ideally this PR would be merged **AFTER** that other PR.
