### PR TITLE
Only use the crypto submodule if present in ABI check

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -148,7 +148,8 @@ class AbiChecker(object):
         my_environment = os.environ.copy()
         my_environment["CFLAGS"] = "-g -Og"
         my_environment["SHARED"] = "1"
-        my_environment["USE_CRYPTO_SUBMODULE"] = "1"
+        if os.path.exists(os.path.join(git_worktree_path, "crypto")):
+            my_environment["USE_CRYPTO_SUBMODULE"] = "1"
         make_output = subprocess.check_output(
             [self.make_command, "lib"],
             env=my_environment,


### PR DESCRIPTION
Enabling the USE_CRYPTO_SUBMODULE option causes problems if the
crypto submodule isn't present. Only enable it if the submodule
actually exists.

## Status
**READY**

## Requires Backporting

Yes, to 2.16 and 2.7
