### PR TITLE
PSA: Adapt mbedtls_ssl_get_key_exchange_md_tls1_2 to PSA hashing

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -765,6 +765,7 @@ int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
+// The hash buffer must have at least MBEDTLS_MD_MAX_SIZE bytes of length.
 int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
                                             unsigned char *hash, size_t *hashlen,
                                             unsigned char *data, size_t data_len,

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -765,7 +765,7 @@ int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
-// The hash buffer must have at least MBEDTLS_MD_MAX_SIZE bytes of length.
+/* The hash buffer must have at least MBEDTLS_MD_MAX_SIZE bytes of length. */
 int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
                                             unsigned char *hash, size_t *hashlen,
                                             unsigned char *data, size_t data_len,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -9988,8 +9988,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     psa_hash_operation_t hash_operation;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( md_alg );
 
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform PSA-based computation of digest "
-                                "of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform PSA-based computation of digest of ServerKeyExchange" ) );
 
     if( ( status = psa_hash_setup( &hash_operation,
                                    hash_alg ) ) != PSA_SUCCESS )
@@ -10052,8 +10051,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type( md_alg );
     *hashlen = mbedtls_md_get_size( md_info );
 
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform mbedtls-based computation of digest "
-                                "of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform mbedtls-based computation of digest of ServerKeyExchange" ) );
 
     mbedtls_md_init( &ctx );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -9988,8 +9988,8 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     psa_hash_operation_t hash_operation;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( md_alg );
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "Perform PSA-based computation of digest \
-    		                     of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform PSA-based computation of digest "
+                                "of ServerKeyExchange" ) );
 
     if( ( status = psa_hash_setup( &hash_operation,
                                    hash_alg ) ) != PSA_SUCCESS )
@@ -10052,8 +10052,8 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type( md_alg );
     *hashlen = mbedtls_md_get_size( md_info );
 
-    MBEDTLS_SSL_DEBUG_MSG( 2, ( "Perform mbedtls-based computation of digest \
-    		                     of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform mbedtls-based computation of digest "
+                                "of ServerKeyExchange" ) );
 
     mbedtls_md_init( &ctx );
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -765,6 +765,7 @@ run_test_psa() {
                 -C "Failed to setup PSA-based cipher context"\
                 -S "Failed to setup PSA-based cipher context"\
                 -s "Protocol is TLSv1.2" \
+                -c "Perform PSA-based computation of digest of ServerKeyExchange" \
                 -S "error" \
                 -C "error"
 }


### PR DESCRIPTION
This PR adapts the mbedtls_ssl_get_key_exchange_md_tls1_2  function to use PSA hashing. 
Note: psa_hash_finish expects a length of the hash buffer. We can either change the API to supply it to mbedtls_ssl_get_key_exchange_md_tls1_2, or expect a buffer of at least MBEDTLS_MD_MAX_SIZE  length and document it. I've decided to use the second option, to avoid API changes. 

I have tested this PR using ssl-opt.sh with a config that had TLS 1 and TLS1_1 commented out, leaving TLS1_2 in. Unfortunately I wasn't able to fully run compat.sh due to a faulty environment configuration - I'm expecting to get these results from the CI.