### PR TITLE
Migrate from gettimeofday to clock_gettime in timing.c

### DIFF
--- a/library/timing.c
+++ b/library/timing.c
@@ -219,7 +219,7 @@ unsigned long mbedtls_timing_hardclock( void )
 
 #if !defined(_WIN32)
 #if defined(__FreeBSD__)
-static clockid_t clock_id = CLOCK_UPTIME_PRECISE;
+static clockid_t clock_id = CLOCK_MONOTONIC_PRECISE;
 #else /* defined(__FreeBSD__) */
 static clockid_t clock_id = CLOCK_MONOTONIC;
 #endif /* defined(__FreeBSD__) */

--- a/library/timing.c
+++ b/library/timing.c
@@ -218,8 +218,12 @@ unsigned long mbedtls_timing_hardclock( void )
 #endif /* !HAVE_HARDCLOCK && _MSC_VER && !EFIX64 && !EFI32 */
 
 #if !defined(_WIN32)
+#if defined(__FreeBSD__)
+static clockid_t clock_id = CLOCK_UPTIME;
+#else /* defined(__FreeBSD__) */
 static clockid_t clock_id = CLOCK_MONOTONIC;
-#endif
+#endif /* defined(__FreeBSD__) */
+#endif /* !defined(_WIN32) */
 
 #if !defined(HAVE_HARDCLOCK)
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -219,7 +219,7 @@ unsigned long mbedtls_timing_hardclock( void )
 
 #if !defined(_WIN32)
 #if defined(__FreeBSD__)
-static clockid_t clock_id = CLOCK_UPTIME;
+static clockid_t clock_id = CLOCK_UPTIME_PRECISE;
 #else /* defined(__FreeBSD__) */
 static clockid_t clock_id = CLOCK_MONOTONIC;
 #endif /* defined(__FreeBSD__) */


### PR DESCRIPTION
## Description
This PR changes use of `gettimeofday` function to `clock_gettime` in order to mitigate risk of the reads from the clock being non-monotonic. In fact, `clock_gettime` used with a proper `clock_id` should guarantee monotonic reads.


## Status
**IN DEVELOPMENT**

## Requires Backporting
Yes
To whichever branch, in which we are experiencing timing test failures

## Migrations
NO

## Additional comments
None


## Steps to test or reproduce
Run the timing tests multiple times. On a FreeBSD virtual machine ran on an x86 Debian Stretch laptop it took ~20k runs of `test_suite_timing`, to observe a failure.

