### PR TITLE
Backport 2.7: ecdsa genkey return proper error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Bugfix
    * Add explicit integer to enumeration type casts to example program
      programs/pkey/gen_key which previously led to compilation failure
      on some toolchains. Reported by phoenixmcallister. Fixes #2170.
+   * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.
 
 = mbed TLS 2.7.8 branch released 2018-11-30
 

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -420,8 +420,13 @@ cleanup:
 int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
                   int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    return( mbedtls_ecp_group_load( &ctx->grp, gid ) ||
-            mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d, &ctx->Q, f_rng, p_rng ) );
+    int ret = 0;
+    ret = mbedtls_ecp_group_load( &ctx->grp, gid );
+    if( ret != 0 )
+        return( ret );
+
+   return( mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d,
+                                    &ctx->Q, f_rng, p_rng ) );
 }
 #endif /* MBEDTLS_ECDSA_GENKEY_ALT */
 


### PR DESCRIPTION
## Description
This is a backport of a bug fixed as part of #2124 
As described in https://github.com/ARMmbed/mbedtls/pull/2124#discussion_r `mbedtls_gen_key()` returned a boolean `1` in case there was an error in one of the called functions, which might result in failures for the calling functions, expecting negative error codes .


## Status
**READY**

