### PR TITLE
all.sh: Fix check_headers_in_cpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Bugfix
      in X.509 module. Fixes #2212.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Fix false failure in all.sh when backup files exist in include/mbedtls
+     (e.g. config.h.bak). Fixed by Peter Kolbus (Garmin) #2407.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -295,7 +295,7 @@ check_tools()
 }
 
 check_headers_in_cpp () {
-    ls include/mbedtls >headers.txt
+    ls include/mbedtls | grep "\.h$" >headers.txt
     <programs/test/cpp_dummy_build.cpp sed -n 's/"$//; s!^#include "mbedtls/!!p' |
     sort |
     diff headers.txt -


### PR DESCRIPTION
## Description
When all.sh invokes check_headers_in_cpp, a backup config.h exists. This
causes a stray difference vs cpp_dummy_build.cpp. Fix by only collecting
the *.h files in include/mbedtls.

Fixes #2406.

## Status
**READY**

## Requires Backporting

[edited by mpg]
- to mbedtls-2.16 - https://github.com/ARMmbed/mbedtls/pull/2412
- mbedtls-2.7 does not have the cpp check so does not need a backport

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce

./tests/scripts/all.sh build_default_make_gcc_and_cxx

