### PR TITLE
Remove all abi dumps, not just ones shared between versions

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -279,8 +279,9 @@ class AbiChecker(object):
                 )
                 if not (self.keep_all_reports or self.brief):
                     os.remove(output_path)
-            os.remove(self.old_version.abi_dumps[mbed_module])
-            os.remove(self.new_version.abi_dumps[mbed_module])
+        for version in [self.old_version, self.new_version]:
+            for mbed_module, mbed_module_dump in version.abi_dumps.items():
+                os.remove(mbed_module_dump)
         if self.can_remove_report_dir:
             os.rmdir(self.report_dir)
         self.log.info(compatibility_report)


### PR DESCRIPTION
While the abi-checking script handled comparing only the modules that were shared between the old and new versions correctly, the cleanup of the abi dumps only removed what was shared. Change the cleanup logic to remove all abi dumps instead.

## Status
**READY**

## Requires Backporting
Yes, to 2.16 and 2.7
