### PR TITLE
Fix CMake build on Windows platform with MinGW toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,14 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
 # to the corresponding path in the source directory.
 function(link_to_source base_name)
     # Get OS dependent path to use in `execute_process`
-    file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${base_name}" link)
-    file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}" target)
+    # with respect to the CMake bug: https://gitlab.kitware.com/cmake/cmake/issues/5939
+    if(MINGW)
+        string(REPLACE "/" "\\" link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
+        string(REPLACE "/" "\\" target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
+    else()
+        file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${base_name}" link)
+        file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}" target)
+    endif()
 
     if (NOT EXISTS ${link})
         if (CMAKE_HOST_UNIX)


### PR DESCRIPTION
## Description

Add additional fix to the issue #1496 that fix CMake build on Windows platform with MinGW toolchain.

## Status

**READY**

## Requires Backporting

NO  

## Migrations

 NO

## Steps to test or reproduce
  - Windows 10, CMake 3.13, MinGW64-x86_64 - build success (without the fix it fails)
  - macOS 10.14, CMake 3.11, Apple Clang 10.0 - always succeeded
