### PR TITLE
Use all.sh and its component list in pre-push hook

### DIFF
--- a/tests/git-scripts/pre-push.sh
+++ b/tests/git-scripts/pre-push.sh
@@ -32,18 +32,4 @@ echo "URL is $URL"
 
 set -eu
 
-run_test()
-{
-    TEST=$1
-    echo "running '$TEST'"
-    if ! `$TEST > /dev/null 2>&1`; then
-        echo "test '$TEST' failed"
-        return 1
-    fi
-}
-
-run_test ./tests/scripts/check-doxy-blocks.pl
-run_test ./tests/scripts/check-names.sh
-run_test ./tests/scripts/check-generated-files.sh
-run_test ./tests/scripts/check-files.py
-run_test ./tests/scripts/doxygen.sh
+tests/scripts/all.sh -q -k 'check_*'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -675,7 +675,12 @@ component_check_names () {
 
 component_check_test_cases () {
     msg "Check: test case descriptions" # < 1s
-    record_status tests/scripts/check-test-cases.py
+    if [ $QUIET -eq 1 ]; then
+        OPT='--quiet'
+    else
+        OPT=''
+    fi
+    record_status tests/scripts/check-test-cases.py $OPT
 }
 
 component_check_doxygen_warnings () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -682,11 +682,12 @@ component_check_names () {
 component_check_test_cases () {
     msg "Check: test case descriptions" # < 1s
     if [ $QUIET -eq 1 ]; then
-        OPT='--quiet'
+        opt='--quiet'
     else
-        OPT=''
+        opt=''
     fi
-    record_status tests/scripts/check-test-cases.py $OPT
+    record_status tests/scripts/check-test-cases.py $opt
+    unset opt
 }
 
 component_check_doxygen_warnings () {
@@ -1942,7 +1943,7 @@ run_component () {
 
     # Restore the build tree to a clean state.
     cleanup
-    current_component=""
+    unset current_component
 }
 
 # Preliminary setup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1886,7 +1886,10 @@ component_check_python_files () {
 
 component_check_generate_test_code () {
     msg "uint test: generate_test_code.py"
-    record_status ./tests/scripts/test_generate_test_code.py
+    # unittest writes out mundane stuff like number or tests run on stderr.
+    # Our convention is to reserve stderr for actual errors, and write
+    # harmless info on stdout so it can be suppress with --quiet.
+    record_status ./tests/scripts/test_generate_test_code.py 2>&1
 }
 
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -510,9 +510,15 @@ pre_setup_quiet_redirect () {
         redirect_out () {
             "$@"
         }
+        redirect_err () {
+            "$@"
+        }
     else
         redirect_out () {
             "$@" >/dev/null
+        }
+        redirect_err () {
+            "$@" 2>/dev/null
         }
     fi
 }
@@ -1925,7 +1931,7 @@ run_component () {
     # Unconditionally create a seedfile that's sufficiently long.
     # Do this before each component, because a previous component may
     # have messed it up or shortened it.
-    dd if=/dev/urandom of=./tests/seedfile bs=64 count=1 >/dev/null 2>&1
+    redirect_err dd if=/dev/urandom of=./tests/seedfile bs=64 count=1
 
     # Run the component code.
     if [ $QUIET -eq 1 ]; then

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1886,7 +1886,7 @@ run_component () {
     # Unconditionally create a seedfile that's sufficiently long.
     # Do this before each component, because a previous component may
     # have messed it up or shortened it.
-    dd if=/dev/urandom of=./tests/seedfile bs=64 count=1
+    dd if=/dev/urandom of=./tests/seedfile bs=64 count=1 >/dev/null 2>&1
 
     # Run the component code.
     "$@"


### PR DESCRIPTION
## Description

Currently there is some level of duplication between all.sh and the pre-push hook: when a fast check is added to all.sh we have to remember to add it to the pre-push hook as well.

This commit adds five components that were previously not run:

- `check_recursion`
- `check_changelog`
- `check_test_cases`
- `check_python_files`
- `check_generate_test_code`

It also changes the behaviour in case in-tree cmake was enabled before pushing or otherwise running the pre-push hook: previously the script failed because check_names is not compatible with cmake, now it silently disables cmake (and succeeds unless there is an actual issue).

## Status
**READY**

## Requires Backporting
Yes, as it's a test script.

- [x] 2.16 #3446
- [x] 2.7 #3447 

## Migrations
NO

## Manuel testing

Though the most important case to test is `tests/scripts/all.sh -q -k 'check_*'` with and without errors, as that's what's used in the pre-push hook, I believe the full test matrix is 2x2x2:

- `--quiet` / `--no-quiet`
- `--keep-going` / `--no-keep-going`
- errors or no errors (an error can be triggerred for example by adding trailing whitespace in `library/aes.c`)

I don't think it's really useful at this point to test anything other that the `check_*` components with `-q`.