### PR TITLE
Backport 2.16: fix compilation under MINGW

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,8 @@ Bugfix
    * Fix private key DER output in the key_app_writer example. File contents
      were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
      Christian Walther in #2239.
+   * Fix compilation error on MINGW32/MINGW64 with deactivated option
+     MBEDTLS_HAVE_ASM in config file. Contributed by merlokk.
 
 Changes
    * Return from various debugging routines immediately if the

--- a/library/timing.c
+++ b/library/timing.c
@@ -230,11 +230,19 @@ unsigned long mbedtls_timing_hardclock( void )
 
     if( hardclock_init == 0 )
     {
+#if defined(__MINGW32__) || defined(__MINGW64__)
+        mingw_gettimeofday( &tv_init, NULL );
+#else
         gettimeofday( &tv_init, NULL );
+#endif /* __MINGW32__ || __MINGW64__ */
         hardclock_init = 1;
     }
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    mingw_gettimeofday( &tv_cur, NULL );
+#else
     gettimeofday( &tv_cur, NULL );
+#endif /* __MINGW32__ || __MINGW64__ */
     return( ( tv_cur.tv_sec  - tv_init.tv_sec  ) * 1000000
           + ( tv_cur.tv_usec - tv_init.tv_usec ) );
 }


### PR DESCRIPTION
## Description
Backport of #2185 to `mbedtls-2.16`


## Status
**READY**

