### PR TITLE
Add mbedtls_ssl_ciphersuites_count() to easily determine the number of available ciphersuites

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS 2.x.x branch released xxxx-xx-xx
 
+Features
+   * Add mbedtls_ssl_ciphersuites_count() to easily determine available cipher suite
+     count. Implemented in PR #2408.
+
 Bugfix
    * Fix a compilation issue with mbedtls_ecp_restart_ctx not being defined
      when MBEDTLS_ECP_ALT is defined. Reported by jwhui. Fixes #2242.

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -406,7 +406,7 @@ struct mbedtls_ssl_ciphersuite_t
 
 const int *mbedtls_ssl_list_ciphersuites( void );
 
-/** 
+/**
  * \brief Function that returns the number of supported ciphersuites
  *
  * \return The Number of supported ciphersuites.

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -405,6 +405,7 @@ struct mbedtls_ssl_ciphersuite_t
 };
 
 const int *mbedtls_ssl_list_ciphersuites( void );
+int mbedtls_ssl_ciphersuites_count( void );
 
 const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_string( const char *ciphersuite_name );
 const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_id( int ciphersuite_id );

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -405,6 +405,11 @@ struct mbedtls_ssl_ciphersuite_t
 };
 
 const int *mbedtls_ssl_list_ciphersuites( void );
+
+/*
+ * Returns the count of ciphersuites available.
+ * Please note that the returned count does not include the final zero element from mbedtls_ssl_list_ciphersuites().
+ */
 int mbedtls_ssl_ciphersuites_count( void );
 
 const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_string( const char *ciphersuite_name );

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -406,9 +406,12 @@ struct mbedtls_ssl_ciphersuite_t
 
 const int *mbedtls_ssl_list_ciphersuites( void );
 
-/*
- * Returns the count of ciphersuites available.
- * Please note that the returned count does not include the final zero element from mbedtls_ssl_list_ciphersuites().
+/** 
+ * \brief Function that returns the number of supported ciphersuites
+ *
+ * \return The Number of supported ciphersuites.
+ *
+ * \note The number of ciphersuites returned do not include the terminating zero element from \c mbedtls_ssl_list_ciphersuites().
  */
 int mbedtls_ssl_ciphersuites_count( void );
 

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -2181,13 +2181,20 @@ const int *mbedtls_ssl_list_ciphersuites( void )
 {
     return( ciphersuite_preference );
 }
+
+int mbedtls_ssl_ciphersuites_count( void )
+{
+    /* Subtract one for the final NULL-entry */
+    return( ( sizeof( ciphersuite_preference ) / sizeof( *ciphersuite_preference ) ) - 1 );
+}
 #else
 #define MAX_CIPHERSUITES    sizeof( ciphersuite_definitions     ) /         \
                             sizeof( ciphersuite_definitions[0]  )
 static int supported_ciphersuites[MAX_CIPHERSUITES];
 static int supported_init = 0;
+static int supported_count = 0;
 
-const int *mbedtls_ssl_list_ciphersuites( void )
+static void mbedtls_ssl_ciphersuites_init( void )
 {
     /*
      * On initial call filter out all ciphersuites not supported by current
@@ -2209,14 +2216,29 @@ const int *mbedtls_ssl_list_ciphersuites( void )
 #else
             if( mbedtls_ssl_ciphersuite_from_id( *p ) != NULL )
 #endif
+            {
                 *(q++) = *p;
+                supported_count++;
+            }
         }
         *q = 0;
 
         supported_init = 1;
     }
+}
+
+const int *mbedtls_ssl_list_ciphersuites( void )
+{
+    mbedtls_ssl_ciphersuites_init();
 
     return( supported_ciphersuites );
+}
+
+int mbedtls_ssl_ciphersuites_count( void )
+{
+    mbedtls_ssl_ciphersuites_init();
+
+    return( supported_count );
 }
 #endif /* MBEDTLS_SSL_CIPHERSUITES */
 


### PR DESCRIPTION
This PR adds a new function `mbedtls_ssl_ciphersuites_count()` to easily determine the amount of available ciphersuites for the SSL subsystem.
Without this helper function, we would have to iterate over the array returned by `mbedtls_ssl_list_ciphersuites()` until we hit `NULL`, whilst counting the elements.
This is a purley cosmetic change, but it cleans the application code up a bit.

_Note:_ We cannot simply export the `MAX_CIPHERSUITES` macro defined in `ssl_ciphersuites.c`, because the initialization routines may filter out ARC4-based suites.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Documentation
- [x] Changelog updated

## Test / Usage example
It is useful for the following example.
It dynamically iterates through all available ciphersuites and checks whether they support PFS. New ciphersuites supported by mbedTLS will automatically be used, without a developer having to look at it.

```C
const int *availableSuites;
int *suitePtr;
int suiteId;
const mbedtls_ssl_ciphersuite_t *suite;

/* +1 for trailing zero */
int allowedSuites[mbedtls_ssl_ciphersuites_count() + 1];

availableSuites = mbedtls_ssl_list_ciphersuites();
suitePtr = allowedSuites;
while (*availableSuites) {
	suiteId = *(availableSuites++);
	suite = mbedtls_ssl_ciphersuite_from_id(suiteId);
	if (!suite) {
		continue;
	}
	/* Filter out any suite not supporting PFS */
	if (mbedtls_ssl_ciphersuite_no_pfs(suite)) {
		continue;
	}
	*(suitePtr++) = suiteId;
}
*suitePtr = 0;

mbedtls_ssl_conf_ciphersuites(&conf, allowedSuites);
```