### PR TITLE
PSA: Update crypto submodule (Hash clone, Key Policy Init, Key slot alloc)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crypto"]
 	path = crypto
 	url = https://github.com/ARMmbed/mbed-crypto
-	branch = iotssl-2697-psa-key-allocation-crypto
+	branch = development

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crypto"]
 	path = crypto
-	url = git@github.com:ARMmbed/mbedtls-psa.git
-	branch = feature-psa
+	url = git@github.com:ARMmbed/mbed-crypto.git
+	branch = development

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crypto"]
 	path = crypto
 	url = https://github.com/ARMmbed/mbed-crypto
-	branch = development
+	branch = iotssl-2697-psa-key-allocation-crypto

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crypto"]
 	path = crypto
-	url = git@github.com:ARMmbed/mbed-crypto.git
+	url = https://github.com/ARMmbed/mbed-crypto
 	branch = development

--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -137,7 +137,7 @@ typedef enum
 typedef struct
 {
     psa_algorithm_t alg;
-    psa_key_slot_t slot;
+    psa_key_handle_t slot;
     mbedtls_cipher_psa_key_ownership slot_state;
 } mbedtls_cipher_context_psa;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -273,7 +273,7 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info );
  *                  ECC key pair.
  * \return          #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
-int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_slot_t key );
+int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
@@ -761,7 +761,7 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
  * \return          An Mbed TLS error code otherwise.
  */
 int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
-                               psa_key_slot_t *slot,
+                               psa_key_handle_t *slot,
                                psa_algorithm_t hash_alg );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -42,21 +42,6 @@
 #include "md.h"
 #include "pk.h"
 
-/* Slot allocation */
-
-static inline psa_status_t mbedtls_psa_get_free_key_slot( psa_key_slot_t *key )
-{
-    for( psa_key_slot_t slot = 1; slot <= 32; slot++ )
-    {
-        if( psa_get_key_information( slot, NULL, NULL ) == PSA_ERROR_EMPTY_SLOT )
-        {
-            *key = slot;
-            return( PSA_SUCCESS );
-        }
-    }
-    return( PSA_ERROR_INSUFFICIENT_MEMORY );
-}
-
 /* Translations for symmetric crypto. */
 
 static inline psa_key_type_t mbedtls_psa_translate_cipher_type(

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -216,6 +216,23 @@ static inline psa_ecc_curve_t mbedtls_psa_translate_ecc_group( mbedtls_ecp_group
     }
 }
 
+#define MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE( curve )                \
+    ( curve == PSA_ECC_CURVE_SECP192R1        ? 192 :             \
+      curve == PSA_ECC_CURVE_SECP224R1        ? 224 :             \
+      curve == PSA_ECC_CURVE_SECP256R1        ? 256 :             \
+      curve == PSA_ECC_CURVE_SECP384R1        ? 384 :             \
+      curve == PSA_ECC_CURVE_SECP521R1        ? 521 :             \
+      curve == PSA_ECC_CURVE_SECP192K1        ? 192 :             \
+      curve == PSA_ECC_CURVE_SECP224K1        ? 224 :             \
+      curve == PSA_ECC_CURVE_SECP256K1        ? 256 :             \
+      curve == PSA_ECC_CURVE_BRAINPOOL_P256R1 ? 256 :             \
+      curve == PSA_ECC_CURVE_BRAINPOOL_P384R1 ? 384 :             \
+      curve == PSA_ECC_CURVE_BRAINPOOL_P512R1 ? 512 :             \
+      0 )
+
+#define MBEDTLS_PSA_ECC_KEY_BYTES_OF_CURVE( curve )                \
+    ( ( MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE( curve ) + 7 ) / 8 )
+
 /* Translations for PK layer */
 
 static inline int mbedtls_psa_err_translate_pk( psa_status_t status )

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -244,6 +244,19 @@ static inline int mbedtls_psa_err_translate_pk( psa_status_t status )
     }
 }
 
+/* Translations for ECC */
+
+/* This function transforms an ECC group identifier from
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+ * into a PSA ECC group identifier. */
+static inline psa_ecc_curve_t mbedtls_psa_parse_tls_ecc_group(
+    uint16_t tls_ecc_grp_reg_id )
+{
+    /* The PSA identifiers are currently aligned with those from
+     * the TLS Supported Groups registry, so no conversion is necessary. */
+    return( (psa_ecc_curve_t) tls_ecc_grp_reg_id );
+}
+
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #endif /* MBEDTLS_PSA_UTIL_H */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2129,7 +2129,7 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
  * \param psk      The identifier of the key slot holding the PSK.
  *                 Until \p conf is destroyed or this function is successfully
  *                 called again, the key slot \p psk must be populated with a
- *                 key of type #PSA_ALG_CATEGORY_KEY_DERIVATION whose policy
+ *                 key of type PSA_ALG_CATEGORY_KEY_DERIVATION whose policy
  *                 allows its use for the key derivation algorithm applied
  *                 in the handshake.
  * \param psk_identity      The pointer to the pre-shared key identity.
@@ -2176,7 +2176,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
  * \param psk      The identifier of the key slot holding the PSK.
  *                 For the duration of the current handshake, the key slot
  *                 must be populated with a key of type
- *                 #PSA_ALG_CATEGORY_KEY_DERIVATION whose policy allows its
+ *                 PSA_ALG_CATEGORY_KEY_DERIVATION whose policy allows its
  *                 use for the key derivation algorithm
  *                 applied in the handshake.
   *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -929,11 +929,11 @@ struct mbedtls_ssl_config
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_slot_t psk_opaque; /*!< PSA key slot holding opaque PSK.
-                                *   This field should only be set via
-                                *   mbedtls_ssl_conf_psk_opaque().
-                                *   If either no PSK or a raw PSK have
-                                *   been configured, this has value \c 0. */
+    psa_key_handle_t psk_opaque; /*!< PSA key slot holding opaque PSK.
+                                  *   This field should only be set via
+                                  *   mbedtls_ssl_conf_psk_opaque().
+                                  *   If either no PSK or a raw PSK have
+                                  *   been configured, this has value \c 0. */
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     unsigned char *psk;      /*!< The raw pre-shared key. This field should
@@ -2144,7 +2144,7 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
 int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
-                                 psa_key_slot_t psk,
+                                 psa_key_handle_t psk,
                                  const unsigned char *psk_identity,
                                  size_t psk_identity_len );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -2184,7 +2184,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
 int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
-                                   psa_key_slot_t psk );
+                                   psa_key_handle_t psk );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /**

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -284,7 +284,7 @@ struct mbedtls_ssl_handshake_params
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_slot_t psk_opaque;          /*!< Opaque PSK from the callback   */
+    psa_key_handle_t psk_opaque;        /*!< Opaque PSK from the callback   */
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     unsigned char *psk;                 /*!<  PSK from the callback         */
     size_t psk_len;                     /*!<  Length of PSK from callback   */

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -308,7 +308,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
             return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
 
         /* Allocate a key slot to use. */
-        status = psa_allocate_key( key_type, key_bitlen, &cipher_psa->slot );
+        status = psa_allocate_key( &cipher_psa->slot );
         if( status != PSA_SUCCESS )
             return( MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED );
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -317,17 +317,17 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
         cipher_psa->slot_state = MBEDTLS_CIPHER_PSA_KEY_OWNED;
 
         /* From that point on, the responsibility for destroying the
-        * key slot is on mbedtls_cipher_free(). This includes the case
-        * where the policy setup or key import below fail, as
-        * mbedtls_cipher_free() needs to be called in any case. */
+         * key slot is on mbedtls_cipher_free(). This includes the case
+         * where the policy setup or key import below fail, as
+         * mbedtls_cipher_free() needs to be called in any case. */
 
         /* Setup policy for the new key slot. */
         psa_key_policy_init( &key_policy );
 
         /* Mbed TLS' cipher layer doesn't enforce the mode of operation
-        * (encrypt vs. decrypt): it is possible to setup a key for encryption
-        * and use it for AEAD decryption. Until tests relying on this
-        * are changed, allow any usage in PSA. */
+         * (encrypt vs. decrypt): it is possible to setup a key for encryption
+         * and use it for AEAD decryption. Until tests relying on this
+         * are changed, allow any usage in PSA. */
         /* key_usage = mbedtls_psa_translate_cipher_operation( operation ); */
         key_usage = PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT;
         psa_key_policy_set_usage( &key_policy, key_usage, cipher_psa->alg );

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -322,7 +322,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
          * mbedtls_cipher_free() needs to be called in any case. */
 
         /* Setup policy for the new key slot. */
-        psa_key_policy_init( &key_policy );
+        key_policy = psa_key_policy_init();
 
         /* Mbed TLS' cipher layer doesn't enforce the mode of operation
          * (encrypt vs. decrypt): it is possible to setup a key for encryption

--- a/library/pk.c
+++ b/library/pk.c
@@ -576,7 +576,7 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
                                  mbedtls_psa_parse_tls_ecc_group ( curve_id ) );
 
     /* allocate a key slot */
-    if( PSA_SUCCESS != psa_allocate_key( key_type, d_len * 8, &key ) )
+    if( PSA_SUCCESS != psa_allocate_key( &key ) )
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* set policy */

--- a/library/pk.c
+++ b/library/pk.c
@@ -580,7 +580,7 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* set policy */
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN,
                                        PSA_ALG_ECDSA(hash_alg) );
     if( PSA_SUCCESS != psa_set_key_policy( key, &policy ) )

--- a/library/pk.c
+++ b/library/pk.c
@@ -573,7 +573,7 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
 
     curve_id = mbedtls_ecp_curve_info_from_grp_id( ec->grp.id )->tls_id;
     key_type = PSA_KEY_TYPE_ECC_KEYPAIR(
-    		                     mbedtls_psa_parse_tls_ecc_group ( curve_id ) );
+                                 mbedtls_psa_parse_tls_ecc_group ( curve_id ) );
 
     /* allocate a key slot */
     if( PSA_SUCCESS != psa_allocate_key( key_type, d_len * 8, &key ) )

--- a/library/pk.c
+++ b/library/pk.c
@@ -572,7 +572,8 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
         return( ret );
 
     curve_id = mbedtls_ecp_curve_info_from_grp_id( ec->grp.id )->tls_id;
-    key_type = PSA_KEY_TYPE_ECC_KEYPAIR(curve_id);
+    key_type = PSA_KEY_TYPE_ECC_KEYPAIR(
+    		                     mbedtls_psa_parse_tls_ecc_group ( curve_id ) );
 
     /* allocate a key slot */
     if( PSA_SUCCESS != psa_allocate_key( key_type, d_len * 8, &key ) )

--- a/library/pk.c
+++ b/library/pk.c
@@ -147,10 +147,10 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info )
 /*
  * Initialise a PSA-wrapping context
  */
-int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_slot_t key )
+int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key )
 {
     const mbedtls_pk_info_t * const info = &mbedtls_pk_opaque_info;
-    psa_key_slot_t *pk_ctx;
+    psa_key_handle_t *pk_ctx;
     psa_key_type_t type;
 
     if( ctx == NULL || ctx->pk_info != NULL )
@@ -168,7 +168,7 @@ int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_slot_t key )
 
     ctx->pk_info = info;
 
-    pk_ctx = (psa_key_slot_t *) ctx->pk_ctx;
+    pk_ctx = (psa_key_handle_t *) ctx->pk_ctx;
     *pk_ctx = key;
 
     return( 0 );
@@ -547,13 +547,13 @@ mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx )
  * Currently only works for EC private keys.
  */
 int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
-                               psa_key_slot_t *slot,
+                               psa_key_handle_t *slot,
                                psa_algorithm_t hash_alg )
 {
 #if !defined(MBEDTLS_ECP_C)
     return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
 #else
-    psa_key_slot_t key;
+    psa_key_handle_t key;
     const mbedtls_ecp_keypair *ec;
     unsigned char d[MBEDTLS_ECP_MAX_BYTES];
     size_t d_len;
@@ -572,9 +572,10 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
         return( ret );
 
     curve_id = mbedtls_ecp_curve_info_from_grp_id( ec->grp.id )->tls_id;
+    key_type = PSA_KEY_TYPE_ECC_KEYPAIR(curve_id);
 
-    /* find a free key slot */
-    if( PSA_SUCCESS != mbedtls_psa_get_free_key_slot( &key ) )
+    /* allocate a key slot */
+    if( PSA_SUCCESS != psa_allocate_key( key_type, d_len * 8, &key ) )
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* set policy */
@@ -585,7 +586,6 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* import private key in slot */
-    key_type = PSA_KEY_TYPE_ECC_KEYPAIR(curve_id);
     if( PSA_SUCCESS != psa_import_key( key, key_type, d, d_len ) )
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -577,9 +577,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     psa_sig_md = PSA_ALG_ECDSA( psa_md );
     psa_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY( curve );
 
-    if( ( ret = psa_allocate_key( psa_type,
-                                  MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE(curve),
-                                  &key_slot ) ) != PSA_SUCCESS )
+    if( ( ret = psa_allocate_key( &key_slot ) ) != PSA_SUCCESS )
           return( mbedtls_psa_err_translate_pk( ret ) );
 
     psa_key_policy_init( &policy );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -580,7 +580,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     if( ( ret = psa_allocate_key( &key_slot ) ) != PSA_SUCCESS )
           return( mbedtls_psa_err_translate_pk( ret ) );
 
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, psa_sig_md );
     if( ( ret = psa_set_key_policy( key_slot, &policy ) ) != PSA_SUCCESS )
     {

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -546,7 +546,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                        const unsigned char *sig, size_t sig_len )
 {
     int ret;
-    psa_key_slot_t key_slot;
+    psa_key_handle_t key_slot;
     psa_key_policy_t policy;
     psa_key_type_t psa_type;
     mbedtls_pk_context key;
@@ -571,14 +571,14 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     if( key_len <= 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    if( ( ret = mbedtls_psa_get_free_key_slot( &key_slot ) ) != PSA_SUCCESS )
-        return( mbedtls_psa_err_translate_pk( ret ) );
-
     psa_md = mbedtls_psa_translate_md( md_alg );
     if( psa_md == 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
     psa_sig_md = PSA_ALG_ECDSA( psa_md );
     psa_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY( curve );
+
+    if( ( ret = psa_allocate_key( psa_type, key_len * 8, &key_slot ) ) != PSA_SUCCESS )
+          return( mbedtls_psa_err_translate_pk( ret ) );
 
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, psa_sig_md );
@@ -879,7 +879,7 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
 
 static void *pk_opaque_alloc_wrap( void )
 {
-    void *ctx = mbedtls_calloc( 1, sizeof( psa_key_slot_t ) );
+    void *ctx = mbedtls_calloc( 1, sizeof( psa_key_handle_t ) );
 
     /* no _init() function to call, an calloc() already zeroized */
 
@@ -888,13 +888,13 @@ static void *pk_opaque_alloc_wrap( void )
 
 static void pk_opaque_free_wrap( void *ctx )
 {
-    mbedtls_platform_zeroize( ctx, sizeof( psa_key_slot_t ) );
+    mbedtls_platform_zeroize( ctx, sizeof( psa_key_handle_t ) );
     mbedtls_free( ctx );
 }
 
 static size_t pk_opaque_get_bitlen( const void *ctx )
 {
-    const psa_key_slot_t *key = (const psa_key_slot_t *) ctx;
+    const psa_key_handle_t *key = (const psa_key_handle_t *) ctx;
     size_t bits;
 
     if( PSA_SUCCESS != psa_get_key_information( *key, NULL, &bits ) )
@@ -999,7 +999,7 @@ static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    const psa_key_slot_t *key = (const psa_key_slot_t *) ctx;
+    const psa_key_handle_t *key = (const psa_key_handle_t *) ctx;
     psa_algorithm_t alg = PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
     size_t bits, buf_len;
     psa_status_t status;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -577,7 +577,9 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     psa_sig_md = PSA_ALG_ECDSA( psa_md );
     psa_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY( curve );
 
-    if( ( ret = psa_allocate_key( psa_type, key_len * 8, &key_slot ) ) != PSA_SUCCESS )
+    if( ( ret = psa_allocate_key( psa_type,
+                                  MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE(curve),
+                                  &key_slot ) ) != PSA_SUCCESS )
           return( mbedtls_psa_err_translate_pk( ret ) );
 
     psa_key_policy_init( &policy );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -168,7 +168,7 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
     if( mbedtls_pk_get_type( key ) == MBEDTLS_PK_OPAQUE )
     {
         size_t buffer_size;
-        psa_key_slot_t* key_slot = (psa_key_slot_t*) key->pk_ctx;
+        psa_key_handle_t* key_slot = (psa_key_handle_t*) key->pk_ctx;
 
         if ( *p < start )
             return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -798,7 +798,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
             psa_status_t status;
             psa_algorithm_t alg;
             psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
-            psa_key_slot_t psk;
+            psa_key_handle_t psk;
 
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "perform PSA-based PSK-to-MS expansion" ) );
 
@@ -7617,7 +7617,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
-                                 psa_key_slot_t psk_slot,
+                                 psa_key_handle_t psk_slot,
                                  const unsigned char *psk_identity,
                                  size_t psk_identity_len )
 {
@@ -7640,7 +7640,7 @@ int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
 }
 
 int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
-                                   psa_key_slot_t psk_slot )
+                                   psa_key_handle_t psk_slot )
 {
     if( psk_slot == 0 || ssl->handshake == NULL )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1594,7 +1594,7 @@ int main( int argc, char *argv[] )
     if( opt.psk_opaque != 0 )
     {
         /* The algorithm has already been determined earlier. */
-        status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &slot );
+        status = psa_allocate_key( &slot );
         if( status != PSA_SUCCESS )
         {
             ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1601,7 +1601,7 @@ int main( int argc, char *argv[] )
             goto exit;
         }
 
-        psa_key_policy_init( &policy );
+        policy = psa_key_policy_init();
         psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
 
         status = psa_set_key_policy( slot, &policy );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -571,7 +571,7 @@ int main( int argc, char *argv[] )
     const char *pers = "ssl_client2";
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_slot_t slot = 0;
+    psa_key_handle_t slot = 0;
     psa_algorithm_t alg = 0;
     psa_key_policy_t policy;
     psa_status_t status;
@@ -594,7 +594,7 @@ int main( int argc, char *argv[] )
     mbedtls_x509_crt clicert;
     mbedtls_pk_context pkey;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_slot_t key_slot = 0; /* invalid key slot */
+    psa_key_handle_t key_slot = 0; /* invalid key slot */
 #endif
 #endif
     char *p, *q;
@@ -1594,7 +1594,7 @@ int main( int argc, char *argv[] )
     if( opt.psk_opaque != 0 )
     {
         /* The algorithm has already been determined earlier. */
-        status = mbedtls_psa_get_free_key_slot( &slot );
+        status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &slot );
         if( status != PSA_SUCCESS )
         {
             ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1239,7 +1239,7 @@ static psa_status_t psa_setup_psk_key_slot( psa_key_handle_t slot,
     psa_status_t status;
     psa_key_policy_t policy;
 
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
 
     status = psa_set_key_policy( slot, &policy );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2667,7 +2667,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if( opt.psk_opaque != 0 )
         {
-            status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &psk_slot );
+            status = psa_allocate_key( &psk_slot );
             if( status != PSA_SUCCESS )
             {
                 fprintf( stderr, "ALLOC FAIL\n" );
@@ -2711,7 +2711,7 @@ int main( int argc, char *argv[] )
             psk_entry *cur_psk;
             for( cur_psk = psk_info; cur_psk != NULL; cur_psk = cur_psk->next )
             {
-                status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, cur_psk->key_len * 8, &cur_psk->slot );
+                status = psa_allocate_key( &cur_psk->slot );
                 if( status != PSA_SUCCESS )
                 {
                     ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -806,7 +806,7 @@ struct _psk_entry
     size_t key_len;
     unsigned char key[MBEDTLS_PSK_MAX_LEN];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_key_slot_t slot;
+    psa_key_handle_t slot;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     psk_entry *next;
 };
@@ -822,7 +822,7 @@ int psk_free( psk_entry *head )
     {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_status_t status;
-        psa_key_slot_t const slot = head->slot;
+        psa_key_handle_t const slot = head->slot;
 
         if( slot != 0 )
         {
@@ -1231,7 +1231,7 @@ int idle( mbedtls_net_context *fd,
 }
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-static psa_status_t psa_setup_psk_key_slot( psa_key_slot_t slot,
+static psa_status_t psa_setup_psk_key_slot( psa_key_handle_t slot,
                                             psa_algorithm_t alg,
                                             unsigned char *psk,
                                             size_t psk_len )
@@ -1268,7 +1268,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_algorithm_t alg = 0;
-    psa_key_slot_t psk_slot = 0;
+    psa_key_handle_t psk_slot = 0;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     unsigned char psk[MBEDTLS_PSK_MAX_LEN];
     size_t psk_len = 0;
@@ -2667,7 +2667,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if( opt.psk_opaque != 0 )
         {
-            status = mbedtls_psa_get_free_key_slot( &psk_slot );
+            status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &psk_slot );
             if( status != PSA_SUCCESS )
             {
                 fprintf( stderr, "ALLOC FAIL\n" );
@@ -2711,7 +2711,7 @@ int main( int argc, char *argv[] )
             psk_entry *cur_psk;
             for( cur_psk = psk_info; cur_psk != NULL; cur_psk = cur_psk->next )
             {
-                status = mbedtls_psa_get_free_key_slot( &cur_psk->slot );
+                status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, cur_psk->key_len * 8, &cur_psk->slot );
                 if( status != PSA_SUCCESS )
                 {
                     ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -84,7 +84,7 @@ psa_key_handle_t pk_psa_genkey( void )
     psa_key_policy_t policy;
 
     /* Allocate a key slot */
-    if( PSA_SUCCESS != psa_allocate_key( type, bits, &key ) )
+    if( PSA_SUCCESS != psa_allocate_key( &key ) )
         return( PK_PSA_INVALID_SLOT );
 
     /* set up policy on key slot */

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -88,7 +88,7 @@ psa_key_handle_t pk_psa_genkey( void )
         return( PK_PSA_INVALID_SLOT );
 
     /* set up policy on key slot */
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN,
                                       PSA_ALG_ECDSA(PSA_ALG_SHA_256) );
     if( PSA_SUCCESS != psa_set_key_policy( key, &policy ) )

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -74,17 +74,17 @@ size_t mbedtls_rsa_key_len_func( void *ctx )
  * or PK_PSA_INVALID_SLOT if no slot was available.
  * The key uses NIST P-256 and is usable for signing with SHA-256.
  */
-psa_key_slot_t pk_psa_genkey( void )
+psa_key_handle_t pk_psa_genkey( void )
 {
-    psa_key_slot_t key;
+    psa_key_handle_t key;
 
     const int curve = PSA_ECC_CURVE_SECP256R1;
     const psa_key_type_t type = PSA_KEY_TYPE_ECC_KEYPAIR(curve);
     const size_t bits = 256;
     psa_key_policy_t policy;
 
-    /* find a free key slot */
-    if( PSA_SUCCESS != mbedtls_psa_get_free_key_slot( &key ) )
+    /* Allocate a key slot */
+    if( PSA_SUCCESS != psa_allocate_key( type, bits, &key ) )
         return( PK_PSA_INVALID_SLOT );
 
     /* set up policy on key slot */
@@ -112,7 +112,7 @@ psa_key_slot_t pk_psa_genkey( void )
 void pk_psa_utils(  )
 {
     mbedtls_pk_context pk, pk2;
-    psa_key_slot_t key;
+    psa_key_handle_t key;
 
     const char * const name = "Opaque";
     const size_t bitlen = 256; /* harcoded in genkey() */
@@ -778,7 +778,7 @@ exit:
 void pk_psa_sign(  )
 {
     mbedtls_pk_context pk;
-    psa_key_slot_t key;
+    psa_key_handle_t key;
     unsigned char hash[50], sig[100], pkey[100];
     size_t sig_len, klen = 0;
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -133,7 +133,7 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
                                  int cert_type )
 {
     mbedtls_pk_context key;
-    psa_key_slot_t slot;
+    psa_key_handle_t slot;
     psa_algorithm_t md_alg_psa;
     mbedtls_x509write_csr req;
     unsigned char buf[4096];


### PR DESCRIPTION
__Summary:__ This PR is based on #2339 and updates the Crypto submodule to the merge commit https://github.com/ARMmbed/mbed-crypto/commit/0b6b87105624b52f1c7c2f9ac4e8e2ff977a58f9 of the sibling https://github.com/ARMmbed/mbed-crypto/pull/22 of #2339. 
This merge introduces the following API changes to the PSA API:
- New hash clone API.
- Modified key policy initialization API: The signature of `psa_key_policy_init` has changed.
- Modified key slot allocation API: `psa_allocate_key()` no longer takes key type and length as arguments.

No changes to the code are yet necessary for the hash clone API, as we haven't used it so far (still to come). The key policy and key slot allocation API change require changes to the code, and this PR makes the necessary adaptations.

__Dependencies:__ 
- #2339 needs to be merged first.
- This PR affects files from the crypto library, and hence has a sibling https://github.com/ARMmbed/mbed-crypto/pull/27 on the crypto side which should be merged first.