### PR TITLE
Consistently call Window's getchar() at the very end of the example programs

### DIFF
--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -139,12 +139,6 @@ int main( int argc, char *argv[] )
     if( argc != 5 )
     {
         mbedtls_printf( USAGE );
-
-#if defined(_WIN32)
-        mbedtls_printf( "\n  Press Enter to exit this program.\n" );
-        fflush( stdout ); getchar();
-#endif
-
         goto exit;
     }
 
@@ -475,6 +469,11 @@ exit:
 
     mbedtls_aes_free( &aes_ctx );
     mbedtls_md_free( &sha_ctx );
+
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
 
     return( exit_code );
 }

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -153,11 +153,6 @@ int main( int argc, char *argv[] )
             list++;
         }
 
-#if defined(_WIN32)
-        mbedtls_printf( "\n  Press Enter to exit this program.\n" );
-        fflush( stdout ); getchar();
-#endif
-
         goto exit;
     }
 
@@ -572,6 +567,11 @@ exit:
 
     mbedtls_cipher_free( &cipher_ctx );
     mbedtls_md_free( &md_ctx );
+
+#if defined(_WIN32)
+    mbedtls_printf( "\n  Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
 
     return( exit_code );
 }

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -248,6 +248,11 @@ int main( int argc, char *argv[] )
 exit:
     mbedtls_md_free( &md_ctx );
 
+#if defined(_WIN32)
+    mbedtls_printf( "\n  Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
+
     return( exit_code );
 }
 #endif /* MBEDTLS_MD_C && MBEDTLS_FS_IO */

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -239,15 +239,15 @@ int main( int argc, char *argv[] )
 
 exit:
 
-#if defined(_WIN32)
-    mbedtls_printf( "  + Press Enter to exit this program.\n" );
-    fflush( stdout ); getchar();
-#endif
-
     mbedtls_ecdh_free( &ctx_srv );
     mbedtls_ecdh_free( &ctx_cli );
     mbedtls_ctr_drbg_free( &ctr_drbg );
     mbedtls_entropy_free( &entropy );
+
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
 
     return( exit_code );
 }

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -249,15 +249,15 @@ int main( int argc, char *argv[] )
 
 exit:
 
-#if defined(_WIN32)
-    mbedtls_printf( "  + Press Enter to exit this program.\n" );
-    fflush( stdout ); getchar();
-#endif
-
     mbedtls_ecdsa_free( &ctx_verify );
     mbedtls_ecdsa_free( &ctx_sign );
     mbedtls_ctr_drbg_free( &ctr_drbg );
     mbedtls_entropy_free( &entropy );
+
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
 
     return( exit_code );
 }

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -110,6 +110,11 @@ cleanup:
     fclose( f );
     mbedtls_entropy_free( &entropy );
 
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
+
     return( exit_code );
 }
 #endif /* MBEDTLS_ENTROPY_C */

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -143,6 +143,11 @@ cleanup:
     mbedtls_ctr_drbg_free( &ctr_drbg );
     mbedtls_entropy_free( &entropy );
 
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
+
     return( exit_code );
 }
 #endif /* MBEDTLS_CTR_DRBG_C && MBEDTLS_ENTROPY_C */

--- a/programs/random/gen_random_havege.c
+++ b/programs/random/gen_random_havege.c
@@ -115,6 +115,12 @@ int main( int argc, char *argv[] )
 exit:
     mbedtls_havege_free( &hs );
     fclose( f );
+
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
+
     return( exit_code );
 }
 #endif /* MBEDTLS_HAVEGE_C */

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -307,6 +307,11 @@ exit:
     mbedtls_x509_crt_free( &ca );
 #endif
 
+#if defined(_WIN32)
+    mbedtls_printf( "  + Press Enter to exit this program.\n" );
+    fflush( stdout ); getchar();
+#endif
+
     return( ret );
 }
 #endif


### PR DESCRIPTION
This change moves all the getchar() calls, that enable user to manually
confirm the program termination, to the very end of the example
programs. This has not been done consistently across the example
programs, which has been raised in a code review. This commit unifies
the getchar() calls atomically for all the examples.

This PR is intended to lighten the overblown #1572.