### PR TITLE
Backport2.7: Change buf size to a valid size

### DIFF
--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -14,7 +14,7 @@ void ecdsa_prim_random( int id )
     mbedtls_ecp_point Q;
     mbedtls_mpi d, r, s;
     rnd_pseudo_info rnd_info;
-    unsigned char buf[66];
+    unsigned char buf[MBEDTLS_MD_MAX_SIZE];
 
     mbedtls_ecp_group_init( &grp );
     mbedtls_ecp_point_init( &Q );


### PR DESCRIPTION
## Description
Backport of #2208 which was already merged but not backported, because no On Target Tests available in version 2.7. However, there is a backport of the tests to version 2.7, so backporting this PR as well to `mbedtls-2.7`


## Status
**READY**
