### PR TITLE
Add output file feature for ssl_client2.c

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1916,18 +1916,18 @@ send_request:
             if( fp != NULL )
             {
                 char *ptmp = (char *)buf;
-                size_t len0 = (size_t)len;
+                int len0 = len;
                 if( parse_header == 0 )
                 {
                     char *px = strstr( (char *)buf, GET_REQUEST_END );
                     if( px != NULL )
                     {
                         ptmp = px + strlen(GET_REQUEST_END);
-                        len0 = (size_t)len - ( (unsigned char *)ptmp - buf );
+                        len0 = len - (int)( (unsigned char *)ptmp - buf );
                     }
                     parse_header = 1;
                 }
-                mbedtls_printf( " %zu bytes read\n", len0 );
+                mbedtls_printf( " %d bytes read\n", len0 );
                 fwrite( ptmp, len0, 1, fp );
             }
             else

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1913,27 +1913,26 @@ send_request:
 
             len = ret;
             buf[len] = '\0';
-            if( fp == NULL )
-            {
-                mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
-            }
-            else
+            if( fp != NULL )
             {
                 char *ptmp = (char *)buf;
                 size_t len0 = (size_t)len;
                 if( parse_header == 0 )
                 {
-                    char *px = strstr((char *)buf, GET_REQUEST_END);
+                    char *px = strstr( (char *)buf, GET_REQUEST_END );
                     if( px != NULL )
                     {
                         ptmp = px + strlen(GET_REQUEST_END);
-                        len0 = (size_t)len - ((unsigned char *)ptmp - buf);
+                        len0 = (size_t)len - ( (unsigned char *)ptmp - buf );
                     }
                     parse_header = 1;
                 }
                 mbedtls_printf( " %zu bytes read\n", len0 );
                 fwrite( ptmp, len0, 1, fp );
             }
+            else
+                mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
+            
             /* End of message should be detected according to the syntax of the
              * application protocol (eg HTTP), just use a dummy test here. */
             if( ret > 0 && buf[len-1] == '\n' )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1012,9 +1012,8 @@ int main( int argc, char *argv[] )
             goto usage;
     }
 
-    if (opt.output_file) {
+    if( opt.output_file != NULL && strlen( opt.output_file ) != 0 )
         fp = fopen(opt.output_file, "wb+");
-    }
 
     /* Event-driven IO is incompatible with the above custom
      * receive and send functions, as the polling builds on
@@ -1914,21 +1913,26 @@ send_request:
 
             len = ret;
             buf[len] = '\0';
-            if (fp == NULL) {
-            mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
-            } else {
+            if( fp == NULL )
+            {
+                mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
+            }
+            else
+            {
                 char *ptmp = (char *)buf;
-                size_t len0 = len;
-                if (parse_header == 0) {
+                size_t len0 = (size_t)len;
+                if( parse_header == 0 )
+                {
                     char *px = strstr((char *)buf, GET_REQUEST_END);
-                    if (px != NULL) {
+                    if( px != NULL )
+                    {
                         ptmp = px + strlen(GET_REQUEST_END);
-                        len0 = len - ((unsigned char *)ptmp - buf);
+                        len0 = (size_t)len - ((unsigned char *)ptmp - buf);
                     }
                     parse_header = 1;
                 }
                 mbedtls_printf( " %zu bytes read\n", len0 );
-                fwrite(ptmp, len0, 1, fp);
+                fwrite( ptmp, len0, 1, fp );
             }
             /* End of message should be detected according to the syntax of the
              * application protocol (eg HTTP), just use a dummy test here. */
@@ -2142,9 +2146,8 @@ exit:
     }
 #endif
 
-    if (fp) {
+    if( fp )
         fclose(fp);
-    }
 
     mbedtls_net_free( &server_fd );
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -116,7 +116,7 @@ int main( void )
 #define DFL_EXTENDED_MS         -1
 #define DFL_ETM                 -1
 
-#define GET_REQUEST "GET %s HTTP/1.0\r\nHost: %s\r\nConnection: keep-alive\r\nExtra-header: "
+#define GET_REQUEST "GET %s HTTP/1.0\r\nExtra-header: "
 #define GET_REQUEST_END "\r\n\r\n"
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -597,7 +597,7 @@ int main( int argc, char *argv[] )
     memset( (void * ) alpn_list, 0, sizeof( alpn_list ) );
 #endif
 
-    if( argc <= 1 )
+    if( argc == 0 )
     {
     usage:
         if( ret == 0 )
@@ -1737,7 +1737,7 @@ send_request:
     fflush( stdout );
 
     len = mbedtls_snprintf( (char *) buf, sizeof( buf ) - 1, GET_REQUEST,
-                            opt.request_page, opt.server_name );
+                            opt.request_page );
     tail_len = (int) strlen( GET_REQUEST_END );
 
     /* Add padding to GET request to reach opt.request_size in length */

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1921,7 +1921,7 @@ send_request:
                 size_t len0 = len;
                 if (parse_header == 0) {
                     char *px = strstr((char *)buf, GET_REQUEST_END);
-                    if (px) { 
+                    if (px != NULL) { 
                         ptmp = px + strlen(GET_REQUEST_END);
                         len0 = len - ((unsigned char *)ptmp - buf);
                     }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -116,7 +116,7 @@ int main( void )
 #define DFL_EXTENDED_MS         -1
 #define DFL_ETM                 -1
 
-#define GET_REQUEST "GET %s HTTP/1.0\r\nHost: %s\r\nConnection: keep-alive"
+#define GET_REQUEST "GET %s HTTP/1.0\r\nHost: %s\r\nConnection: keep-alive\r\nExtra-header: "
 #define GET_REQUEST_END "\r\n\r\n"
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1921,7 +1921,7 @@ send_request:
                 size_t len0 = len;
                 if (parse_header == 0) {
                     char *px = strstr((char *)buf, GET_REQUEST_END);
-                    if (px != NULL) { 
+                    if (px != NULL) {
                         ptmp = px + strlen(GET_REQUEST_END);
                         len0 = len - ((unsigned char *)ptmp - buf);
                     }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1932,7 +1932,7 @@ send_request:
             }
             else
                 mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
-            
+
             /* End of message should be detected according to the syntax of the
              * application protocol (eg HTTP), just use a dummy test here. */
             if( ret > 0 && buf[len-1] == '\n' )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1917,18 +1917,18 @@ send_request:
             if (fp == NULL) {
             mbedtls_printf( " %d bytes read\n\n%s", len, (char *) buf );
             } else {
-                char *p = (char *)buf;
+                char *ptmp = (char *)buf;
                 size_t len0 = len;
                 if (parse_header == 0) {
                     char *px = strstr((char *)buf, GET_REQUEST_END);
                     if (px) { 
-                        p = px + strlen(GET_REQUEST_END);
-                        len0 = len - ((unsigned char *)p - buf);
+                        ptmp = px + strlen(GET_REQUEST_END);
+                        len0 = len - ((unsigned char *)ptmp - buf);
                     }
                     parse_header = 1;
                 }
-                mbedtls_printf( " %d bytes read\n", len0 );
-                fwrite(p, len0, 1, fp);
+                mbedtls_printf( " %zu bytes read\n", len0 );
+                fwrite(ptmp, len0, 1, fp);
             }
             /* End of message should be detected according to the syntax of the
              * application protocol (eg HTTP), just use a dummy test here. */


### PR DESCRIPTION
Add a `output file` option for the `ssl_client2.c` module.

The purpose of adding this feature is to make it easier for testers to use this client to download files directly from the https website. Of course, there are a lot of condition judgements  are not implemented  in this commits, but it is enought for working in most cases.
