### PR TITLE
Don't call mbedtls_cipher_setkey twice

### DIFF
--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1011,7 +1011,7 @@ void auth_crypt_tv( int cipher_id, data_t * key, data_t * iv,
     TEST_ASSERT( memcmp( output, clear->x, clear->len ) == 0 );
 
     /* then encrypt the clear->x and make sure we get the same ciphertext and tag->x */
-    TEST_ASSERT( mbedtls_cipher_reset( &ctx ) == 0 );
+    mbedtls_cipher_free( &ctx );
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if( use_psa == 1 )
     {

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1011,6 +1011,20 @@ void auth_crypt_tv( int cipher_id, data_t * key, data_t * iv,
     TEST_ASSERT( memcmp( output, clear->x, clear->len ) == 0 );
 
     /* then encrypt the clear->x and make sure we get the same ciphertext and tag->x */
+    TEST_ASSERT( mbedtls_cipher_reset( &ctx ) == 0 );
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    if( use_psa == 1 )
+    {
+        TEST_ASSERT( 0 == mbedtls_cipher_setup_psa( &ctx,
+                              mbedtls_cipher_info_from_type( cipher_id ),
+                              tag->len ) );
+    }
+    else
+#endif
+    {
+        TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
+                              mbedtls_cipher_info_from_type( cipher_id ) ) );
+    }
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len,
                                              MBEDTLS_ENCRYPT ) );
 


### PR DESCRIPTION
The documentation doesn't explicitly say whether it's allowed or not.
This currently works with the default software implementation, but
only by accident. It isn't guaranteed to work with new ciphers or with
alternative implementations of individual ciphers, and it doesn't work
with the PSA wrappers. So don't do it.

Alternative to https://github.com/ARMmbed/mbedtls/pull/2581

Follow-up that documents that this is forbidden and add a check and a test: https://github.com/ARMmbed/mbedtls/pull/2584
