### PR TITLE
Fix uninitialized variable in x509_crt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,8 @@ Bugfix
      hang.
    * Clarify documentation of mbedtls_ssl_set_own_cert() regarding the absence
      of check for certificate/key matching. Reported by Attila Molnar, #507.
+   * Fix compiler warning in x509_crt.  Discovered and fixed by
+     Andy Gross (Linaro), #2392.
 
 = mbed TLS 2.14.1 branch released 2018-11-30
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2088,15 +2088,13 @@ check_signature:
             continue;
         }
 
+        *r_parent = parent;
+        *r_signature_is_good = signature_is_good;
+
         break;
     }
 
-    if( parent != NULL )
-    {
-        *r_parent = parent;
-        *r_signature_is_good = signature_is_good;
-    }
-    else
+    if( parent == NULL )
     {
         *r_parent = fallback_parent;
         *r_signature_is_good = fallback_signature_is_good;


### PR DESCRIPTION
This patch fixes an issue we encountered with more stringent compiler
warnings.  The signature_is_good variable has a possibility of being
used uninitialized.  This patch initializes the variable at the top
of the function.

Signed-off-by: Andy Gross <andy.gross@linaro.org>

We found this issue while using mbedtls inside the Zephyr project.  We recently have started using the x509 features and this exposed this specific issue due to our compiler settings.  I am unsure about backporting as we are using 2.16.0.

**Gatekeeping note:** (added by mpg) this PR should be merge both development and mbedtls-2.16. The issue is not present in mbedtls-2.7 so no need for backports.