### PR TITLE
Backport 2.7: Fixes in AEAD cipher test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,9 @@ Bugfix
    * Fix private key DER output in the key_app_writer example. File contents
      were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
      Christian Walther in #2239.
+   * Fix bugs in the AEAD test suite which would be exposed by ciphers which
+     either used both encrypt and decrypt key schedules, or which perform padding.
+     GCM and CCM were not affected. Fixed by Jack Lloyd.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -627,6 +627,9 @@ void auth_crypt_tv( int cipher_id, char *hex_key, char *hex_iv,
     TEST_ASSERT( memcmp( output, clear, clear_len ) == 0 );
 
     /* then encrypt the clear and make sure we get the same ciphertext and tag */
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len,
+                                             MBEDTLS_ENCRYPT ) );
+
     memset( output, 0xFF, sizeof( output ) );
     outlen = 0;
 
@@ -635,8 +638,8 @@ void auth_crypt_tv( int cipher_id, char *hex_key, char *hex_iv,
                                my_tag, tag_len );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( outlen == clear_len );
-    TEST_ASSERT( memcmp( output, cipher, clear_len ) == 0 );
+    TEST_ASSERT( outlen == cipher_len );
+    TEST_ASSERT( memcmp( output, cipher, cipher_len ) == 0 );
     TEST_ASSERT( memcmp( my_tag, tag, tag_len ) == 0 );
 
     /* make sure we didn't overwrite */


### PR DESCRIPTION
## Description
Backport of bugfix from #2463 to `mbedtls-2.7`


## Status
**READY**

