### PR TITLE
Backport 2.7: Give credit to OSS-Fuzz for #2404

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,8 @@ Bugfix
    * Fix potential memory leak in X.509 self test. Found and fixed by
      Junhwan Park, #2106.
    * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
-     used with negative inputs. Found by Guido Vranken in #2404.
+     used with negative inputs. Found by Guido Vranken in #2404. Credit to
+     OSS-Fuzz.
    * Fix bugs in the AEAD test suite which would be exposed by ciphers which
      either used both encrypt and decrypt key schedules, or which perform padding.
      GCM and CCM were not affected. Fixed by Jack Lloyd.


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2555

Add "Credit to OSS-Fuzz", in addition to Guido Vranken, for identifying
bug #2404.