### PR TITLE
Add docker-based test scripts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -103,6 +103,9 @@ Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h
      suggests). #2671
    * Make `make clean` clean all programs always. Fixes #1862.
+   * Add a Dockerfile and helper scripts (all-in-docker.sh, basic-in-docker.sh,
+     docker-env.sh) to simplify running test suites on a Linux host. Contributed
+     by Peter Kolbus (Garmin).
 
 = mbed TLS 2.17.0 branch released 2019-03-19
 

--- a/tests/compat-in-docker.sh
+++ b/tests/compat-in-docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# compat-in-docker.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+# This runs compat.sh in a Docker container.
+#
+# Notes for users
+# ---------------
+# If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified the path must
+# correspond to an executable inside the Docker container. The special
+# values "next" (OpenSSL only) and "legacy" are also allowed as shorthand
+# for the installations inside the container.
+#
+# See also:
+# - scripts/docker_env.sh for general Docker prerequisites and other information.
+# - compat.sh for notes about invocation of that script.
+
+source tests/scripts/docker_env.sh
+
+case "${OPENSSL_CMD:-default}" in
+    "legacy")  export OPENSSL_CMD="/usr/local/openssl-1.0.1j/bin/openssl";;
+    "next")    export OPENSSL_CMD="/usr/local/openssl-1.1.1a/bin/openssl";;
+    *) ;;
+esac
+
+case "${GNUTLS_CLI:-default}" in
+    "legacy")  export GNUTLS_CLI="/usr/local/gnutls-3.3.8/bin/gnutls-cli";;
+    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.6.5/bin/gnutls-cli";;
+    *) ;;
+esac
+
+case "${GNUTLS_SERV:-default}" in
+    "legacy")  export GNUTLS_SERV="/usr/local/gnutls-3.3.8/bin/gnutls-serv";;
+    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.6.5/bin/gnutls-serv";;
+    *) ;;
+esac
+
+run_in_docker \
+    -e M_CLI \
+    -e M_SRV \
+    -e GNUTLS_CLI \
+    -e GNUTLS_SERV \
+    -e OPENSSL_CMD \
+    -e OSSL_NO_DTLS \
+    tests/compat.sh \
+    $@

--- a/tests/compat-in-docker.sh
+++ b/tests/compat-in-docker.sh
@@ -2,10 +2,6 @@
 
 # compat-in-docker.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 # This runs compat.sh in a Docker container.
@@ -20,6 +16,23 @@
 # See also:
 # - scripts/docker_env.sh for general Docker prerequisites and other information.
 # - compat.sh for notes about invocation of that script.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 source tests/scripts/docker_env.sh
 

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -28,8 +28,8 @@ ARG MAKEFLAGS_PARALLEL=""
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update \
-    && apt -y install software-properties-common \
+RUN apt-get update \
+    && apt-get -y install software-properties-common \
     && rm -rf /var/lib/apt/lists
 
 RUN add-apt-repository -y ppa:team-gcc-arm-embedded/ppa

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -22,7 +22,7 @@
 #
 # This file is part of Mbed TLS (https://tls.mbed.org)
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 ARG MAKEFLAGS_PARALLEL=""
 

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -21,10 +21,11 @@
 # limitations under the License.
 #
 # This file is part of Mbed TLS (https://tls.mbed.org)
-
-FROM ubuntu:bionic
-
 ARG MAKEFLAGS_PARALLEL=""
+ARG MY_REGISTRY=
+
+FROM ${MY_REGISTRY}ubuntu:bionic
+
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/tests/docker/xenial/Dockerfile
+++ b/tests/docker/xenial/Dockerfile
@@ -1,0 +1,153 @@
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# Defines a Docker container suitable to build and run all tests (all.sh),
+# except for those that use a proprietary toolchain.
+
+FROM ubuntu:xenial
+
+ARG MAKEFLAGS_PARALLEL=""
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update \
+    && apt -y install software-properties-common \
+    && rm -rf /var/lib/apt/lists
+
+RUN add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+
+RUN apt-get update \
+    && apt-get -y install \
+    # mbedtls build/test dependencies
+    build-essential \
+    clang \
+    cmake \
+    doxygen \
+    gcc-arm-none-eabi \
+    gcc-mingw-w64-i686 \
+    gcc-multilib \
+    g++-multilib \
+    gdb \
+    git \
+    graphviz \
+    lsof \
+    python \
+    python3-pip \
+    python3 \
+    pylint3 \
+    valgrind \
+    wget \
+    # libnettle build dependencies
+    libgmp-dev \
+    m4 \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build a static, legacy openssl from sources with sslv3 enabled
+# Based on https://gist.github.com/bmaupin/8caca3a1e8c3c5686141 (build-openssl.sh)
+# Note: openssl-1.0.2 and earlier has known build issues with parallel make.
+RUN cd /tmp \
+    && wget https://www.openssl.org/source/old/1.0.1/openssl-1.0.1j.tar.gz -qO- | tar xz \
+    && cd openssl-1.0.1j \
+    && ./config --openssldir=/usr/local/openssl-1.0.1j no-shared \
+    && (make ${MAKEFLAGS_PARALLEL} || make -j 1) \
+    && make install_sw \
+    && rm -rf /tmp/openssl*
+ENV OPENSSL_LEGACY=/usr/local/openssl-1.0.1j/bin/openssl
+
+# Build OPENSSL as 1.0.2g
+RUN cd /tmp \
+    && wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz -qO- | tar xz \
+    && cd openssl-1.0.2g \
+    && ./config --openssldir=/usr/local/openssl-1.0.2g no-shared \
+    && (make ${MAKEFLAGS_PARALLEL} || make -j 1) \
+    && make install_sw \
+    && rm -rf /tmp/openssl*
+ENV OPENSSL=/usr/local/openssl-1.0.2g/bin/openssl
+
+# Build a new openssl binary for ARIA/CHACHA20 support
+# Based on https://gist.github.com/bmaupin/8caca3a1e8c3c5686141 (build-openssl.sh)
+RUN cd /tmp \
+    && wget https://www.openssl.org/source/openssl-1.1.1a.tar.gz -qO- | tar xz \
+    && cd openssl-1.1.1a \
+    && ./config --prefix=/usr/local/openssl-1.1.1a -Wl,--enable-new-dtags,-rpath,'${LIBRPATH}' no-shared \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install_sw \
+    && rm -rf /tmp/openssl*
+ENV OPENSSL_NEXT=/usr/local/openssl-1.1.1a/bin/openssl
+
+# Build libnettle 2.7.1 (needed by legacy gnutls)
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz -qO- | tar xz \
+    && cd nettle-2.7.1 \
+    && ./configure --disable-documentation \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && /sbin/ldconfig \
+    && rm -rf /tmp/nettle*
+
+# Build legacy gnutls (3.3.8)
+RUN cd /tmp \
+    && wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.3/gnutls-3.3.8.tar.xz -qO- | tar xJ \
+    && cd gnutls-3.3.8 \
+    && ./configure --prefix=/usr/local/gnutls-3.3.8 --exec_prefix=/usr/local/gnutls-3.3.8 --disable-shared --disable-guile --disable-doc \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && rm -rf /tmp/gnutls*
+ENV GNUTLS_LEGACY_CLI=/usr/local/gnutls-3.3.8/bin/gnutls-cli
+ENV GNUTLS_LEGACY_SERV=/usr/local/gnutls-3.3.8/bin/gnutls-serv
+
+# Build libnettle 3.1 (needed by gnutls)
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/nettle/nettle-3.1.tar.gz -qO- | tar xz \
+    && cd nettle-3.1 \
+    && ./configure --disable-documentation \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && /sbin/ldconfig \
+    && rm -rf /tmp/nettle*
+
+# Build gnutls (3.4.10)
+RUN cd /tmp \
+    && wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.4/gnutls-3.4.10.tar.xz -qO- | tar xJ \
+    && cd gnutls-3.4.10 \
+    && ./configure --prefix=/usr/local/gnutls-3.4.10 --exec_prefix=/usr/local/gnutls-3.4.10 \
+        --with-included-libtasn1 --without-p11-kit \
+        --disable-shared --disable-guile --disable-doc \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && rm -rf /tmp/gnutls*
+ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
+ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
+
+# Build libnettle 3.4 (needed by gnutls next)
+RUN cd /tmp \
+    && wget https://ftp.gnu.org/gnu/nettle/nettle-3.4.1.tar.gz -qO- | tar xz \
+    && cd nettle-3.4.1 \
+    && ./configure --disable-documentation \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && /sbin/ldconfig \
+    && rm -rf /tmp/nettle*
+
+# Build gnutls next (3.6.5)
+RUN cd /tmp \
+    && wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.5.tar.xz -qO- | tar xJ \
+    && cd gnutls-3.6.5 \
+    && ./configure --prefix=/usr/local/gnutls-3.6.5 --exec_prefix=/usr/local/gnutls-3.6.5 \
+        --with-included-libtasn1 --with-included-unistring --without-p11-kit \
+        --disable-shared --disable-guile --disable-doc \
+    && make ${MAKEFLAGS_PARALLEL} \
+    && make install \
+    && rm -rf /tmp/gnutls*
+
+ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.6.5/bin/gnutls-cli
+ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.6.5/bin/gnutls-serv
+
+RUN pip3 install --no-cache-dir \
+    mbed-host-tests \
+    mock

--- a/tests/docker/xenial/Dockerfile
+++ b/tests/docker/xenial/Dockerfile
@@ -1,12 +1,26 @@
-#
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
+# Dockerfile
 #
 # Purpose
-#
+# -------
 # Defines a Docker container suitable to build and run all tests (all.sh),
 # except for those that use a proprietary toolchain.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 FROM ubuntu:xenial
 

--- a/tests/make-in-docker.sh
+++ b/tests/make-in-docker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+
+# make-in-docker.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+# This runs make in a Docker container.
+#
+# See also:
+# - scripts/docker_env.sh for general Docker prerequisites and other information.
+
+source tests/scripts/docker_env.sh
+
+run_in_docker make $@

--- a/tests/make-in-docker.sh
+++ b/tests/make-in-docker.sh
@@ -2,16 +2,29 @@
 
 # make-in-docker.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 # This runs make in a Docker container.
 #
 # See also:
 # - scripts/docker_env.sh for general Docker prerequisites and other information.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 source tests/scripts/docker_env.sh
 

--- a/tests/scripts/all-in-docker.sh
+++ b/tests/scripts/all-in-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+# all-in-docker.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+# This runs all.sh (except for armcc) in a Docker container.
+#
+# Notes for users
+# ---------------
+# See docker_env.sh for prerequisites and other information.
+#
+# See also all.sh for notes about invocation of that script.
+
+source tests/scripts/docker_env.sh
+
+# Run tests that are possible with openly available compilers
+run_in_docker tests/scripts/all.sh \
+    --no-armcc \
+    $@

--- a/tests/scripts/all-in-docker.sh
+++ b/tests/scripts/all-in-docker.sh
@@ -2,10 +2,6 @@
 
 # all-in-docker.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 # This runs all.sh (except for armcc) in a Docker container.
@@ -15,6 +11,23 @@
 # See docker_env.sh for prerequisites and other information.
 #
 # See also all.sh for notes about invocation of that script.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 source tests/scripts/docker_env.sh
 

--- a/tests/scripts/basic-in-docker.sh
+++ b/tests/scripts/basic-in-docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+# basic-in-docker.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+# This runs a rough equivalent of the travis.yml in a Docker container.
+# The tests are run for both clang and gcc.
+#
+# Notes for users
+# ---------------
+# See docker_env.sh for prerequisites and other information.
+
+source tests/scripts/docker_env.sh
+
+run_in_docker tests/scripts/recursion.pl library/*.c
+run_in_docker tests/scripts/check-generated-files.sh
+run_in_docker tests/scripts/check-doxy-blocks.pl
+run_in_docker tests/scripts/check-names.sh
+run_in_docker tests/scripts/check-files.py
+run_in_docker tests/scripts/doxygen.sh
+
+for compiler in clang gcc; do
+    run_in_docker -e CC=${compiler} cmake -D CMAKE_BUILD_TYPE:String="Check" .
+    run_in_docker -e CC=${compiler} make
+    run_in_docker -e CC=${compiler} make test
+    run_in_docker programs/test/selftest
+    run_in_docker -e OSSL_NO_DTLS=1 tests/compat.sh
+    run_in_docker tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
+    run_in_docker tests/scripts/test-ref-configs.pl
+    run_in_docker tests/scripts/curves.pl
+    run_in_docker tests/scripts/key-exchanges.pl
+done

--- a/tests/scripts/basic-in-docker.sh
+++ b/tests/scripts/basic-in-docker.sh
@@ -2,10 +2,6 @@
 
 # basic-in-docker.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 # This runs a rough equivalent of the travis.yml in a Docker container.
@@ -14,6 +10,23 @@
 # Notes for users
 # ---------------
 # See docker_env.sh for prerequisites and other information.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 source tests/scripts/docker_env.sh
 

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -14,7 +14,10 @@
 # This script expects a Linux x86_64 system with a recent version of Docker
 # installed and available for use, as well as http/https access. If a proxy
 # server must be used, invoke this script with the usual environment variables
-# (http_proxy and https_proxy) set appropriately.
+# (http_proxy and https_proxy) set appropriately. If an alternate Docker
+# registry is needed, specify MBEDTLS_DOCKER_REGISTRY to point at the
+# host name.
+#
 #
 # Running this script directly will check for Docker availability and set up
 # the Docker image.
@@ -63,8 +66,10 @@ ${DOCKER} image build \
     -t ${DOCKER_IMAGE_TAG} \
     --cache-from=${DOCKER_IMAGE_TAG} \
     --build-arg MAKEFLAGS_PARALLEL="-j $(nproc)" \
+    --network host \
     ${http_proxy+--build-arg http_proxy=${http_proxy}} \
     ${https_proxy+--build-arg https_proxy=${https_proxy}} \
+    ${MBEDTLS_DOCKER_REGISTRY+--build-arg MY_REGISTRY="${MBEDTLS_DOCKER_REGISTRY}/"} \
     tests/docker/${MBEDTLS_DOCKER_GUEST}
 
 run_in_docker()

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -eu
+
+# docker_env.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+#
+# This is a helper script to enable running tests under a Docker container,
+# thus making it easier to get set up as well as isolating test dependencies
+# (which include legacy/insecure configurations of openssl and gnutls).
+#
+# Notes for users
+# ---------------
+# This script expects a Linux x86_64 system with a recent version of Docker
+# installed and available for use, as well as http/https access. If a proxy
+# server must be used, invoke this script with the usual environment variables
+# (http_proxy and https_proxy) set appropriately.
+#
+# Running this script directly will check for Docker availability and set up
+# the Docker image.
+
+
+# default values, can be overridden by the environment
+: ${MBEDTLS_DOCKER_GUEST:=xenial}
+
+
+DOCKER_IMAGE_TAG="armmbed/mbedtls-test:${MBEDTLS_DOCKER_GUEST}"
+
+# Make sure docker is available
+if ! which docker > /dev/null; then
+    echo "Docker is required but doesn't seem to be installed. See https://www.docker.com/ to get started"
+    exit 1
+fi
+
+# Figure out if we need to 'sudo docker'
+if groups | grep docker > /dev/null; then
+    DOCKER="docker"
+else
+    echo "Using sudo to invoke docker since you're not a member of the docker group..."
+    DOCKER="sudo docker"
+fi
+
+# Build the Docker image
+echo "Getting docker image up to date (this may take a few minutes)..."
+${DOCKER} image build \
+    -t ${DOCKER_IMAGE_TAG} \
+    --cache-from=${DOCKER_IMAGE_TAG} \
+    --build-arg MAKEFLAGS_PARALLEL="-j $(nproc)" \
+    ${http_proxy+--build-arg http_proxy=${http_proxy}} \
+    ${https_proxy+--build-arg https_proxy=${https_proxy}} \
+    tests/docker/${MBEDTLS_DOCKER_GUEST}
+
+run_in_docker()
+{
+    ENV_ARGS=""
+    while [ "$1" == "-e" ]; do
+        ENV_ARGS="${ENV_ARGS} $1 $2"
+        shift 2
+    done
+
+    ${DOCKER} container run -it --rm \
+        --cap-add SYS_PTRACE \
+        --user "$(id -u):$(id -g)" \
+        --volume $PWD:$PWD \
+        --workdir $PWD \
+        -e MAKEFLAGS \
+        -e PYLINTHOME=/tmp/.pylintd \
+        ${ENV_ARGS} \
+        ${DOCKER_IMAGE_TAG} \
+        $@
+}

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -2,10 +2,6 @@
 
 # docker_env.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2018-2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 #
@@ -22,6 +18,23 @@
 #
 # Running this script directly will check for Docker availability and set up
 # the Docker image.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 
 # default values, can be overridden by the environment

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -38,7 +38,7 @@
 
 
 # default values, can be overridden by the environment
-: ${MBEDTLS_DOCKER_GUEST:=xenial}
+: ${MBEDTLS_DOCKER_GUEST:=bionic}
 
 
 DOCKER_IMAGE_TAG="armmbed/mbedtls-test:${MBEDTLS_DOCKER_GUEST}"

--- a/tests/ssl-opt-in-docker.sh
+++ b/tests/ssl-opt-in-docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# ssl-opt-in-docker.sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2019, ARM Limited, All Rights Reserved
+#
+# Purpose
+# -------
+# This runs ssl-opt.sh in a Docker container.
+#
+# Notes for users
+# ---------------
+# If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified the path must
+# correspond to an executable inside the Docker container. The special
+# values "next" and "legacy" are also allowed as shorthand for the
+# installations inside the container.
+#
+# See also:
+# - scripts/docker_env.sh for general Docker prerequisites and other information.
+# - ssl-opt.sh for notes about invocation of that script.
+
+source tests/scripts/docker_env.sh
+
+case "${OPENSSL_CMD:-default}" in
+    "legacy")  export OPENSSL_CMD="/usr/local/openssl-1.0.1j/bin/openssl";;
+    "next")    export OPENSSL_CMD="/usr/local/openssl-1.1.1a/bin/openssl";;
+    *) ;;
+esac
+
+case "${GNUTLS_CLI:-default}" in
+    "legacy")  export GNUTLS_CLI="/usr/local/gnutls-3.3.8/bin/gnutls-cli";;
+    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.6.5/bin/gnutls-cli";;
+    *) ;;
+esac
+
+case "${GNUTLS_SERV:-default}" in
+    "legacy")  export GNUTLS_SERV="/usr/local/gnutls-3.3.8/bin/gnutls-serv";;
+    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.6.5/bin/gnutls-serv";;
+    *) ;;
+esac
+
+run_in_docker \
+    -e P_SRV \
+    -e P_CLI \
+    -e P_PXY \
+    -e GNUTLS_CLI \
+    -e GNUTLS_SERV \
+    -e OPENSSL_CMD \
+    tests/ssl-opt.sh \
+    $@

--- a/tests/ssl-opt-in-docker.sh
+++ b/tests/ssl-opt-in-docker.sh
@@ -2,17 +2,13 @@
 
 # ssl-opt-in-docker.sh
 #
-# This file is part of mbed TLS (https://tls.mbed.org)
-#
-# Copyright (c) 2019, ARM Limited, All Rights Reserved
-#
 # Purpose
 # -------
 # This runs ssl-opt.sh in a Docker container.
 #
 # Notes for users
 # ---------------
-# If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified the path must
+# If OPENSSL_CMD, GNUTLS_CLI, or GNUTLS_SERV are specified, the path must
 # correspond to an executable inside the Docker container. The special
 # values "next" and "legacy" are also allowed as shorthand for the
 # installations inside the container.
@@ -20,6 +16,23 @@
 # See also:
 # - scripts/docker_env.sh for general Docker prerequisites and other information.
 # - ssl-opt.sh for notes about invocation of that script.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 source tests/scripts/docker_env.sh
 


### PR DESCRIPTION
## Description
Adds a Dockerfile and some test scripts per #2313 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
I picked Ubuntu 16.04 LTS since it's an older release that I'm familiar with, and one with some support left in it. If you'd be happier with a different base distribution let me know. I'm also not sure if there would be more preferred versions of openssl and gnutls.

This is my first PR, so there's probably something else I'm missing about the contribution process or patch too. Happy to take care of anything you flag in review.

Backporting to 2.16 may be useful but not required.

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
On a Linux x86_64 box with a recent Docker properly installed, run tests/scripts/all-in-docker.sh or tests/scripts/basic-in-docker.sh.
