### PR TITLE
Backport 2.7: Reword ssl_conf_max_frag_len documentation to clarify its necessity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,8 @@ Changes
      Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
    * Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh.
      Contributed by Peter Kolbus (Garmin).
+   * Change wording in the `mbedtls_ssl_conf_max_frag_len()`'s documentation to
+     improve clarity. Fixes #2258.
 
 = mbed TLS 2.7.10 branch released 2019-03-19
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2106,12 +2106,23 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
- * \brief          Set the maximum fragment length to emit and/or negotiate
- *                 (Default: MBEDTLS_SSL_MAX_CONTENT_LEN, usually 2^14 bytes)
+ * \brief          Set the maximum fragment length to emit and/or negotiate.
+ *                 (Typical: the smaller of #MBEDTLS_SSL_IN_CONTENT_LEN and
+ *                 #MBEDTLS_SSL_OUT_CONTENT_LEN, usually `2^14` bytes)
  *                 (Server: set maximum fragment length to emit,
- *                 usually negotiated by the client during handshake
+ *                 usually negotiated by the client during handshake)
  *                 (Client: set maximum fragment length to emit *and*
  *                 negotiate with the server during handshake)
+ *                 (Default: #MBEDTLS_SSL_MAX_FRAG_LEN_NONE)
+ *
+ * \note           On the client side, the maximum fragment length extension
+ *                 *will not* be used, unless the maximum fragment length has
+ *                 been set via this function to a value different than
+ *                 #MBEDTLS_SSL_MAX_FRAG_LEN_NONE.
+ *
+ * \note           This sets the maximum length for a record's payload,
+ *                 excluding record overhead that will be added to it, see
+ *                 \c mbedtls_ssl_get_record_expansion().
  *
  * \param conf     SSL configuration
  * \param mfl_code Code for maximum fragment length (allowed values:

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2107,8 +2107,8 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
  * \brief          Set the maximum fragment length to emit and/or negotiate.
- *                 (Typical: the smaller of #MBEDTLS_SSL_IN_CONTENT_LEN and
- *                 #MBEDTLS_SSL_OUT_CONTENT_LEN, usually `2^14` bytes)
+ *                 (Typical: #MBEDTLS_SSL_MAX_CONTENT_LEN, by default that is
+ *                 set to `2^14` bytes)
  *                 (Server: set maximum fragment length to emit,
  *                 usually negotiated by the client during handshake)
  *                 (Client: set maximum fragment length to emit *and*

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2115,6 +2115,10 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  *                 negotiate with the server during handshake)
  *                 (Default: #MBEDTLS_SSL_MAX_FRAG_LEN_NONE)
  *
+ * \note           With TLS, this currently only affects ApplicationData (sent
+ *                 with \c mbedtls_ssl_read()), not handshake messages.
+ *                 With DTLS, this affects both ApplicationData and handshake.
+ *
  * \note           On the client side, the maximum fragment length extension
  *                 *will not* be used, unless the maximum fragment length has
  *                 been set via this function to a value different than


### PR DESCRIPTION
This is a backport of #2410