### PR TITLE
Fix compilation failure when MBEDTLS_SSL_HW_RECORD_ACCEL is enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ New deprecations
    * Deprecate MBEDTLS_SSL_HW_RECORD_ACCEL that enables function hooks in the
      SSL module for hardware acceleration of individual records.
 
+Bugfix
+   * Fix compilation failure when both MBEDTLS_SSL_PROTO_DTLS and
+     MBEDTLS_SSL_HW_RECORD_ACCEL are enabled.
+
 = mbed TLS 2.21.0 branch released 2020-02-20
 
 New deprecations

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -826,6 +826,9 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                    const unsigned char randbytes[64],
                                    int minor_ver,
                                    unsigned endpoint,
+#if !defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
+                                   const
+#endif
                                    mbedtls_ssl_context *ssl )
 {
     int ret = 0;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -804,7 +804,7 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
  * - [in] minor_ver: SSL/TLS minor version
  * - [in] endpoint: client or server
  * - [in] ssl: optionally used for:
- *        - MBEDTLS_SSL_HW_RECORD_ACCEL: whole context
+ *        - MBEDTLS_SSL_HW_RECORD_ACCEL: whole context (non-const)
  *        - MBEDTLS_SSL_EXPORT_KEYS: ssl->conf->{f,p}_export_keys
  *        - MBEDTLS_DEBUG_C: ssl->conf->{f,p}_dbg
  */
@@ -826,7 +826,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                    const unsigned char randbytes[64],
                                    int minor_ver,
                                    unsigned endpoint,
-                                   const mbedtls_ssl_context *ssl )
+                                   mbedtls_ssl_context *ssl )
 {
     int ret = 0;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1380,6 +1380,12 @@ component_build_armcc () {
     armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
 }
 
+component_build_ssl_hw_record_accel() {
+    msg "build: default config with MBEDTLS_SSL_HW_RECORD_ACCEL enabled"
+    scripts/config.pl set MBEDTLS_SSL_HW_RECORD_ACCEL
+    make CFLAGS='-Werror -O1'
+}
+
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
     scripts/config.py set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES


### PR DESCRIPTION
## Description
Fix compilation failure when both MBEDTLS_SSL_HW_RECORD_ACCEL and MBEDTLS_SSL_PROTO_DTLS are enabled. The problem was caused because a fragment of code that is conditionally compiled into a function in ssl_tls.c depended on a variable `ret` that was not declared.

The problem was fixed by simply declaring the variable `ret` when MBEDTLS_SSL_HW_RECORD_ACCEL is defined.

This change also adds a build test to all.sh.

## Status
**READY**

## Requires Backporting
Yes 

- mbedtls-2.16 https://github.com/ARMmbed/mbedtls/pull/2439
- mbedtls-2.7 https://github.com/ARMmbed/mbedtls/pull/2440

## Migrations
NO