### PR TITLE
Update library version to 2.18.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
-= mbed TLS x.x.x branch released xxxx-xx-xx
+= mbed TLS 2.18.0 branch released 2019-06-11
 
 Features
    * Add the Any Policy certificate policy oid, as defined in

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.17.0 source code documentation
+ * @mainpage mbed TLS v2.18.0 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.17.0"
+PROJECT_NAME           = "mbed TLS v2.18.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  17
+#define MBEDTLS_VERSION_MINOR  18
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02110000
-#define MBEDTLS_VERSION_STRING         "2.17.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.17.0"
+#define MBEDTLS_VERSION_NUMBER         0x02120000
+#define MBEDTLS_VERSION_STRING         "2.18.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.18.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -172,14 +172,14 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 if(USE_SHARED_MBEDTLS_LIBRARY)
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.17.0 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.18.0 SOVERSION 1)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${CMAKE_SOURCE_DIR}/include/
         PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.17.0 SOVERSION 12)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.18.0 SOVERSION 13)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${CMAKE_SOURCE_DIR}/include/

--- a/library/Makefile
+++ b/library/Makefile
@@ -35,8 +35,8 @@ LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
-SOEXT_TLS=so.12
-SOEXT_X509=so.0
+SOEXT_TLS=so.13
+SOEXT_X509=so.1
 SOEXT_CRYPTO=so.3
 
 # Set AR_DASH= (empty string) to use an ar implementation that does not accept

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.17.0"
+check_compiletime_version:"2.18.0"
 
 Check runtime library version
-check_runtime_version:"2.17.0"
+check_runtime_version:"2.18.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
Increase the SO versions of libmbedx509 and libmbedtls due to the
addition of fields in publicly visible (non-opaque) structs:
  - mbedtls_ssl_config
  - mbedtls_ssl_context
  - mbedtls_x509_crt

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- ~[ ] Documentation~
- [x] Changelog updated
- ~[ ] Backported~
