### PR TITLE
update the test script

### DIFF
--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -270,7 +270,7 @@ class MbedTlsTest(BaseHostTest):
                 data_bytes += b'S'
                 self.align_32bit(data_bytes)
                 data_bytes += self.int32_to_big_endian_bytes(i)
-                data_bytes += bytes(param, 'ascii')
+                data_bytes += bytearray(param, encoding='ascii')
                 data_bytes += b'\0'   # Null terminate
             elif typ == 'hex':
                 binary_data = self.hex_str_bytes(param)
@@ -309,7 +309,7 @@ class MbedTlsTest(BaseHostTest):
 
         param_bytes, length = self.test_vector_to_bytes(function_id,
                                                         dependencies, args)
-        self.send_kv(length.hex(), param_bytes.hex())
+        self.send_kv(''.join('{:02x}'.format(x) for x in length), ''.join('{:02x}'.format(x) for x in param_bytes))
 
     @staticmethod
     def get_result(value):

--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -80,6 +80,7 @@ class TestDataParser(object):
         if len(split_char) > 1:
             raise ValueError('Expected split character. Found string!')
         out = list(map(split_colon_fn, re.split(r'(?<!\\)' + split_char, inp_str)))
+        out = [x for x in out if x]
         return out
 
     def __parse(self, data_f):
@@ -260,7 +261,7 @@ class MbedTlsTest(BaseHostTest):
         data_bytes += bytearray([function_id, len(parameters)])
         for typ, param in parameters:
             if typ == 'int' or typ == 'exp':
-                i = int(param)
+                i = int(param, 0)
                 data_bytes += b'I' if typ == 'int' else b'E'
                 self.align_32bit(data_bytes)
                 data_bytes += self.int32_to_big_endian_bytes(i)

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -69,28 +69,14 @@ int verify_dependencies( uint8_t count, uint8_t * dep_p )
 uint8_t receive_byte()
 {
     uint8_t byte;
-    uint8_t c;
+    uint8_t c[3];
+    char *endptr;
+    c[0] = greentea_getc();
+    c[1] = greentea_getc();
+    c[2] = '\0';
 
-    c = greentea_getc();
-    if( c >= '0' && c <= '9' )
-        c -= '0';
-    else if( c >= 'a' && c <= 'f' )
-        c = ( c -'a' ) + 10;
-    else if( c >= 'A' && c <= 'F' )
-        c = ( c - 'A' ) + 10;
-
-    byte = c * 0x10;
-
-    c = greentea_getc();
-    if( c >= '0' && c <= '9' )
-        c -= '0';
-    else if( c >= 'a' && c <= 'f' )
-        c = ( c -'a' ) + 10;
-    else if( c >= 'A' && c <= 'F' )
-        c = ( c - 'A' ) + 10;
-
-    byte += c ;
-    return( byte);
+    assert( unhexify( &byte, &c ) != 2 );
+    return( byte );
 }
 
 /**

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -59,10 +59,43 @@ int verify_dependencies( uint8_t count, uint8_t * dep_p )
     return( DEPENDENCY_SUPPORTED );
 }
 
+/**
+ * \brief       Receives hex string on serial interface, and converts to a byte.
+ *
+ * \param none
+ *
+ * \return      unsigned int8
+ */
+uint8_t receive_byte()
+{
+    uint8_t byte;
+    uint8_t c;
+
+    c = greentea_getc();
+    if( c >= '0' && c <= '9' )
+        c -= '0';
+    else if( c >= 'a' && c <= 'f' )
+        c = ( c -'a' ) + 10;
+    else if( c >= 'A' && c <= 'F' )
+        c = ( c - 'A' ) + 10;
+
+    byte = c * 0x10;
+
+    c = greentea_getc();
+    if( c >= '0' && c <= '9' )
+        c -= '0';
+    else if( c >= 'a' && c <= 'f' )
+        c = ( c -'a' ) + 10;
+    else if( c >= 'A' && c <= 'F' )
+        c = ( c - 'A' ) + 10;
+
+    byte += c ;
+    return( byte);
+}
 
 /**
  * \brief       Receives unsigned integer on serial interface.
- *              Integers are encoded in network order.
+ *              Integers are encoded in network order, and sent as hex ascii string.
  *
  * \param none
  *
@@ -71,10 +104,10 @@ int verify_dependencies( uint8_t count, uint8_t * dep_p )
 uint32_t receive_uint32()
 {
     uint32_t value;
-    value =  (uint8_t)greentea_getc() << 24;
-    value |= (uint8_t)greentea_getc() << 16;
-    value |= (uint8_t)greentea_getc() << 8;
-    value |= (uint8_t)greentea_getc();
+    value =  receive_byte() << 24;
+    value |= receive_byte() << 16;
+    value |= receive_byte() << 8;
+    value |= receive_byte();
     return( (uint32_t)value );
 }
 
@@ -132,7 +165,7 @@ uint8_t * receive_data( uint32_t * data_len )
     greentea_getc(); // read ';' received after key i.e. *data_len
 
     for( i = 0; i < *data_len; i++ )
-        data[i] = greentea_getc();
+        data[i] = receive_byte();
 
     /* Read closing braces */
     for( i = 0; i < 2; i++ )

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -75,7 +75,7 @@ uint8_t receive_byte()
     c[1] = greentea_getc();
     c[2] = '\0';
 
-    assert( unhexify( &byte, &c ) != 2 );
+    assert( unhexify( &byte, c ) != 2 );
     return( byte );
 }
 
@@ -90,10 +90,17 @@ uint8_t receive_byte()
 uint32_t receive_uint32()
 {
     uint32_t value;
-    value =  receive_byte() << 24;
-    value |= receive_byte() << 16;
-    value |= receive_byte() << 8;
-    value |= receive_byte();
+    const uint8_t c[9] = { greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           greentea_getc(),
+                           '\0'
+                         };
+    assert( unhexify( &value, c ) != 8 );
     return( (uint32_t)value );
 }
 


### PR DESCRIPTION
## Description
Update `mbedtls_test.py` script to work with Python 3.7.
resolves #2653


## Status
**READY**

## Requires Backporting
Possibly, since this is in our test infrastructure, but the On Target Tests is not introduced yet in `mbedtls-2.7` ( It will be in #2075 )

## Additional comments
The CI will possibly need to change
Ran the script with the entropy on target test

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


