### PR TITLE
Print a command trace if the check-names.sh exits unexpectedly

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -597,7 +597,7 @@ component_check_files () {
 
 component_check_names () {
     msg "test/build: declared and exported names" # < 3s
-    record_status tests/scripts/check-names.sh
+    record_status tests/scripts/check-names.sh -v
 }
 
 component_check_doxygen_warnings () {

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -16,12 +16,22 @@ if grep --version|head -n1|grep GNU >/dev/null; then :; else
     exit 1
 fi
 
+trace=
+if [ $# -ne 0 ] && [ "$1" = "-v" ]; then
+  shift
+  trace='-x'
+  exec 2>check-names.err
+  trap 'echo "FAILED UNEXPECTEDLY, status=$?";
+        cat check-names.err' EXIT
+  set -x
+fi
+
 printf "Analysing source code...\n"
 
-tests/scripts/list-macros.sh
+sh $trace tests/scripts/list-macros.sh
 tests/scripts/list-enum-consts.pl
-tests/scripts/list-identifiers.sh
-tests/scripts/list-symbols.sh
+sh $trace tests/scripts/list-identifiers.sh
+sh $trace tests/scripts/list-symbols.sh
 
 FAIL=0
 
@@ -80,6 +90,12 @@ else
     echo "FAIL"
     echo "$TYPOS"
     FAIL=1
+fi
+
+if [ -n "$trace" ]; then
+  set +x
+  trap - EXIT
+  rm check-names.err
 fi
 
 printf "\nOverall: "

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -2,14 +2,20 @@
 #
 # This file is part of mbed TLS (https://tls.mbed.org)
 #
-# Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
-#
-# Purpose
-#
-# This script confirms that the naming of all symbols and identifiers in mbed
-# TLS are consistent with the house style and are also self-consistent.
-#
+# Copyright (c) 2015-2019, ARM Limited, All Rights Reserved
+
 set -eu
+
+if [ $# -ne 0 ] && [ "$1" = "--help" ]; then
+    cat <<EOF
+$0 [-v]
+This script confirms that the naming of all symbols and identifiers in mbed
+TLS are consistent with the house style and are also self-consistent.
+
+  -v    If the script fails unexpectedly, print a command trace.
+EOF
+    exit
+fi
 
 if grep --version|head -n1|grep GNU >/dev/null; then :; else
     echo "This script requires GNU grep.">&2

--- a/tests/scripts/list-symbols.sh
+++ b/tests/scripts/list-symbols.sh
@@ -14,8 +14,20 @@ fi
 
 cp include/mbedtls/config.h include/mbedtls/config.h.bak
 scripts/config.pl full
-CFLAGS=-fno-asynchronous-unwind-tables make clean lib >/dev/null 2>&1
+make_ret=
+CFLAGS=-fno-asynchronous-unwind-tables make clean lib \
+      >list-symbols.make.log 2>&1 ||
+  {
+    make_ret=$?
+    echo "Build failure: CFLAGS=-fno-asynchronous-unwind-tables make clean lib"
+    cat list-symbols.make.log >&2
+  }
+rm list-symbols.make.log
 mv include/mbedtls/config.h.bak include/mbedtls/config.h
+if [ -n "$make_ret" ]; then
+    exit "$make_ret"
+fi
+
 if uname | grep -F Darwin >/dev/null; then
     nm -gUj library/libmbed*.a 2>/dev/null | sed -n -e 's/^_//p'
 elif uname | grep -F Linux >/dev/null; then


### PR DESCRIPTION
We've observed that sometimes check-names.sh exits unexpectedly with
status 2 and no error message. The failure is not reproducible. This
commits makes the script print a trace if it exits unexpectedly.
