### PR TITLE
Backport 2.16: Fix signed-to-unsigned integer conversion warning in X.509 module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.xx.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix signed-to-unsigned integer conversion warning
+     in X.509 module. Fixes #2212.
+
 = mbed TLS 2.16.0 branch released 2018-12-21
 
 Features

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -368,7 +368,7 @@ static void x509_crt_verify_chain_reset(
     for( i = 0; i < MBEDTLS_X509_MAX_VERIFY_CHAIN_SIZE; i++ )
     {
         ver_chain->items[i].crt = NULL;
-        ver_chain->items[i].flags = -1;
+        ver_chain->items[i].flags = (uint32_t) -1;
     }
 
     ver_chain->len = 0;


### PR DESCRIPTION
This is the backport to Mbed TLS 2.16 of #2213, fixing #2212.