### PR TITLE
Backport 2.16: Fix mpi_bigendian_to_host() on bigendian systems that don't have BYTE_ORDER defined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,9 @@ Bugfix
      for the parameter.
    * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
      sni entry parameter. Reported by inestlerode in #560.
+   * Fix bug in endianness conversion in bignum module. This lead to
+     functionally incorrect code on bigendian systems which don't have
+     __BYTE_ORDER__ defined. Reported by Brendan Shanks. Fixes #2622.
 
 Changes
    * Return from various debugging routines immediately if the

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -742,10 +742,15 @@ cleanup:
 static mbedtls_mpi_uint mpi_uint_bigendian_to_host_c( mbedtls_mpi_uint x )
 {
     uint8_t i;
+    unsigned char *x_ptr;
     mbedtls_mpi_uint tmp = 0;
-    /* This works regardless of the endianness. */
-    for( i = 0; i < ciL; i++, x >>= 8 )
-        tmp |= ( x & 0xFF ) << ( ( ciL - 1 - i ) << 3 );
+
+    for( i = 0, x_ptr = (unsigned char*) &x; i < ciL; i++, x_ptr++ )
+    {
+        tmp <<= CHAR_BIT;
+        tmp |= (mbedtls_mpi_uint) *x_ptr;
+    }
+
     return( tmp );
 }
 


### PR DESCRIPTION
This is the backport to Mbed TLS 2.16 of #2623.