### PR TITLE
Backport 2.16: all.sh: Fix check_headers_in_cpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ Bugfix
    * Remove the mbedtls namespacing from the header file, to fix a "file not found"
      build error. Fixed by Haijun Gu #2319.
    * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.
+   * Fix false failure in all.sh when backup files exist in include/mbedtls
+     (e.g. config.h.bak). Fixed by Peter Kolbus (Garmin) #2407.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -295,7 +295,7 @@ check_tools()
 }
 
 check_headers_in_cpp () {
-    ls include/mbedtls >headers.txt
+    ls include/mbedtls | grep "\.h$" >headers.txt
     <programs/test/cpp_dummy_build.cpp sed -n 's/"$//; s!^#include "mbedtls/!!p' |
     sort |
     diff headers.txt -


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2407 to mbedtls-2.16.

CC @pkolbus