### PR TITLE
Deprecate feature MBEDTLS_SSL_HW_RECORD_ACCEL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+New deprecations
+   * Deprecate MBEDTLS_SSL_HW_RECORD_ACCEL that enables function hooks in the
+     SSL module for hardware acceleration of individual records.
+
 = mbed TLS 2.21.0 branch released 2020-02-20
 
 New deprecations

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -798,6 +798,14 @@
 #endif
 #endif /* MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO */
 
+#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
+#if defined(MBEDTLS_DEPRECATED_REMOVED)
+#error "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will likely be removed in a future version of Mbed TLS"
+#elif defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will likely be removed in a future version of Mbed TLS"
+#endif
+#endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
+
 /*
  * Avoid warning from -pedantic. This is a convenient place for this
  * workaround since this is included by every single file before the

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -803,7 +803,7 @@
 #error "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will be removed in a future version of Mbed TLS"
 #elif defined(MBEDTLS_DEPRECATED_WARNING)
 #warning "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will be removed in a future version of Mbed TLS"
-#endif
+#endif /* MBEDTLS_DEPRECATED_REMOVED */
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 
 /*

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -800,9 +800,9 @@
 
 #if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
 #if defined(MBEDTLS_DEPRECATED_REMOVED)
-#error "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will likely be removed in a future version of Mbed TLS"
+#error "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will be removed in a future version of Mbed TLS"
 #elif defined(MBEDTLS_DEPRECATED_WARNING)
-#warning "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will likely be removed in a future version of Mbed TLS"
+#warning "MBEDTLS_SSL_HW_RECORD_ACCEL is deprecated and will be removed in a future version of Mbed TLS"
 #endif
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1527,6 +1527,9 @@
  * Enable hooking functions in SSL module for hardware acceleration of
  * individual records.
  *
+ * \deprecated This option is deprecated and will likely be removed in a
+ *             future version of Mbed TLS.
+ *
  * Uncomment this macro to enable hooking functions.
  */
 //#define MBEDTLS_SSL_HW_RECORD_ACCEL

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1527,8 +1527,8 @@
  * Enable hooking functions in SSL module for hardware acceleration of
  * individual records.
  *
- * \deprecated This option is deprecated and will likely be removed in a
- *             future version of Mbed TLS.
+ * \deprecated This option is deprecated and will be removed in a future
+ *             version of Mbed TLS.
  *
  * Uncomment this macro to enable hooking functions.
  */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1784,8 +1784,8 @@
  *
  * Fallback to old (pre-2.7), non-conforming implementation of the truncated
  * HMAC extension which also truncates the HMAC key. Note that this option is
- * only meant for a transitory upgrade period and is likely to be removed in
- * a future version of the library.
+ * only meant for a transitory upgrade period and will be removed in a future
+ * version of the library.
  *
  * \warning The old implementation is non-compliant and has a security weakness
  *          (2^80 brute force attack on the HMAC key used for a single,
@@ -1794,7 +1794,7 @@
  *          bandwidth, and (2) the peer is an Mbed TLS stack that doesn't use
  *          the fixed implementation yet (pre-2.7).
  *
- * \deprecated This option is deprecated and will likely be removed in a
+ * \deprecated This option is deprecated and will be removed in a
  *             future version of Mbed TLS.
  *
  * Uncomment to fallback to old, non-compliant truncated HMAC implementation.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1326,18 +1326,34 @@ struct mbedtls_ssl_context
 #define MBEDTLS_SSL_CHANNEL_OUTBOUND    0
 #define MBEDTLS_SSL_CHANNEL_INBOUND     1
 
-extern int (*mbedtls_ssl_hw_record_init)(mbedtls_ssl_context *ssl,
-                const unsigned char *key_enc, const unsigned char *key_dec,
-                size_t keylen,
-                const unsigned char *iv_enc,  const unsigned char *iv_dec,
-                size_t ivlen,
-                const unsigned char *mac_enc, const unsigned char *mac_dec,
-                size_t maclen);
-extern int (*mbedtls_ssl_hw_record_activate)(mbedtls_ssl_context *ssl, int direction);
-extern int (*mbedtls_ssl_hw_record_reset)(mbedtls_ssl_context *ssl);
-extern int (*mbedtls_ssl_hw_record_write)(mbedtls_ssl_context *ssl);
-extern int (*mbedtls_ssl_hw_record_read)(mbedtls_ssl_context *ssl);
-extern int (*mbedtls_ssl_hw_record_finish)(mbedtls_ssl_context *ssl);
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_init)(
+                    mbedtls_ssl_context *ssl,
+                    const unsigned char *key_enc, const unsigned char *key_dec,
+                    size_t keylen,
+                    const unsigned char *iv_enc,  const unsigned char *iv_dec,
+                    size_t ivlen,
+                    const unsigned char *mac_enc, const unsigned char *mac_dec,
+                    size_t maclen);
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_activate)(
+                                                    mbedtls_ssl_context *ssl,
+                                                    int direction );
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_reset)(
+                                                    mbedtls_ssl_context *ssl );
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_write)(
+                                                    mbedtls_ssl_context *ssl );
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_read)(
+                                                    mbedtls_ssl_context *ssl );
+MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_finish)(
+                                                    mbedtls_ssl_context *ssl );
+
+#undef MBEDTLS_DEPRECATED
+
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 
 /**

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1323,8 +1323,10 @@ struct mbedtls_ssl_context
 
 #if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
 
-#define MBEDTLS_SSL_CHANNEL_OUTBOUND    0
-#define MBEDTLS_SSL_CHANNEL_INBOUND     1
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+
+#define MBEDTLS_SSL_CHANNEL_OUTBOUND   MBEDTLS_DEPRECATED_NUMERIC_CONSTANT( 0 )
+#define MBEDTLS_SSL_CHANNEL_INBOUND    MBEDTLS_DEPRECATED_NUMERIC_CONSTANT( 1 )
 
 #if defined(MBEDTLS_DEPRECATED_WARNING)
 #define MBEDTLS_DEPRECATED      __attribute__((deprecated))
@@ -1353,6 +1355,7 @@ MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_finish)(
                                                     mbedtls_ssl_context *ssl );
 
 #undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #endif /* MBEDTLS_SSL_HW_RECORD_ACCEL */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3188,7 +3188,7 @@ void mbedtls_ssl_conf_extended_master_secret( mbedtls_ssl_config *conf, char ems
  * \warning        Use of RC4 in DTLS/TLS has been prohibited by RFC 7465
  *                 for security reasons. Use at your own risk.
  *
- * \note           This function is deprecated and will likely be removed in
+ * \note           This function is deprecated and will be removed in
  *                 a future version of the library.
  *                 RC4 is disabled by default at compile time and needs to be
  *                 actively enabled for use with legacy systems.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1332,7 +1332,7 @@ struct mbedtls_ssl_context
 #define MBEDTLS_DEPRECATED      __attribute__((deprecated))
 #else
 #define MBEDTLS_DEPRECATED
-#endif
+#endif /* MBEDTLS_DEPRECATED_WARNING */
 
 MBEDTLS_DEPRECATED extern int (*mbedtls_ssl_hw_record_init)(
                     mbedtls_ssl_context *ssl,


### PR DESCRIPTION
## Description
Deprecate the feature MBEDTLS_SSL_HW_RECORD_ACCEL and its associated global function pointers. This feature is largely undocumented, untested and its usefulness is not clear.

## Status
**READY**

## Requires Backporting
NO  

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

## Comments
There are no hard/functional dependencies on other changes, but the use of the macros MBEDTLS_DEPRECATED_REMOVED and MBEDTLS_DEPRECATED_WARNING is according to the documentation changes in https://github.com/ARMmbed/mbedtls/pull/2236. Ideally this PR would be merged **AFTER** that other PR.