### PR TITLE
Backport 2.16: Fix the default port number in `usage`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,8 @@ Bugfix
    * Fix private key DER output in the key_app_writer example. File contents
      were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
      Christian Walther in #2239.
+   * Fix incorrect default port number in ssl_mail_client example's usage.
+     Found and fixed by irwir. #2337
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -110,9 +110,9 @@ int main( void )
 
 #if defined(MBEDTLS_BASE64_C)
 #define USAGE_AUTH \
-    "    authentication=%%d   default: 0 (disabled)\n"      \
-    "    user_name=%%s        default: \"user\"\n"          \
-    "    user_pwd=%%s         default: \"password\"\n"
+    "    authentication=%%d   default: 0 (disabled)\n"          \
+    "    user_name=%%s        default: \"" DFL_USER_NAME "\"\n" \
+    "    user_pwd=%%s         default: \"" DFL_USER_PWD "\"\n"
 #else
 #define USAGE_AUTH \
     "    authentication options disabled. (Require MBEDTLS_BASE64_C)\n"
@@ -129,17 +129,17 @@ int main( void )
 #endif /* MBEDTLS_FS_IO */
 
 #define USAGE \
-    "\n usage: ssl_mail_client param=<>...\n"               \
-    "\n acceptable parameters:\n"                           \
-    "    server_name=%%s      default: localhost\n"         \
-    "    server_port=%%d      default: 4433\n"              \
-    "    debug_level=%%d      default: 0 (disabled)\n"      \
+    "\n usage: ssl_mail_client param=<>...\n"                 \
+    "\n acceptable parameters:\n"                             \
+    "    server_name=%%s      default: " DFL_SERVER_NAME "\n" \
+    "    server_port=%%d      default: " DFL_SERVER_PORT "\n" \
+    "    debug_level=%%d      default: 0 (disabled)\n"        \
     "    mode=%%d             default: 0 (SSL/TLS) (1 for STARTTLS)\n"  \
-    USAGE_AUTH                                              \
-    "    mail_from=%%s        default: \"\"\n"              \
-    "    mail_to=%%s          default: \"\"\n"              \
-    USAGE_IO                                                \
-    "    force_ciphersuite=<name>    default: all enabled\n"\
+    USAGE_AUTH                                                \
+    "    mail_from=%%s        default: \"\"\n"                \
+    "    mail_to=%%s          default: \"\"\n"                \
+    USAGE_IO                                                  \
+    "    force_ciphersuite=<name>    default: all enabled\n"  \
     " acceptable ciphersuite names:\n"
 
 #if defined(MBEDTLS_CHECK_PARAMS)
@@ -324,7 +324,7 @@ static int write_and_get_response( mbedtls_net_context *sock_fd, unsigned char *
     mbedtls_printf("\n%s", buf);
     if( len && ( ret = mbedtls_net_send( sock_fd, buf, len ) ) <= 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_ssl_write returned %d\n\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_net_send returned %d\n\n", ret );
             return -1;
     }
 
@@ -336,7 +336,7 @@ static int write_and_get_response( mbedtls_net_context *sock_fd, unsigned char *
 
         if( ret <= 0 )
         {
-            mbedtls_printf( "failed\n  ! read returned %d\n\n", ret );
+            mbedtls_printf( "failed\n  ! mbedtls_net_recv returned %d\n\n", ret );
             return -1;
         }
 


### PR DESCRIPTION

## Description
Backport of #2368 to `mbedtls-2.16`


## Status
**READY**

