### PR TITLE
[Backport 2.7] Only use the crypto submodule if present in ABI check 

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -148,7 +148,8 @@ class AbiChecker(object):
         my_environment = os.environ.copy()
         my_environment["CFLAGS"] = "-g -Og"
         my_environment["SHARED"] = "1"
-        my_environment["USE_CRYPTO_SUBMODULE"] = "1"
+        if os.path.exists(os.path.join(git_worktree_path, "crypto")):
+            my_environment["USE_CRYPTO_SUBMODULE"] = "1"
         make_output = subprocess.check_output(
             [self.make_command, "lib"],
             env=my_environment,


### PR DESCRIPTION
This is the 2.7 backport of #2636.