### PR TITLE
test: Always use `make clean` by itself

### DIFF
--- a/tests/scripts/list-symbols.sh
+++ b/tests/scripts/list-symbols.sh
@@ -14,12 +14,13 @@ fi
 
 cp include/mbedtls/config.h include/mbedtls/config.h.bak
 scripts/config.pl full
+make clean
 make_ret=
-CFLAGS=-fno-asynchronous-unwind-tables make clean lib \
+CFLAGS=-fno-asynchronous-unwind-tables make lib \
       >list-symbols.make.log 2>&1 ||
   {
     make_ret=$?
-    echo "Build failure: CFLAGS=-fno-asynchronous-unwind-tables make clean lib"
+    echo "Build failure: CFLAGS=-fno-asynchronous-unwind-tables make lib"
     cat list-symbols.make.log >&2
   }
 rm list-symbols.make.log


### PR DESCRIPTION
When running make with parallelization, running both "clean" and "lib"
with a single make invocation can lead to each target building in
parallel. It's bad if lib is partially done building something, and then
clean deletes what was built. This can lead to errors later on in the
lib target.

    $ make -j9 clean lib
      CC    aes.c
      CC    aesni.c
      CC    arc4.c
      CC    aria.c
      CC    asn1parse.c
      CC    ./library/error.c
      CC    ./library/version.c
      CC    ./library/version_features.c
      AR    libmbedcrypto.a
    ar: aes.o: No such file or directory
    Makefile:120: recipe for target 'libmbedcrypto.a' failed
    make[2]: *** [libmbedcrypto.a] Error 1
    Makefile:152: recipe for target 'libmbedcrypto.a' failed
    make[1]: *** [libmbedcrypto.a] Error 2
    Makefile:19: recipe for target 'lib' failed
    make: *** [lib] Error 2
    make: *** Waiting for unfinished jobs....

To avoid this sort of trouble, always invoke clean by itself without
other targets throughout the library. Don't run clean in parallel with
other rules. The only place where clean was run in parallel with other
targets was in list-symbols.sh.

## Status
**READY**

## Requires Backporting
Yes
2.16
2.7

## Migrations
NO