### PR TITLE
Backport 2.7: Fix 1-byte buffer overflow in mbedtls_mpi_write_string() for negative MPIs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,8 +8,6 @@ Features
      https://sweet32.info/SWEET32_CCS16.pdf.
 
 Bugfix
-   * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
-     used with negative inputs. Found by Guido Vranken in #2404.
    * Run the AD too long test only if MBEDTLS_CCM_ALT is not defined.
      Raised as a comment in #1996.
    * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.
@@ -32,6 +30,8 @@ Bugfix
    * Fix private key DER output in the key_app_writer example. File contents
      were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
      Christian Walther in #2239.
+   * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
+     used with negative inputs. Found by Guido Vranken in #2404.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@ Features
      https://sweet32.info/SWEET32_CCS16.pdf.
 
 Bugfix
+   * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
+     used with negative inputs. Found by Guido Vranken in #2404.
    * Run the AD too long test only if MBEDTLS_CCM_ALT is not defined.
      Raised as a comment in #1996.
    * Fix returning the value 1 when mbedtls_ecdsa_genkey failed.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -572,7 +572,10 @@ int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
     mbedtls_mpi_init( &T );
 
     if( X->s == -1 )
+    {
         *p++ = '-';
+        buflen--;
+    }
 
     if( radix == 16 )
     {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -560,7 +560,7 @@ int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
     if( radix >= 16 ) n >>= 1;   /* Number of hexadecimal digits necessary to
                                   * present `n`. */
 
-    n += 1; /* NULL termination */
+    n += 1; /* Terminating null byte */
     n += 1; /* Compensate for the divisions above, which round down `n`
              * in case it's not even. */
     n += 1; /* Potential '-'-sign. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -552,15 +552,20 @@ int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
     if( radix < 2 || radix > 16 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
-    n = mbedtls_mpi_bitlen( X );
-    if( radix >=  4 ) n >>= 1;
-    if( radix >= 16 ) n >>= 1;
-    /*
-     * Round up the buffer length to an even value to ensure that there is
-     * enough room for hexadecimal values that can be represented in an odd
-     * number of digits.
-     */
-    n += 3 + ( ( n + 1 ) & 1 );
+    n = mbedtls_mpi_bitlen( X ); /* Number of bits necessary to present `n`. */
+    if( radix >=  4 ) n >>= 1;   /* Number of 4-adic digits necessary to present
+                                  * `n`. If radix > 4, this might be a strict
+                                  * overapproximation of the number of
+                                  * radix-adic digits needed to present `n`. */
+    if( radix >= 16 ) n >>= 1;   /* Number of hexadecimal digits necessary to
+                                  * present `n`. */
+
+    n += 1; /* NULL termination */
+    n += 1; /* Compensate for the divisions above, which round down `n`
+             * in case it's not even. */
+    n += 1; /* Potential '-'-sign. */
+    n += ( n & 1 ); /* Make n even to have enough space for hexadecimal writing,
+                     * which always uses an even number of hex-digits. */
 
     if( buflen < n )
     {

--- a/tests/suites/test_suite_mpi.data
+++ b/tests/suites/test_suite_mpi.data
@@ -19,6 +19,9 @@ mpi_read_write_string:16:"-20":10:"-32":100:0:0
 Base test mpi_read_write_string #3 (Negative decimal)
 mpi_read_write_string:16:"-23":16:"-23":100:0:0
 
+Base test mpi_read_write_string #4 (Buffer just fits)
+mpi_read_write_string:16:"-4":4:"-10":4:0:0
+
 Test mpi_read_write_string #1 (Invalid character)
 mpi_read_write_string:10:"a28":0:"":100:MBEDTLS_ERR_MPI_INVALID_CHARACTER:0
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -81,6 +81,8 @@ void mpi_read_write_string( int radix_X, char *input_X, int radix_A,
 
     mbedtls_mpi_init( &X );
 
+    memset( str, '!', sizeof( str ) );
+
     TEST_ASSERT( mbedtls_mpi_read_string( &X, radix_X, input_X ) == result_read );
     if( result_read == 0 )
     {
@@ -88,6 +90,7 @@ void mpi_read_write_string( int radix_X, char *input_X, int radix_A,
         if( result_write == 0 )
         {
             TEST_ASSERT( strcasecmp( str, input_A ) == 0 );
+            TEST_ASSERT( str[len] == '!' );
         }
     }
 


### PR DESCRIPTION
Backport of #2405.