### PR TITLE
Backport 2.16: fix memory leak in mpi_miller_rabin()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ Bugfix
      previously lead to a stack overflow on constrained targets.
    * Add `MBEDTLS_SELF_TEST` for the mbedtls_self_test functions
      in the header files, which missed the precompilation check. #971
+   * Fix memory leak in in mpi_miller_rabin(). Contributed by
+     Jens Wiklander <jens.wiklander@linaro.org> in #2363
 
 = mbed TLS 2.16.0 branch released 2018-12-21
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2329,7 +2329,8 @@ static int mpi_miller_rabin( const mbedtls_mpi *X, size_t rounds,
             }
 
             if (count++ > 30) {
-                return MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+                ret = MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+                goto cleanup;
             }
 
         } while ( mbedtls_mpi_cmp_mpi( &A, &W ) >= 0 ||


### PR DESCRIPTION
## Description
Backport of #2363 to `mbedtls-2.16`


## Status
**READY**
