### PR TITLE
Add output length parameter to mbedtls_pkcs12_pbe_ext()

### DIFF
--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -94,6 +94,31 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 const unsigned char *pwd,  size_t pwdlen,
                 const unsigned char *input, size_t len,
                 unsigned char *output );
+/**
+ * \brief            PKCS12 Password Based function (encryption / decryption)
+ *                   for cipher-based and mbedtls_md-based PBE's
+ *
+ *                   Added output parameter that return actual number of bytes
+ *                   written to the output buffer
+ *
+ * \param pbe_params an ASN1 buffer containing the pkcs-12PbeParams structure
+ * \param mode       either MBEDTLS_PKCS12_PBE_ENCRYPT or MBEDTLS_PKCS12_PBE_DECRYPT
+ * \param cipher_type the cipher used
+ * \param md_type     the mbedtls_md used
+ * \param pwd        the password used (may be NULL if no password is used)
+ * \param pwdlen     length of the password (may be 0)
+ * \param input      the input data
+ * \param len        data length
+ * \param output     the output buffer
+ * \param olen       actual number of bytes written to output
+ *
+ * \return           0 if successful, or a MBEDTLS_ERR_XXX code
+ */
+int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params, int mode,
+                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
+                const unsigned char *pwd,  size_t pwdlen,
+                const unsigned char *input, size_t len,
+                unsigned char *output, size_t *olen );
 
 #endif /* MBEDTLS_ASN1_PARSE_C */
 

--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -73,52 +73,70 @@ int mbedtls_pkcs12_pbe_sha1_rc4_128( mbedtls_asn1_buf *pbe_params, int mode,
                              const unsigned char *input, size_t len,
                              unsigned char *output );
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
 /**
- * \brief            PKCS12 Password Based function (encryption / decryption)
- *                   for cipher-based and mbedtls_md-based PBE's
+ * \brief            This function performs Password Based PKCS#12 (encryption
+ *                   / decryption) for cipher-based and message digest-based
+ *                   PBEs.
  *
- * \param pbe_params an ASN1 buffer containing the pkcs-12PbeParams structure
- * \param mode       either MBEDTLS_PKCS12_PBE_ENCRYPT or MBEDTLS_PKCS12_PBE_DECRYPT
- * \param cipher_type the cipher used
- * \param md_type     the mbedtls_md used
- * \param pwd        the password used (may be NULL if no password is used)
- * \param pwdlen     length of the password (may be 0)
- * \param input      the input data
- * \param len        data length
- * \param output     the output buffer
+ * \param pbe_params  The ASN.1 algorithm params.
+ * \param mode        The operation mode (either #MBEDTLS_PKCS12_PBE_ENCRYPT or
+ *                    #MBEDTLS_PKCS12_PBE_DECRYPT).
+ * \param cipher_type The cipher used.
+ * \param md_type     The message digest used.
+ * \param pwd         The password to use (may be NULL if no password is used).
+ * \param pwdlen      The length of the password at \p pwd (may be 0).
+ * \param input       The buffer with the input data to process.
+ * \param len         The length of the input data buffer at \c input.
+ * \param output      The buffer to hold the output data.
  *
- * \return           0 if successful, or a MBEDTLS_ERR_XXX code
+ * \return           \c 0 on successful.
+ * \return           A negative error code on failure.
  */
-int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
-                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
-                const unsigned char *pwd,  size_t pwdlen,
-                const unsigned char *input, size_t len,
-                unsigned char *output );
+MBEDTLS_DEPRECATED int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params,
+                                           int mode,
+                                           mbedtls_cipher_type_t cipher_type,
+                                           mbedtls_md_type_t md_type,
+                                           const unsigned char *pwd,
+                                           size_t pwdlen,
+                                           const unsigned char *input,
+                                           size_t len,
+                                           unsigned char *output );
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
 /**
- * \brief            PKCS12 Password Based function (encryption / decryption)
- *                   for cipher-based and mbedtls_md-based PBE's
+ * \brief            This function performs Password Based PKCS#12 (encryption
+ *                   / decryption) for cipher-based and message digest-based
+ *                   PBEs.
  *
- *                   Added output parameter that return actual number of bytes
- *                   written to the output buffer
+ * \param pbe_params  The ASN.1 algorithm params.
+ * \param mode        The operation mode (either #MBEDTLS_PKCS12_PBE_ENCRYPT or
+ *                    #MBEDTLS_PKCS12_PBE_DECRYPT).
+ * \param cipher_type The cipher used.
+ * \param md_type     The message digest used.
+ * \param pwd         The password to use (may be NULL if no password is used).
+ * \param pwdlen      The length of the password at \p pwd (may be 0).
+ * \param input       The buffer with the input data to process.
+ * \param len         The length of the input data buffer at \c input.
+ * \param output      The buffer to hold the output data.
+ * \param olen        The number of bytes written to the output buffer
+ *                    \p output.
  *
- * \param pbe_params an ASN1 buffer containing the pkcs-12PbeParams structure
- * \param mode       either MBEDTLS_PKCS12_PBE_ENCRYPT or MBEDTLS_PKCS12_PBE_DECRYPT
- * \param cipher_type the cipher used
- * \param md_type     the mbedtls_md used
- * \param pwd        the password used (may be NULL if no password is used)
- * \param pwdlen     length of the password (may be 0)
- * \param input      the input data
- * \param len        data length
- * \param output     the output buffer
- * \param olen       actual number of bytes written to output
- *
- * \return           0 if successful, or a MBEDTLS_ERR_XXX code
+ * \return           \c 0 on successful.
+ * \return           A negative error code on failure.
  */
 int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params, int mode,
-                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
-                const unsigned char *pwd,  size_t pwdlen,
-                const unsigned char *input, size_t len,
-                unsigned char *output, size_t *olen );
+                            mbedtls_cipher_type_t cipher_type,
+                            mbedtls_md_type_t md_type,
+                            const unsigned char *pwd,  size_t pwdlen,
+                            const unsigned char *input, size_t len,
+                            unsigned char *output, size_t *olen );
 
 #endif /* MBEDTLS_ASN1_PARSE_C */
 

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -177,18 +177,30 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 const unsigned char *data, size_t len,
                 unsigned char *output )
 {
+    size_t olen = 0;
+    return mbedtls_pkcs12_pbe_ext(pbe_params, mode, cipher_type, md_type,
+            pwd, pwdlen, data, len, output, &olen);
+}
+
+int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params, int mode,
+                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
+                const unsigned char *pwd,  size_t pwdlen,
+                const unsigned char *data, size_t len,
+                unsigned char *output, size_t *olen )
+{
     int ret, keylen = 0;
     unsigned char key[32];
     unsigned char iv[16];
     const mbedtls_cipher_info_t *cipher_info;
     mbedtls_cipher_context_t cipher_ctx;
-    size_t olen = 0;
+    size_t enclen = 0;
 
     cipher_info = mbedtls_cipher_info_from_type( cipher_type );
     if( cipher_info == NULL )
         return( MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE );
 
     keylen = cipher_info->key_bitlen / 8;
+    *olen = 0;
 
     if( ( ret = pkcs12_pbe_derive_key_iv( pbe_params, md_type, pwd, pwdlen,
                                           key, keylen,
@@ -212,13 +224,15 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
         goto exit;
 
     if( ( ret = mbedtls_cipher_update( &cipher_ctx, data, len,
-                                output, &olen ) ) != 0 )
+                                output, &enclen ) ) != 0 )
     {
         goto exit;
     }
+    *olen += enclen;
 
-    if( ( ret = mbedtls_cipher_finish( &cipher_ctx, output + olen, &olen ) ) != 0 )
+    if( ( ret = mbedtls_cipher_finish( &cipher_ctx, output + enclen, &enclen ) ) != 0 )
         ret = MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH;
+    *olen += enclen;
 
 exit:
     mbedtls_platform_zeroize( key, sizeof( key ) );

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -171,6 +171,7 @@ exit:
 #endif /* MBEDTLS_ARC4_C */
 }
 
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
 int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
                 const unsigned char *pwd,  size_t pwdlen,
@@ -178,15 +179,22 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 unsigned char *output )
 {
     size_t olen = 0;
-    return mbedtls_pkcs12_pbe_ext(pbe_params, mode, cipher_type, md_type,
-            pwd, pwdlen, data, len, output, &olen);
-}
 
-int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params, int mode,
-                mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
-                const unsigned char *pwd,  size_t pwdlen,
-                const unsigned char *data, size_t len,
-                unsigned char *output, size_t *olen )
+    return mbedtls_pkcs12_pbe_ext( pbe_params, mode, cipher_type, md_type,
+                                   pwd, pwdlen, data, len, output, &olen );
+}
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
+
+int mbedtls_pkcs12_pbe_ext( mbedtls_asn1_buf *pbe_params,
+                            int mode,
+                            mbedtls_cipher_type_t cipher_type,
+                            mbedtls_md_type_t md_type,
+                            const unsigned char *pwd,
+                            size_t pwdlen,
+                            const unsigned char *data,
+                            size_t len,
+                            unsigned char *output,
+                            size_t *olen )
 {
     int ret, keylen = 0;
     unsigned char key[32];

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1053,6 +1053,7 @@ static int pk_parse_key_pkcs8_encrypted_der(
 #if defined(MBEDTLS_PKCS12_C)
     mbedtls_cipher_type_t cipher_alg;
     mbedtls_md_type_t md_alg;
+    size_t olen;
 #endif
 
     p = key;
@@ -1098,9 +1099,10 @@ static int pk_parse_key_pkcs8_encrypted_der(
 #if defined(MBEDTLS_PKCS12_C)
     if( mbedtls_oid_get_pkcs12_pbe_alg( &pbe_alg_oid, &md_alg, &cipher_alg ) == 0 )
     {
-        if( ( ret = mbedtls_pkcs12_pbe( &pbe_params, MBEDTLS_PKCS12_PBE_DECRYPT,
-                                cipher_alg, md_alg,
-                                pwd, pwdlen, p, len, buf ) ) != 0 )
+        ret = mbedtls_pkcs12_pbe_ext( &pbe_params, MBEDTLS_PKCS12_PBE_DECRYPT,
+                                      cipher_alg, md_alg,
+                                      pwd, pwdlen, p, len, buf, &olen );
+        if( ret != 0 )
         {
             if( ret == MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH )
                 return( MBEDTLS_ERR_PK_PASSWORD_MISMATCH );


### PR DESCRIPTION
## Description
This PR is based on the community contribution at https://github.com/ARMmbed/mbedtls/pull/423. The idea is to add a new output parameter to the function mbedtls_pkcs12_pbe() that contains the number of bytes written to the output buffer. This PR implements this by deprecating the old function mbedtls_pkcs12_pbe() and adds a new one mbedtls_pkcs12_pbe_ext().

## Status
**READY**

## Requires Backporting
NO, this requires an API change

## Migrations
Replacing the use of the deprecated function for the new function.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

## Comments
I think that currently the libary does not have any tests for the PKCS#12 module, so this PR does not include any tests because it barely changes any of the functionality.