### PR TITLE
Backport 2.7: Add depends-ciphers.pl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ script:
 - tests/scripts/test-ref-configs.pl
 - tests/scripts/curves.pl
 - tests/scripts/key-exchanges.pl
+- tests/scripts/depends-pkalgs.pl
+- tests/scripts/depends-hashes.pl
+- tests/scripts/depends-ciphers.pl
 after_failure:
 - tests/scripts/travis-log-failure.sh
 env:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix some test cases which would not compile or run correctly when some
+     ciphers were not enabled, and add tests/scripts/depends-ciphers.pl in
+     order to prevent similar issues in the future.
+
 = mbed TLS 2.7.9 branch released 2018-12-21
 
 Bugfix

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -39,13 +39,14 @@
     !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) || \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C) || \
     !defined(MBEDTLS_ERROR_C) || !defined(MBEDTLS_SHA256_C) || \
-    !defined(MBEDTLS_PEM_WRITE_C)
+    !defined(MBEDTLS_PEM_WRITE_C) || !defined(MBEDTLS_RSA_C)
 int main( void )
 {
     mbedtls_printf( "MBEDTLS_X509_CRT_WRITE_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "
             "MBEDTLS_FS_IO and/or MBEDTLS_SHA256_C and/or "
             "MBEDTLS_ENTROPY_C and/or MBEDTLS_CTR_DRBG_C and/or "
-            "MBEDTLS_ERROR_C not defined.\n");
+            "MBEDTLS_ERROR_C and/or MBEDTLS_SHA256_C and/or "
+            "MBEDTLS_PEM_WRITE_C and/or MBEDTLS_RSA_C not defined.\n");
     return( 0 );
 }
 #else

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -559,6 +559,10 @@ msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
 cleanup
 record_status tests/scripts/depends-hashes.pl
 
+msg "test/build: depends-ciphers.pl (gcc)" # ~ 3 min
+cleanup
+record_status tests/scripts/depends-ciphers.pl
+
 msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
 cleanup
 record_status tests/scripts/depends-pkalgs.pl

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -68,8 +68,8 @@ for my $cipher (@ciphers) {
         }
     }
 
-    #system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
-    #    and abort "Failed to build lib: $cipher\n";
+    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
+        and abort "Failed to build lib: $cipher\n";
     #system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
     #system( "make test" ) and abort "Failed test suite: $cipher\n";
 }

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -71,7 +71,7 @@ for my $cipher (@ciphers) {
     system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
         and abort "Failed to build lib: $cipher\n";
     system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
-    #system( "make test" ) and abort "Failed test suite: $cipher\n";
+    system( "make test" ) and abort "Failed test suite: $cipher\n";
 }
 
 system( "mv $config_h.bak $config_h" ) and die "$config_h not restored\n";

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+
+# depends-ciphers.pl
+#
+# Copyright (c) 2018, ARM Limited, All Rights Reserved
+#
+# Purpose
+#
+# To test the code dependencies on individual ciphers in each test suite. This
+# is a verification step to ensure we don't ship test suites that do not work
+# for some build options.
+#
+# The process is:
+#       for each possible cipher
+#           build the library and test suites with the hash disabled
+#           execute the test suites
+#
+# And any test suite with the wrong dependencies will fail.
+#
+# Usage: tests/scripts/depends-ciphers.pl
+#
+# This script should be executed from the root of the project directory.
+#
+# For best effect, run either with cmake disabled, or cmake enabled in a mode
+# that includes -Werror.
+
+use warnings;
+use strict;
+
+-d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
+
+my $config_h = 'include/mbedtls/config.h';
+
+# get a list of ciphers from the cipher module
+my $cipher_h = 'include/mbedtls/cipher.h';
+my $sed_cmd = 's/^    MBEDTLS_CIPHER_ID_\([A-Z0-9_]*\),.*/\1/p';
+my @ciphers = split( /\s+/, `sed -n -e '$sed_cmd' $cipher_h` );
+@ciphers = map { "MBEDTLS_${_}_C" } grep { ! m/NULL|3DES/ } @ciphers;
+
+# Some algorithms can't be disabled on their own as others depend on them, so
+# we list those reverse-dependencies here to keep check_config.h happy.
+my %revdeps = (
+    'MBEDTLS_AES_C'         => ['MBEDTLS_CTR_DRBG_C'],
+);
+
+system( "cp $config_h $config_h.bak" ) and die;
+sub abort {
+    system( "mv $config_h.bak $config_h" ) and warn "$config_h not restored\n";
+    # use an exit code between 1 and 124 for git bisect (die returns 255)
+    warn $_[0];
+    exit 1;
+}
+
+for my $cipher (@ciphers) {
+    system( "cp $config_h.bak $config_h" ) and die "$config_h not restored\n";
+    system( "make clean" ) and die;
+
+    print "\n******************************************\n";
+    print "* Testing without cipher: $cipher\n";
+    print "******************************************\n";
+
+    system( "scripts/config.pl unset $cipher" )
+        and abort "Failed to disable $cipher\n";
+    if( exists $revdeps{$cipher} ) {
+        for my $opt (@{ $revdeps{$cipher} }) {
+            system( "scripts/config.pl unset $opt" )
+                and abort "Failed to disable $opt\n";
+        }
+    }
+
+    #system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
+    #    and abort "Failed to build lib: $cipher\n";
+    #system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
+    #system( "make test" ) and abort "Failed test suite: $cipher\n";
+}
+
+system( "mv $config_h.bak $config_h" ) and die "$config_h not restored\n";
+system( "make clean" ) and die;
+exit 0;

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -68,10 +68,8 @@ for my $cipher (@ciphers) {
         }
     }
 
-    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
-        and abort "Failed to build lib: $cipher\n";
-    system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
-    system( "make test" ) and abort "Failed test suite: $cipher\n";
+    system( "CFLAGS='-Werror -O1' make" ) and abort "Failed to build: $cipher\n";
+    system( "make test" ) and abort "Failed to run tests: $cipher\n";
 }
 
 system( "mv $config_h.bak $config_h" ) and die "$config_h not restored\n";

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -70,7 +70,7 @@ for my $cipher (@ciphers) {
 
     system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
         and abort "Failed to build lib: $cipher\n";
-    #system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
+    system( "cd tests && make" ) and abort "Failed to build tests: $cipher\n";
     #system( "make test" ) and abort "Failed test suite: $cipher\n";
 }
 

--- a/tests/scripts/depends-ciphers.pl
+++ b/tests/scripts/depends-ciphers.pl
@@ -40,7 +40,7 @@ my @ciphers = split( /\s+/, `sed -n -e '$sed_cmd' $cipher_h` );
 # Some algorithms can't be disabled on their own as others depend on them, so
 # we list those reverse-dependencies here to keep check_config.h happy.
 my %revdeps = (
-    'MBEDTLS_AES_C'         => ['MBEDTLS_CTR_DRBG_C'],
+    'MBEDTLS_AES_C'         => ['MBEDTLS_CTR_DRBG_C', 'MBEDTLS_NIST_KW_C'],
 );
 
 system( "cp $config_h $config_h.bak" ) and die;
@@ -58,6 +58,12 @@ for my $cipher (@ciphers) {
     print "\n******************************************\n";
     print "* Testing without cipher: $cipher\n";
     print "******************************************\n";
+
+    system( "scripts/config.pl full" )
+        and abort "Failed to enable full config\n";
+    # memory backtrace slows down tests too much
+    system( "scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE" )
+        and abort "Failed to disable MBEDTLS_MEMORY_BACKTRACE\n";
 
     system( "scripts/config.pl unset $cipher" )
         and abort "Failed to disable $cipher\n";

--- a/tests/scripts/depends-hashes.pl
+++ b/tests/scripts/depends-hashes.pl
@@ -66,10 +66,8 @@ for my $hash (@hashes) {
             and abort "Failed to disable $opt\n";
     }
 
-    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
-        and abort "Failed to build lib: $hash\n";
-    system( "cd tests && make" ) and abort "Failed to build tests: $hash\n";
-    system( "make test" ) and abort "Failed test suite: $hash\n";
+    system( "CFLAGS='-Werror -O1' make" ) and abort "Failed to build: $hash\n";
+    system( "make test" ) and abort "Failed to run tests: $hash\n";
 }
 
 system( "mv $config_h.bak $config_h" ) and die "$config_h not restored\n";

--- a/tests/scripts/depends-pkalgs.pl
+++ b/tests/scripts/depends-pkalgs.pl
@@ -80,10 +80,8 @@ while( my ($alg, $extras) = each %algs ) {
             and abort "Failed to disable $opt\n";
     }
 
-    system( "CFLAGS='-Werror -Wall -Wextra' make lib" )
-        and abort "Failed to build lib: $alg\n";
-    system( "cd tests && make" ) and abort "Failed to build tests: $alg\n";
-    system( "make test" ) and abort "Failed test suite: $alg\n";
+    system( "CFLAGS='-Werror -O1' make" ) and abort "Failed to build: $alg\n";
+    system( "make test" ) and abort "Failed to run tests: $alg\n";
 }
 
 system( "mv $config_h.bak $config_h" ) and die "$config_h not restored\n";

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -317,8 +317,8 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
-void dec_empty_buf()
+/* BEGIN_CASE depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC */
+void dec_empty_buf(  )
 {
     unsigned char key[32];
     unsigned char iv[16];

--- a/tests/suites/test_suite_cmac.data
+++ b/tests/suites/test_suite_cmac.data
@@ -22,15 +22,15 @@ mbedtls_cmac_setkey:MBEDTLS_CIPHER_DES_EDE3_ECB:192:0
 
 CMAC init #5 AES-224: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:224:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #6 AES-0: bad key size
 depends_on:MBEDTLS_AES_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_AES:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_AES_128_ECB:0:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC init #7 Camellia: wrong cipher
 depends_on:MBEDTLS_CAMELLIA_C
-mbedtls_cmac_setkey:MBEDTLS_CIPHER_ID_CAMELLIA:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
+mbedtls_cmac_setkey:MBEDTLS_CIPHER_CAMELLIA_128_ECB:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC Single Blocks #1 - Empty block, no updates
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":-1:"":-1:"":-1:"":-1:"bb1d6929e95937287fa37d129b756746"

--- a/tests/suites/test_suite_cmac.data
+++ b/tests/suites/test_suite_cmac.data
@@ -2,6 +2,7 @@ CMAC self test
 mbedtls_cmac_self_test:
 
 CMAC null arguments
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_null_args:
 
 CMAC init #1 AES-128: OK
@@ -33,32 +34,42 @@ depends_on:MBEDTLS_CAMELLIA_C
 mbedtls_cmac_setkey:MBEDTLS_CIPHER_CAMELLIA_128_ECB:128:MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA
 
 CMAC Single Blocks #1 - Empty block, no updates
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":-1:"":-1:"":-1:"":-1:"bb1d6929e95937287fa37d129b756746"
 
 CMAC Single Blocks #2 - Single 16 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172a":16:"":-1:"":-1:"":-1:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Single Blocks #3 - Single 64 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":64:"":-1:"":-1:"":-1:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #1 - Multiple 8 byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96":8:"e93d7e117393172a":8:"":-1:"":-1:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Multiple Blocks #2 - Multiple 16 byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96e93d7e117393172a":16:"ae2d8a571e03ac9c9eb76fac45af8e51":16:"30c81c46a35ce411e5fbc1191a0a52ef":16:"f69f2445df4f9b17ad2b417be66c3710":16:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #3 - Multiple variable sized blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"6bc1bee22e409f96":8:"e93d7e117393172aae2d8a571e03ac9c":16:"9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52ef":24:"f69f2445df4f9b17ad2b417be66c3710":16:"51f0bebf7e3b9d92fc49741779363cfe"
 
 CMAC Multiple Blocks #4 - Multiple 8 byte blocks with gaps
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_blocks:MBEDTLS_CIPHER_AES_128_ECB:"2b7e151628aed2a6abf7158809cf4f3c":128:16:"":0:"6bc1bee22e409f96":8:"":0:"e93d7e117393172a":8:"070a16b46b4d4144f79bdd9dd04a287c"
 
 CMAC Multiple Operations, same key #1 - Empty, empty
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367":"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367"
 
 CMAC Multiple Operations, same key #2 - Empty, 64 byte block
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"":-1:"":-1:"":-1:"d17ddf46adaacde531cac483de7a9367":"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":64:"":-1:"":-1:"a1d5df0eed790f794d77589659f39a11"
 
 CMAC Multiple Operations, same key #3 - variable byte blocks
+depends_on:MBEDTLS_AES_C
 mbedtls_cmac_multiple_operations_same_key:MBEDTLS_CIPHER_AES_192_ECB:"8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b":192:16:"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51":32:"30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":32:"":-1:"a1d5df0eed790f794d77589659f39a11":"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51":32:"30c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710":32:"":-1:"a1d5df0eed790f794d77589659f39a11"
 

--- a/tests/suites/test_suite_cmac.function
+++ b/tests/suites/test_suite_cmac.function
@@ -78,6 +78,7 @@ void mbedtls_cmac_null_args( )
                                       NULL ) ==
                                             MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
+#if defined(MBEDTLS_AES_C)
     TEST_ASSERT( mbedtls_aes_cmac_prf_128( NULL, 16,
                                            test_data, 16,
                                            test_output ) ==
@@ -92,6 +93,7 @@ void mbedtls_cmac_null_args( )
                                            test_data, 16,
                                            NULL ) ==
                                               MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+#endif
 
 exit:
     mbedtls_cipher_free( &ctx );

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -159,7 +159,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST */
+/* BEGIN_CASE depends_on:MBEDTLS_SELF_TEST:MBEDTLS_AES_C */
 void gcm_selftest()
 {
     TEST_ASSERT( mbedtls_gcm_self_test( 1 ) == 0 );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -1126,7 +1126,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:MBEDTLS_CTR_DRBG_C:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
 void mbedtls_rsa_validate_params( int radix_N, char *input_N,
                                   int radix_P, char *input_P,
                                   int radix_Q, char *input_Q,


### PR DESCRIPTION
Backport of #1919 to mbedtls-2.7

Compared to the original, a new commit was added to this backport to fix an issue found by the enhancement of `depends-pk-algs.pl` in 2.7, that was not present in 2.16.