### PR TITLE
PSA: Implement tls_prf_generic using the PSA API

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -507,8 +507,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     psa_key_handle_t master_slot;
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
 
-    if( ( status = psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                     slen * 8, &master_slot ) ) != PSA_SUCCESS )
+    if( ( status = psa_allocate_key( &master_slot ) ) != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     if( status != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
@@ -517,7 +516,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     else
         alg = PSA_ALG_TLS12_PRF(PSA_ALG_SHA_256);
 
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_DERIVE,
                               alg );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -504,10 +504,12 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     psa_status_t status;
     psa_algorithm_t alg;
     psa_key_policy_t policy;
-    psa_key_slot_t master_slot;
+    psa_key_handle_t master_slot;
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
 
-    status = mbedtls_psa_get_free_key_slot( &master_slot );
+    if( ( status = psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                     slen * 8, &master_slot ) ) != PSA_SUCCESS )
+        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     if( status != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     if( md_type == MBEDTLS_MD_SHA384 )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -559,7 +559,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     if( status != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 
-    return 0;
+    return( 0 );
 }
 
 #else /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -550,7 +550,10 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
 
     status = psa_generator_abort( &generator );
     if( status != PSA_SUCCESS )
+    {
+        psa_destroy_key( master_slot );
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+    }
 
     status = psa_destroy_key( master_slot );
     if( status != PSA_SUCCESS )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -509,8 +509,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
 
     if( ( status = psa_allocate_key( &master_slot ) ) != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-    if( status != PSA_SUCCESS )
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+
     if( md_type == MBEDTLS_MD_SHA384 )
         alg = PSA_ALG_TLS12_PRF(PSA_ALG_SHA_384);
     else


### PR DESCRIPTION
This PR introduces a tls_prf_generic implementation using the PSA API. 

I have tested this PR using ssl-opt.sh with a config that had TLS 1 and TLS1_1 commented out, leaving TLS1_2 in. Unfortunately I wasn't able to fully run compat.sh due to a faulty environment configuration - I'm expecting to get these results from the CI.