### PR TITLE
cipher: Enable re-use of cipher contexts for PSA

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -304,9 +304,17 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
         if( key_bitlen % 8 != 0 )
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-        /* Don't allow keys to be set multiple times. */
+        /* If the key is already set, clear the old key before continuing. */
         if( cipher_psa->slot_state != MBEDTLS_CIPHER_PSA_KEY_UNSET )
-            return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+        {
+            /* The key has already been allocated and imported. Clear the key
+             * before continuing. */
+            status = psa_destroy_key( cipher_psa->slot );
+            if ( status != PSA_SUCCESS )
+            {
+                return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+            }
+        }
 
         key_type = mbedtls_psa_translate_cipher_type(
             ctx->cipher_info->type );


### PR DESCRIPTION
Non-PSA-backed ciphers allow calling mbedtls_cipher_setkey() multiple
times. Enable re-use of the same cipher context when changing keys or
operations with PSA-backed ciphers. If a key has been set already, clear
the previous key and re-import the new key.

## Why?

Our users expect to be able to re-use cipher contexts, or at least be able to call `mbedtls_cipher_setkey()` multiple times without freeing the context inbetween. (See 1dbc5a257fd0 as one instance.) If this use case is to continue to be allowed, then we need to change how we handle PSA-backed ciphers.

This fixes a test failure observed from https://github.com/ARMmbed/mbed-crypto/pull/94, where `tests/suites/test_suite_cipher.function` calls `mbedtls_cipher_setkey()` twice in a row to change from `MBEDTLS_DECRYPT` to `MBEDTLS_ENCRYPT`
```
Start 20: cipher.ccm-suite
20/78 Test #20: cipher.ccm-suite ...................***Failed    0.02 sec
AES-128-CCM test vector NIST #1 (P=0, N=7, A=0, T=4) .............. PASS
...
Camellia-CCM test vector RFC 5528 #24 ............................. PASS
AES-128-CCM test vector NIST #1 PSA (P=0, N=7, A=0, T=4) .......... FAILED
  0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len, MBEDTLS_ENCRYPT )
  at line 1015, /var/lib/build/tests/suites/test_suite_cipher.function

AES-128-CCM test vector NIST #2 PSA (P=0, N=7, A=0, T=4) .......... PASS
AES-128-CCM test vector NIST #3 PSA (P=0, N=7, A=0, T=16) ......... FAILED
  0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len, MBEDTLS_ENCRYPT )
  at line 1015, /var/lib/build/tests/suites/test_suite_cipher.function
```

## Status
**READY**

## Requires Backporting
NO  - Only for the development branch. None of the LTS branches are PSA capable.

## Migrations
NO