### PR TITLE
SHA-256: Guard macro arguments inside parentheses

### DIFF
--- a/library/sha256.c
+++ b/library/sha256.c
@@ -172,8 +172,8 @@ static const uint32_t K[] =
     0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2,
 };
 
-#define  SHR(x,n) ((x & 0xFFFFFFFF) >> n)
-#define ROTR(x,n) (SHR(x,n) | (x << (32 - n)))
+#define  SHR(x,n) (((x) & 0xFFFFFFFF) >> (n))
+#define ROTR(x,n) (SHR(x,n) | ((x) << (32 - (n))))
 
 #define S0(x) (ROTR(x, 7) ^ ROTR(x,18) ^  SHR(x, 3))
 #define S1(x) (ROTR(x,17) ^ ROTR(x,19) ^  SHR(x,10))
@@ -181,20 +181,20 @@ static const uint32_t K[] =
 #define S2(x) (ROTR(x, 2) ^ ROTR(x,13) ^ ROTR(x,22))
 #define S3(x) (ROTR(x, 6) ^ ROTR(x,11) ^ ROTR(x,25))
 
-#define F0(x,y,z) ((x & y) | (z & (x | y)))
-#define F1(x,y,z) (z ^ (x & (y ^ z)))
+#define F0(x,y,z) (((x) & (y)) | ((z) & ((x) | (y))))
+#define F1(x,y,z) ((z) ^ ((x) & ((y) ^ (z))))
 
-#define R(t)                                    \
-(                                               \
-    W[t] = S1(W[t -  2]) + W[t -  7] +          \
-           S0(W[t - 15]) + W[t - 16]            \
+#define R(t)                                            \
+(                                                       \
+    W[t] = S1(W[(t) -  2]) + W[(t) -  7] +              \
+           S0(W[(t) - 15]) + W[(t) - 16]                \
 )
 
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
+#define P(a,b,c,d,e,f,g,h,x,K)                          \
+{                                                       \
+    temp1 = (h) + S3(e) + F1(e,f,g) + (K) + (x);        \
+    temp2 = S2(a) + F0(a,b,c);                          \
+    d += temp1; h = temp1 + temp2;                      \
 }
 
 int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,


### PR DESCRIPTION
## Description
Prevent unexpected problems when expanding macro arguments. This isn't causing a real problem right now, but it is good practice.

## Status
**READY**