### PR TITLE
cpp_dummy_build: Add missing header psa_util.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ Bugfix
      GCM and CCM were not affected. Fixed by Jack Lloyd.
    * Fix incorrect default port number in ssl_mail_client example's usage.
      Found and fixed by irwir. #2337
+   * Add psa_util.h to test/cpp_dummy_build to fix build_default_make_gcc_and_cxx.
+     Fixed by Peter Kolbus (Garmin). #2579
 
 Changes
    * Server's RSA certificate in certs.c was SHA-1 signed. In the default

--- a/programs/test/cpp_dummy_build.cpp
+++ b/programs/test/cpp_dummy_build.cpp
@@ -81,6 +81,7 @@
 #include "mbedtls/platform_time.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
+#include "mbedtls/psa_util.h"
 #include "mbedtls/ripemd160.h"
 #include "mbedtls/rsa.h"
 #include "mbedtls/rsa_internal.h"


### PR DESCRIPTION
## Description

Add missing header so that all.sh can run to completion. Fixes #2579.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Run `./tests/scripts/all.sh build_default_make_gcc_and_cxx`
