### PR TITLE
Backport2.7: Test AD too long only when CCM_ALT not defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Bugfix
    * Add explicit integer to enumeration type casts to example program
      programs/pkey/gen_key which previously led to compilation failure
      on some toolchains. Reported by phoenixmcallister. Fixes #2170.
+   * Run the AD too long test only if MBEDTLS_CCM_ALT is not defined.
+     Raised as a comment in #1996.
 
 = mbed TLS 2.7.8 branch released 2018-11-30
 

--- a/tests/suites/test_suite_ccm.data
+++ b/tests/suites/test_suite_ccm.data
@@ -36,6 +36,7 @@ CCM lengths #6 tag length not even
 ccm_lengths:5:10:5:7:MBEDTLS_ERR_CCM_BAD_INPUT
 
 CCM lenghts #7 AD too long (2^16 - 2^8 + 1)
+depends_on:!MBEDTLS_CCM_ALT
 ccm_lengths:5:10:65281:8:MBEDTLS_ERR_CCM_BAD_INPUT
 
 CCM lengths #8 msg too long for this IV length (2^16, q = 2)


### PR DESCRIPTION

## Description
Backport of #2228 to `mbedtls-2.7`


## Status
**READY**

