### PR TITLE
bn_mul.h: disable MULADDC code for cpu before armv6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Bugfix
      previously lead to a stack overflow on constrained targets.
    * Add `MBEDTLS_SELF_TEST` for the mbedtls_self_test functions
      in the header files, which missed the precompilation check. #971
+   * Fix compilation issue on ARM platform before armv6.
+     The `umaal` arm instruction is only available on ARM cpu with DSP starting
+     with armv6. Fixed by Vivien HENRIET (Overkiz). #2324
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -636,7 +636,7 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1) && (__ARM_ARCH >= 6)
 
 #define MULADDC_INIT                            \
     asm(


### PR DESCRIPTION
The umaal instruction is available for ARM cpu with DSP starting with armv6 thus it does not work on armv5e

## Requires Backporting
2.16.0
