### PR TITLE
psa: PSA entropy is compatible with other entropy

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -541,11 +541,6 @@
 #error "MBEDTLS_PSA_INJECT_ENTROPY defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PSA_INJECT_ENTROPY) &&              \
-    !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES)
-#error "MBEDTLS_PSA_INJECT_ENTROPY is not compatible with actual entropy sources"
-#endif
-
 #if defined(MBEDTLS_PSA_ITS_FILE_C) && \
     !defined(MBEDTLS_FS_IO)
 #error "MBEDTLS_PSA_ITS_FILE_C defined, but not all prerequisites"


### PR DESCRIPTION
MBEDTLS_PSA_INJECT_ENTROPY is compatible with actual entropy sources.
PSA entropy injection is implemented using the standard Mbed TLS NV Seed
feature, and is as compatible with other entropy sources as the standard
Mbed TLS NV Seed feature which does support entropy mixing.

## Status
**READY**

## Requires Backporting
No. `development` is the only affected branch.

## Todos
- [x] Tests
- ~[ ] Documentation~
- ~[ ] Changelog updated~
- ~[ ] Backported~