### PR TITLE
Fix dead code in mbedtls_mpi_exp_mod()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,10 @@ Changes
      produced by some optimizing compilers, showing up as failures in
      e.g. RSA or ECC signature operations. Reported in #1722, fix suggested
      by Aurelien Jarno and submitted by Jeffrey Martin.
+   * Remove dead code from bignum.c in the default configuration.
+     Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
+   * Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh.
+     Contributed by Peter Kolbus (Garmin).
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1869,8 +1869,10 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     wsize = ( i > 671 ) ? 6 : ( i > 239 ) ? 5 :
             ( i >  79 ) ? 4 : ( i >  23 ) ? 3 : 1;
 
+#if( MBEDTLS_MPI_WINDOW_SIZE < 6 )
     if( wsize > MBEDTLS_MPI_WINDOW_SIZE )
         wsize = MBEDTLS_MPI_WINDOW_SIZE;
+#endif
 
     j = N->n + 1;
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, j ) );

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -976,6 +976,16 @@ support_test_mx32 () {
     esac
 }
 
+component_test_min_mpi_window_size () {
+    msg "build: Default + MBEDTLS_MPI_WINDOW_SIZE=1 (ASan build)" # ~ 10s
+    scripts/config.pl set MBEDTLS_MPI_WINDOW_SIZE 1
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: MBEDTLS_MPI_WINDOW_SIZE=1 - main suites (inc. selftests) (ASan build)" # ~ 10s
+    make test
+}
+
 component_test_have_int32 () {
     msg "build: gcc, force 32-bit bignum limbs"
     scripts/config.pl unset MBEDTLS_HAVE_ASM


### PR DESCRIPTION
## Description
Address a finding from Coverity's DEADCODE checker in bignum.c when the default MBEDTLS_MPI_WINDOW_SIZE is used. This doesn't result in incorrect code, but depending on the compiler there may be a very tiny ROM and performance improvement. It also makes for one less finding that users of Coverity & mbed TLS need to look at.

Resolves #2309 

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
n/a

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Existing tests cover the default window size. Added test to all.sh for coverage in the case a different size is used.
