### PR TITLE
Backport 2.7: Support for large entropy length

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Bugfix
    * Remove a duplicate #include in a sample program. Fixed by Masashi Honma #2326.
    * Reduce stack usage of `mpi_write_hlp()` by eliminating recursion.
      Fixes #2190.
+   * Fix issue in seeding HMAC DRBG when MBEDTLS_SHA512_C is disabled.
+     Reported by dbedev. Fixes #770.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -162,6 +162,10 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
                         identifiers. Can be NULL.
  * \param len           The length of the personalization data.
  *
+ * \warning             \p f_entropy MUST fill the buffer with full entropy
+ *                      and MUST be able to do so for buffer lengths up to
+ *                      at least `MBEDTLS_ENTROPY_BLOCK_SIZE` bytes.
+ *
  * \return              \c 0 on success, or
  *                      #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on failure.
  */

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -132,6 +132,10 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
  *                      256 bits if md_alg is SHA-256 or higher.
  *                      Note that SHA-256 is just as efficient as SHA-224.
  *
+ * \warning             \p f_entropy MUST fill the buffer with full entropy
+ *                      and MUST be able to do so for buffer lengths up to
+ *                      at least `MBEDTLS_ENTROPY_BLOCK_SIZE` bytes.
+ *
  * \return              0 if successful, or
  *                      MBEDTLS_ERR_MD_BAD_INPUT_DATA, or
  *                      MBEDTLS_ERR_MD_ALLOC_FAILED, or

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -33,6 +33,7 @@
 #if defined(MBEDTLS_CTR_DRBG_C)
 
 #include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
 
 #include <string.h>
 
@@ -339,7 +340,8 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
                      const unsigned char *additional, size_t len )
 {
     unsigned char seed[MBEDTLS_CTR_DRBG_MAX_SEED_INPUT];
-    size_t seedlen = 0;
+    unsigned char *p = seed;
+    size_t seedlen = 0, remaining_entropy_len, size_to_gather;
     int ret;
 
     if( ctx->entropy_len > MBEDTLS_CTR_DRBG_MAX_SEED_INPUT ||
@@ -348,13 +350,23 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
 
     memset( seed, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
 
-    /*
-     * Gather entropy_len bytes of entropy to seed state
-     */
-    if( 0 != ctx->f_entropy( ctx->p_entropy, seed,
-                             ctx->entropy_len ) )
+    remaining_entropy_len = ctx->entropy_len;
+
+    while( remaining_entropy_len > 0 )
     {
-        return( MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED );
+        size_to_gather = ( remaining_entropy_len > MBEDTLS_ENTROPY_BLOCK_SIZE ) ?
+                           MBEDTLS_ENTROPY_BLOCK_SIZE : remaining_entropy_len;
+        /*
+         * Gather entropy_len bytes of entropy to seed state
+         */
+        if( 0 != ctx->f_entropy( ctx->p_entropy, p,
+                                 size_to_gather ) )
+        {
+            return( MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED );
+        }
+
+        remaining_entropy_len -= size_to_gather;
+        p += size_to_gather;
     }
 
     seedlen += ctx->entropy_len;

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -1,10 +1,15 @@
 /* BEGIN_HEADER */
 #include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
 
 static int test_offset_idx;
 static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len )
 {
     const unsigned char *p = (unsigned char *) data;
+
+    if( len > MBEDTLS_ENTROPY_BLOCK_SIZE )
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+
     memcpy( buf, p + test_offset_idx, len );
     test_offset_idx += len;
     return( 0 );

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -199,6 +199,11 @@ void ctr_drbg_entropy_usage( )
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
     TEST_ASSERT( test_offset_idx - last_idx == 13 );
 
+    mbedtls_ctr_drbg_set_entropy_len( &ctx, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
+    last_idx = test_offset_idx;
+    TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
+    TEST_ASSERT( test_offset_idx - last_idx == MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
+
 exit:
     mbedtls_ctr_drbg_free( &ctx );
 }

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -1,4 +1,5 @@
 /* BEGIN_HEADER */
+#include "mbedtls/entropy.h"
 #include "mbedtls/hmac_drbg.h"
 
 typedef struct
@@ -13,6 +14,9 @@ static int mbedtls_test_entropy_func( void *data, unsigned char *buf, size_t len
 
     if( len > ctx->len )
         return( -1 );
+
+    if( len > MBEDTLS_ENTROPY_BLOCK_SIZE )
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
 
     memcpy( buf, ctx->p, len );
 

--- a/tests/suites/test_suite_hmac_drbg.misc.data
+++ b/tests/suites/test_suite_hmac_drbg.misc.data
@@ -10,6 +10,10 @@ HMAC_DRBG entropy usage SHA-256
 depends_on:MBEDTLS_SHA256_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA256
 
+HMAC_DRBG entropy usage SHA-256 accumulator
+depends_on:MBEDTLS_SHA256_C:!MBEDTLS_SHA512_C
+hmac_drbg_entropy_usage:MBEDTLS_MD_SHA256
+
 HMAC_DRBG entropy usage SHA-384
 depends_on:MBEDTLS_SHA512_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA384
@@ -17,6 +21,10 @@ hmac_drbg_entropy_usage:MBEDTLS_MD_SHA384
 HMAC_DRBG entropy usage SHA-512
 depends_on:MBEDTLS_SHA512_C
 hmac_drbg_entropy_usage:MBEDTLS_MD_SHA512
+
+HMAC_DRBG NIST CAVS 14.3 No Reseed no SHA-512(SHA-256,256+128,0,0)
+depends_on:MBEDTLS_SHA256_C:!MBEDTLS_SHA512_C
+hmac_drbg_no_reseed:MBEDTLS_MD_SHA256:"ca851911349384bffe89de1cbdc46e6831e44d34a4fb935ee285dd14b71a7488659ba96c601dc69fc902940805ec0ca8":"":"":"":"e528e9abf2dece54d47c7e75e5fe302149f817ea9fb4bee6f4199697d04d5b89d54fbb978a15b5c443c9ec21036d2460b6f73ebad0dc2aba6e624abf07745bc107694bb7547bb0995f70de25d6b29e2d3011bb19d27676c07162c8b5ccde0668961df86803482cb37ed6d5c0bb8d50cf1f50d476aa0458bdaba806f48be9dcb8"
 
 HMAC_DRBG write/update seed file SHA-1
 depends_on:MBEDTLS_SHA1_C


### PR DESCRIPTION
## Description
Backport of #1063 to `mbedtls-2.7`


## Status
**READY**

