### PR TITLE
Backport 2.7: Add check against multiple configurations files being defined

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -30,6 +30,10 @@
 #ifndef MBEDTLS_CHECK_CONFIG_H
 #define MBEDTLS_CHECK_CONFIG_H
 
+#if defined(MBEDTLS_CONFIG_FILE) && defined(MBEDTLS_USER_CONFIG_FILE)
+#error "MBEDTLS_USER_CONFIG_FILE cannot be included if MBEDTLS_CONFIG_FILE is defined."
+#endif
+
 /*
  * We assume CHAR_BIT is 8 in many places. In practice, this is true on our
  * target platforms, so not an issue, but let's just be extra sure.


### PR DESCRIPTION
## Description
This is a backport of PR #2044.

This PR adds an additional check to `check_config.h` to ensure `MBEDTLS_USER_CONFIG_FILE` cannot be defined if `MBEDTLS_CONFIG_FILE` is defined. If both are defined `MBEDTLS_USER_CONFIG_FILE` will not be included because it's only included within `MBEDTLS_USER_CONFIG_FILE`. This may confuse users who expect both to be included if defined.

This PR is dependent on #1999 makes no sense without it. That's because `check_config.h` is currently only included in `config.h`, and may not be included in a custom configuration. #1999 adds it to all .c files, to ensure it's always included. This check needs to be included in all files, because if someone defines `MBEDTLS_CONFIG_FILE` with their own configuration file, `check_config.h` may never be included.

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
