### PR TITLE
Backport 2.16: Add guards for MBEDTLS_X509_CRL_PARSE_C in sample

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -67,6 +67,8 @@ Bugfix
      extensions in CSRs and CRTs that caused these bitstrings to not be encoded
      correctly as trailing zeroes were not accounted for as unused bits in the
      leading content octet. Fixes #1610.
+   * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
+     sni entry parameter. Reported by inestlerode in #560.
 
 Changes
    * Include configuration file in all header files that use configuration,


### PR DESCRIPTION
## Description
Backport of #2540 to `mbedtls-2.16`


## Status
**READY**

