### PR TITLE
[backport 2.7] all.sh: make it possible to run a subset of the components

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -91,6 +91,12 @@ if(CMAKE_COMPILER_IS_CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
 endif(CMAKE_COMPILER_IS_CLANG)
 
+if(UNSAFE_BUILD)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+    set(CMAKE_C_FLAGS_ASAN "${CMAKE_C_FLAGS_ASAN} -Wno-error")
+    set(CMAKE_C_FLAGS_ASANDBG "${CMAKE_C_FLAGS_ASANDBG} -Wno-error")
+endif(UNSAFE_BUILD)
+
 if(WIN32)
     set(libs ${libs} ws2_32)
 endif(WIN32)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -459,6 +459,13 @@ if_build_succeeded () {
     fi
 }
 
+# to be used instead of ! for commands run with
+# record_status or if_build_succeeded
+not() {
+    ! "$@"
+}
+
+
 pre_print_configuration () {
     msg "info: $0 configuration"
     echo "MEMORY: $MEMORY"
@@ -920,7 +927,7 @@ component_build_arm_none_eabi_gcc_no_udbl_division () {
     scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
     echo "Checking that software 64-bit division is not required"
-    ! grep __aeabi_uldiv library/*.o
+    if_build_succeeded not grep __aeabi_uldiv library/*.o
 }
 
 component_build_armcc () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -154,11 +154,9 @@ pre_initialize_variables () {
     done
 }
 
-# Test whether $1 is excluded via the command line.
-is_component_excluded()
+# Test whether the component $1 is included in the command line patterns.
+is_component_included()
 {
-    # Is $1 excluded via $COMPONENTS (a space-separated list of wildcard
-    # patterns)?
     set -f
     for pattern in $COMMAND_LINE_COMPONENTS; do
         set +f
@@ -174,6 +172,13 @@ usage()
 Usage: $0 [OPTION]... [COMPONENT]...
 Run mbedtls release validation tests.
 By default, run all tests. With one or more COMPONENT, run only those.
+COMPONENT can be the name of a component or a shell wildcard pattern.
+
+Examples:
+  $0 "check_*"
+    Run all sanity checks.
+  $0 --no-armcc --except test_memsan
+    Run everything except builds that require armcc and MemSan.
 
 Special options:
   -h|--help             Print this help and exit.
@@ -185,11 +190,8 @@ General options:
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
      --armcc            Run ARM Compiler builds (on by default).
-     --except           If some components are passed on the command line,
-                        run all the tests except for these components. In
-                        this mode, you can pass shell wildcard patterns as
-                        component names, e.g. "$0 --except 'test_*'" to
-                        exclude all components that run tests.
+     --except           Exclude the COMPONENTs listed on the command line,
+                        instead of running only those.
      --no-armcc         Skip ARM Compiler builds.
      --no-force         Refuse to overwrite modified files (default).
      --no-keep-going    Stop at the first error (default).
@@ -295,7 +297,7 @@ check_tools()
 
 pre_parse_command_line () {
     COMMAND_LINE_COMPONENTS=
-    all_except=
+    all_except=0
     no_armcc=
 
     while [ $# -gt 0 ]; do
@@ -336,29 +338,26 @@ pre_parse_command_line () {
         shift
     done
 
+    # With no list of components, run everything.
     if [ -z "$COMMAND_LINE_COMPONENTS" ]; then
         all_except=1
     fi
 
     # --no-armcc is a legacy option. The modern way is --except '*_armcc*'.
     # Ignore it if components are listed explicitly on the command line.
-    if [ -n "$no_armcc" ] && [ -n "$all_except" ]; then
+    if [ -n "$no_armcc" ] && [ $all_except -eq 1 ]; then
         COMMAND_LINE_COMPONENTS="$COMMAND_LINE_COMPONENTS *_armcc*"
         # --no-armcc also disables yotta.
         COMMAND_LINE_COMPONENTS="$COMMAND_LINE_COMPONENTS *_yotta*"
     fi
 
     # Build the list of components to run.
-    if [ -n "$all_except" ]; then
-        RUN_COMPONENTS=
-        for component in $SUPPORTED_COMPONENTS; do
-            if ! is_component_excluded "$component"; then
-                RUN_COMPONENTS="$RUN_COMPONENTS $component"
-            fi
-        done
-    else
-        RUN_COMPONENTS="$COMMAND_LINE_COMPONENTS"
-    fi
+    RUN_COMPONENTS=
+    for component in $SUPPORTED_COMPONENTS; do
+        if is_component_included "$component"; [ $? -eq $all_except ]; then
+            RUN_COMPONENTS="$RUN_COMPONENTS $component"
+        fi
+    done
 
     unset all_except
     unset no_armcc

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -539,7 +539,6 @@ component_test_ref_configs () {
 
 component_test_sslv3 () {
     msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -557,7 +556,6 @@ component_test_sslv3 () {
 
 component_test_no_renegotiation () {
     msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -571,7 +569,6 @@ component_test_no_renegotiation () {
 
 component_test_rsa_no_crt () {
     msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_RSA_NO_CRT
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -588,7 +585,6 @@ component_test_rsa_no_crt () {
 
 component_test_full_cmake_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
@@ -606,7 +602,6 @@ component_test_full_cmake_clang () {
 
 component_build_deprecated () {
     msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
     # Build with -O -Wextra to catch a maximum of issues.
@@ -653,7 +648,6 @@ component_test_no_platform () {
     # This should catch missing mbedtls_printf definitions, and by disabling file
     # IO, it should catch missing '#include <stdio.h>'
     msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_PLATFORM_C
     scripts/config.pl unset MBEDTLS_NET_C
@@ -675,7 +669,6 @@ component_test_no_platform () {
 component_build_no_std_function () {
     # catch compile bugs in _uninit functions
     msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
     scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
@@ -684,7 +677,6 @@ component_build_no_std_function () {
 
 component_build_no_ssl_srv () {
     msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_SRV_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
@@ -692,7 +684,6 @@ component_build_no_ssl_srv () {
 
 component_build_no_ssl_cli () {
     msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_SSL_CLI_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
@@ -702,7 +693,6 @@ component_build_no_sockets () {
     # Note, C99 compliance can also be tested with the sockets support disabled,
     # as that requires a POSIX platform (which isn't the same as C99).
     msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
     scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
@@ -711,7 +701,6 @@ component_build_no_sockets () {
 
 component_test_no_max_fragment_length () {
     msg "build: default config except MFL extension (ASan build)" # ~ 30s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
@@ -722,7 +711,6 @@ component_test_no_max_fragment_length () {
 
 component_test_null_entropy () {
     msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
     scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
     scripts/config.pl set MBEDTLS_ENTROPY_C
@@ -738,7 +726,6 @@ component_test_null_entropy () {
 
 component_test_platform_calloc_macro () {
     msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
     scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
     scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
@@ -761,7 +748,6 @@ component_test_m32_o0 () {
     if uname -a | grep -F x86_64 >/dev/null; then
         # Build once with -O0, to compile out the i386 specific inline assembly
         msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
-        cp "$CONFIG_H" "$CONFIG_BAK"
         scripts/config.pl full
         make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
 
@@ -774,7 +760,6 @@ component_test_m32_o1 () {
     if uname -a | grep -F x86_64 >/dev/null; then
         # Build again with -O1, to compile in the i386 specific inline assembly
         msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
-        cp "$CONFIG_H" "$CONFIG_BAK"
         scripts/config.pl full
         make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
 
@@ -786,7 +771,6 @@ component_test_m32_o1 () {
 component_test_mx32 () {
     if uname -a | grep -F x86_64 >/dev/null; then
         msg "build: 64-bit ILP32, make, gcc" # ~ 30s
-        cp "$CONFIG_H" "$CONFIG_BAK"
         scripts/config.pl full
         make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
 
@@ -797,7 +781,6 @@ component_test_mx32 () {
 
 component_test_have_int32 () {
     msg "build: gcc, force 32-bit bignum limbs"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
     scripts/config.pl unset MBEDTLS_PADLOCK_C
@@ -809,7 +792,6 @@ component_test_have_int32 () {
 
 component_test_have_int64 () {
     msg "build: gcc, force 64-bit bignum limbs"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl unset MBEDTLS_HAVE_ASM
     scripts/config.pl unset MBEDTLS_AESNI_C
     scripts/config.pl unset MBEDTLS_PADLOCK_C
@@ -821,7 +803,6 @@ component_test_have_int64 () {
 
 component_build_arm_none_eabi_gcc () {
     msg "build: arm-none-eabi-gcc, make" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -839,7 +820,6 @@ component_build_arm_none_eabi_gcc () {
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -860,7 +840,6 @@ component_build_arm_none_eabi_gcc_no_udbl_division () {
 
 component_build_armcc () {
     msg "build: ARM Compiler 5, make"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_NET_C
     scripts/config.pl unset MBEDTLS_TIMING_C
@@ -901,7 +880,6 @@ component_build_armcc () {
 
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
-    cp "$CONFIG_H" "$CONFIG_BAK"
     scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
     make CFLAGS='-Werror -Wall -Wextra'
     msg "test: allow SHA1 in certificates by default"
@@ -927,7 +905,6 @@ component_test_memsan () {
     # MemSan currently only available on Linux 64 bits
     if uname -a | grep 'Linux.*x86_64' >/dev/null; then
         msg "build: MSan (clang)" # ~ 1 min 20s
-        cp "$CONFIG_H" "$CONFIG_BAK"
         scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
         CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
         make
@@ -1021,6 +998,9 @@ post_report () {
 
 # Run one component and clean up afterwards.
 run_component () {
+    # Back up the configuration in case the component modifies it.
+    # The cleanup function will restore it.
+    cp -p "$CONFIG_H" "$CONFIG_BAK"
     current_component="$1"
     "$@"
     cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -366,8 +366,9 @@ pre_parse_command_line () {
 
 pre_check_git () {
     if [ $FORCE -eq 1 ]; then
+        rm -rf "$OUT_OF_SOURCE_DIR"
         if [ $YOTTA -eq 1 ]; then
-            rm -rf yotta/module "$OUT_OF_SOURCE_DIR"
+            rm -rf yotta/module
         fi
         git checkout-index -f -q $CONFIG_H
         cleanup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -482,14 +482,14 @@ component_test_default_cmake_gcc_asan () {
     msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
     if_build_succeeded tests/ssl-opt.sh
 
-    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-    record_status tests/scripts/test-ref-configs.pl
-
-    msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
-    make
-
     msg "test: compat.sh (ASan build)" # ~ 6 min
     if_build_succeeded tests/compat.sh
+}
+
+component_test_ref_configs () {
+    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    record_status tests/scripts/test-ref-configs.pl
 }
 
 component_test_sslv3 () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -223,12 +223,16 @@ trap 'fatal_signal TERM' TERM
 
 msg()
 {
+    if [ -n "${current_component:-}" ]; then
+        current_section="${current_component#component_}: $1"
+    else
+        current_section="$1"
+    fi
     echo ""
     echo "******************************************************************"
-    echo "* $1 "
+    echo "* $current_section "
     printf "* "; date
     echo "******************************************************************"
-    current_section=$1
 }
 
 armc6_build_test()
@@ -1017,6 +1021,7 @@ post_report () {
 
 # Run one component and clean up afterwards.
 run_component () {
+    current_component="$1"
     "$@"
     cleanup
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -94,7 +94,6 @@ pre_initialize_variables () {
     MEMORY=0
     FORCE=0
     KEEP_GOING=0
-    RUN_ARMCC=1
     YOTTA=1
 
     # Default commands, can be overriden by the environment
@@ -272,10 +271,11 @@ check_tools()
 pre_parse_command_line () {
     COMMAND_LINE_COMPONENTS=
     all_except=
+    no_armcc=
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --armcc) RUN_ARMCC=1;;
+            --armcc) no_armcc=;;
             --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
             --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
             --except) all_except=1;;
@@ -289,7 +289,7 @@ pre_parse_command_line () {
             --list-all-components) printf '%s\n' $ALL_COMPONENTS; exit;;
             --list-components) printf '%s\n' $SUPPORTED_COMPONENTS; exit;;
             --memory|-m) MEMORY=1;;
-            --no-armcc) RUN_ARMCC=0;;
+            --no-armcc) no_armcc=1;;
             --no-force) FORCE=0;;
             --no-keep-going) KEEP_GOING=0;;
             --no-memory) MEMORY=0;;
@@ -315,6 +315,14 @@ pre_parse_command_line () {
         all_except=1
     fi
 
+    # --no-armcc is a legacy option. The modern way is --except '*_armcc*'.
+    # Ignore it if components are listed explicitly on the command line.
+    if [ -n "$no_armcc" ] && [ -n "$all_except" ]; then
+        COMMAND_LINE_COMPONENTS="$COMMAND_LINE_COMPONENTS *_armcc*"
+        # --no-armcc also disables yotta.
+        COMMAND_LINE_COMPONENTS="$COMMAND_LINE_COMPONENTS *_yotta*"
+    fi
+
     # Build the list of components to run.
     if [ -n "$all_except" ]; then
         RUN_COMPONENTS=
@@ -328,6 +336,7 @@ pre_parse_command_line () {
     fi
 
     unset all_except
+    unset no_armcc
 }
 
 pre_check_git () {
@@ -460,15 +469,22 @@ pre_check_tools () {
     check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
                 "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
                 "arm-none-eabi-gcc" "i686-w64-mingw32-gcc"
-    if [ $RUN_ARMCC -ne 0 ]; then
-        check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
-    fi
+    case $RUN_COMPONENTS in
+        *_armcc*|*_yotta*)
+            check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR";;
+    esac
 
     msg "info: output_env.sh"
-    OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
-           GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
-           GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
-           ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
+    set env
+    set "$@" OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY"
+    set "$@" GNUTLS_CLI="$GNUTLS_CLI" GNUTLS_SERV="$GNUTLS_SERV"
+    set "$@" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV"
+    case $RUN_COMPONENTS in
+        *_armcc*|*_yotta*)
+            set "$@" ARMC5_CC="$ARMC5_CC" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;
+        *) set "$@" RUN_ARMCC=0;;
+    esac
+    "$@" scripts/output_env.sh
 }
 
 
@@ -524,12 +540,13 @@ component_check_doxygen_warnings () {
 ################################################################
 
 component_build_yotta () {
-    if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
-        # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
-        # path, and uses whatever version of armcc it finds there.
-        msg "build: create and build yotta module" # ~ 30s
-        record_status tests/scripts/yotta-build.sh
-    fi
+    # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
+    # path, and uses whatever version of armcc it finds there.
+    msg "build: create and build yotta module" # ~ 30s
+    record_status tests/scripts/yotta-build.sh
+}
+support_build_yotta () {
+    [ $YOTTA -ne 0 ]
 }
 
 component_test_default_cmake_gcc_asan () {
@@ -879,25 +896,23 @@ component_build_armcc () {
     scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
     scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
 
-    if [ $RUN_ARMCC -ne 0 ]; then
-        make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
-        make clean
+    make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+    make clean
 
-        # ARM Compiler 6 - Target ARMv7-A
-        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
+    # ARM Compiler 6 - Target ARMv7-A
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
 
-        # ARM Compiler 6 - Target ARMv7-M
-        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
+    # ARM Compiler 6 - Target ARMv7-M
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
 
-        # ARM Compiler 6 - Target ARMv8-A - AArch32
-        armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
+    # ARM Compiler 6 - Target ARMv8-A - AArch32
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
 
-        # ARM Compiler 6 - Target ARMv8-M
-        armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
+    # ARM Compiler 6 - Target ARMv8-M
+    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
 
-        # ARM Compiler 6 - Target ARMv8-A - AArch64
-        armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
-    fi
+    # ARM Compiler 6 - Target ARMv8-A - AArch64
+    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
 }
 
 component_test_allow_sha1 () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1010,7 +1010,7 @@ component_test_memsan () {
     fi
 }
 
-component_test_memcheck () {
+component_test_valgrind () {
     msg "build: Release (clang)"
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
     make

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -94,6 +94,7 @@ pre_initialize_variables () {
     CONFIG_H='include/mbedtls/config.h'
     CONFIG_BAK="$CONFIG_H.bak"
 
+    COMPONENTS=
     MEMORY=0
     FORCE=0
     KEEP_GOING=0
@@ -126,8 +127,12 @@ pre_initialize_variables () {
 usage()
 {
     cat <<EOF
-Usage: $0 [OPTION]...
-  -h|--help             Print this help.
+Usage: $0 [OPTION]... [COMPONENT]...
+Run mbedtls release validation tests.
+By default, run all tests. With one or more COMPONENT, run only those.
+
+Special options:
+  -h|--help             Print this help and exit.
 
 General options:
   -f|--force            Force the tests to overwrite any modified files.
@@ -259,14 +264,20 @@ pre_parse_command_line () {
             --release-test|-r) SEED=1;;
             --seed|-s) shift; SEED="$1";;
             --yotta) YOTTA=1;;
-            *)
+            -*)
                 echo >&2 "Unknown option: $1"
                 echo >&2 "Run $0 --help for usage."
                 exit 120
                 ;;
+            *)
+                COMPONENTS="$COMPONENTS $1";;
         esac
         shift
     done
+
+    if [ -z "$COMPONENTS" ]; then
+        COMPONENTS="$ALL_COMPONENTS"
+    fi
 }
 
 pre_check_git () {
@@ -999,7 +1010,7 @@ pre_check_tools
 cleanup
 
 # Run all the test components.
-for component in $ALL_COMPONENTS; do
+for component in $COMPONENTS; do
     run_component "component_$component"
 done
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -864,17 +864,6 @@ component_test_allow_sha1 () {
     if_build_succeeded tests/ssl-opt.sh -f SHA-1
 }
 
-component_test_rsa_no_crt_again () {
-    msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl set MBEDTLS_RSA_NO_CRT
-    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-    make
-
-    msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
-    make test
-}
-
 component_build_mingw () {
     msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -387,7 +387,7 @@ pre_check_git () {
             exit 1
         fi
 
-        if ! git diff-files --quiet include/mbedtls/config.h; then
+        if ! git diff --quiet include/mbedtls/config.h; then
             err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
             echo "You can either delete or preserve your work, or force the test by rerunning the"
             echo "script as: $0 --force"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -450,35 +450,55 @@ pre_print_configuration () {
 
 # Make sure the tools we need are available.
 pre_check_tools () {
-    ARMC5_CC="$ARMC5_BIN_DIR/armcc"
-    ARMC5_AR="$ARMC5_BIN_DIR/armar"
-    ARMC6_CC="$ARMC6_BIN_DIR/armclang"
-    ARMC6_AR="$ARMC6_BIN_DIR/armar"
+    # Build the list of variables to pass to output_env.sh.
+    set env
 
-    # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
-    # we just export the variables they require
-    export OPENSSL_CMD="$OPENSSL"
-    export GNUTLS_CLI="$GNUTLS_CLI"
-    export GNUTLS_SERV="$GNUTLS_SERV"
+    case " $RUN_COMPONENTS " in
+        # Require OpenSSL and GnuTLS if running any tests (as opposed to
+        # only doing builds). Not all tests run OpenSSL and GnuTLS, but this
+        # is a good enough approximation in practice.
+        *" test_"*)
+            # To avoid setting OpenSSL and GnuTLS for each call to compat.sh
+            # and ssl-opt.sh, we just export the variables they require.
+            export OPENSSL_CMD="$OPENSSL"
+            export GNUTLS_CLI="$GNUTLS_CLI"
+            export GNUTLS_SERV="$GNUTLS_SERV"
+            # Avoid passing --seed flag in every call to ssl-opt.sh
+            if [ -n "${SEED-}" ]; then
+                export SEED
+            fi
+            set "$@" OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY"
+            set "$@" GNUTLS_CLI="$GNUTLS_CLI" GNUTLS_SERV="$GNUTLS_SERV"
+            set "$@" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI"
+            set "$@" GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV"
+            check_tools "$OPENSSL" "$OPENSSL_LEGACY" \
+                        "$GNUTLS_CLI" "$GNUTLS_SERV" \
+                        "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV"
+            ;;
+    esac
 
-    # Avoid passing --seed flag in every call to ssl-opt.sh
-    if [ -n "${SEED-}" ]; then
-        export SEED
-    fi
+    case " $RUN_COMPONENTS " in
+        *_doxygen[_\ ]*) check_tools "doxygen" "dot";;
+    esac
 
-    check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
-                "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-                "arm-none-eabi-gcc" "i686-w64-mingw32-gcc"
-    case $RUN_COMPONENTS in
+    case " $RUN_COMPONENTS " in
+        *_arm_none_eabi_gcc[_\ ]*) check_tools "arm-none-eabi-gcc";;
+    esac
+
+    case " $RUN_COMPONENTS " in
+        *_mingw[_\ ]*) check_tools "i686-w64-mingw32-gcc";;
+    esac
+
+    case " $RUN_COMPONENTS " in
         *_armcc*|*_yotta*)
+            ARMC5_CC="$ARMC5_BIN_DIR/armcc"
+            ARMC5_AR="$ARMC5_BIN_DIR/armar"
+            ARMC6_CC="$ARMC6_BIN_DIR/armclang"
+            ARMC6_AR="$ARMC6_BIN_DIR/armar"
             check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR";;
     esac
 
     msg "info: output_env.sh"
-    set env
-    set "$@" OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY"
-    set "$@" GNUTLS_CLI="$GNUTLS_CLI" GNUTLS_SERV="$GNUTLS_SERV"
-    set "$@" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV"
     case $RUN_COMPONENTS in
         *_armcc*|*_yotta*)
             set "$@" ARMC5_CC="$ARMC5_CC" ARMC6_CC="$ARMC6_CC" RUN_ARMCC=1;;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -110,7 +110,7 @@ pre_initialize_variables () {
     : ${ARMC6_BIN_DIR:=/usr/bin}
 
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
-    if [ -n "${MAKEFLAGS+set}" ]; then
+    if [ -z "${MAKEFLAGS+set}" ]; then
         export MAKEFLAGS="-j"
     fi
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -717,7 +717,7 @@ component_test_null_entropy () {
     scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
     scripts/config.pl unset MBEDTLS_ENTROPY_HARDWARE_ALT
     scripts/config.pl unset MBEDTLS_HAVEGE_C
-    CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan -D UNSAFE_BUILD=ON .
     make
 
     msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -153,6 +153,8 @@ By default, run all tests. With one or more COMPONENT, run only those.
 
 Special options:
   -h|--help             Print this help and exit.
+  --list-all-components List all available test components and exit.
+  --list-components     List components supported on this platform and exit.
 
 General options:
   -f|--force            Force the tests to overwrite any modified files.
@@ -284,6 +286,8 @@ pre_parse_command_line () {
             --gnutls-serv) shift; GNUTLS_SERV="$1";;
             --help|-h) usage; exit;;
             --keep-going|-k) KEEP_GOING=1;;
+            --list-all-components) printf '%s\n' $ALL_COMPONENTS; exit;;
+            --list-components) printf '%s\n' $SUPPORTED_COMPONENTS; exit;;
             --memory|-m) MEMORY=1;;
             --no-armcc) RUN_ARMCC=0;;
             --no-force) FORCE=0;;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -55,21 +55,46 @@
 # Notes for maintainers
 # ---------------------
 #
+# The bulk of the code is organized into functions that follow one of the
+# following naming conventions:
+#  * pre_XXX: things to do before running the tests, in order.
+#  * component_XXX: independent components. They can be run in any order.
+#      * component_check_XXX: quick tests that aren't worth parallelizing.
+#      * component_build_XXX: build things but don't run them.
+#      * component_test_XXX: build and test.
+#  * support_XXX: if support_XXX exists and returns false then
+#    component_XXX is not run by default.
+#  * post_XXX: things to do after running the tests.
+#  * other: miscellaneous support functions.
+#
+# Each component must start by invoking `msg` with a short informative message.
+#
+# The framework performs some cleanup tasks after each component. This
+# means that components can assume that the working directory is in a
+# cleaned-up state, and don't need to perform the cleanup themselves.
+# * Run `make clean`.
+# * Restore `include/mbedtks/config.h` from a backup made before running
+#   the component.
+# * Check out `Makefile`, `library/Makefile`, `programs/Makefile` and
+#   `tests/Makefile` from git. This cleans up after an in-tree use of
+#   CMake.
+#
+# Any command that is expected to fail must be protected so that the
+# script keeps running in --keep-going mode despite `set -e`. In keep-going
+# mode, if a protected command fails, this is logged as a failure and the
+# script will exit with a failure status once it has run all components.
+# Commands can be protected in any of the following ways:
+# * `make` is a function which runs the `make` command with protection.
+#   Note that you must write `make VAR=value`, not `VAR=value make`,
+#   because the `VAR=value make` syntax doesn't work with functions.
+# * Put `report_status` before the command to protect it.
+# * Put `if_build_successful` before a command. This protects it, and
+#   additionally skips it if a prior invocation of `make` in the same
+#   component failed.
+#
 # The tests are roughly in order from fastest to slowest. This doesn't
 # have to be exact, but in general you should add slower tests towards
 # the end and fast checks near the beginning.
-#
-# Sanity checks have the following form:
-#   1. msg "short description of what is about to be done"
-#   2. run sanity check (failure stops the script)
-#
-# Build or build-and-test steps have the following form:
-#   1. msg "short description of what is about to be done"
-#   2. cleanup
-#   3. preparation (config.pl, cmake, ...) (failure stops the script)
-#   4. make
-#   5. Run tests if relevant. All tests must be prefixed with
-#      if_build_successful for the sake of --keep-going.
 
 
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -80,38 +80,42 @@
 # Abort on errors (and uninitialised variables)
 set -eu
 
-if [ "$( uname )" != "Linux" ]; then
-    echo "This script only works in Linux" >&2
-    exit 1
-elif [ -d library -a -d include -a -d tests ]; then :; else
-    echo "Must be run from mbed TLS root" >&2
-    exit 1
-fi
+pre_check_environment () {
+    if [ "$( uname )" != "Linux" ]; then
+        echo "This script only works in Linux" >&2
+        exit 1
+    elif [ -d library -a -d include -a -d tests ]; then :; else
+        echo "Must be run from mbed TLS root" >&2
+        exit 1
+    fi
+}
 
-CONFIG_H='include/mbedtls/config.h'
-CONFIG_BAK="$CONFIG_H.bak"
+pre_initialize_variables () {
+    CONFIG_H='include/mbedtls/config.h'
+    CONFIG_BAK="$CONFIG_H.bak"
 
-MEMORY=0
-FORCE=0
-KEEP_GOING=0
-RUN_ARMCC=1
-YOTTA=1
+    MEMORY=0
+    FORCE=0
+    KEEP_GOING=0
+    RUN_ARMCC=1
+    YOTTA=1
 
-# Default commands, can be overriden by the environment
-: ${OPENSSL:="openssl"}
-: ${OPENSSL_LEGACY:="$OPENSSL"}
-: ${GNUTLS_CLI:="gnutls-cli"}
-: ${GNUTLS_SERV:="gnutls-serv"}
-: ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
-: ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
-: ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
-: ${ARMC5_BIN_DIR:=/usr/bin}
-: ${ARMC6_BIN_DIR:=/usr/bin}
+    # Default commands, can be overriden by the environment
+    : ${OPENSSL:="openssl"}
+    : ${OPENSSL_LEGACY:="$OPENSSL"}
+    : ${GNUTLS_CLI:="gnutls-cli"}
+    : ${GNUTLS_SERV:="gnutls-serv"}
+    : ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
+    : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
+    : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
+    : ${ARMC5_BIN_DIR:=/usr/bin}
+    : ${ARMC6_BIN_DIR:=/usr/bin}
 
-# if MAKEFLAGS is not set add the -j option to speed up invocations of make
-if [ -n "${MAKEFLAGS+set}" ]; then
-    export MAKEFLAGS="-j"
-fi
+    # if MAKEFLAGS is not set add the -j option to speed up invocations of make
+    if [ -n "${MAKEFLAGS+set}" ]; then
+        export MAKEFLAGS="-j"
+    fi
+}
 
 usage()
 {
@@ -198,17 +202,15 @@ msg()
     current_section=$1
 }
 
-if [ $RUN_ARMCC -ne 0 ]; then
-    armc6_build_test()
-    {
-        FLAGS="$1"
+armc6_build_test()
+{
+    FLAGS="$1"
 
-        msg "build: ARM Compiler 6 ($FLAGS), make"
-        ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
-                        WARNING_CFLAGS='-xc -std=c99' make lib
-        make clean
-    }
-fi
+    msg "build: ARM Compiler 6 ($FLAGS), make"
+    ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
+                    WARNING_CFLAGS='-xc -std=c99' make lib
+    make clean
+}
 
 err_msg()
 {
@@ -225,72 +227,75 @@ check_tools()
     done
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --armcc) RUN_ARMCC=1;;
-        --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
-        --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
-        --force|-f) FORCE=1;;
-        --gnutls-cli) shift; GNUTLS_CLI="$1";;
-        --gnutls-legacy-cli) shift; GNUTLS_LEGACY_CLI="$1";;
-        --gnutls-legacy-serv) shift; GNUTLS_LEGACY_SERV="$1";;
-        --gnutls-serv) shift; GNUTLS_SERV="$1";;
-        --help|-h) usage; exit;;
-        --keep-going|-k) KEEP_GOING=1;;
-        --memory|-m) MEMORY=1;;
-        --no-armcc) RUN_ARMCC=0;;
-        --no-force) FORCE=0;;
-        --no-keep-going) KEEP_GOING=0;;
-        --no-memory) MEMORY=0;;
-        --no-yotta) YOTTA=0;;
-        --openssl) shift; OPENSSL="$1";;
-        --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
-        --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
-        --random-seed) unset SEED;;
-        --release-test|-r) SEED=1;;
-        --seed|-s) shift; SEED="$1";;
-        --yotta) YOTTA=1;;
-        *)
-            echo >&2 "Unknown option: $1"
-            echo >&2 "Run $0 --help for usage."
-            exit 120
-            ;;
-    esac
-    shift
-done
+pre_parse_command_line () {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --armcc) RUN_ARMCC=1;;
+            --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
+            --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
+            --force|-f) FORCE=1;;
+            --gnutls-cli) shift; GNUTLS_CLI="$1";;
+            --gnutls-legacy-cli) shift; GNUTLS_LEGACY_CLI="$1";;
+            --gnutls-legacy-serv) shift; GNUTLS_LEGACY_SERV="$1";;
+            --gnutls-serv) shift; GNUTLS_SERV="$1";;
+            --help|-h) usage; exit;;
+            --keep-going|-k) KEEP_GOING=1;;
+            --memory|-m) MEMORY=1;;
+            --no-armcc) RUN_ARMCC=0;;
+            --no-force) FORCE=0;;
+            --no-keep-going) KEEP_GOING=0;;
+            --no-memory) MEMORY=0;;
+            --no-yotta) YOTTA=0;;
+            --openssl) shift; OPENSSL="$1";;
+            --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
+            --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
+            --random-seed) unset SEED;;
+            --release-test|-r) SEED=1;;
+            --seed|-s) shift; SEED="$1";;
+            --yotta) YOTTA=1;;
+            *)
+                echo >&2 "Unknown option: $1"
+                echo >&2 "Run $0 --help for usage."
+                exit 120
+                ;;
+        esac
+        shift
+    done
+}
 
-if [ $FORCE -eq 1 ]; then
-    if [ $YOTTA -eq 1 ]; then
-        rm -rf yotta/module "$OUT_OF_SOURCE_DIR"
+pre_check_git () {
+    if [ $FORCE -eq 1 ]; then
+        if [ $YOTTA -eq 1 ]; then
+            rm -rf yotta/module "$OUT_OF_SOURCE_DIR"
+        fi
+        git checkout-index -f -q $CONFIG_H
+        cleanup
+    else
+
+        if [ $YOTTA -ne 0 ] && [ -d yotta/module ]; then
+            err_msg "Warning - there is an existing yotta module in the directory 'yotta/module'"
+            echo "You can either delete your work and retry, or force the test to overwrite the"
+            echo "test by rerunning the script as: $0 --force"
+            exit 1
+        fi
+
+        if [ -d "$OUT_OF_SOURCE_DIR" ]; then
+            echo "Warning - there is an existing directory at '$OUT_OF_SOURCE_DIR'" >&2
+            echo "You can either delete this directory manually, or force the test by rerunning"
+            echo "the script as: $0 --force --out-of-source-dir $OUT_OF_SOURCE_DIR"
+            exit 1
+        fi
+
+        if ! git diff-files --quiet include/mbedtls/config.h; then
+            err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
+            echo "You can either delete or preserve your work, or force the test by rerunning the"
+            echo "script as: $0 --force"
+            exit 1
+        fi
     fi
-    git checkout-index -f -q $CONFIG_H
-    cleanup
-else
+}
 
-    if [ $YOTTA -ne 0 ] && [ -d yotta/module ]; then
-        err_msg "Warning - there is an existing yotta module in the directory 'yotta/module'"
-        echo "You can either delete your work and retry, or force the test to overwrite the"
-        echo "test by rerunning the script as: $0 --force"
-        exit 1
-    fi
-
-    if [ -d "$OUT_OF_SOURCE_DIR" ]; then
-        echo "Warning - there is an existing directory at '$OUT_OF_SOURCE_DIR'" >&2
-        echo "You can either delete this directory manually, or force the test by rerunning"
-        echo "the script as: $0 --force --out-of-source-dir $OUT_OF_SOURCE_DIR"
-        exit 1
-    fi
-
-    if ! git diff-files --quiet include/mbedtls/config.h; then
-        err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
-        echo "You can either delete or preserve your work, or force the test by rerunning the"
-        echo "script as: $0 --force"
-        exit 1
-    fi
-fi
-
-build_status=0
-if [ $KEEP_GOING -eq 1 ]; then
+pre_setup_keep_going () {
     failure_summary=
     failure_count=0
     start_red=
@@ -344,53 +349,60 @@ $text"
             echo "Killed by SIG$1."
         fi
     }
-else
-    record_status () {
-        "$@"
-    }
-fi
+}
+
 if_build_succeeded () {
     if [ $build_status -eq 0 ]; then
         record_status "$@"
     fi
 }
 
-msg "info: $0 configuration"
-echo "MEMORY: $MEMORY"
-echo "FORCE: $FORCE"
-echo "SEED: ${SEED-"UNSET"}"
-echo "OPENSSL: $OPENSSL"
-echo "OPENSSL_LEGACY: $OPENSSL_LEGACY"
-echo "GNUTLS_CLI: $GNUTLS_CLI"
-echo "GNUTLS_SERV: $GNUTLS_SERV"
-echo "GNUTLS_LEGACY_CLI: $GNUTLS_LEGACY_CLI"
-echo "GNUTLS_LEGACY_SERV: $GNUTLS_LEGACY_SERV"
-echo "ARMC5_BIN_DIR: $ARMC5_BIN_DIR"
-echo "ARMC6_BIN_DIR: $ARMC6_BIN_DIR"
-
-ARMC5_CC="$ARMC5_BIN_DIR/armcc"
-ARMC5_AR="$ARMC5_BIN_DIR/armar"
-ARMC6_CC="$ARMC6_BIN_DIR/armclang"
-ARMC6_AR="$ARMC6_BIN_DIR/armar"
-
-# To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
-# we just export the variables they require
-export OPENSSL_CMD="$OPENSSL"
-export GNUTLS_CLI="$GNUTLS_CLI"
-export GNUTLS_SERV="$GNUTLS_SERV"
-
-# Avoid passing --seed flag in every call to ssl-opt.sh
-if [ -n "${SEED-}" ]; then
-  export SEED
-fi
+pre_print_configuration () {
+    msg "info: $0 configuration"
+    echo "MEMORY: $MEMORY"
+    echo "FORCE: $FORCE"
+    echo "SEED: ${SEED-"UNSET"}"
+    echo "OPENSSL: $OPENSSL"
+    echo "OPENSSL_LEGACY: $OPENSSL_LEGACY"
+    echo "GNUTLS_CLI: $GNUTLS_CLI"
+    echo "GNUTLS_SERV: $GNUTLS_SERV"
+    echo "GNUTLS_LEGACY_CLI: $GNUTLS_LEGACY_CLI"
+    echo "GNUTLS_LEGACY_SERV: $GNUTLS_LEGACY_SERV"
+    echo "ARMC5_BIN_DIR: $ARMC5_BIN_DIR"
+    echo "ARMC6_BIN_DIR: $ARMC6_BIN_DIR"
+}
 
 # Make sure the tools we need are available.
-check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
-            "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
-            "arm-none-eabi-gcc" "i686-w64-mingw32-gcc"
-if [ $RUN_ARMCC -ne 0 ]; then
-    check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
-fi
+pre_check_tools () {
+    ARMC5_CC="$ARMC5_BIN_DIR/armcc"
+    ARMC5_AR="$ARMC5_BIN_DIR/armar"
+    ARMC6_CC="$ARMC6_BIN_DIR/armclang"
+    ARMC6_AR="$ARMC6_BIN_DIR/armar"
+
+    # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
+    # we just export the variables they require
+    export OPENSSL_CMD="$OPENSSL"
+    export GNUTLS_CLI="$GNUTLS_CLI"
+    export GNUTLS_SERV="$GNUTLS_SERV"
+
+    # Avoid passing --seed flag in every call to ssl-opt.sh
+    if [ -n "${SEED-}" ]; then
+        export SEED
+    fi
+
+    check_tools "$OPENSSL" "$OPENSSL_LEGACY" "$GNUTLS_CLI" "$GNUTLS_SERV" \
+                "$GNUTLS_LEGACY_CLI" "$GNUTLS_LEGACY_SERV" "doxygen" "dot" \
+                "arm-none-eabi-gcc" "i686-w64-mingw32-gcc"
+    if [ $RUN_ARMCC -ne 0 ]; then
+        check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR"
+    fi
+
+    msg "info: output_env.sh"
+    OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
+           GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
+           GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
+           ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
+}
 
 
 
@@ -409,502 +421,499 @@ fi
 #
 # Indicative running times are given for reference.
 
-msg "info: output_env.sh"
-OPENSSL="$OPENSSL" OPENSSL_LEGACY="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_CLI" \
-    GNUTLS_SERV="$GNUTLS_SERV" GNUTLS_LEGACY_CLI="$GNUTLS_LEGACY_CLI" \
-    GNUTLS_LEGACY_SERV="$GNUTLS_LEGACY_SERV" ARMC5_CC="$ARMC5_CC" \
-    ARMC6_CC="$ARMC6_CC" RUN_ARMCC="$RUN_ARMCC" scripts/output_env.sh
+run_all_the_tests () {
 
-msg "test: recursion.pl" # < 1s
-record_status tests/scripts/recursion.pl library/*.c
+    msg "test: recursion.pl" # < 1s
+    record_status tests/scripts/recursion.pl library/*.c
 
-msg "test: freshness of generated source files" # < 1s
-record_status tests/scripts/check-generated-files.sh
+    msg "test: freshness of generated source files" # < 1s
+    record_status tests/scripts/check-generated-files.sh
 
-msg "test: doxygen markup outside doxygen blocks" # < 1s
-record_status tests/scripts/check-doxy-blocks.pl
+    msg "test: doxygen markup outside doxygen blocks" # < 1s
+    record_status tests/scripts/check-doxy-blocks.pl
 
-msg "test: check-files.py" # < 1s
-cleanup
-record_status tests/scripts/check-files.py
-
-msg "test/build: declared and exported names" # < 3s
-cleanup
-record_status tests/scripts/check-names.sh
-
-msg "test: doxygen warnings" # ~ 3s
-cleanup
-record_status tests/scripts/doxygen.sh
-
-
-
-################################################################
-#### Build and test many configurations and targets
-################################################################
-
-if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
-    # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
-    # path, and uses whatever version of armcc it finds there.
-    msg "build: create and build yotta module" # ~ 30s
+    msg "test: check-files.py" # < 1s
     cleanup
-    record_status tests/scripts/yotta-build.sh
-fi
+    record_status tests/scripts/check-files.py
 
-msg "build: cmake, gcc, ASan" # ~ 1 min 50s
-cleanup
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
-if_build_succeeded tests/ssl-opt.sh
-
-msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
-record_status tests/scripts/test-ref-configs.pl
-
-msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
-make
-
-msg "test: compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh
-
-msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
-
-msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
-
-msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
-if_build_succeeded tests/ssl-opt.sh
-
-msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
-make test
-
-msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
-if_build_succeeded tests/ssl-opt.sh -f RSA
-
-msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
-if_build_succeeded tests/compat.sh -t RSA
-
-msg "build: cmake, full config, clang" # ~ 50s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
-make
-
-msg "test: main suites (full config)" # ~ 5s
-make test
-
-msg "test: ssl-opt.sh default (full config)" # ~ 1s
-if_build_succeeded tests/ssl-opt.sh -f Default
-
-msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
-if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
-
-msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
-# Build with -O -Wextra to catch a maximum of issues.
-make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
-make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
-
-msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
-# No cleanup, just tweak the configuration and rebuild
-make clean
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
-# Build with -O -Wextra to catch a maximum of issues.
-make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
-make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
-
-msg "test/build: curves.pl (gcc)" # ~ 4 min
-cleanup
-record_status tests/scripts/curves.pl
-
-msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
-cleanup
-record_status tests/scripts/depends-hashes.pl
-
-msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
-cleanup
-record_status tests/scripts/depends-pkalgs.pl
-
-msg "test/build: key-exchanges (gcc)" # ~ 1 min
-cleanup
-record_status tests/scripts/key-exchanges.pl
-
-msg "build: Unix make, -Os (gcc)" # ~ 30s
-cleanup
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
-
-# Full configuration build, without platform support, file IO and net sockets.
-# This should catch missing mbedtls_printf definitions, and by disabling file
-# IO, it should catch missing '#include <stdio.h>'
-msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_PLATFORM_C
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_PLATFORM_MEMORY
-scripts/config.pl unset MBEDTLS_PLATFORM_PRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_FPRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_SNPRINTF_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT
-scripts/config.pl unset MBEDTLS_PLATFORM_EXIT_ALT
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
-scripts/config.pl unset MBEDTLS_FS_IO
-# Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
-# to re-enable platform integration features otherwise disabled in C99 builds
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
-
-# catch compile bugs in _uninit functions
-msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
-
-msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_SRV_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
-
-msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_SSL_CLI_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
-
-# Note, C99 compliance can also be tested with the sockets support disabled,
-# as that requires a POSIX platform (which isn't the same as C99).
-msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0 -std=c99 -pedantic' lib
-
-msg "build: default config except MFL extension (ASan build)" # ~ 30s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: ssl-opt.sh, MFL-related tests"
-if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
-
-msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
-scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
-scripts/config.pl set MBEDTLS_ENTROPY_C
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_ENTROPY_HARDWARE_ALT
-scripts/config.pl unset MBEDTLS_HAVEGE_C
-CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
-make
-
-msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
-make test
-
-msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
-scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
-scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
-make test
-
-if uname -a | grep -F Linux >/dev/null; then
-    msg "build/test: make shared" # ~ 40s
+    msg "test/build: declared and exported names" # < 3s
     cleanup
-    make SHARED=1 all check
-fi
+    record_status tests/scripts/check-names.sh
 
-if uname -a | grep -F x86_64 >/dev/null; then
-    # Build once with -O0, to compile out the i386 specific inline assembly
-    msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
+    msg "test: doxygen warnings" # ~ 3s
     cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl full
-    make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
+    record_status tests/scripts/doxygen.sh
 
-    msg "test: i386, make, gcc -O0 (ASan build)"
-    make test
 
-    # Build again with -O1, to compile in the i386 specific inline assembly
-    msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
+
+    ################################################################
+    #### Build and test many configurations and targets
+    ################################################################
+
+    if [ $RUN_ARMCC -ne 0 ] && [ $YOTTA -ne 0 ]; then
+        # Note - use of yotta is deprecated, and yotta also requires armcc to be on the
+        # path, and uses whatever version of armcc it finds there.
+        msg "build: create and build yotta module" # ~ 30s
+        cleanup
+        record_status tests/scripts/yotta-build.sh
+    fi
+
+    msg "build: cmake, gcc, ASan" # ~ 1 min 50s
     cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl full
-    make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
-
-    msg "test: i386, make, gcc -O1 (ASan build)"
-    make test
-
-    msg "build: 64-bit ILP32, make, gcc" # ~ 30s
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl full
-    make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
-
-    msg "test: 64-bit ILP32, make, gcc"
-    make test
-fi # x86_64
-
-msg "build: gcc, force 32-bit bignum limbs"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
-
-msg "test: gcc, force 32-bit bignum limbs"
-make test
-
-msg "build: gcc, force 64-bit bignum limbs"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl unset MBEDTLS_HAVE_ASM
-scripts/config.pl unset MBEDTLS_AESNI_C
-scripts/config.pl unset MBEDTLS_PADLOCK_C
-make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
-
-msg "test: gcc, force 64-bit bignum limbs"
-make test
-
-msg "build: arm-none-eabi-gcc, make" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
-
-msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
-echo "Checking that software 64-bit division is not required"
-! grep __aeabi_uldiv library/*.o
-
-msg "build: ARM Compiler 5, make"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl full
-scripts/config.pl unset MBEDTLS_NET_C
-scripts/config.pl unset MBEDTLS_TIMING_C
-scripts/config.pl unset MBEDTLS_FS_IO
-scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
-scripts/config.pl unset MBEDTLS_HAVE_TIME
-scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
-scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
-# following things are not in the default config
-scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
-scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
-scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
-scripts/config.pl unset MBEDTLS_THREADING_C
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
-scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
-scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
-
-if [ $RUN_ARMCC -ne 0 ]; then
-    make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
-    make clean
-
-    # ARM Compiler 6 - Target ARMv7-A
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
-
-    # ARM Compiler 6 - Target ARMv7-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
-
-    # ARM Compiler 6 - Target ARMv8-A - AArch32
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
-
-    # ARM Compiler 6 - Target ARMv8-M
-    armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
-
-    # ARM Compiler 6 - Target ARMv8-A - AArch64
-    armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
-fi
-
-msg "build: allow SHA1 in certificates by default"
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
-make CFLAGS='-Werror -Wall -Wextra'
-msg "test: allow SHA1 in certificates by default"
-make test
-if_build_succeeded tests/ssl-opt.sh -f SHA-1
-
-msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
-cleanup
-cp "$CONFIG_H" "$CONFIG_BAK"
-scripts/config.pl set MBEDTLS_RSA_NO_CRT
-CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
-make
-
-msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
-make test
-
-msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
-cleanup
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
-
-# note Make tests only builds the tests, but doesn't run them
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
-make WINDOWS_BUILD=1 clean
-
-msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
-make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
-make WINDOWS_BUILD=1 clean
-
-# MemSan currently only available on Linux 64 bits
-if uname -a | grep 'Linux.*x86_64' >/dev/null; then
-
-    msg "build: MSan (clang)" # ~ 1 min 20s
-    cleanup
-    cp "$CONFIG_H" "$CONFIG_BAK"
-    scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
-    CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
     make
 
-    msg "test: main suites (MSan)" # ~ 10s
+    msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
 
-    msg "test: ssl-opt.sh (MSan)" # ~ 1 min
+    msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
     if_build_succeeded tests/ssl-opt.sh
 
-    # Optional part(s)
+    msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
+    record_status tests/scripts/test-ref-configs.pl
 
-    if [ "$MEMORY" -gt 0 ]; then
-        msg "test: compat.sh (MSan)" # ~ 6 min 20s
-        if_build_succeeded tests/compat.sh
-    fi
-
-else # no MemSan
-
-    msg "build: Release (clang)"
-    cleanup
-    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
+    msg "build: with ASan (rebuild after ref-configs)" # ~ 1 min
     make
 
-    msg "test: main suites valgrind (Release)"
-    make memcheck
+    msg "test: compat.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/compat.sh
 
-    # Optional part(s)
-    # Currently broken, programs don't seem to receive signals
-    # under valgrind on OS X
+    msg "build: Default + SSLv3 (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_SSL_PROTO_SSL3
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-    if [ "$MEMORY" -gt 0 ]; then
-        msg "test: ssl-opt.sh --memcheck (Release)"
-        if_build_succeeded tests/ssl-opt.sh --memcheck
+    msg "test: SSLv3 - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
+
+    msg "build: SSLv3 - compat.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2'
+    if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" tests/compat.sh -m 'ssl3'
+
+    msg "build: SSLv3 - ssl-opt.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/ssl-opt.sh
+
+    msg "build: Default + !MBEDTLS_SSL_RENEGOTIATION (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_SSL_RENEGOTIATION
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: !MBEDTLS_SSL_RENEGOTIATION - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
+
+    msg "test: !MBEDTLS_SSL_RENEGOTIATION - ssl-opt.sh (ASan build)" # ~ 6 min
+    if_build_succeeded tests/ssl-opt.sh
+
+    msg "build: Default + RSA_NO_CRT (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_RSA_NO_CRT
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: RSA_NO_CRT - main suites (inc. selftests) (ASan build)" # ~ 50s
+    make test
+
+    msg "test: RSA_NO_CRT - RSA-related part of ssl-opt.sh (ASan build)" # ~ 5s
+    if_build_succeeded tests/ssl-opt.sh -f RSA
+
+    msg "test: RSA_NO_CRT - RSA-related part of compat.sh (ASan build)" # ~ 3 min
+    if_build_succeeded tests/compat.sh -t RSA
+
+    msg "build: cmake, full config, clang" # ~ 50s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
+    CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
+    make
+
+    msg "test: main suites (full config)" # ~ 5s
+    make test
+
+    msg "test: ssl-opt.sh default (full config)" # ~ 1s
+    if_build_succeeded tests/ssl-opt.sh -f Default
+
+    msg "test: compat.sh RC4, DES & NULL (full config)" # ~ 2 min
+    if_build_succeeded env OPENSSL_CMD="$OPENSSL_LEGACY" GNUTLS_CLI="$GNUTLS_LEGACY_CLI" GNUTLS_SERV="$GNUTLS_LEGACY_SERV" tests/compat.sh -e '3DES\|DES-CBC3' -f 'NULL\|DES\|RC4\|ARCFOUR'
+
+    msg "build: make, full config + DEPRECATED_WARNING, gcc -O" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl set MBEDTLS_DEPRECATED_WARNING
+    # Build with -O -Wextra to catch a maximum of issues.
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra' lib programs
+    make CC=gcc CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+
+    msg "build: make, full config + DEPRECATED_REMOVED, clang -O" # ~ 30s
+    # No cleanup, just tweak the configuration and rebuild
+    make clean
+    scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
+    scripts/config.pl set MBEDTLS_DEPRECATED_REMOVED
+    # Build with -O -Wextra to catch a maximum of issues.
+    make CC=clang CFLAGS='-O -Werror -Wall -Wextra' lib programs
+    make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
+
+    msg "test/build: curves.pl (gcc)" # ~ 4 min
+    cleanup
+    record_status tests/scripts/curves.pl
+
+    msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
+    cleanup
+    record_status tests/scripts/depends-hashes.pl
+
+    msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
+    cleanup
+    record_status tests/scripts/depends-pkalgs.pl
+
+    msg "test/build: key-exchanges (gcc)" # ~ 1 min
+    cleanup
+    record_status tests/scripts/key-exchanges.pl
+
+    msg "build: Unix make, -Os (gcc)" # ~ 30s
+    cleanup
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -Os'
+
+    # Full configuration build, without platform support, file IO and net sockets.
+    # This should catch missing mbedtls_printf definitions, and by disabling file
+    # IO, it should catch missing '#include <stdio.h>'
+    msg "build: full config except platform/fsio/net, make, gcc, C99" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_PLATFORM_C
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_PLATFORM_MEMORY
+    scripts/config.pl unset MBEDTLS_PLATFORM_PRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_FPRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_SNPRINTF_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT
+    scripts/config.pl unset MBEDTLS_PLATFORM_EXIT_ALT
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    # Note, _DEFAULT_SOURCE needs to be defined for platforms using glibc version >2.19,
+    # to re-enable platform integration features otherwise disabled in C99 builds
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -std=c99 -pedantic -O0 -D_DEFAULT_SOURCE' lib programs
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0' test
+
+    # catch compile bugs in _uninit functions
+    msg "build: full config with NO_STD_FUNCTION, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl set MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+
+    msg "build: full config except ssl_srv.c, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_SSL_SRV_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+
+    msg "build: full config except ssl_cli.c, make, gcc" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_SSL_CLI_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0'
+
+    # Note, C99 compliance can also be tested with the sockets support disabled,
+    # as that requires a POSIX platform (which isn't the same as C99).
+    msg "build: full config except net_sockets.c, make, gcc -std=c99 -pedantic" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C # getaddrinfo() undeclared, etc.
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY # uses syscall() on GNU/Linux
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -O0 -std=c99 -pedantic' lib
+
+    msg "build: default config except MFL extension (ASan build)" # ~ 30s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: ssl-opt.sh, MFL-related tests"
+    if_build_succeeded tests/ssl-opt.sh -f "Max fragment length"
+
+    msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY
+    scripts/config.pl set MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+    scripts/config.pl set MBEDTLS_ENTROPY_C
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_ENTROPY_HARDWARE_ALT
+    scripts/config.pl unset MBEDTLS_HAVEGE_C
+    CC=gcc cmake  -D UNSAFE_BUILD=ON -D CMAKE_C_FLAGS:String="-fsanitize=address -fno-common -O3" .
+    make
+
+    msg "test: MBEDTLS_TEST_NULL_ENTROPY - main suites (inc. selftests) (ASan build)"
+    make test
+
+    msg "build: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
+    scripts/config.pl set MBEDTLS_PLATFORM_CALLOC_MACRO calloc
+    scripts/config.pl set MBEDTLS_PLATFORM_FREE_MACRO   free
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: MBEDTLS_PLATFORM_{CALLOC/FREE}_MACRO enabled (ASan build)"
+    make test
+
+    if uname -a | grep -F Linux >/dev/null; then
+        msg "build/test: make shared" # ~ 40s
+        cleanup
+        make SHARED=1 all check
     fi
 
-    if [ "$MEMORY" -gt 1 ]; then
-        msg "test: compat.sh --memcheck (Release)"
-        if_build_succeeded tests/compat.sh --memcheck
+    if uname -a | grep -F x86_64 >/dev/null; then
+        # Build once with -O0, to compile out the i386 specific inline assembly
+        msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s
+        cleanup
+        cp "$CONFIG_H" "$CONFIG_BAK"
+        scripts/config.pl full
+        make CC=gcc CFLAGS='-O0 -Werror -Wall -Wextra -m32 -fsanitize=address'
+
+        msg "test: i386, make, gcc -O0 (ASan build)"
+        make test
+
+        # Build again with -O1, to compile in the i386 specific inline assembly
+        msg "build: i386, make, gcc -O1 (ASan build)" # ~ 30s
+        cleanup
+        cp "$CONFIG_H" "$CONFIG_BAK"
+        scripts/config.pl full
+        make CC=gcc CFLAGS='-O1 -Werror -Wall -Wextra -m32 -fsanitize=address'
+
+        msg "test: i386, make, gcc -O1 (ASan build)"
+        make test
+
+        msg "build: 64-bit ILP32, make, gcc" # ~ 30s
+        cleanup
+        cp "$CONFIG_H" "$CONFIG_BAK"
+        scripts/config.pl full
+        make CC=gcc CFLAGS='-Werror -Wall -Wextra -mx32'
+
+        msg "test: 64-bit ILP32, make, gcc"
+        make test
+    fi # x86_64
+
+    msg "build: gcc, force 32-bit bignum limbs"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT32'
+
+    msg "test: gcc, force 32-bit bignum limbs"
+    make test
+
+    msg "build: gcc, force 64-bit bignum limbs"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl unset MBEDTLS_HAVE_ASM
+    scripts/config.pl unset MBEDTLS_AESNI_C
+    scripts/config.pl unset MBEDTLS_PADLOCK_C
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -DMBEDTLS_HAVE_INT64'
+
+    msg "test: gcc, force 64-bit bignum limbs"
+    make test
+
+    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+
+    msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+    echo "Checking that software 64-bit division is not required"
+    ! grep __aeabi_uldiv library/*.o
+
+    msg "build: ARM Compiler 5, make"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_NET_C
+    scripts/config.pl unset MBEDTLS_TIMING_C
+    scripts/config.pl unset MBEDTLS_FS_IO
+    scripts/config.pl unset MBEDTLS_ENTROPY_NV_SEED
+    scripts/config.pl unset MBEDTLS_HAVE_TIME
+    scripts/config.pl unset MBEDTLS_HAVE_TIME_DATE
+    scripts/config.pl set MBEDTLS_NO_PLATFORM_ENTROPY
+    # following things are not in the default config
+    scripts/config.pl unset MBEDTLS_DEPRECATED_WARNING
+    scripts/config.pl unset MBEDTLS_HAVEGE_C # depends on timing.c
+    scripts/config.pl unset MBEDTLS_THREADING_PTHREAD
+    scripts/config.pl unset MBEDTLS_THREADING_C
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # execinfo.h
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C # calls exit
+    scripts/config.pl unset MBEDTLS_PLATFORM_TIME_ALT # depends on MBEDTLS_HAVE_TIME
+
+    if [ $RUN_ARMCC -ne 0 ]; then
+        make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+        make clean
+
+        # ARM Compiler 6 - Target ARMv7-A
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-a"
+
+        # ARM Compiler 6 - Target ARMv7-M
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv7-m"
+
+        # ARM Compiler 6 - Target ARMv8-A - AArch32
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv8.2-a"
+
+        # ARM Compiler 6 - Target ARMv8-M
+        armc6_build_test "--target=arm-arm-none-eabi -march=armv8-m.main"
+
+        # ARM Compiler 6 - Target ARMv8-A - AArch64
+        armc6_build_test "--target=aarch64-arm-none-eabi -march=armv8.2-a"
     fi
 
-fi # MemSan
+    msg "build: allow SHA1 in certificates by default"
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES
+    make CFLAGS='-Werror -Wall -Wextra'
+    msg "test: allow SHA1 in certificates by default"
+    make test
+    if_build_succeeded tests/ssl-opt.sh -f SHA-1
 
-msg "build: cmake 'out-of-source' build"
-cleanup
-MBEDTLS_ROOT_DIR="$PWD"
-mkdir "$OUT_OF_SOURCE_DIR"
-cd "$OUT_OF_SOURCE_DIR"
-cmake "$MBEDTLS_ROOT_DIR"
-make
+    msg "build: Default + MBEDTLS_RSA_NO_CRT (ASan build)" # ~ 6 min
+    cleanup
+    cp "$CONFIG_H" "$CONFIG_BAK"
+    scripts/config.pl set MBEDTLS_RSA_NO_CRT
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
 
-msg "test: cmake 'out-of-source' build"
-make test
-# Test an SSL option that requires an auxiliary script in test/scripts/.
-# Also ensure that there are no error messages such as
-# "No such file or directory", which would indicate that some required
-# file is missing (ssl-opt.sh tolerates the absence of some files so
-# may exit with status 0 but emit errors).
-if_build_succeeded ./tests/ssl-opt.sh -f 'Fallback SCSV: beginning of list' 2>ssl-opt.err
-if [ -s ssl-opt.err ]; then
-  cat ssl-opt.err >&2
-  record_status [ ! -s ssl-opt.err ]
-  rm ssl-opt.err
-fi
-cd "$MBEDTLS_ROOT_DIR"
-rm -rf "$OUT_OF_SOURCE_DIR"
-unset MBEDTLS_ROOT_DIR
+    msg "test: MBEDTLS_RSA_NO_CRT - main suites (inc. selftests) (ASan build)"
+    make test
+
+    msg "build: Windows cross build - mingw64, make (Link Library)" # ~ 30s
+    cleanup
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 lib programs
+
+    # note Make tests only builds the tests, but doesn't run them
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror' WINDOWS_BUILD=1 tests
+    make WINDOWS_BUILD=1 clean
+
+    msg "build: Windows cross build - mingw64, make (DLL)" # ~ 30s
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 lib programs
+    make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
+    make WINDOWS_BUILD=1 clean
+
+    # MemSan currently only available on Linux 64 bits
+    if uname -a | grep 'Linux.*x86_64' >/dev/null; then
+
+        msg "build: MSan (clang)" # ~ 1 min 20s
+        cleanup
+        cp "$CONFIG_H" "$CONFIG_BAK"
+        scripts/config.pl unset MBEDTLS_AESNI_C # memsan doesn't grok asm
+        CC=clang cmake -D CMAKE_BUILD_TYPE:String=MemSan .
+        make
+
+        msg "test: main suites (MSan)" # ~ 10s
+        make test
+
+        msg "test: ssl-opt.sh (MSan)" # ~ 1 min
+        if_build_succeeded tests/ssl-opt.sh
+
+        # Optional part(s)
+
+        if [ "$MEMORY" -gt 0 ]; then
+            msg "test: compat.sh (MSan)" # ~ 6 min 20s
+            if_build_succeeded tests/compat.sh
+        fi
+
+    else # no MemSan
+
+        msg "build: Release (clang)"
+        cleanup
+        CC=clang cmake -D CMAKE_BUILD_TYPE:String=Release .
+        make
+
+        msg "test: main suites valgrind (Release)"
+        make memcheck
+
+        # Optional part(s)
+        # Currently broken, programs don't seem to receive signals
+        # under valgrind on OS X
+
+        if [ "$MEMORY" -gt 0 ]; then
+            msg "test: ssl-opt.sh --memcheck (Release)"
+            if_build_succeeded tests/ssl-opt.sh --memcheck
+        fi
+
+        if [ "$MEMORY" -gt 1 ]; then
+            msg "test: compat.sh --memcheck (Release)"
+            if_build_succeeded tests/compat.sh --memcheck
+        fi
+
+    fi # MemSan
+
+    msg "build: cmake 'out-of-source' build"
+    cleanup
+    MBEDTLS_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+    cmake "$MBEDTLS_ROOT_DIR"
+    make
+
+    msg "test: cmake 'out-of-source' build"
+    make test
+    # Test an SSL option that requires an auxiliary script in test/scripts/.
+    # Also ensure that there are no error messages such as
+    # "No such file or directory", which would indicate that some required
+    # file is missing (ssl-opt.sh tolerates the absence of some files so
+    # may exit with status 0 but emit errors).
+    if_build_succeeded ./tests/ssl-opt.sh -f 'Fallback SCSV: beginning of list' 2>ssl-opt.err
+    if [ -s ssl-opt.err ]; then
+        cat ssl-opt.err >&2
+        record_status [ ! -s ssl-opt.err ]
+        rm ssl-opt.err
+    fi
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    unset MBEDTLS_ROOT_DIR
+}
 
 
 
@@ -912,7 +921,38 @@ unset MBEDTLS_ROOT_DIR
 #### Termination
 ################################################################
 
-msg "Done, cleaning up"
+post_report () {
+    msg "Done, cleaning up"
+    cleanup
+
+    final_report
+}
+
+
+
+################################################################
+#### Run all the things
+################################################################
+
+# Preliminary setup
+pre_check_environment
+pre_initialize_variables
+pre_parse_command_line "$@"
+
+pre_check_git
+build_status=0
+if [ $KEEP_GOING -eq 1 ]; then
+    pre_setup_keep_going
+else
+    record_status () {
+        "$@"
+    }
+fi
+pre_print_configuration
+pre_check_tools
 cleanup
 
-final_report
+run_all_the_tests
+
+# We're done.
+post_report


### PR DESCRIPTION
This is a backport to `mbedtls-2.7` of #2325 and #2332. The history is slightly different because I went directly for an automatic listing of components.

Tip for reviewers: review the first three commits individually, then the rest of the PR, to make sure that no components got lost or corrupted. Compare the end state of `all.sh` with the state on 2.16 to see that the differences are justified (yotta removal, new components, new tools).

----

Here is a full list of commits from https://github.com/ARMmbed/mbedtls/pull/2325 and the original version of https://github.com/ARMmbed/mbedtls/pull/2332 (saved on the branch https://github.com/gilles-peskine-arm/mbedtls/tree/all_sh-component_detection-2.16-1) and how I backported them:

* 8f073121248d8af5f3b51c0a0f74fd81c3a14a34 "Move the code into functions. No behavior change.": redone as "Move the code into functions. No behavior change." + "Break up the tests into components" with adaptations to list the components automatically (from 4c5ad6b4b22552f15a40137d75def4a4274d5dad).
* 9f8f92ca9b1cd65fab0f78e0b164bb703ab7b873 "Remove duplicate component for RSA_NO_CRT": backported (not an exact cherry-pick because 2.7 doesn't have run_all_components).
* e48351a33f4fd129694bd2cc87d7a6b617265d82 "Move cleanup into the common wrapper function": included in "Break up the tests into components".
* 782f411bf501af065a216899abeac17b39b69136 "Move test-ref-configs into its own component": backported (not an exact cherry-pick because 2.7 doesn't have run_all_components).
* 348fb9a597da3b1c85af30f60b8c820e5e9f61ea "New option --list-components": ; done in a much simpler way (thanks to the automatic listing of components) in "Add command line options to list available components".
* 92525111dc6d538eb5d398aa4a286fc4ad5386a6 "all.sh: with non-option arguments, run only these components": backported (not an exact cherry-pick because 2.7 doesn't have run_all_components).
* 81b96ed6034441960ba54ffe33989ad5b2b8ac69 "Add --except mode: run all components except a list": cherry-picked with some adaptations because 2.7 has the list of components in $ALL_COMPONENTS.
* ffcdeff00a02843ce2a901e35dc0df87f651c85a "Add the current component name to msg output and the final report": cherry-picked.
* 608953eb8c1d50563dfc709b31e883851595683d "Back up and restore config.h systematically": backported (same principle, different list of config.h handling code to remove).
* b28636b86516465a77c2fd80f22e50ee6a2a5280 "Merge tag 'mbedtls-2.16.0' into all_sh-2.14": not applicable.
* 55f7c9443031f82ffaac289ac48cfca6b0b0582d "Fix inconsistent indentation": not applicable.
* 5fa32a7a7ada3577ce5af92901018a62c8bc43eb "Use CMAKE_BUILD_TYPE to do Asan builds": cherry-picked.
* 4976e82a9e1cff956e4d1f2f68ed6da9a1e6cb8d "Gdb script: improve portability of ASLR disabling disabling": not applicable.
* a16c2b1ff1cf70e862b3fcb6590ad56d536f0993 "all.sh: don't insist on Linux; always run Valgrind": backported (adapted to 2.7 which doesn't have run_all_components; the ssl-opt.sh part is not applicable).
* a1fc4b5ead6e6e4165288987122d0d735a1740cc "all.sh: fix MAKEFLAGS setting": cherry-picked.
* 0b66a2626ba4efc90cb3af7ee476e63ec3f4eed3 "all.sh: list components automatically": already partly done in "Break up the tests into components" and "all.sh: with non-option arguments, run only these components"; finished with "Add conditional component inclusion facility" and "Add command line options to list available components".
* 99a900c10620c9a1528e3916693b6be4a6e92ab7 "all.sh: Always build the list of components to run": already partly done in "all.sh: with non-option arguments, run only these components"; completed in "Minor cleanups to component name gathering".
* f88ec2bcffd7bfaac0b1b9c1ee114f0126d21a72 "all.sh: only look for armcc if it is used": backported and adapted for the changes in tool requiremenets and extended to take care of Yotta.
* 9e5d97f8f863167a005834b22317f10a54e18f1d "all.sh: only check tools that are going to be used": cherry-picked and adapted to the different set of tools for 2.7 (no OPENSSL_NEXT, no gdb, armcc used for yotta) plus the parts of "Merge the code to call output_env.sh in" that hadn't already been done.
* e4f11248d5a48ead3c4ccd4c963cf5772369108f "Merge the code to call output_env.sh in": already done in "Move the code into functions. No behavior change." and .
* 006d9eb9d25a331c52fe324b03ae64755dbf92e2 "all.sh: Update the maintainter documentation": cherry-picked.
* 01df1b65434552d6040fd8c80e7233222fde665d "Fix sometimes-spurious warning about changed config.h": cherry-picked.
* bcb38afb3dd4e9546a422cbf59eeacd71c480224 "Delete $OUT_OF_SOURCE_DIR under --force": adapted as "Delete $OUT_OF_SOURCE_DIR under --force even without Yotta".
* 7d651c06e4bf50284ac7aa6a54c6d90f2f9da900 "Support wildcard patterns with a positive list of components to run": cherry-picked.
* e3e41f955d5bc4b30f34fdac2a73d6c6c8704a4d "Rename test_memcheck to test_valgrind": cherry-picked

Additional commits to align 2.7 with development:

* "Add missing protection on __aeabi_uldiv check under --keep-going"
