### PR TITLE
Backport 2.7: key_app_writer writes invalid private key DER file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Bugfix
    * Remove a duplicate #include in a sample program. Fixed by Masashi Honma #2326.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Fix private key DER output in the key_app_writer example. File contents
+     were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
+     Christian Walther in #2239.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -175,7 +175,7 @@ static int write_private_key( mbedtls_pk_context *key, const char *output_file )
             return( ret );
 
         len = ret;
-        c = output_buf + sizeof(output_buf) - len - 1;
+        c = output_buf + sizeof(output_buf) - len;
     }
 
     if( ( f = fopen( output_file, "w" ) ) == NULL )


### PR DESCRIPTION
## Description
Backport of #2239 to `mbedtls-2.7`


## Status
**READY**


