### PR TITLE
Show failure in ssl-opts.sh  when key export fails

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3718,7 +3718,7 @@ handshake:
         {
             mbedtls_printf( " failed\n  ! mbedtls_ssl_tls_prf returned -0x%x\n\n",
                             (unsigned int) -ret );
-            goto exit;
+            goto reset;
         }
 
         mbedtls_printf( "    EAP-TLS key material is:" );
@@ -3739,7 +3739,7 @@ handshake:
          {
              mbedtls_printf( " failed\n  ! mbedtls_ssl_tls_prf returned -0x%x\n\n",
                              (unsigned int) -ret );
-             goto exit;
+             goto reset;
          }
 
         mbedtls_printf( "    EAP-TLS IV is:" );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -9141,7 +9141,11 @@ run_test    "export keys functionality" \
             -s "exported ivlen is "  \
             -c "exported maclen is " \
             -c "exported keylen is " \
-            -c "exported ivlen is "
+            -c "exported ivlen is " \
+            -c "EAP-TLS key material is:"\
+            -s "EAP-TLS key material is:"\
+            -c "EAP-TLS IV is:" \
+            -s "EAP-TLS IV is:"
 
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_MEMORY_DEBUG


### PR DESCRIPTION
## Description
1. When `ssl_server2` export key functionality,
don't exit the server, but reset it.
2. Add text filters for `export keys functionality` test in sll-opts.sh
to check for additional output, for verifying export succeeded.

This PR will fix the false positive reported in #2662 , but it doesn't fix the root cause for the failure, which is reported in https://github.com/ARMmbed/mbed-crypto/issues/137

## Status
**READY**

## Requires Backporting
NO  
This bug is on a new feature which isn't in any LTS branch

## Additional comments
Once this PR wioll be merged, the CI will fail, until https://github.com/ARMmbed/mbed-crypto/issues/137 is fixed and merged!

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


