### PR TITLE
PSA: ssl_tls: use PSA to compute running handshake hash for TLS 1.2

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -27,6 +27,10 @@
 #include "ssl.h"
 #include "cipher.h"
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#include "psa/crypto.h"
+#endif
+
 #if defined(MBEDTLS_MD5_C)
 #include "md5.h"
 #endif
@@ -370,10 +374,18 @@ struct mbedtls_ssl_handshake_params
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA256_C)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_hash_operation_t fin_sha256_psa;
+#else
     mbedtls_sha256_context fin_sha256;
 #endif
+#endif
 #if defined(MBEDTLS_SHA512_C)
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_hash_operation_t fin_sha512_psa;
+#else
     mbedtls_sha512_context fin_sha512;
+#endif
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -382,7 +382,7 @@ struct mbedtls_ssl_handshake_params
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_operation_t fin_sha512_psa;
+    psa_hash_operation_t fin_sha384_psa;
 #else
     mbedtls_sha512_context fin_sha512;
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1410,17 +1410,17 @@ void ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char hash[48
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;
     psa_status_t status;
-    psa_hash_operation_t sha512_psa = psa_hash_operation_init();
+    psa_hash_operation_t sha384_psa = psa_hash_operation_init();
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> PSA calc verify sha384" ) );
-    status = psa_hash_clone( &ssl->handshake->fin_sha512_psa, &sha512_psa );
+    status = psa_hash_clone( &ssl->handshake->fin_sha384_psa, &sha384_psa );
     if( status != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "PSA hash clone failed" ) );
         return;
     }
 
-    status = psa_hash_finish( &sha512_psa, hash, 48, &hash_size );
+    status = psa_hash_finish( &sha384_psa, hash, 48, &hash_size );
     if( status != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "PSA hash finish failed" ) );
@@ -6221,7 +6221,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_setup( &ssl->handshake->fin_sha512_psa, PSA_ALG_SHA_384 );
+    psa_hash_setup( &ssl->handshake->fin_sha384_psa, PSA_ALG_SHA_384 );
 #else
     mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512, 1 );
 #endif
@@ -6247,7 +6247,7 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_update( &ssl->handshake->fin_sha512_psa, buf, len );
+    psa_hash_update( &ssl->handshake->fin_sha384_psa, buf, len );
 #else
     mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512, buf, len );
 #endif
@@ -6283,7 +6283,7 @@ static void ssl_update_checksum_sha384( mbedtls_ssl_context *ssl,
                                         const unsigned char *buf, size_t len )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_update( &ssl->handshake->fin_sha512_psa, buf, len );
+    psa_hash_update( &ssl->handshake->fin_sha384_psa, buf, len );
 #else
     mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512, buf, len );
 #endif
@@ -6521,7 +6521,7 @@ static void ssl_calc_finished_tls_sha384(
     unsigned char padbuf[48];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;
-    psa_hash_operation_t sha512_psa;
+    psa_hash_operation_t sha384_psa;
     psa_status_t status;
 #else
     mbedtls_sha512_context sha512;
@@ -6536,18 +6536,18 @@ static void ssl_calc_finished_tls_sha384(
                 : "server finished";
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    sha512_psa = psa_hash_operation_init();
+    sha384_psa = psa_hash_operation_init();
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc PSA finished tls sha384" ) );
 
-    status = psa_hash_clone( &ssl->handshake->fin_sha512_psa, &sha512_psa );
+    status = psa_hash_clone( &ssl->handshake->fin_sha384_psa, &sha384_psa );
     if( status != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "PSA hash clone failed" ) );
         return;
     }
 
-    status = psa_hash_finish( &sha512_psa, padbuf, sizeof( padbuf ), &hash_size );
+    status = psa_hash_finish( &sha384_psa, padbuf, sizeof( padbuf ), &hash_size );
     if( status != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "PSA hash finish failed" ) );
@@ -6901,8 +6901,8 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    handshake->fin_sha512_psa = psa_hash_operation_init();
-    psa_hash_setup( &handshake->fin_sha512_psa, PSA_ALG_SHA_384 );
+    handshake->fin_sha384_psa = psa_hash_operation_init();
+    psa_hash_setup( &handshake->fin_sha384_psa, PSA_ALG_SHA_384 );
 #else
     mbedtls_sha512_init(   &handshake->fin_sha512    );
     mbedtls_sha512_starts_ret( &handshake->fin_sha512, 1 );
@@ -9218,7 +9218,7 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_abort( &handshake->fin_sha512_psa );
+    psa_hash_abort( &handshake->fin_sha384_psa );
 #else
     mbedtls_sha512_free(   &handshake->fin_sha512    );
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6214,6 +6214,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA256_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_hash_abort( &ssl->handshake->fin_sha256_psa );
     psa_hash_setup( &ssl->handshake->fin_sha256_psa, PSA_ALG_SHA_256 );
 #else
     mbedtls_sha256_starts_ret( &ssl->handshake->fin_sha256, 0 );
@@ -6221,6 +6222,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_hash_abort( &ssl->handshake->fin_sha384_psa );
     psa_hash_setup( &ssl->handshake->fin_sha384_psa, PSA_ALG_SHA_384 );
 #else
     mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512, 1 );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -761,9 +761,11 @@ run_test_psa() {
                 -c "Successfully setup PSA-based decryption cipher context" \
                 -c "Successfully setup PSA-based encryption cipher context" \
                 -c "PSA calc verify" \
+                -c "calc PSA finished" \
                 -s "Successfully setup PSA-based decryption cipher context" \
                 -s "Successfully setup PSA-based encryption cipher context" \
                 -s "PSA calc verify" \
+                -s "calc PSA finished" \
                 -C "Failed to setup PSA-based cipher context"\
                 -S "Failed to setup PSA-based cipher context"\
                 -s "Protocol is TLSv1.2" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -755,13 +755,15 @@ run_test() {
 run_test_psa() {
     requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
     run_test    "PSA-supported ciphersuite: $1" \
-                "$P_SRV debug_level=1 force_version=tls1_2" \
-                "$P_CLI debug_level=1 force_version=tls1_2 force_ciphersuite=$1" \
+                "$P_SRV debug_level=2 force_version=tls1_2" \
+                "$P_CLI debug_level=2 force_version=tls1_2 force_ciphersuite=$1" \
                 0 \
                 -c "Successfully setup PSA-based decryption cipher context" \
                 -c "Successfully setup PSA-based encryption cipher context" \
+                -c "PSA calc verify" \
                 -s "Successfully setup PSA-based decryption cipher context" \
                 -s "Successfully setup PSA-based encryption cipher context" \
+                -s "PSA calc verify" \
                 -C "Failed to setup PSA-based cipher context"\
                 -S "Failed to setup PSA-based cipher context"\
                 -s "Protocol is TLSv1.2" \


### PR DESCRIPTION
This PR introduces running handshake hash computation for TLS 1.2. If MBEDTLS_USE_PSA_CRYPTO is defined, the standard contexts are replaced with PSA ones. I've tested this PR by running ssl-opt.sh tests with a configuration using PSA and tls1.2 only. For SHA384, I'll inspect the CI logs of compat.sh. 