### PR TITLE
all.sh: Require i686-w64-mingw32-gcc version >= 6

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1209,6 +1209,12 @@ component_build_mingw () {
     make CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar LD=i686-w64-minggw32-ld CFLAGS='-Werror -Wall -Wextra' WINDOWS_BUILD=1 SHARED=1 tests
     make WINDOWS_BUILD=1 clean
 }
+support_build_mingw() {
+    case $(i686-w64-mingw32-gcc -dumpversion) in
+        [0-5]*) false;;
+        *) true;;
+    esac
+}
 
 component_test_memsan () {
     msg "build: MSan (clang)" # ~ 1 min 20s


### PR DESCRIPTION
Require mingw gcc version 6 or greater in order to ensure
BCryptGenRandom() is available.

This should enable https://github.com/ARMmbed/mbedtls/pull/1453 to pass CI after it is rebased.

Along with merging this PR, CI must be updated to run all.sh's mingw64 job on a supported platform, like Ubuntu 18.04.

## Status
**READY**

## Requires Backporting
NO  - LTS branches don't depend on BCryptGenRandom(), so they can run mingw tests fine with older gcc.

## Migrations
NO