### PR TITLE
Use current cmake directory instead of source root directory

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -150,22 +150,22 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
         add_library(${mbedcrypto_static_target} STATIC ${src_crypto})
         set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
         target_link_libraries(${mbedcrypto_static_target} ${libs})
-        target_include_directories(${mbedcrypto_static_target} PUBLIC ${CMAKE_SOURCE_DIR}/include/)
+        target_include_directories(${mbedcrypto_static_target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/)
     endif()
 
     add_library(${mbedx509_static_target} STATIC ${src_x509})
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
     target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
     target_include_directories(${mbedx509_static_target}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/include/)
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
     target_include_directories(${mbedtls_static_target}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/include/
         )
 
     if(USE_CRYPTO_SUBMODULE)
@@ -184,22 +184,22 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
         add_library(mbedcrypto SHARED ${src_crypto})
         set_target_properties(mbedcrypto PROPERTIES VERSION 2.17.0 SOVERSION 3)
         target_link_libraries(mbedcrypto ${libs})
-        target_include_directories(mbedcrypto PUBLIC ${CMAKE_SOURCE_DIR}/include/)
+        target_include_directories(mbedcrypto PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/)
     endif()
 
     add_library(mbedx509 SHARED ${src_x509})
     set_target_properties(mbedx509 PROPERTIES VERSION 2.17.0 SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
     set_target_properties(mbedtls PROPERTIES VERSION 2.17.0 SOVERSION 12)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/include/)
 
     if(USE_CRYPTO_SUBMODULE)
         install(TARGETS mbedtls mbedx509


### PR DESCRIPTION
Use current cmake directory instead of source root directory for using as subproject

${CMAKE_SOURCE_DIR} is the root dir of project, so that you can get headers files not found during compliation if using mbedtls as subproject.
Switching to use ${CMAKE_CURRENT_SOURCE_DIR} fixes the problem.