### PR TITLE
support asm on armcc5

### DIFF
--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -762,6 +762,46 @@
 #endif /* MIPS */
 #endif /* GNUC */
 
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 6000000)
+
+#if defined(__TARGET_FEATURE_DSPMUL)
+/* support umaal */
+
+#define MULADDC_INIT                        \
+    asm(
+
+#define MULADDC_CORE                        \
+            "umaal  *d, c, b, *s    \n\t"   \
+            "adds   s, s, #4        \n\t"   \
+            "adds   d, d, #4        \n\t"
+
+#define MULADDC_STOP                        \
+    );
+
+#elif defined(__TARGET_FEATURE_MULTIPLY)
+/* support umlal */
+
+#define MULADDC_INIT                        \
+{                                           \
+    mbedtls_mpi_uint r;                     \
+    asm(
+
+#define MULADDC_CORE                        \
+            "mov    r, #0           \n\t"   \
+            "umlal  c, r, b, *s     \n\t"   \
+            "adds   *d, *d, c       \n\t"   \
+            "adc    c, r, #0        \n\t"   \
+            "adds   s, s, #4        \n\t"   \
+            "adds   d, d, #4        \n\t"
+
+#define MULADDC_STOP                        \
+    );                                      \
+}
+
+#endif
+
+#endif /* armcc5 */
+
 #if (defined(_MSC_VER) && defined(_M_IX86)) || defined(__WATCOMC__)
 
 #define MULADDC_INIT                            \


### PR DESCRIPTION
## Description
armcc5 use a different asm syntax, it uses c/c++ variable directly.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
I have used this on Brevent Booster (USB Dongle to simulate ADB) since 2018.
However, I don't know whether armcc5 should be supported.

## Steps to test or reproduce
This is a rewrite for current gnu version of `umlal`.
However, some codes are rearranged.

### MULADDC_INIT of gnu version
```asm
ldr    r0, %3   /* s */
ldr    r1, %4   /* d */
ldr    r2, %5   /* c */
ldr    r3, %6   /* b */
```
No need for armcc5.

### MULADDC_CORE of gnu version
```asm
ldr    r4, [r0], #4             /* r0 = s, r4 = *s, then ++s */
mov    r5, #0
ldr    r6, [r1]                 /* r1 = d, r6 = *d */
umlal  r2, r5, r3, r4           /* r2 = c, r3 = b, r4 = *s => umlal c, r5, b, *s */
adds   r7, r6, r2               /* r6 = *d, r2 = c => adds r7, *d, c */
adc    r2, r5, #0               /* r2 = c => adc c, r5, #0 */
str    r7, [r1], #4             /* r1 = d, *d = r7, then ++d */
```
So, armcc5 is the same with gnu's syntax.
However, we defined a tmp r.

### MULADDC_STOP of gnu version
```asm
str    r2, %0           /* store r2 (c) to c */
str    r1, %1           /* store r1 (d) to d */
str    r0, %2           /* store r0 (s) to s */
```
No need for armcc5.
