### PR TITLE
bn_mul.h: Use optimized MULADDC code only on ARM >= 6

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -636,7 +636,8 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1) && \
+      __TARGET_ARCH_ARM >= 6
 
 #define MULADDC_INIT                            \
     asm(


### PR DESCRIPTION
The optimized code uses umaal which was only introduced with ARMv6 and
is not available on older versions.
This broke compilation with arm926ej-s CPU for me.

Fixes: 16b1bd89326 ("bn_mul.h: add ARM DSP optimized MULADDC code")
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>