### PR TITLE
Add certificate policy oid x509 extension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Features
    * It is now possible to use NIST key wrap mode via the mbedtls_cipher API.
      Contributed by Jack Lloyd and Fortanix Inc.
    * Add the Wi-SUN Field Area Network (FAN) device extended key usage.
+   * Add the oid certificate policy x509 extension.
 
 Bugfix
    * Fix private key DER output in the key_app_writer example. File contents

--- a/library/oid.c
+++ b/library/oid.c
@@ -254,24 +254,28 @@ typedef struct {
 static const oid_x509_ext_t oid_x509_ext[] =
 {
     {
-        { ADD_LEN( MBEDTLS_OID_BASIC_CONSTRAINTS ),    "id-ce-basicConstraints",   "Basic Constraints" },
+        { ADD_LEN( MBEDTLS_OID_BASIC_CONSTRAINTS ),    "id-ce-basicConstraints",    "Basic Constraints" },
         MBEDTLS_OID_X509_EXT_BASIC_CONSTRAINTS,
     },
     {
-        { ADD_LEN( MBEDTLS_OID_KEY_USAGE ),            "id-ce-keyUsage",           "Key Usage" },
+        { ADD_LEN( MBEDTLS_OID_KEY_USAGE ),            "id-ce-keyUsage",            "Key Usage" },
         MBEDTLS_OID_X509_EXT_KEY_USAGE,
     },
     {
-        { ADD_LEN( MBEDTLS_OID_EXTENDED_KEY_USAGE ),   "id-ce-extKeyUsage",        "Extended Key Usage" },
+        { ADD_LEN( MBEDTLS_OID_EXTENDED_KEY_USAGE ),   "id-ce-extKeyUsage",         "Extended Key Usage" },
         MBEDTLS_OID_X509_EXT_EXTENDED_KEY_USAGE,
     },
     {
-        { ADD_LEN( MBEDTLS_OID_SUBJECT_ALT_NAME ),     "id-ce-subjectAltName",     "Subject Alt Name" },
+        { ADD_LEN( MBEDTLS_OID_SUBJECT_ALT_NAME ),     "id-ce-subjectAltName",      "Subject Alt Name" },
         MBEDTLS_OID_X509_EXT_SUBJECT_ALT_NAME,
     },
     {
-        { ADD_LEN( MBEDTLS_OID_NS_CERT_TYPE ),         "id-netscape-certtype",     "Netscape Certificate Type" },
+        { ADD_LEN( MBEDTLS_OID_NS_CERT_TYPE ),         "id-netscape-certtype",      "Netscape Certificate Type" },
         MBEDTLS_OID_X509_EXT_NS_CERT_TYPE,
+    },
+    {
+        { ADD_LEN( MBEDTLS_OID_CERTIFICATE_POLICIES ), "id-ce-certificatePolicies", "Certificate Policies" },
+        MBEDTLS_OID_X509_EXT_CERTIFICATE_POLICIES,
     },
     {
         { NULL, 0, NULL, NULL },

--- a/tests/suites/test_suite_oid.data
+++ b/tests/suites/test_suite_oid.data
@@ -33,3 +33,27 @@ oid_get_extended_key_usage:"5533445566":""
 
 OID get Ext Key Usage wrong oid - id-ce-authorityKeyIdentifier
 oid_get_extended_key_usage:"551D23":""
+
+OID get x509 extension - id-ce-basicConstraints
+oid_get_x509_extension:"551D13":MBEDTLS_OID_X509_EXT_BASIC_CONSTRAINTS
+
+OID get x509 extension - id-ce-keyUsage
+oid_get_x509_extension:"551D0F":MBEDTLS_OID_X509_EXT_KEY_USAGE
+
+OID get x509 extension - id-ce-extKeyUsage
+oid_get_x509_extension:"551D25":MBEDTLS_OID_X509_EXT_EXTENDED_KEY_USAGE
+
+OID get x509 extension - id-ce-subjectAltName
+oid_get_x509_extension:"551D11":MBEDTLS_OID_X509_EXT_SUBJECT_ALT_NAME
+
+OID get x509 extension - id-netscape-certtype
+oid_get_x509_extension:"6086480186F8420101":MBEDTLS_OID_X509_EXT_NS_CERT_TYPE
+
+OID get x509 extension - id-ce-certificatePolicies
+oid_get_x509_extension:"551D20":MBEDTLS_OID_X509_EXT_CERTIFICATE_POLICIES
+
+OID get x509 extension - invalid oid
+oid_get_x509_extension:"5533445566":0
+
+OID get x509 extension - wrong oid - id-ce
+oid_get_x509_extension:"551D":0

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -10,8 +10,8 @@
  * END_DEPENDENCIES
  */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ASN1_WRITE_C*/
-void oid_get_certificate_policies( data_t * oid, char * result_str )
+/* BEGIN_CASE */
+void oid_get_certificate_policies( data_t *oid, char *result_str )
 {
     mbedtls_asn1_buf asn1_buf = { 0, 0, NULL };
     int ret;

--- a/tests/suites/test_suite_oid.function
+++ b/tests/suites/test_suite_oid.function
@@ -55,3 +55,26 @@ void oid_get_extended_key_usage( data_t *oid, char *result_str )
     }
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void oid_get_x509_extension( data_t *oid, int exp_type )
+{
+    mbedtls_asn1_buf ext_oid = { 0, 0, NULL };
+    int ret;
+    int ext_type;
+
+    ext_oid.tag = MBEDTLS_ASN1_OID;
+    ext_oid.p = oid->x;
+    ext_oid.len = oid->len;
+
+    ret = mbedtls_oid_get_x509_ext_type( &ext_oid, &ext_type );
+    if( exp_type == 0 )
+    {
+        TEST_ASSERT( ret == MBEDTLS_ERR_OID_NOT_FOUND );
+    }
+    else
+    {
+        TEST_ASSERT( ext_type == exp_type );
+    }
+}
+/* END_CASE */


### PR DESCRIPTION
## Description
Add oid x509 extensions support and add the certificate policy oid.


## Status
**READY**

## Requires Backporting
NO  


## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


