### PR TITLE
Backport 2.16: test: Always use `make clean` by itself

### DIFF
--- a/tests/scripts/list-symbols.sh
+++ b/tests/scripts/list-symbols.sh
@@ -14,12 +14,13 @@ fi
 
 cp include/mbedtls/config.h include/mbedtls/config.h.bak
 scripts/config.pl full
+make clean
 make_ret=
-CFLAGS=-fno-asynchronous-unwind-tables make clean lib \
+CFLAGS=-fno-asynchronous-unwind-tables make lib \
       >list-symbols.make.log 2>&1 ||
   {
     make_ret=$?
-    echo "Build failure: CFLAGS=-fno-asynchronous-unwind-tables make clean lib"
+    echo "Build failure: CFLAGS=-fno-asynchronous-unwind-tables make lib"
     cat list-symbols.make.log >&2
   }
 rm list-symbols.make.log


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2664