### PR TITLE
Fix the proxy seed in Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ after_failure:
 - tests/scripts/travis-log-failure.sh
 env:
   global:
-    secure: "barHldniAfXyoWOD/vcO+E6/Xm4fmcaUoC9BeKW+LwsHqlDMLvugaJnmLXkSpkbYhVL61Hzf3bo0KPJn88AFc5Rkf8oYHPjH4adMnVXkf3B9ghHCgznqHsAH3choo6tnPxaFgOwOYmLGb382nQxfE5lUdvnM/W/psQjWt66A1+k="
+    - SEED=1
+    - secure: "barHldniAfXyoWOD/vcO+E6/Xm4fmcaUoC9BeKW+LwsHqlDMLvugaJnmLXkSpkbYhVL61Hzf3bo0KPJn88AFc5Rkf8oYHPjH4adMnVXkf3B9ghHCgznqHsAH3choo6tnPxaFgOwOYmLGb382nQxfE5lUdvnM/W/psQjWt66A1+k="
 
 addons:
   apt:


### PR DESCRIPTION
This is what we do in Jenkins, so it only makes sense to do it here as well.
This will avoid random failures for no other reason than the proxy was
dropping all the messages due to an unlucky PRNG seed.

See https://docs.travis-ci.com/user/environment-variables/ for syntax

## Status
**READY**

## Requires Backporting
Yes - all branches (will wait for this one to pass Travis and have at least one approval before backporting)

## Migrations

NO

## Todos
- [ ] Backported
