### PR TITLE
Add parameter validation for Camellia module

### DIFF
--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -72,52 +72,68 @@ mbedtls_camellia_context;
 #endif /* MBEDTLS_CAMELLIA_ALT */
 
 /**
- * \brief          Initialize CAMELLIA context
+ * \brief          Initialize a CAMELLIA context.
  *
- * \param ctx      CAMELLIA context to be initialized
+ * \param ctx      The CAMELLIA context to be initialized.
+ *                 This must not be \c NULL.
  */
 void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
 
 /**
- * \brief          Clear CAMELLIA context
+ * \brief          Clear a CAMELLIA context.
  *
- * \param ctx      CAMELLIA context to be cleared
+ * \param ctx      The CAMELLIA context to be cleared. May be \c NULL,
+ *                 in which case this function is a no-op. If it is not
+ *                 \c NULL, it must be initialized.
  */
 void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
 
 /**
- * \brief          CAMELLIA key schedule (encryption)
+ * \brief          Perform a CAMELLIA key schedule (encryption).
  *
- * \param ctx      CAMELLIA context to be initialized
- * \param key      encryption key
- * \param keybits  must be 128, 192 or 256
+ * \param ctx      The CAMELLIA context to use. This must be initialized.
+ * \param key      The encryption key to use. Must be a readable buffer
+ *                 of size \p keybits bits.
+ * \param keybits  The length of \p key in Bits. Must be either \c 128,
+ *                 \c 192 or \c 256.
  *
- * \return         0 if successful, or MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
  */
-int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx, const unsigned char *key,
-                         unsigned int keybits );
+int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
+                                 const unsigned char *key,
+                                 unsigned int keybits );
 
 /**
- * \brief          CAMELLIA key schedule (decryption)
+ * \brief          Perform a CAMELLIA key schedule (decryption).
  *
- * \param ctx      CAMELLIA context to be initialized
- * \param key      decryption key
- * \param keybits  must be 128, 192 or 256
+ * \param ctx      The CAMELLIA context to use. This must be initialized.
+ * \param key      The decryption key. Must be a readable buffer
+ *                 of size \p keybits bits.
+ * \param keybits  The length of \p key in Bits. Must be either \c 128,
+ *                 \c 192 or \c 256.
  *
- * \return         0 if successful, or MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
  */
-int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx, const unsigned char *key,
-                         unsigned int keybits );
+int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
+                                 const unsigned char *key,
+                                 unsigned int keybits );
 
 /**
- * \brief          CAMELLIA-ECB block encryption/decryption
+ * \brief          Perform a CAMELLIA-ECB block encryption/decryption.
  *
- * \param ctx      CAMELLIA context
- * \param mode     MBEDTLS_CAMELLIA_ENCRYPT or MBEDTLS_CAMELLIA_DECRYPT
- * \param input    16-byte input block
- * \param output   16-byte output block
+ * \param ctx      The CAMELLIA context to use. Must be initialized
+ *                 and bound to a key.
+ * \param mode     The mode of operation. Must be either
+ *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
+ * \param input    The input block. Must be a readable buffer
+ *                 of size \c 16 Bytes.
+ * \param output   The output block. Must be a writable buffer
+ *                 of size \c 16 Bytes.
  *
- * \return         0 if successful
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
  */
 int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
                     int mode,
@@ -126,9 +142,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief          CAMELLIA-CBC buffer encryption/decryption
- *                 Length should be a multiple of the block
- *                 size (16 bytes)
+ * \brief          Perform a CAMELLIA-CBC buffer encryption/decryption.
  *
  * \note           Upon exit, the content of the IV is updated so that you can
  *                 call the function same function again on the following
@@ -138,15 +152,24 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *                 IV, you should either save it manually or use the cipher
  *                 module instead.
  *
- * \param ctx      CAMELLIA context
- * \param mode     MBEDTLS_CAMELLIA_ENCRYPT or MBEDTLS_CAMELLIA_DECRYPT
- * \param length   length of the input data
- * \param iv       initialization vector (updated after use)
- * \param input    buffer holding the input data
- * \param output   buffer holding the output data
+ * \param ctx      The CAMELLIA context to use. Must be initialized
+ *                 and bound to a key.
+ * \param mode     The mode of operation. Possible values are
+ *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
+ * \param length   The length in Bytes of the input data.
+ *                 Must be a multiple of \c 16.
+ * \param iv       The initialization vector. This must be RW buffer
+ *                 of length \c 16 Bytes. It is updated to allow streaming
+ *                 use as explained above.
+ * \param input    The buffer holding the input data. Must point to a readable
+ *                 buffer of length \p length Bytes. May be \c NULL if
+ *                 `length == 0`.
+ * \param input    The buffer holding the output data. Must point to a writable
+ *                 buffer of length \p length Bytes. May be \c NULL if
+ *                 `length == 0`.
  *
- * \return         0 if successful, or
- *                 MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
  */
 int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
                     int mode,
@@ -158,11 +181,13 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief          CAMELLIA-CFB128 buffer encryption/decryption
+ * \brief          Perform a CAMELLIA-CFB128 buffer encryption/decryption.
  *
- * Note: Due to the nature of CFB you should use the same key schedule for
- * both encryption and decryption. So a context initialized with
- * mbedtls_camellia_setkey_enc() for both MBEDTLS_CAMELLIA_ENCRYPT and CAMELLIE_DECRYPT.
+ * \note           Due to the nature of CFB you should use the same key
+ *                 schedule for both encryption and decryption. So a
+ *                 context initialized with mbedtls_camellia_setkey_enc()
+ *                 for both #MBEDTLS_CAMELLIA_ENCRYPT and
+ *                 #MBEDTLS_CAMELLIA_DECRYPT.
  *
  * \note           Upon exit, the content of the IV is updated so that you can
  *                 call the function same function again on the following
@@ -172,16 +197,26 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *                 IV, you should either save it manually or use the cipher
  *                 module instead.
  *
- * \param ctx      CAMELLIA context
- * \param mode     MBEDTLS_CAMELLIA_ENCRYPT or MBEDTLS_CAMELLIA_DECRYPT
- * \param length   length of the input data
- * \param iv_off   offset in IV (updated after use)
- * \param iv       initialization vector (updated after use)
- * \param input    buffer holding the input data
- * \param output   buffer holding the output data
+ * \param ctx      The CAMELLIA context to use. Must be initialized
+ *                 and bound to a key.
+ * \param mode     The mode of operation. Possible values are
+ *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
+ * \param length   The length of the input data. Any value is allowed.
+ * \param iv_off   The current offset in the IV. This must be smaller
+ *                 than \c 16. It is updated after this call to allow
+ *                 the aforementioned streaming usage.
+ * \param iv       The initialization vector. Must be an RW buffer of
+ *                 length \c 16 Bytes. It is updated after this call to
+ *                 allow the aforementioned streaming usage.
+ * \param input    The buffer holding the input data. Must be a readable
+ *                 buffer of size \p length Bytes. May be \c NULL if
+ *                 \p length is \c 0.
+ * \param output   The buffer to hold the output data. Must be a writable
+ *                 buffer of length \p length Bytes. May be \c NULL if
+ *                 \p length is \c 0.
  *
- * \return         0 if successful, or
- *                 MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA.
+ * \return         \c 0 if successful.
+ * \return         A negative error code on failure.
  */
 int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
                        int mode,
@@ -194,11 +229,13 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief               CAMELLIA-CTR buffer encryption/decryption
+ * \brief      CAMELLIA-CTR buffer encryption/decryption
  *
- * Note: Due to the nature of CTR you should use the same key schedule for
- * both encryption and decryption. So a context initialized with
- * mbedtls_camellia_setkey_enc() for both MBEDTLS_CAMELLIA_ENCRYPT and MBEDTLS_CAMELLIA_DECRYPT.
+ * \note       Due to the nature of CTR you should use the same key
+ *             schedule for both encryption and decryption. So a
+ *             context initialized with mbedtls_camellia_setkey_enc()
+ *             for both #MBEDTLS_CAMELLIA_ENCRYPT and
+ *             #MBEDTLS_CAMELLIA_DECRYPT.
  *
  * \warning    You must never reuse a nonce value with the same key. Doing so
  *             would void the encryption for the two messages encrypted with
@@ -238,24 +275,31 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *             more than 2**32 messages with the same key.
  *
  *             Note that for both stategies, sizes are measured in blocks and
- *             that a CAMELLIA block is 16 bytes.
+ *             that a CAMELLIA block is \c 16 bytes.
  *
  * \warning    Upon return, \p stream_block contains sensitive data. Its
  *             content must not be written to insecure storage and should be
  *             securely discarded as soon as it's no longer needed.
  *
- * \param ctx           CAMELLIA context
- * \param length        The length of the data
- * \param nc_off        The offset in the current stream_block (for resuming
+ * \param ctx           The CAMELLIA context to use.
+ * \param length        The length of the input data. Any value is allowed.
+ * \param nc_off        The offset in the current \p stream_block (for resuming
  *                      within current cipher stream). The offset pointer to
- *                      should be 0 at the start of a stream.
- * \param nonce_counter The 128-bit nonce and counter.
- * \param stream_block  The saved stream-block for resuming. Is overwritten
- *                      by the function.
- * \param input         The input data stream
- * \param output        The output data stream
+ *                      should be \c 0 at the start of a stream. It is updated
+ *                      at the end of this call.
+ * \param nonce_counter The 128-bit nonce and counter. Must be an RW buffer of
+ *                      length \c 16 Bytes.
+ * \param stream_block  The saved stream-block for resuming. Must be an
+ *                      RW buffer of length \c 16 Bytes.
+ * \param input         The input data stream. Must be a readable buffer of
+ *                      size \p length Bytes. This may be \c NULL if \p length
+ *                      is \c 0.
+ * \param output        The output data stream. Must be a writable buffer of
+ *                      size \p length Bytes. This may be \c NULL if \p length
+ *                      is \c 0.
  *
- * \return         0 if successful
+ * \return              \c 0 if successful.
+ * \return              A negative error code on failure.
  */
 int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
                        size_t length,

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -45,9 +45,6 @@
 
 #define MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH -0x0026 /**< Invalid data input length. */
 
-/** TEMPORARY -- THIS IS IN CONFLICT WITH EXISTING ERROR CODES AND NEEDS CHANGE. */
-#define MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA       -0x0024  /**< Invalid data input length. */
-
 /* MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED is deprecated and should not be used.
  */
 #define MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED              -0x0027  /**< Camellia hardware accelerator failed. */

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -96,7 +96,7 @@ void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
  * \param key      The encryption key to use. This must be a readable buffer
- *                 of size \p keybits bits.
+ *                 of size \p keybits Bits.
  * \param keybits  The length of \p key in Bits. This must be either \c 128,
  *                 \c 192 or \c 256.
  *
@@ -112,7 +112,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
  * \param key      The decryption key. This must be a readable buffer
- *                 of size \p keybits bits.
+ *                 of size \p keybits Bits.
  * \param keybits  The length of \p key in Bits. This must be either \c 128,
  *                 \c 192 or \c 256.
  *
@@ -157,7 +157,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
- * \param mode     The mode of operation. Possible values are
+ * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  * \param length   The length in Bytes of the input data.
  *                 Must be a multiple of \c 16.
@@ -202,7 +202,7 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
- * \param mode     The mode of operation. Possible values are
+ * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  * \param length   The length of the input data. Any value is allowed.
  * \param iv_off   The current offset in the IV. This must be smaller

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -165,11 +165,9 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *                 of length \c 16 Bytes. It is updated to allow streaming
  *                 use as explained above.
  * \param input    The buffer holding the input data. This must point to a
- *                 readable buffer of length \p length Bytes. This may be
- *                 \c NULL if `length == 0`.
+ *                 readable buffer of length \p length Bytes.
  * \param output   The buffer holding the output data. This must point to a
- *                 writable buffer of length \p length Bytes. This may be
- *                 \c NULL if `length == 0`.
+ *                 writable buffer of length \p length Bytes.
  *
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
@@ -212,11 +210,9 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *                 of length \c 16 Bytes. It is updated after this call to
  *                 allow the aforementioned streaming usage.
  * \param input    The buffer holding the input data. This must be a readable
- *                 buffer of size \p length Bytes. This may be \c NULL if
- *                 \p length is \c 0.
+ *                 buffer of size \p length Bytes.
  * \param output   The buffer to hold the output data. This must be a writable
- *                 buffer of length \p length Bytes. This may be \c NULL if
- *                 \p length is \c 0.
+ *                 buffer of length \p length Bytes.
  *
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
@@ -297,11 +293,9 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  * \param stream_block  The saved stream-block for resuming. This must be a
  *                      read/write buffer of length \c 16 Bytes.
  * \param input         The input data stream. This must be a readable buffer of
- *                      size \p length Bytes. This may be \c NULL if \p length
- *                      is \c 0.
+ *                      size \p length Bytes.
  * \param output        The output data stream. This must be a writable buffer
- *                      of size \p length Bytes. This may be \c NULL if
- *                      \p length is \c 0.
+ *                      of size \p length Bytes.
  *
  * \return              \c 0 if successful.
  * \return              A negative error code on failure.

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -45,6 +45,9 @@
 
 #define MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH -0x0026 /**< Invalid data input length. */
 
+/** TEMPORARY -- THIS IS IN CONFLICT WITH EXISTING ERROR CODES AND NEEDS CHANGE. */
+#define MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA       -0x0024  /**< Invalid data input length. */
+
 /* MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED is deprecated and should not be used.
  */
 #define MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED              -0x0027  /**< Camellia hardware accelerator failed. */

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -159,15 +159,15 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *                 and bound to a key.
  * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
- * \param length   The length in Bytes of the input data.
- *                 Must be a multiple of \c 16.
+ * \param length   The length in Bytes of the input data \p input.
+ *                 This must be a multiple of \c 16.
  * \param iv       The initialization vector. This must be RW buffer
  *                 of length \c 16 Bytes. It is updated to allow streaming
  *                 use as explained above.
  * \param input    The buffer holding the input data. This must point to a
  *                 readable buffer of length \p length Bytes. This may be
  *                 \c NULL if `length == 0`.
- * \param input    The buffer holding the output data. This must point to a
+ * \param output   The buffer holding the output data. This must point to a
  *                 writable buffer of length \p length Bytes. This may be
  *                 \c NULL if `length == 0`.
  *
@@ -204,7 +204,7 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *                 and bound to a key.
  * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
- * \param length   The length of the input data. Any value is allowed.
+ * \param length   The length of the input data \p input. Any value is allowed.
  * \param iv_off   The current offset in the IV. This must be smaller
  *                 than \c 16. It is updated after this call to allow
  *                 the aforementioned streaming usage.
@@ -284,8 +284,10 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *             content must not be written to insecure storage and should be
  *             securely discarded as soon as it's no longer needed.
  *
- * \param ctx           The CAMELLIA context to use.
- * \param length        The length of the input data. Any value is allowed.
+ * \param ctx           The CAMELLIA context to use. This must be initialized
+ *                      and bound to a key.
+ * \param length        The length of the input data \p input.
+ *                      Any value is allowed.
  * \param nc_off        The offset in the current \p stream_block (for resuming
  *                      within current cipher stream). The offset pointer to
  *                      should be \c 0 at the start of a stream. It is updated

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -85,7 +85,7 @@ void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
 /**
  * \brief          Clear a CAMELLIA context.
  *
- * \param ctx      The CAMELLIA context to be cleared. May be \c NULL,
+ * \param ctx      The CAMELLIA context to be cleared. This may be \c NULL,
  *                 in which case this function is a no-op. If it is not
  *                 \c NULL, it must be initialized.
  */
@@ -95,9 +95,9 @@ void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
  * \brief          Perform a CAMELLIA key schedule (encryption).
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
- * \param key      The encryption key to use. Must be a readable buffer
+ * \param key      The encryption key to use. This must be a readable buffer
  *                 of size \p keybits bits.
- * \param keybits  The length of \p key in Bits. Must be either \c 128,
+ * \param keybits  The length of \p key in Bits. This must be either \c 128,
  *                 \c 192 or \c 256.
  *
  * \return         \c 0 if successful.
@@ -111,9 +111,9 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
  * \brief          Perform a CAMELLIA key schedule (decryption).
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
- * \param key      The decryption key. Must be a readable buffer
+ * \param key      The decryption key. This must be a readable buffer
  *                 of size \p keybits bits.
- * \param keybits  The length of \p key in Bits. Must be either \c 128,
+ * \param keybits  The length of \p key in Bits. This must be either \c 128,
  *                 \c 192 or \c 256.
  *
  * \return         \c 0 if successful.
@@ -126,13 +126,13 @@ int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
 /**
  * \brief          Perform a CAMELLIA-ECB block encryption/decryption.
  *
- * \param ctx      The CAMELLIA context to use. Must be initialized
+ * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
- * \param mode     The mode of operation. Must be either
+ * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
- * \param input    The input block. Must be a readable buffer
+ * \param input    The input block. This must be a readable buffer
  *                 of size \c 16 Bytes.
- * \param output   The output block. Must be a writable buffer
+ * \param output   The output block. This must be a writable buffer
  *                 of size \c 16 Bytes.
  *
  * \return         \c 0 if successful.
@@ -155,7 +155,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *                 IV, you should either save it manually or use the cipher
  *                 module instead.
  *
- * \param ctx      The CAMELLIA context to use. Must be initialized
+ * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
  * \param mode     The mode of operation. Possible values are
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
@@ -164,12 +164,12 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  * \param iv       The initialization vector. This must be RW buffer
  *                 of length \c 16 Bytes. It is updated to allow streaming
  *                 use as explained above.
- * \param input    The buffer holding the input data. Must point to a readable
- *                 buffer of length \p length Bytes. May be \c NULL if
- *                 `length == 0`.
- * \param input    The buffer holding the output data. Must point to a writable
- *                 buffer of length \p length Bytes. May be \c NULL if
- *                 `length == 0`.
+ * \param input    The buffer holding the input data. This must point to a
+ *                 readable buffer of length \p length Bytes. This may be
+ *                 \c NULL if `length == 0`.
+ * \param input    The buffer holding the output data. This must point to a
+ *                 writable buffer of length \p length Bytes. This may be
+ *                 \c NULL if `length == 0`.
  *
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
@@ -200,7 +200,7 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *                 IV, you should either save it manually or use the cipher
  *                 module instead.
  *
- * \param ctx      The CAMELLIA context to use. Must be initialized
+ * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
  * \param mode     The mode of operation. Possible values are
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
@@ -208,14 +208,14 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  * \param iv_off   The current offset in the IV. This must be smaller
  *                 than \c 16. It is updated after this call to allow
  *                 the aforementioned streaming usage.
- * \param iv       The initialization vector. Must be an RW buffer of
+ * \param iv       The initialization vector. This must be an RW buffer of
  *                 length \c 16 Bytes. It is updated after this call to
  *                 allow the aforementioned streaming usage.
- * \param input    The buffer holding the input data. Must be a readable
- *                 buffer of size \p length Bytes. May be \c NULL if
+ * \param input    The buffer holding the input data. This must be a readable
+ *                 buffer of size \p length Bytes. This may be \c NULL if
  *                 \p length is \c 0.
- * \param output   The buffer to hold the output data. Must be a writable
- *                 buffer of length \p length Bytes. May be \c NULL if
+ * \param output   The buffer to hold the output data. This must be a writable
+ *                 buffer of length \p length Bytes. This may be \c NULL if
  *                 \p length is \c 0.
  *
  * \return         \c 0 if successful.
@@ -271,7 +271,7 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *
  *             The per-message nonce (or information sufficient to reconstruct
  *             it) needs to be communicated with the ciphertext and must be unique.
- *             The recommended way to ensure uniqueness is to use a message
+ *             unique. The recommended way to ensure uniqueness is to use a message
  *             counter. An alternative is to generate random nonces, but this
  *             limits the number of messages that can be securely encrypted:
  *             for example, with 96-bit random nonces, you should not encrypt
@@ -290,16 +290,16 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *                      within current cipher stream). The offset pointer to
  *                      should be \c 0 at the start of a stream. It is updated
  *                      at the end of this call.
- * \param nonce_counter The 128-bit nonce and counter. Must be an RW buffer of
- *                      length \c 16 Bytes.
- * \param stream_block  The saved stream-block for resuming. Must be an
+ * \param nonce_counter The 128-bit nonce and counter. This must be an RW buffer
+ *                      of length \c 16 Bytes.
+ * \param stream_block  The saved stream-block for resuming. This must be an
  *                      RW buffer of length \c 16 Bytes.
- * \param input         The input data stream. Must be a readable buffer of
+ * \param input         The input data stream. This must be a readable buffer of
  *                      size \p length Bytes. This may be \c NULL if \p length
  *                      is \c 0.
- * \param output        The output data stream. Must be a writable buffer of
- *                      size \p length Bytes. This may be \c NULL if \p length
- *                      is \c 0.
+ * \param output        The output data stream. This must be a writable buffer
+ *                      of size \p length Bytes. This may be \c NULL if
+ *                      \p length is \c 0.
  *
  * \return              \c 0 if successful.
  * \return              A negative error code on failure.

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -89,7 +89,7 @@ void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
 void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
 
 /**
- * \brief          Perform a CAMELLIA key schedule (encryption).
+ * \brief          Perform a CAMELLIA key schedule operation for encryption.
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
  * \param key      The encryption key to use. This must be a readable buffer
@@ -105,7 +105,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
                                  unsigned int keybits );
 
 /**
- * \brief          Perform a CAMELLIA key schedule (decryption).
+ * \brief          Perform a CAMELLIA key schedule operation for decryption.
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized.
  * \param key      The decryption key. This must be a readable buffer
@@ -121,7 +121,7 @@ int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
                                  unsigned int keybits );
 
 /**
- * \brief          Perform a CAMELLIA-ECB block encryption/decryption.
+ * \brief          Perform a CAMELLIA-ECB block encryption/decryption operation.
  *
  * \param ctx      The CAMELLIA context to use. This must be initialized
  *                 and bound to a key.
@@ -142,7 +142,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
- * \brief          Perform a CAMELLIA-CBC buffer encryption/decryption.
+ * \brief          Perform a CAMELLIA-CBC buffer encryption/decryption operation.
  *
  * \note           Upon exit, the content of the IV is updated so that you can
  *                 call the function same function again on the following
@@ -157,7 +157,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  * \param mode     The mode of operation. This must be either
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  * \param length   The length in Bytes of the input data \p input.
- *                 This must be a multiple of \c 16.
+ *                 This must be a multiple of \c 16 Bytes.
  * \param iv       The initialization vector. This must be a read/write buffer
  *                 of length \c 16 Bytes. It is updated to allow streaming
  *                 use as explained above.
@@ -179,13 +179,14 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /**
- * \brief          Perform a CAMELLIA-CFB128 buffer encryption/decryption.
+ * \brief          Perform a CAMELLIA-CFB128 buffer encryption/decryption
+ *                 operation.
  *
- * \note           Due to the nature of CFB you should use the same key
- *                 schedule for both encryption and decryption. So a
- *                 context initialized with mbedtls_camellia_setkey_enc()
- *                 for both #MBEDTLS_CAMELLIA_ENCRYPT and
- *                 #MBEDTLS_CAMELLIA_DECRYPT.
+ * \note           Due to the nature of CFB mode, you should use the same
+ *                 key for both encryption and decryption. In particular, calls
+ *                 to this function should be preceded by a key-schedule via
+ *                 mbedtls_camellia_setkey_enc() regardless of whether \p mode
+ *                 is #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  *
  * \note           Upon exit, the content of the IV is updated so that you can
  *                 call the function same function again on the following
@@ -225,13 +226,13 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /**
- * \brief      CAMELLIA-CTR buffer encryption/decryption
+ * \brief      Perform a CAMELLIA-CTR buffer encryption/decryption operation.
  *
- * \note       Due to the nature of CTR you should use the same key
- *             schedule for both encryption and decryption. So a
- *             context initialized with mbedtls_camellia_setkey_enc()
- *             for both #MBEDTLS_CAMELLIA_ENCRYPT and
- *             #MBEDTLS_CAMELLIA_DECRYPT.
+ * *note       Due to the nature of CTR mode, you should use the same
+ *             key for both encryption and decryption. In particular, calls
+ *             to this function should be preceded by a key-schedule via
+ *             mbedtls_camellia_setkey_enc() regardless of whether \p mode
+ *             is #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  *
  * \warning    You must never reuse a nonce value with the same key. Doing so
  *             would void the encryption for the two messages encrypted with
@@ -254,21 +255,22 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *             per-message nonce, handled by yourself, and the second one
  *             updated by this function internally.
  *
- *             For example, you might reserve the first 12 bytes for the
- *             per-message nonce, and the last 4 bytes for internal use. In that
- *             case, before calling this function on a new message you need to
- *             set the first 12 bytes of \p nonce_counter to your chosen nonce
- *             value, the last 4 to 0, and \p nc_off to 0 (which will cause \p
- *             stream_block to be ignored). That way, you can encrypt at most
- *             2**96 messages of up to 2**32 blocks each with the same key.
+ *             For example, you might reserve the first \c 12 Bytes for the
+ *             per-message nonce, and the last \c 4 Bytes for internal use.
+ *             In that case, before calling this function on a new message you
+ *             need to set the first \c 12 Bytes of \p nonce_counter to your
+ *             chosen nonce value, the last four to \c 0, and \p nc_off to \c 0
+ *             (which will cause \p stream_block to be ignored). That way, you
+ *             can encrypt at most \c 2**96 messages of up to \c 2**32 blocks
+ *             each  with the same key.
  *
  *             The per-message nonce (or information sufficient to reconstruct
- *             it) needs to be communicated with the ciphertext and must be unique.
- *             unique. The recommended way to ensure uniqueness is to use a message
- *             counter. An alternative is to generate random nonces, but this
- *             limits the number of messages that can be securely encrypted:
- *             for example, with 96-bit random nonces, you should not encrypt
- *             more than 2**32 messages with the same key.
+ *             it) needs to be communicated with the ciphertext and must be.
+ *             unique. The recommended way to ensure uniqueness is to use a
+ *             message counter. An alternative is to generate random nonces,
+ *             but this limits the number of messages that can be securely
+ *             encrypted: for example, with 96-bit random nonces, you should
+ *             not encrypt more than 2**32 messages with the same key.
  *
  *             Note that for both stategies, sizes are measured in blocks and
  *             that a CAMELLIA block is \c 16 bytes.

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -265,7 +265,7 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *             each  with the same key.
  *
  *             The per-message nonce (or information sufficient to reconstruct
- *             it) needs to be communicated with the ciphertext and must be.
+ *             it) needs to be communicated with the ciphertext and must be
  *             unique. The recommended way to ensure uniqueness is to use a
  *             message counter. An alternative is to generate random nonces,
  *             but this limits the number of messages that can be securely
@@ -273,7 +273,7 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *             not encrypt more than 2**32 messages with the same key.
  *
  *             Note that for both stategies, sizes are measured in blocks and
- *             that a CAMELLIA block is \c 16 bytes.
+ *             that a CAMELLIA block is \c 16 Bytes.
  *
  * \warning    Upon return, \p stream_block contains sensitive data. Its
  *             content must not be written to insecure storage and should be

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -86,7 +86,7 @@ void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
  * \brief          Clear a CAMELLIA context.
  *
  * \param ctx      The CAMELLIA context to be cleared. This may be \c NULL,
- *                 in which case this function is a no-op. If it is not
+ *                 in which case this function returns immediately. If it is not
  *                 \c NULL, it must be initialized.
  */
 void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
@@ -161,7 +161,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  * \param length   The length in Bytes of the input data \p input.
  *                 This must be a multiple of \c 16.
- * \param iv       The initialization vector. This must be RW buffer
+ * \param iv       The initialization vector. This must be a read/write buffer
  *                 of length \c 16 Bytes. It is updated to allow streaming
  *                 use as explained above.
  * \param input    The buffer holding the input data. This must point to a
@@ -206,10 +206,10 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  *                 #MBEDTLS_CAMELLIA_ENCRYPT or #MBEDTLS_CAMELLIA_DECRYPT.
  * \param length   The length of the input data \p input. Any value is allowed.
  * \param iv_off   The current offset in the IV. This must be smaller
- *                 than \c 16. It is updated after this call to allow
+ *                 than \c 16 Bytes. It is updated after this call to allow
  *                 the aforementioned streaming usage.
- * \param iv       The initialization vector. This must be an RW buffer of
- *                 length \c 16 Bytes. It is updated after this call to
+ * \param iv       The initialization vector. This must be a read/write buffer
+ *                 of length \c 16 Bytes. It is updated after this call to
  *                 allow the aforementioned streaming usage.
  * \param input    The buffer holding the input data. This must be a readable
  *                 buffer of size \p length Bytes. This may be \c NULL if
@@ -286,16 +286,16 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  *
  * \param ctx           The CAMELLIA context to use. This must be initialized
  *                      and bound to a key.
- * \param length        The length of the input data \p input.
+ * \param length        The length of the input data \p input in Bytes.
  *                      Any value is allowed.
  * \param nc_off        The offset in the current \p stream_block (for resuming
  *                      within current cipher stream). The offset pointer to
  *                      should be \c 0 at the start of a stream. It is updated
  *                      at the end of this call.
- * \param nonce_counter The 128-bit nonce and counter. This must be an RW buffer
- *                      of length \c 16 Bytes.
- * \param stream_block  The saved stream-block for resuming. This must be an
- *                      RW buffer of length \c 16 Bytes.
+ * \param nonce_counter The 128-bit nonce and counter. This must be a read/write
+ *                      buffer of length \c 16 Bytes.
+ * \param stream_block  The saved stream-block for resuming. This must be a
+ *                      read/write buffer of length \c 16 Bytes.
  * \param input         The input data stream. This must be a readable buffer of
  *                      size \p length Bytes. This may be \c NULL if \p length
  *                      is \c 0.

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -353,6 +353,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
     uint32_t SIGMA[6][2];
     uint32_t KC[16];
     uint32_t TK[20];
+
     CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( key != NULL );
 
@@ -570,11 +571,11 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  * Camellia-CBC buffer encryption/decryption
  */
 int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
-                    int mode,
-                    size_t length,
-                    unsigned char iv[16],
-                    const unsigned char *input,
-                    unsigned char *output )
+                                int mode,
+                                size_t length,
+                                unsigned char iv[16],
+                                const unsigned char *input,
+                                unsigned char *output )
 {
     int i;
     unsigned char temp[16];

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -49,6 +49,12 @@
 
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 
+/* Parameter validation macros */
+#define CAMELLIA_VALIDATE_RET( cond )                                       \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA )
+#define CAMELLIA_VALIDATE( cond )                                           \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
 /*
  * 32-bit integer manipulation macros (big endian)
  */
@@ -321,6 +327,7 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
 
 void mbedtls_camellia_init( mbedtls_camellia_context *ctx )
 {
+    CAMELLIA_VALIDATE( ctx != NULL );
     memset( ctx, 0, sizeof( mbedtls_camellia_context ) );
 }
 
@@ -335,8 +342,9 @@ void mbedtls_camellia_free( mbedtls_camellia_context *ctx )
 /*
  * Camellia key schedule (encryption)
  */
-int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx, const unsigned char *key,
-                         unsigned int keybits )
+int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
+                                 const unsigned char *key,
+                                 unsigned int keybits )
 {
     int idx;
     size_t i;
@@ -345,6 +353,9 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx, const unsigned c
     uint32_t SIGMA[6][2];
     uint32_t KC[16];
     uint32_t TK[20];
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( key != NULL );
+    CAMELLIA_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
 
     RK = ctx->rk;
 
@@ -440,14 +451,18 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx, const unsigned c
 /*
  * Camellia key schedule (decryption)
  */
-int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx, const unsigned char *key,
-                         unsigned int keybits )
+int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
+                                 const unsigned char *key,
+                                 unsigned int keybits )
 {
     int idx, ret;
     size_t i;
     mbedtls_camellia_context cty;
     uint32_t *RK;
     uint32_t *SK;
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( key != NULL );
+    CAMELLIA_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
 
     mbedtls_camellia_init( &cty );
 
@@ -495,6 +510,11 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
 {
     int NR;
     uint32_t *RK, X[4];
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
+                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    CAMELLIA_VALIDATE_RET( input  != NULL );
+    CAMELLIA_VALIDATE_RET( output != NULL );
 
     ( (void) mode );
 
@@ -560,6 +580,12 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
 {
     int i;
     unsigned char temp[16];
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
+                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    CAMELLIA_VALIDATE_RET( iv != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
 
     if( length % 16 )
         return( MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH );
@@ -614,7 +640,18 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
                        unsigned char *output )
 {
     int c;
-    size_t n = *iv_off;
+    size_t n;
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( mode == MBEDTLS_CAMELLIA_ENCRYPT ||
+                           mode == MBEDTLS_CAMELLIA_DECRYPT );
+    CAMELLIA_VALIDATE_RET( iv     != NULL );
+    CAMELLIA_VALIDATE_RET( iv_off != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
+
+    n = *iv_off;
+    if( n >= 16 )
+        return( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA );
 
     if( mode == MBEDTLS_CAMELLIA_DECRYPT )
     {
@@ -662,7 +699,17 @@ int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
                        unsigned char *output )
 {
     int c, i;
-    size_t n = *nc_off;
+    size_t n;
+    CAMELLIA_VALIDATE_RET( ctx != NULL );
+    CAMELLIA_VALIDATE_RET( nonce_counter != NULL );
+    CAMELLIA_VALIDATE_RET( stream_block  != NULL );
+    CAMELLIA_VALIDATE_RET( nc_off != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || input  != NULL );
+    CAMELLIA_VALIDATE_RET( length == 0 || output != NULL );
+
+    n = *nc_off;
+    if( n >= 16 )
+        return( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA );
 
     while( length-- )
     {

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -355,7 +355,6 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
     uint32_t TK[20];
     CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( key != NULL );
-    CAMELLIA_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
 
     RK = ctx->rk;
 
@@ -462,7 +461,6 @@ int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
     uint32_t *SK;
     CAMELLIA_VALIDATE_RET( ctx != NULL );
     CAMELLIA_VALIDATE_RET( key != NULL );
-    CAMELLIA_VALIDATE_RET( keybits == 128 || keybits == 192 || keybits == 256 );
 
     mbedtls_camellia_init( &cty );
 

--- a/tests/suites/test_suite_camellia.data
+++ b/tests/suites/test_suite_camellia.data
@@ -1,3 +1,6 @@
+Camellia parameter validation
+camellia_invalid_param:
+
 Camellia-128-ECB Encrypt RFC3713 #1
 camellia_encrypt_ecb:"0123456789abcdeffedcba9876543210":"0123456789abcdeffedcba9876543210":"67673138549669730857065648eabe43":0
 

--- a/tests/suites/test_suite_camellia.data
+++ b/tests/suites/test_suite_camellia.data
@@ -1,4 +1,7 @@
-Camellia parameter validation
+Camellia - Valid parameters
+camellia_valid_param:
+
+Camellia - Invalid parameters
 camellia_invalid_param:
 
 Camellia-128-ECB Encrypt RFC3713 #1

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -13,7 +13,6 @@ void camellia_invalid_param( )
     mbedtls_camellia_context ctx;
     unsigned char buf[16] = { 0 };
     const size_t valid_keybits   = 128;
-    const size_t invalid_keybits = 42;
     const int invalid_mode = 42;
     const int valid_mode = MBEDTLS_CAMELLIA_ENCRYPT;
     size_t off;
@@ -30,10 +29,6 @@ void camellia_invalid_param( )
                             mbedtls_camellia_setkey_enc( &ctx,
                                                          NULL,
                                                          valid_keybits ) );
-    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
-                            mbedtls_camellia_setkey_enc( &ctx,
-                                                         buf,
-                                                         invalid_keybits ) );
 
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_dec( NULL,
@@ -43,10 +38,6 @@ void camellia_invalid_param( )
                             mbedtls_camellia_setkey_dec( &ctx,
                                                          NULL,
                                                          valid_keybits ) );
-    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
-                            mbedtls_camellia_setkey_dec( &ctx,
-                                                         buf,
-                                                         invalid_keybits ) );
 
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_ecb( NULL,

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -7,6 +7,13 @@
  * END_DEPENDENCIES
  */
 
+/* BEGIN_CASE */
+void camellia_valid_param( )
+{
+    TEST_VALID_PARAM( mbedtls_camellia_free( NULL ) );
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_CHECK_PARAMS:!MBEDTLS_PARAM_FAILED_ALT */
 void camellia_invalid_param( )
 {
@@ -19,7 +26,6 @@ void camellia_invalid_param( )
     ((void) off);
 
     TEST_INVALID_PARAM( mbedtls_camellia_init( NULL ) );
-    TEST_VALID_PARAM( mbedtls_camellia_free( NULL ) );
 
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_enc( NULL,

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -12,6 +12,10 @@ void camellia_invalid_param( )
 {
     mbedtls_camellia_context ctx;
     unsigned char buf[16] = { 0 };
+    const size_t valid_keybits   = 128;
+    const size_t invalid_keybits = 42;
+    const int invalid_mode = 42;
+    const int valid_mode = MBEDTLS_CAMELLIA_ENCRYPT;
     size_t off;
     ((void) off);
 
@@ -21,70 +25,70 @@ void camellia_invalid_param( )
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_enc( NULL,
                                                          buf,
-                                                         128 ) );
+                                                         valid_keybits ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_enc( &ctx,
                                                          NULL,
-                                                         128 ) );
+                                                         valid_keybits ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_enc( &ctx,
                                                          buf,
-                                                         42 ) );
+                                                         invalid_keybits ) );
 
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_dec( NULL,
                                                          buf,
-                                                         128 ) );
+                                                         valid_keybits ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_dec( &ctx,
                                                          NULL,
-                                                         128 ) );
+                                                         valid_keybits ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_setkey_dec( &ctx,
                                                          buf,
-                                                         42 ) );
+                                                         invalid_keybits ) );
 
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_ecb( NULL,
-                                                     MBEDTLS_CAMELLIA_ENCRYPT,
-                                                     buf, buf ) );
-    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
-                            mbedtls_camellia_crypt_ecb( &ctx,
-                                                        42,
+                                                        valid_mode,
                                                         buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_ecb( &ctx,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        invalid_mode,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ecb( &ctx,
+                                                        valid_mode,
                                                         NULL, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_ecb( &ctx,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        valid_mode,
                                                         buf, NULL ) );
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cbc( NULL,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        valid_mode,
                                                         sizeof( buf ),
                                                         buf, buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cbc( &ctx,
-                                                        42,
+                                                        invalid_mode,
                                                         sizeof( buf ),
                                                         buf, buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cbc( &ctx,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        valid_mode,
                                                         sizeof( buf ),
                                                         NULL, buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cbc( &ctx,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        valid_mode,
                                                         sizeof( buf ),
                                                         buf, NULL, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cbc( &ctx,
-                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        valid_mode,
                                                         sizeof( buf ),
                                                         buf, buf, NULL ) );
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
@@ -92,37 +96,37 @@ void camellia_invalid_param( )
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( NULL,
-                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           valid_mode,
                                                            sizeof( buf ),
                                                            &off, buf,
                                                            buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( &ctx,
-                                                           42,
+                                                           invalid_mode,
                                                            sizeof( buf ),
                                                            &off, buf,
                                                            buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( &ctx,
-                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           valid_mode,
                                                            sizeof( buf ),
                                                            NULL, buf,
                                                            buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( &ctx,
-                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           valid_mode,
                                                            sizeof( buf ),
                                                            &off, NULL,
                                                            buf, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( &ctx,
-                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           valid_mode,
                                                            sizeof( buf ),
                                                            &off, buf,
                                                            NULL, buf ) );
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
                             mbedtls_camellia_crypt_cfb128( &ctx,
-                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           valid_mode,
                                                            sizeof( buf ),
                                                            &off, buf,
                                                            buf, NULL ) );

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -7,6 +7,171 @@
  * END_DEPENDENCIES
  */
 
+/* BEGIN_CASE depends_on:MBEDTLS_CHECK_PARAMS:!MBEDTLS_PARAM_FAILED_ALT */
+void camellia_invalid_param( )
+{
+    mbedtls_camellia_context ctx;
+    unsigned char buf[16] = { 0 };
+    size_t off;
+    ((void) off);
+
+    TEST_INVALID_PARAM( mbedtls_camellia_init( NULL ) );
+    TEST_VALID_PARAM( mbedtls_camellia_free( NULL ) );
+
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_enc( NULL,
+                                                         buf,
+                                                         128 ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_enc( &ctx,
+                                                         NULL,
+                                                         128 ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_enc( &ctx,
+                                                         buf,
+                                                         42 ) );
+
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_dec( NULL,
+                                                         buf,
+                                                         128 ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_dec( &ctx,
+                                                         NULL,
+                                                         128 ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_setkey_dec( &ctx,
+                                                         buf,
+                                                         42 ) );
+
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ecb( NULL,
+                                                     MBEDTLS_CAMELLIA_ENCRYPT,
+                                                     buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ecb( &ctx,
+                                                        42,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ecb( &ctx,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        NULL, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ecb( &ctx,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        buf, NULL ) );
+
+#if defined(MBEDTLS_CIPHER_MODE_CBC)
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cbc( NULL,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        sizeof( buf ),
+                                                        buf, buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cbc( &ctx,
+                                                        42,
+                                                        sizeof( buf ),
+                                                        buf, buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cbc( &ctx,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        sizeof( buf ),
+                                                        NULL, buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cbc( &ctx,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        sizeof( buf ),
+                                                        buf, NULL, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cbc( &ctx,
+                                                        MBEDTLS_CAMELLIA_ENCRYPT,
+                                                        sizeof( buf ),
+                                                        buf, buf, NULL ) );
+#endif /* MBEDTLS_CIPHER_MODE_CBC */
+
+#if defined(MBEDTLS_CIPHER_MODE_CFB)
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( NULL,
+                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           sizeof( buf ),
+                                                           &off, buf,
+                                                           buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( &ctx,
+                                                           42,
+                                                           sizeof( buf ),
+                                                           &off, buf,
+                                                           buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( &ctx,
+                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           sizeof( buf ),
+                                                           NULL, buf,
+                                                           buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( &ctx,
+                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           sizeof( buf ),
+                                                           &off, NULL,
+                                                           buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( &ctx,
+                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           sizeof( buf ),
+                                                           &off, buf,
+                                                           NULL, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_cfb128( &ctx,
+                                                           MBEDTLS_CAMELLIA_ENCRYPT,
+                                                           sizeof( buf ),
+                                                           &off, buf,
+                                                           buf, NULL ) );
+#endif /* MBEDTLS_CIPHER_MODE_CFB */
+
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( NULL,
+                                                        sizeof( buf ),
+                                                        &off,
+                                                        buf, buf,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( &ctx,
+                                                        sizeof( buf ),
+                                                        NULL,
+                                                        buf, buf,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( &ctx,
+                                                        sizeof( buf ),
+                                                        &off,
+                                                        NULL, buf,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( &ctx,
+                                                        sizeof( buf ),
+                                                        &off,
+                                                        buf, NULL,
+                                                        buf, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( &ctx,
+                                                        sizeof( buf ),
+                                                        &off,
+                                                        buf, buf,
+                                                        NULL, buf ) );
+    TEST_INVALID_PARAM_RET( MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA,
+                            mbedtls_camellia_crypt_ctr( &ctx,
+                                                        sizeof( buf ),
+                                                        &off,
+                                                        buf, buf,
+                                                        buf, NULL ) );
+#endif /* MBEDTLS_CIPHER_MODE_CTR */
+
+exit:
+    return;
+}
+/* END_CASE */
+
 /* BEGIN_CASE */
 void camellia_encrypt_ecb( data_t * key_str, data_t * src_str,
                            data_t * hex_dst_string, int setkey_result )


### PR DESCRIPTION
__Summary:__ Based on #1643, this PR adds parameter validation for the Camellia module.

__Work left:__ Allocate free error code for `MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA`. Slightly annoying because there are already two similar error codes `MBEDTLS_ERR_CAMELLIA_INVALID_KEY_LENGTH` and `MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH`, and we're running out of low level error codes.