### PR TITLE
Fix debug level in informational log messages

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1238,7 +1238,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
         if( ret == 0 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Successfully setup PSA-based encryption cipher context" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Successfully setup PSA-based encryption cipher context" ) );
             psa_fallthrough = 0;
         }
         else
@@ -1281,7 +1281,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
         if( ret == 0 )
         {
-            MBEDTLS_SSL_DEBUG_MSG( 1, ( "Successfully setup PSA-based decryption cipher context" ) );
+            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Successfully setup PSA-based decryption cipher context" ) );
             psa_fallthrough = 0;
         }
         else
@@ -10444,7 +10444,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( md_alg );
 
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform PSA-based computation of digest of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Perform PSA-based computation of digest of ServerKeyExchange" ) );
 
     if( ( status = psa_hash_setup( &hash_operation,
                                    hash_alg ) ) != PSA_SUCCESS )
@@ -10507,7 +10507,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
     const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type( md_alg );
     *hashlen = mbedtls_md_get_size( md_info );
 
-    MBEDTLS_SSL_DEBUG_MSG( 1, ( "Perform mbedtls-based computation of digest of ServerKeyExchange" ) );
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "Perform mbedtls-based computation of digest of ServerKeyExchange" ) );
 
     mbedtls_md_init( &ctx );
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -767,8 +767,8 @@ run_test() {
 run_test_psa() {
     requires_config_enabled MBEDTLS_USE_PSA_CRYPTO
     run_test    "PSA-supported ciphersuite: $1" \
-                "$P_SRV debug_level=2 force_version=tls1_2" \
-                "$P_CLI debug_level=2 force_version=tls1_2 force_ciphersuite=$1" \
+                "$P_SRV debug_level=3 force_version=tls1_2" \
+                "$P_CLI debug_level=3 force_version=tls1_2 force_ciphersuite=$1" \
                 0 \
                 -c "Successfully setup PSA-based decryption cipher context" \
                 -c "Successfully setup PSA-based encryption cipher context" \


### PR DESCRIPTION
This PR changes the debug level from 1 to 3 for some purely informational PSA-related debug messages. Level 1 should only be used for error messages.