### PR TITLE
SSL reproducible test mode

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2013,7 +2013,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf( stderr, "Warning: reproducible without constant time\n" );
+        fprintf( stderr, "Warning: reproducible option used without constant time\n" );
 #endif
     }
     else

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -312,6 +312,9 @@ int main( void )
 #define USAGE_ETM ""
 #endif
 
+#define USAGE_REPRODUCIBLE \
+    "    reproducible=0/1     default: 0 (disabled)\n"
+
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 #define USAGE_RENEGO \
     "    renegotiation=%%d    default: 0 (disabled)\n"      \
@@ -383,6 +386,7 @@ int main( void )
     USAGE_FALLBACK                                          \
     USAGE_EMS                                               \
     USAGE_ETM                                               \
+    USAGE_REPRODUCIBLE                                      \
     USAGE_CURVES                                            \
     USAGE_RECSPLIT                                          \
     USAGE_DHMLEN                                            \
@@ -545,21 +549,6 @@ mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
-}
-
-int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
-{
-    int ret;
-    size_t i;
-
-    //use mbedtls_ctr_drbg_random to find bugs in it
-    ret = mbedtls_ctr_drbg_random( p_rng, output, output_len );
-    for ( i = 0; i < output_len; i++ )
-    {
-        //replace result with pseudo random
-        output[i] = (unsigned char) rand();
-    }
-    return( ret );
 }
 
 int dummy_entropy( void *data, unsigned char *output, size_t len )
@@ -1709,6 +1698,7 @@ int main( int argc, char *argv[] )
     mbedtls_entropy_init( &entropy );
     if (opt.reproducible)
     {
+        srand( 1 );
         if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy,
                                            &entropy, (const unsigned char *) pers,
                                            strlen( pers ) ) ) != 0 )
@@ -2009,8 +1999,6 @@ int main( int argc, char *argv[] )
 
     if (opt.reproducible)
     {
-        srand( 1 );
-        mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
 #if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -566,6 +566,7 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
     size_t i;
     (void) data;
+    int ret;
 
     ret = mbedtls_entropy_func( data, output, len );
     for ( i = 0; i < len; i++ )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -567,13 +567,13 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
     size_t i;
     (void) data;
 
-    //ret = mbedtls_entropy_func( data, output, len );
+    ret = mbedtls_entropy_func( data, output, len );
     for ( i = 0; i < len; i++ )
     {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
@@ -2013,7 +2013,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf( stderr, "Warning: reproduce without constant time\n" );
+        fprintf( stderr, "Warning: reproducible without constant time\n" );
 #endif
     }
     else

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -565,8 +565,8 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
 int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
     size_t i;
-    (void) data;
     int ret;
+    (void) data;
 
     ret = mbedtls_entropy_func( data, output, len );
     for ( i = 0; i < len; i++ )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -483,7 +483,7 @@ struct options
     const char *cid_val;        /* the CID to use for incoming messages     */
     const char *cid_val_renego; /* the CID to use for incoming messages
                                  * after renegotiation                      */
-    int reproducible;              /* make communication reproducible          */
+    int reproducible;           /* make communication reproducible          */
 } opt;
 
 int query_config( const char *config );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2010,10 +2010,10 @@ int main( int argc, char *argv[] )
     {
         srand( 1 );
         mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-#if defined(MBEDTLS_HAVE_TIME)
         fprintf( stderr, "Warning: reproducible option used without constant time\n" );
 #endif
 #endif

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2013,7 +2013,9 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
+#if defined(MBEDTLS_HAVE_TIME)
         fprintf( stderr, "Warning: reproducible option used without constant time\n" );
+#endif
 #endif
     }
     else

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2007,10 +2007,7 @@ int main( int argc, char *argv[] )
 #endif
 #endif
     }
-    else
-    {
-        mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
-    }
+    mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );
 
     mbedtls_ssl_conf_read_timeout( &conf, opt.read_timeout );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -553,8 +553,9 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
     size_t i;
 
     //use mbedtls_ctr_drbg_random to find bugs in it
-    ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
-    for (i=0; i<output_len; i++) {
+    ret = mbedtls_ctr_drbg_random( p_rng, output, output_len );
+    for ( i = 0; i < output_len; i++ )
+    {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
@@ -566,10 +567,9 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
     size_t i;
     (void) data;
 
-    //use mbedtls_entropy_func to find bugs in it
-    //test performance impact of entropy
-    //ret = mbedtls_entropy_func(data, output, len);
-    for (i=0; i<len; i++) {
+    //ret = mbedtls_entropy_func( data, output, len );
+    for ( i = 0; i < len; i++ )
+    {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
@@ -1706,22 +1706,25 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     mbedtls_entropy_init( &entropy );
-    if (opt.reproducible) {
+    if (opt.reproducible)
+    {
         if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy,
-                                          &entropy, (const unsigned char *) pers,
-                                          strlen( pers ) ) ) != 0 )
+                                           &entropy, (const unsigned char *) pers,
+                                           strlen( pers ) ) ) != 0 )
         {
             mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
-                           -ret );
+                            -ret );
             goto exit;
         }
-    } else {
+    }
+    else
+    {
         if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
-                                          &entropy, (const unsigned char *) pers,
-                                          strlen( pers ) ) ) != 0 )
+                                           &entropy, (const unsigned char *) pers,
+                                           strlen( pers ) ) ) != 0 )
         {
             mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
-                           -ret );
+                            -ret );
             goto exit;
         }
     }
@@ -2003,15 +2006,18 @@ int main( int argc, char *argv[] )
         }
 #endif
 
-    if (opt.reproducible) {
-        srand(1);
+    if (opt.reproducible)
+    {
+        srand( 1 );
         mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf(stderr, "Warning: reprpduce without constant time\n");
+        fprintf( stderr, "Warning: reproduce without constant time\n" );
 #endif
-    } else {
+    }
+    else
+    {
         mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     }
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2829,10 +2829,10 @@ int main( int argc, char *argv[] )
     {
         srand( 1 );
         mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-#if defined(MBEDTLS_HAVE_TIME)
         fprintf( stderr, "Warning: reproducible option used without constant time\n" );
 #endif
 #endif

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -677,8 +677,8 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
 int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
     size_t i;
-    (void) data;
     int ret;
+    (void) data;
 
     ret = mbedtls_entropy_func( data, output, len );
     for (i = 0; i < len; i++ ) {

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -173,6 +173,7 @@ int main( void )
 #define DFL_ETM                 -1
 #define DFL_CA_CALLBACK         0
 #define DFL_EAP_TLS             0
+#define DFL_REPRODUCIBLE        0
 
 #define LONG_RESPONSE "<p>01-blah-blah-blah-blah-blah-blah-blah-blah-blah\r\n" \
     "02-blah-blah-blah-blah-blah-blah-blah-blah-blah-blah-blah-blah-blah\r\n"  \
@@ -597,6 +598,7 @@ struct options
     const char *cid_val;        /* the CID to use for incoming messages     */
     const char *cid_val_renego; /* the CID to use for incoming messages
                                  * after renegotiation                      */
+    int reproducible;              /* make communication reproducible          */
 } opt;
 
 int query_config( const char *config );
@@ -650,6 +652,41 @@ static void my_debug( void *ctx, int level,
 
     mbedtls_fprintf( (FILE *) ctx, "%s:%04d: |%d| %s", basename, line, level, str );
     fflush(  (FILE *) ctx  );
+}
+
+mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
+{
+    (void) time;
+    return 0x5af2a056;
+}
+
+int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
+{
+    int ret;
+    size_t i;
+
+    //use mbedtls_ctr_drbg_random to find bugs in it
+    ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
+    for (i=0; i<output_len; i++) {
+        //replace result with pseudo random
+        output[i] = (unsigned char) rand();
+    }
+    return( ret );
+}
+
+int dummy_entropy( void *data, unsigned char *output, size_t len )
+{
+    size_t i;
+    (void) data;
+
+    //use mbedtls_entropy_func to find bugs in it
+    //test performance impact of entropy
+    //ret = mbedtls_entropy_func(data, output, len);
+    for (i=0; i<len; i++) {
+        //replace result with pseudo random
+        output[i] = (unsigned char) rand();
+    }
+    return( 0 );
 }
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
@@ -1728,6 +1765,7 @@ int main( int argc, char *argv[] )
     opt.extended_ms         = DFL_EXTENDED_MS;
     opt.etm                 = DFL_ETM;
     opt.eap_tls             = DFL_EAP_TLS;
+    opt.reproducible        = DFL_REPRODUCIBLE;
 
     for( i = 1; i < argc; i++ )
     {
@@ -2146,6 +2184,10 @@ int main( int argc, char *argv[] )
             if( opt.eap_tls < 0 || opt.eap_tls > 1 )
                 goto usage;
         }
+        else if( strcmp( p, "reproducible" ) == 0 )
+        {
+            opt.reproducible = 1;
+        }
         else
             goto usage;
     }
@@ -2446,13 +2488,24 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     mbedtls_entropy_init( &entropy );
-    if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
-                                       &entropy, (const unsigned char *) pers,
-                                       strlen( pers ) ) ) != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
-                        -ret );
-        goto exit;
+    if (opt.reproducible) {
+        if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy,
+                                          &entropy, (const unsigned char *) pers,
+                                          strlen( pers ) ) ) != 0 )
+        {
+            mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
+                           -ret );
+            goto exit;
+        }
+    } else {
+        if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
+                                          &entropy, (const unsigned char *) pers,
+                                          strlen( pers ) ) ) != 0 )
+        {
+            mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
+                           -ret );
+            goto exit;
+        }
     }
 
     mbedtls_printf( " ok\n" );
@@ -2771,7 +2824,17 @@ int main( int argc, char *argv[] )
         }
 #endif
 
-    mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
+    if (opt.reproducible) {
+        srand(1);
+        mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
+#if defined(MBEDTLS_PLATFORM_TIME_ALT)
+        mbedtls_platform_set_time( dummy_constant_time );
+#else
+        fprintf(stderr, "Warning: reprpduce without constant time\n");
+#endif
+    } else {
+        mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
+    }
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );
 
 #if defined(MBEDTLS_SSL_CACHE_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -666,8 +666,8 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
     size_t i;
 
     //use mbedtls_ctr_drbg_random to find bugs in it
-    ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
-    for (i=0; i<output_len; i++) {
+    ret = mbedtls_ctr_drbg_random( p_rng, output, output_len );
+    for ( i = 0; i < output_len; i++ ) {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
@@ -679,10 +679,8 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
     size_t i;
     (void) data;
 
-    //use mbedtls_entropy_func to find bugs in it
-    //test performance impact of entropy
-    //ret = mbedtls_entropy_func(data, output, len);
-    for (i=0; i<len; i++) {
+    //ret = mbedtls_entropy_func( data, output, len );
+    for (i = 0; i < len; i++ ) {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
@@ -2488,22 +2486,25 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     mbedtls_entropy_init( &entropy );
-    if (opt.reproducible) {
+    if (opt.reproducible)
+    {
         if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy,
-                                          &entropy, (const unsigned char *) pers,
-                                          strlen( pers ) ) ) != 0 )
+                                           &entropy, (const unsigned char *) pers,
+                                           strlen( pers ) ) ) != 0 )
         {
             mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
-                           -ret );
+                            -ret );
             goto exit;
         }
-    } else {
+    }
+    else
+    {
         if( ( ret = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
-                                          &entropy, (const unsigned char *) pers,
-                                          strlen( pers ) ) ) != 0 )
+                                           &entropy, (const unsigned char *) pers,
+                                           strlen( pers ) ) ) != 0 )
         {
             mbedtls_printf( " failed\n  ! mbedtls_ctr_drbg_seed returned -0x%x\n",
-                           -ret );
+                            -ret );
             goto exit;
         }
     }
@@ -2824,15 +2825,18 @@ int main( int argc, char *argv[] )
         }
 #endif
 
-    if (opt.reproducible) {
-        srand(1);
+    if (opt.reproducible)
+    {
+        srand( 1 );
         mbedtls_ssl_conf_rng( &conf, dummy_random, &ctr_drbg );
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf(stderr, "Warning: reprpduce without constant time\n");
+        fprintf( stderr, "Warning: reproduce without constant time\n" );
 #endif
-    } else {
+    }
+    else
+    {
         mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     }
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -598,7 +598,7 @@ struct options
     const char *cid_val;        /* the CID to use for incoming messages     */
     const char *cid_val_renego; /* the CID to use for incoming messages
                                  * after renegotiation                      */
-    int reproducible;              /* make communication reproducible          */
+    int reproducible;           /* make communication reproducible          */
 } opt;
 
 int query_config( const char *config );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -679,12 +679,12 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
     size_t i;
     (void) data;
 
-    //ret = mbedtls_entropy_func( data, output, len );
+    ret = mbedtls_entropy_func( data, output, len );
     for (i = 0; i < len; i++ ) {
         //replace result with pseudo random
         output[i] = (unsigned char) rand();
     }
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK)
@@ -2832,7 +2832,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf( stderr, "Warning: reproduce without constant time\n" );
+        fprintf( stderr, "Warning: reproducible without constant time\n" );
 #endif
     }
     else

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2827,10 +2827,7 @@ int main( int argc, char *argv[] )
 #endif
 #endif
     }
-    else
-    {
-        mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
-    }
+    mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );
 
 #if defined(MBEDTLS_SSL_CACHE_C)

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -678,6 +678,7 @@ int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
     size_t i;
     (void) data;
+    int ret;
 
     ret = mbedtls_entropy_func( data, output, len );
     for (i = 0; i < len; i++ ) {

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2832,7 +2832,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
-        fprintf( stderr, "Warning: reproducible without constant time\n" );
+        fprintf( stderr, "Warning: reproducible option used without constant time\n" );
 #endif
     }
     else

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2832,7 +2832,9 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
         mbedtls_platform_set_time( dummy_constant_time );
 #else
+#if defined(MBEDTLS_HAVE_TIME)
         fprintf( stderr, "Warning: reproducible option used without constant time\n" );
+#endif
 #endif
     }
     else


### PR DESCRIPTION
## Description
Improve maintenance and usage of SSL test programs by adding a reproducible mode to sample programs :
- initialize the PRNG to a constant seed 
- using a faketime


## Status
**READY**

## Requires Backporting
- This PR is a new feature\enhancement

NO  

## Migrations
If there is any API change, what's the incentive and logic for it.
NO

## Additional comments
See #1272 and https://github.com/ARMmbed/mbedtls/pull/1622#issuecomment-499592417 cc @gilles-peskine-arm 

## Todos
- [?] Tests
- [?] Documentation
- [X] Changelog to update
- [ ] Backported


## Steps to test or reproduce
