### PR TITLE
Backport 2.16: ecdsa genkey return proper error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -800,11 +800,16 @@ cleanup:
 int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
                   int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
+    int ret = 0;
     ECDSA_VALIDATE_RET( ctx   != NULL );
     ECDSA_VALIDATE_RET( f_rng != NULL );
 
-    return( mbedtls_ecp_group_load( &ctx->grp, gid ) ||
-            mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d, &ctx->Q, f_rng, p_rng ) );
+    ret = mbedtls_ecp_group_load( &ctx->grp, gid );
+    if( ret != 0 )
+        return( ret );
+
+   return( mbedtls_ecp_gen_keypair( &ctx->grp, &ctx->d,
+                                    &ctx->Q, f_rng, p_rng ) );
 }
 #endif /* !MBEDTLS_ECDSA_GENKEY_ALT */
 


### PR DESCRIPTION
## Description
This is a backport of #2345 and forward port of #2296 


## Status
**READY**
