### PR TITLE
Add --internal option to list-identifiers.sh

### DIFF
--- a/tests/scripts/list-identifiers.sh
+++ b/tests/scripts/list-identifiers.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Outputs a file containing identifiers from internal header files or all
+# header files, based on --internal flag.
+#
+# Usage: list-identifiers.sh [ -i | --internal ]
 
 set -eu
 
@@ -7,7 +12,29 @@ if [ -d include/mbedtls ]; then :; else
     exit 1
 fi
 
-HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h|bn_mul' )
+INTERNAL=""
+
+until [ -z "${1-}" ]
+do
+  case "$1" in
+    -i|--internal)
+      INTERNAL="1"
+      ;;
+    *)
+      # print error
+      echo "Unknown argument: '$1'"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ $INTERNAL ]
+then
+    HEADERS=$( ls include/mbedtls/*_internal.h | egrep -v 'compat-1\.3\.h|bn_mul' )
+else
+    HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h|bn_mul' )
+fi
 
 rm -f identifiers
 

--- a/tests/scripts/list-identifiers.sh
+++ b/tests/scripts/list-identifiers.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# Outputs a file containing identifiers from internal header files or all
-# header files, based on --internal flag.
+# Create a file named identifiers containing identifiers from internal header
+# files or all header files, based on --internal flag.
+# Outputs the line count of the file to stdout.
 #
 # Usage: list-identifiers.sh [ -i | --internal ]
 


### PR DESCRIPTION
## Description
When doing ABI/API checking, its useful to have a list of all the identifiers that are defined in the internal header files, as we do not promise compatibility for them. This option allows for a simple method of getting them for use with the ABI checking script.


## Status
**READY**

## Requires Backporting
Yes, to 2.16 and 2.7
