### PR TITLE
Remove a redundant function call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,9 @@ Bugfix
      for the parameter.
    * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
      sni entry parameter. Reported by inestlerode in #560.
+   * Remove redundant line for getting the bitlen of a bignum, since the variable
+     holding the returned value is overwritten a line after.
+     Found by irwir in #2377.
 
 Changes
    * Server's RSA certificate in certs.c was SHA-1 signed. In the default

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2410,8 +2410,6 @@ static int mpi_miller_rabin( const mbedtls_mpi *X, size_t rounds,
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R, &W ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &R, s ) );
 
-    i = mbedtls_mpi_bitlen( X );
-
     for( i = 0; i < rounds; i++ )
     {
         /*


### PR DESCRIPTION
## Description
Remove a call to `mbedtls_mpi_bitlen()` since the returned value is
overwritten in the line after. This is redundant since da31fa137a1183d3feed5981af6d05c550a8c005.
Fixes #2377.


## Status
**READY**

## Requires Backporting
Yes
`mbedtls-2.16`

## Migrations
NO


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
