### PR TITLE
Remove compiler warning if only MBEDTLS_PK_PARSE_C is defined

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1370,8 +1370,8 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
     }
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 
-    if( ( ret = pk_parse_key_pkcs8_unencrypted_der(
-                    pk, key, keylen, f_rng, p_rng ) ) == 0 )
+    ret = pk_parse_key_pkcs8_unencrypted_der( pk, key, keylen, f_rng, p_rng );
+    if( ret == 0 )
     {
         return( 0 );
     }


### PR DESCRIPTION
Warning reported with IAR compiler:
"mbedtls\library\pkparse.c",1167  Warning[Pe550]: variable "ret" was set but never used

Backports: https://github.com/ARMmbed/mbedtls/pull/4903, https://github.com/ARMmbed/mbedtls/pull/4904