### PR TITLE
Ecdsa genkey return proper error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -800,11 +800,16 @@ cleanup:
 int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
                   int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
+    int ret = 0;
     ECDSA_VALIDATE_RET( ctx   != NULL );
     ECDSA_VALIDATE_RET( f_rng != NULL );
 
-    return( mbedtls_ecp_group_load( &ctx->grp, gid ) ||
-            mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d, &ctx->Q, f_rng, p_rng ) );
+    ret = mbedtls_ecp_group_load( &ctx->grp, gid );
+    if( ret != 0 )
+        return( ret );
+
+   return( mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d,
+                                    &ctx->Q, f_rng, p_rng ) );
 }
 #endif /* !MBEDTLS_ECDSA_GENKEY_ALT */
 


### PR DESCRIPTION
## Description
As described in https://github.com/ARMmbed/mbedtls/pull/2124#discussion_r  mbedtls_gen_key() returned a boolean 1 in case there was an error in one of the called functions, which might result in failures for the calling functions, expecting negative error codes .


## Status
**READY**

## Requires Backporting
Yes 
`mbedtls-2.7`
`mbedtls-2.16`


## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [x] Backported


