### PR TITLE
Backport 2.16: Fixes in AEAD cipher test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,9 @@ Bugfix
    * Fix private key DER output in the key_app_writer example. File contents
      were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
      Christian Walther in #2239.
+   * Fix bugs in the AEAD test suite which would be exposed by ciphers which
+     either used both encrypt and decrypt key schedules, or which perform padding.
+     GCM and CCM were not affected. Fixed by Jack Lloyd.
 
 Changes
    * Include configuration file in all header files that use configuration,

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -976,6 +976,9 @@ void auth_crypt_tv( int cipher_id, data_t * key, data_t * iv,
     TEST_ASSERT( memcmp( output, clear->x, clear->len ) == 0 );
 
     /* then encrypt the clear->x and make sure we get the same ciphertext and tag->x */
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len,
+                                             MBEDTLS_ENCRYPT ) );
+
     memset( output, 0xFF, sizeof( output ) );
     outlen = 0;
 
@@ -984,8 +987,8 @@ void auth_crypt_tv( int cipher_id, data_t * key, data_t * iv,
                                my_tag, tag->len );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( outlen == clear->len );
-    TEST_ASSERT( memcmp( output, cipher->x, clear->len ) == 0 );
+    TEST_ASSERT( outlen == cipher->len );
+    TEST_ASSERT( memcmp( output, cipher->x, cipher->len ) == 0 );
     TEST_ASSERT( memcmp( my_tag, tag->x, tag->len ) == 0 );
 
     /* make sure we didn't overwrite */


### PR DESCRIPTION
## Description
Backport of bugfix from #2463 to `mbedtls-2.16`


## Status
**READY**