### PR TITLE
Backport 2.16: Fix some possibly-undefined variable warnings

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -258,7 +258,7 @@ int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
  */
 static int entropy_gather_internal( mbedtls_entropy_context *ctx )
 {
-    int ret, i, have_one_strong = 0;
+    int ret = 0, i, have_one_strong = 0;
     unsigned char buf[MBEDTLS_ENTROPY_MAX_GATHER];
     size_t olen;
 

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -74,7 +74,7 @@ int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
     unsigned char rounds = ( additional != NULL && add_len != 0 ) ? 2 : 1;
     unsigned char sep[1];
     unsigned char K[MBEDTLS_MD_MAX_SIZE];
-    int ret;
+    int ret = 0;
 
     for( sep[0] = 0; sep[0] < rounds; sep[0]++ )
     {

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -540,7 +540,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
 {
 #if defined(MBEDTLS_PEM_PARSE_C)
     int ret;
-    size_t use_len;
+    size_t use_len = 0;
     mbedtls_pem_context pem;
     int is_pem = 0;
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2014,7 +2014,7 @@ static int x509_crt_find_parent_in(
 {
     int ret;
     mbedtls_x509_crt *parent, *fallback_parent;
-    int signature_is_good, fallback_signature_is_good;
+    int signature_is_good = 0, fallback_signature_is_good;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     /* did we have something in progress? */


### PR DESCRIPTION
…to 0.

Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
This PR resolves a number of warning that appear when building in Xcode. There were some local variables that could potentially not be initialized (at least according to the static code analyzer in Xcode.)


## Status
Ready?

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

I don't know

## Migrations
If there is any API change, what's the incentive and logic for it.

None.

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.