### PR TITLE
PSA: use policy wildcard for hash signatures

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1421,7 +1421,7 @@ int main( int argc, char *argv[] )
     if( opt.key_opaque != 0 )
     {
         if( ( ret = mbedtls_pk_wrap_as_opaque( &pkey, &key_slot,
-                                               PSA_ALG_SHA_256 ) ) != 0 )
+                                               PSA_ALG_ANY_HASH ) ) != 0 )
         {
             mbedtls_printf( " failed\n  !  "
                             "mbedtls_pk_wrap_as_opaque returned -0x%x\n\n", -ret );


### PR DESCRIPTION
## Description

In some circumstances, such as a TLS handshake, we can't know in advance what hash will be used for signing with a key at the time the key is set up. PSA Crypto kindly introduced a wildcard hash usable in policies just to meet our use case. This PR makes sure we take advantage of it when we should.

After reviewing the results of `grep -R PSA_ALG_ library programs tests include` it turned out there was only one such place: in `ssl_client2.c`. I chose to still hardcode `SHA-256` in the PK test suite, as it already hardcodes P-256 as the curve, and we fully control what hash we use in test cases (as opposed to a TLS handshake where we negociate it with the peer).

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Steps to test or reproduce

Tested by running `tests/ssl-opt.sh -f Opaque`  in a `MBEDTLS_USE_PSA_CRYPTO` build.
