### PR TITLE
Reword ssl_conf_max_frag_len documentation to clarify its necessity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,8 @@ Changes
      Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
    * Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh.
      Contributed by Peter Kolbus (Garmin).
+   * Change wording in the `mbedtls_ssl_conf_max_frag_len()`'s documentation to
+     improve clarity. Fixes #2258.
 
 = mbed TLS 2.17.0 branch released 2019-03-19
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2754,19 +2754,18 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
- * \brief          Set the maximum fragment length to emit and/or negotiate
- *                 (Typical: the smaller of MBEDTLS_SSL_IN_CONTENT_LEN and
- *                 MBEDTLS_SSL_OUT_CONTENT_LEN, usually 2^14 bytes)
+ * \brief          Set the maximum fragment length to emit and/or negotiate.
+ *                 (Typical: the smaller of #MBEDTLS_SSL_IN_CONTENT_LEN and
+ *                 #MBEDTLS_SSL_OUT_CONTENT_LEN, usually `2^14` bytes)
  *                 (Server: set maximum fragment length to emit,
  *                 usually negotiated by the client during handshake)
  *                 (Client: set maximum fragment length to emit *and*
  *                 negotiate with the server during handshake)
  *
- * \note           By default the \c mfl_code field of the \c mbedtls_ssl_config
- *                 structure is equal to `0 == MBEDTLS_SSL_MAX_FRAG_LEN_NONE`.
- *                 Therefore, the maximum fragment length extension *will not*
- *                 be used, unless the maximum fragment length has been set to a
- *                 different value via this function.
+ * \note           On the client side, the maximum fragment length extension
+ *                 *will not* be used, unless the maximum fragment length has
+ *                 been set via this function to a value different than
+ *                 #MBEDTLS_SSL_MAX_FRAG_LEN_NONE.
  *
  * \note           With TLS, this currently only affects ApplicationData (sent
  *                 with \c mbedtls_ssl_read()), not handshake messages.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2761,6 +2761,7 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  *                 usually negotiated by the client during handshake)
  *                 (Client: set maximum fragment length to emit *and*
  *                 negotiate with the server during handshake)
+ *                 (Default: #MBEDTLS_SSL_MAX_FRAG_LEN_NONE)
  *
  * \note           On the client side, the maximum fragment length extension
  *                 *will not* be used, unless the maximum fragment length has

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2762,10 +2762,10 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  *                 (Client: set maximum fragment length to emit *and*
  *                 negotiate with the server during handshake)
  *
- * \note           By default the \c mfl_code field ofthe \c mbedtls_ssl_config
- *                 structure is equal `0 == MBEDTLS_SSL_MAX_FRAG_LEN_NONE`.
- *                 This means the max fragment length extension *will not* be
- *                 used unless set to other value via this function.
+ * \note           By default the \c mfl_code field of the \c mbedtls_ssl_config
+ *                 structure is equal to `0 == MBEDTLS_SSL_MAX_FRAG_LEN_NONE`.
+ *                 This means the maximum fragment length extension *will not*
+ *                 be used unless set to another value via this function.
  *
  * \note           With TLS, this currently only affects ApplicationData (sent
  *                 with \c mbedtls_ssl_read()), not handshake messages.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2755,12 +2755,17 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
  * \brief          Set the maximum fragment length to emit and/or negotiate
- *                 (Default: the smaller of MBEDTLS_SSL_IN_CONTENT_LEN and
+ *                 (Typical: the smaller of MBEDTLS_SSL_IN_CONTENT_LEN and
  *                 MBEDTLS_SSL_OUT_CONTENT_LEN, usually 2^14 bytes)
  *                 (Server: set maximum fragment length to emit,
- *                 usually negotiated by the client during handshake
+ *                 usually negotiated by the client during handshake)
  *                 (Client: set maximum fragment length to emit *and*
  *                 negotiate with the server during handshake)
+ *
+ * \note           By default the \c mfl_code field ofthe \c mbedtls_ssl_config
+ *                 structure is equal `0 == MBEDTLS_SSL_MAX_FRAG_LEN_NONE`.
+ *                 This means the max fragment length extension *will not* be
+ *                 used unless set to other value via this function.
  *
  * \note           With TLS, this currently only affects ApplicationData (sent
  *                 with \c mbedtls_ssl_read()), not handshake messages.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2764,8 +2764,9 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  *
  * \note           By default the \c mfl_code field of the \c mbedtls_ssl_config
  *                 structure is equal to `0 == MBEDTLS_SSL_MAX_FRAG_LEN_NONE`.
- *                 This means the maximum fragment length extension *will not*
- *                 be used unless set to another value via this function.
+ *                 Therefore, the maximum fragment length extension *will not*
+ *                 be used, unless the maximum fragment length has been set to a
+ *                 different value via this function.
  *
  * \note           With TLS, this currently only affects ApplicationData (sent
  *                 with \c mbedtls_ssl_read()), not handshake messages.


### PR DESCRIPTION
This PR is supposed to fix #2258 by increasing precision of the max fragment length API documentation.

## Needs backports
YES - 2.16 and 2.7