### PR TITLE
Added target properties to allow modern use of CMake

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.xx.x branch released xxxx-xx-xx
+Change
+   * In CMake buildsystem added target_include_directories to allow easier use
+     of mbedTLS as submodule in CMake projects
+     by MaderPL in #2277
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -142,14 +142,17 @@ endif()
 if(USE_STATIC_MBEDTLS_LIBRARY)
     add_library(${mbedcrypto_static_target} STATIC ${src_crypto})
     set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
+    target_include_directories(${mbedcrypto_static_target} INTERFACE ../include/) 
     target_link_libraries(${mbedcrypto_static_target} ${libs})
 
     add_library(${mbedx509_static_target} STATIC ${src_x509})
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
+    target_include_directories(${mbedx509_static_target} INTERFACE ../include/)
     target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
+    target_include_directories(${mbedtls_static_target} INTERFACE ../include/)
     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
 
     install(TARGETS ${mbedtls_static_target} ${mbedx509_static_target} ${mbedcrypto_static_target}
@@ -160,14 +163,17 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
     set_target_properties(mbedcrypto PROPERTIES VERSION 2.16.0 SOVERSION 3)
+    target_include_directories(mbedcrypto INTERFACE ../include/)
     target_link_libraries(mbedcrypto ${libs})
 
     add_library(mbedx509 SHARED ${src_x509})
     set_target_properties(mbedx509 PROPERTIES VERSION 2.16.0 SOVERSION 0)
+    target_include_directories(mbedx509 INTERFACE ../include/)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
 
     add_library(mbedtls SHARED ${src_tls})
     set_target_properties(mbedtls PROPERTIES VERSION 2.16.0 SOVERSION 12)
+    target_include_directories(mbedtls INTERFACE ../include/)
     target_link_libraries(mbedtls ${libs} mbedx509)
 
     install(TARGETS mbedtls mbedx509 mbedcrypto


### PR DESCRIPTION
In definition of libraries a new directive was added to allow easier
use of library as submodule. In this aproach include directory is
added as property, so all targets lniking to library will automatically
get proper include path.