### PR TITLE
Update the LTS branch list in the contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,9 @@ It would be highly appreciated if contributions are backported to LTS branches i
 
 Currently maintained LTS branches are:
 
-1. [mbedtls-2.1](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.1)
+1. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
 
-2. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)
+1. [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
 
 
 Tests


### PR DESCRIPTION
1. Remove the reference to `mbedtls-2.1` since it's End Of Life.
2. Add reference to `mbedtls-2.16` since it's a new LTS branch.

