### PR TITLE
Remove "mbedtls/" prefix in include file path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,10 +3,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.xx.x branch released xxxx-xx-xx
 	
 Bugfix
-    * Fix for file not found, which was reporting in header files.
-      In header files at mbedlts/include folder, The include path has prefix 
-      "mbedtls/" may cause the header file not be found in the case of 
-      mbedtls as a dynamic/static library.
+   * Fix for file not found, which was reporting in header files.
+     In header files at mbedlts/include folder, The include path has prefix 
+     "mbedtls/" may cause the header file not be found in the case of 
+     mbedtls as a dynamic/static library.
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,11 +3,8 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.xx.x branch released xxxx-xx-xx
 
 Bugfix
-   * Fix for file not found, which was reporting in header files.
-     In header files at mbedlts/include folder, The include path has prefix
-     "mbedtls/" may cause the header file not be found in the case of
-      * Remove the mbedtls namespacing from the header file, to fix a "file not found"build error. Fixed by Haijun Gu 
-         #2319.
+   * Remove the mbedtls namespacing from the header file, to fix a "file not found"
+     build error. Fixed by Haijun Gu #2319.
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS x.xx.x branch released xxxx-xx-xx
-	
+
 Bugfix
    * Fix for file not found, which was reporting in header files.
-     In header files at mbedlts/include folder, The include path has prefix 
-     "mbedtls/" may cause the header file not be found in the case of 
+     In header files at mbedlts/include folder, The include path has prefix
+     "mbedtls/" may cause the header file not be found in the case of
      mbedtls as a dynamic/static library.
 
 = mbed TLS 2.16.0 branch released 2018-12-21

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+	
+Bugfix
+    * Fix for file not found, which was reporting in header files.
+      In header files at mbedlts/include folder, The include path has prefix 
+      "mbedtls/" may cause the header file not be found in the case of 
+      mbedtls as a dynamic/static library.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,8 @@ Bugfix
    * Fix for file not found, which was reporting in header files.
      In header files at mbedlts/include folder, The include path has prefix
      "mbedtls/" may cause the header file not be found in the case of
-     mbedtls as a dynamic/static library.
+      * Remove the mbedtls namespacing from the header file, to fix a "file not found"build error. Fixed by Haijun Gu 
+         #2319.
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -36,7 +36,7 @@
 #endif
 
 #include <stddef.h>
-#include "mbedtls/platform_util.h"
+#include "platform_util.h"
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
 #define MBEDTLS_CIPHER_MODE_AEAD

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -26,14 +26,14 @@
 #define MBEDTLS_PLATFORM_UTIL_H
 
 #if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
+#include "config.h"
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
 
 #include <stddef.h>
 #if defined(MBEDTLS_HAVE_TIME_DATE)
-#include "mbedtls/platform_time.h"
+#include "platform_time.h"
 #include <time.h>
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -34,7 +34,7 @@
 #define MBEDTLS_POLY1305_H
 
 #if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
+#include "config.h"
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif


### PR DESCRIPTION
## Status
**READY**

## Additional comments
Fix for file not found, which was reporting in header files. In header files at mbedlts/include folder, The include path has prefix  "mbedtls/" may cause the header file not be found in the case of  mbedtls as a dynamic/static library.

## Todos
- [X] Tests
- [ ] Documentation
- [X] Changelog updated
- [ ] Backported
