### PR TITLE
Initialize PSA Crypto operation contexts

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1238,7 +1238,7 @@ int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
             (mbedtls_cipher_context_psa *) ctx->cipher_ctx;
 
         psa_status_t status;
-        psa_cipher_operation_t cipher_op;
+        psa_cipher_operation_t cipher_op = PSA_CIPHER_OPERATION_INIT;
         size_t part_len;
 
         if( ctx->operation == MBEDTLS_DECRYPT )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6529,7 +6529,7 @@ static void ssl_calc_finished_tls_sha256(
     unsigned char padbuf[32];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;
-    psa_hash_operation_t sha256_psa;
+    psa_hash_operation_t sha256_psa = PSA_HASH_OPERATION_INIT;
     psa_status_t status;
 #else
     mbedtls_sha256_context sha256;
@@ -6605,7 +6605,7 @@ static void ssl_calc_finished_tls_sha384(
     unsigned char padbuf[48];
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;
-    psa_hash_operation_t sha384_psa;
+    psa_hash_operation_t sha384_psa = PSA_HASH_OPERATION_INIT;
     psa_status_t status;
 #else
     mbedtls_sha512_context sha512;
@@ -10203,7 +10203,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
                                             mbedtls_md_type_t md_alg )
 {
     psa_status_t status;
-    psa_hash_operation_t hash_operation;
+    psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( md_alg );
 
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform PSA-based computation of digest of ServerKeyExchange" ) );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1908,7 +1908,7 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
     if( mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash ) != 0 )
         return( -1 );
 #else
-    psa_hash_operation_t hash_operation;
+    psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( child->sig_md );
 
     if( psa_hash_setup( &hash_operation, hash_alg ) != PSA_SUCCESS )

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -142,7 +142,7 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
     size_t len = 0;
     mbedtls_pk_type_t pk_alg;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_operation_t hash_operation;
+    psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( ctx->md_alg );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */


### PR DESCRIPTION
It is now required to initialize PSA Crypto operation contexts before
calling psa_*_setup(). Otherwise, one gets a PSA_ERROR_BAD_STATE error.

This PR fixes a few places where missing initialization was noticed, but may not fix all instances (in particular, there may be some initialization issues with operation contexts like `psa_hash_operation_t fin_sha256_psa;` inside `struct mbedtls_ssl_handshake_params`).

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
These missing initializations were noticed when running `./tests/scripts/all.sh -f -r test_use_psa_crypto_full_cmake_asan` after adding state validation type checks to Mbed Crypto. See https://github.com/ARMmbed/mbed-crypto/pull/58 for the PR that adds state validation checks.