### PR TITLE
Backport 2.16: Remove a redundant function call 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,9 @@ Bugfix
      for the parameter.
    * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
      sni entry parameter. Reported by inestlerode in #560.
+   * Remove redundant line for getting the bitlen of a bignum, since the variable
+     holding the returned value is overwritten a line after.
+     Found by irwir in #2377.
 
 Changes
    * Return from various debugging routines immediately if the

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2333,8 +2333,6 @@ static int mpi_miller_rabin( const mbedtls_mpi *X, size_t rounds,
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R, &W ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &R, s ) );
 
-    i = mbedtls_mpi_bitlen( X );
-
     for( i = 0; i < rounds; i++ )
     {
         /*


### PR DESCRIPTION
## Description
Backport of #2577 to `mbedtls-2.16`

## Status
**READY**

