### PR TITLE
Fix typo in data_file generator code

### DIFF
--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -153,7 +153,7 @@ test-int-ca3-badsign.crt: test-int-ca3.crt
 all_final += test-int-ca3-badsign.crt
 server10_int3-bs.pem: server10.crt test-int-ca3-badsign.crt
 	cat server10.crt test-int-ca3-badsign.crt > $@
-all_final += server10-bs_int3-bs.pem
+all_final += server10_int3-bs.pem
 
 rsa_pkcs1_2048_public.pem: server8.key
 	$(OPENSSL)  rsa -in $< -outform PEM -RSAPublicKey_out -out $@


### PR DESCRIPTION
The file to generate is `server10_int3-bs.pem`, not
`server10-bs_int3-bs.pem`.

## Status
**READY**

## Requires Backporting
mbedtls-2.16 - Yes
mbedtls-2.7 - No, no server10_int3-bs.pem present.

## Migrations
NO

## Todos
- [ ] Backported
