### PR TITLE
Fix CMake build error on Windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,14 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
 # to the corresponding path in the source directory.
 function(link_to_source base_name)
     # Get OS dependent path to use in `execute_process`
-    file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${base_name}" link)
-    file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}" target)
+    if (CMAKE_HOST_WIN32)
+        #mklink is an internal command of cmd.exe it can only work with \
+        string(REPLACE "/" "\\" link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
+        string(REPLACE "/" "\\" target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
+    else()
+        set(link "${CMAKE_CURRENT_BINARY_DIR}/${base_name}")
+        set(target "${CMAKE_CURRENT_SOURCE_DIR}/${base_name}")
+    endif()
 
     if (NOT EXISTS ${link})
         if (CMAKE_HOST_UNIX)


### PR DESCRIPTION
## Description
Fixes https://github.com/ARMmbed/mbedtls/issues/1496 

Edited by roneld to use [github key words](https://help.github.com/en/articles/closing-issues-using-keywords)

## Status
**READY

## Requires Backporting
YES
Since this issue introduce from 2.7.x, so if some one want build it on windows platform with Cmake, this patch should be apply. 

[Edit] Since this issue is introduced since 2.7.x, this PR requires bacporting to `mbedtls-2.7` and `mbedtls-2.16`
## Migrations
NO

## Additional comments
Test on
- Ubuntu 16.04.2  cmake version 3.10.2 
- Cygwin cmake version 3.11.1
- Windows mingw-w6 x86_64-8.1.0-posix-seh-rt_v6-rev0 and  cmake version 3.11.1 

