### PR TITLE
ssl: Don't access non-existent encrypt_then_mac field

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -953,7 +953,8 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> derive keys" ) );
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
     transform->encrypt_then_mac = session->encrypt_then_mac;
 #endif
     transform->minor_ver = ssl->minor_ver;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -953,6 +953,20 @@ component_test_no_max_fragment_length_small_ssl_out_content_len () {
     if_build_succeeded tests/ssl-opt.sh -f "Max fragment length\|Large buffer"
 }
 
+component_test_when_no_ciphersuites_have_mac () {
+    msg "build: when no ciphersuites have MAC"
+    scripts/config.pl unset MBEDTLS_CIPHER_NULL_CIPHER
+    scripts/config.pl unset MBEDTLS_ARC4_C
+    scripts/config.pl unset MBEDTLS_CIPHER_MODE_CBC
+    make
+
+    msg "test: !MBEDTLS_SSL_SOME_MODES_USE_MAC"
+    make test
+
+    msg "test ssl-opt.sh: !MBEDTLS_SSL_SOME_MODES_USE_MAC"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
 component_test_null_entropy () {
     msg "build: default config with  MBEDTLS_TEST_NULL_ENTROPY (ASan build)"
     scripts/config.pl set MBEDTLS_TEST_NULL_ENTROPY

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -964,7 +964,7 @@ component_test_when_no_ciphersuites_have_mac () {
     make test
 
     msg "test ssl-opt.sh: !MBEDTLS_SSL_SOME_MODES_USE_MAC"
-    if_build_succeeded tests/ssl-opt.sh
+    if_build_succeeded tests/ssl-opt.sh -f 'Default\|EtM' -e 'without EtM'
 }
 
 component_test_null_entropy () {

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -159,7 +159,8 @@ static int build_transforms( mbedtls_ssl_transform *t_in,
      * Setup transforms
      */
 
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
+    defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
     t_out->encrypt_then_mac = etm;
     t_in->encrypt_then_mac = etm;
 #else


### PR DESCRIPTION
When MBEDTLS_SSL_ENCRYPT_THEN_MAC is enabled, but not
MBEDTLS_SSL_SOME_MODES_USE_MAC, mbedtls_ssl_derive_keys() and
build_transforms() will attempt to use a non-existent `encrypt_then_mac`
field in the ssl_transform.

```
    Compile [ 93.7%]: ssl_tls.c
    [Error] ssl_tls.c@865,14: 'mbedtls_ssl_transform {aka struct mbedtls_ssl_transform}' ha
s no member named 'encrypt_then_mac'
    [ERROR] ./mbed-os/features/mbedtls/src/ssl_tls.c: In function 'mbedtls_ssl_derive_keys'
:
    ./mbed-os/features/mbedtls/src/ssl_tls.c:865:14: error: 'mbedtls_ssl_transform {aka str
uct mbedtls_ssl_transform}' has no member named 'encrypt_then_mac'
         transform->encrypt_then_mac = session->encrypt_then_mac;
                  ^~
```

Change mbedtls_ssl_derive_keys() and build_transforms() to only access
`encrypt_then_mac` if `encrypt_then_mac` is actually present.

Add a regression test to detect when we have regressions with
configurations that do not include any MAC ciphersuites.

Fixes d56ed2491be9 ("Reduce size of `ssl_transform` if no MAC ciphersuite is enabled")

## Status
**READY**

## Requires Backporting
NO. This is a regression present only in the development branch.

## Migrations
NO

## Todos
- [X] Tests
- ~[ ] Documentation~
- ~[ ] Changelog updated~
- ~[ ] Backported~

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.