### PR TITLE
Skip uncritical unsupported extensions

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -820,7 +820,17 @@ static int x509_get_crt_ext( unsigned char **p,
             break;
 
         default:
-            return( MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE );
+            /*
+             * If this is a non-critical extension, which the oid layer
+             * supports, but there isn't an x509 parser for it,
+             * skip the extension.
+             */
+#if !defined(MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION)
+            if( is_critical )
+                return( MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE );
+            else
+#endif
+                *p = end_ext_octet;
         }
     }
 


### PR DESCRIPTION
## Description
Skip extensions that have support in the `oid` layer`, but
no parser found in the x509 layer, in case these are not critical.


## Status
**READY**

## Requires Backporting
NO  


## Additional comments
Tested with #2536 with the following command:
~~~
./cert_app mode=ssl server_name=os.mbed.com debug_level=3 server_port=443
~~~
`os.mbed.com` certificate has a non critical certificate policies extensions.

This PR is related to #2530 and #2535, so I don't think a ChangeLog entry is required
