### PR TITLE
Fix misuse of signed ints in the HAVEGE module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -58,11 +58,13 @@ Bugfix
    * Set the next sequence of the subject_alt_name to NULL when deleting
      sequence on failure. Found and fix suggested by Philippe Antoine.
      Credit to OSS-Fuzz.
+   * Fix misuse of signed arithmetic in the HAVEGE module. #2598
 
 API Changes
    * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,
      and the used tls-prf.
    * Add public API for tls-prf function, according to requested enum.
+   * The HAVEGE state type now uses uint32_t elements instead of int.
 
 Changes
    * Server's RSA certificate in certs.c was SHA-1 signed. In the default

--- a/include/mbedtls/havege.h
+++ b/include/mbedtls/havege.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define MBEDTLS_HAVEGE_COLLECT_SIZE 1024
 
@@ -43,9 +44,9 @@ extern "C" {
  */
 typedef struct mbedtls_havege_state
 {
-    int PT1, PT2, offset[2];
-    int pool[MBEDTLS_HAVEGE_COLLECT_SIZE];
-    int WALK[8192];
+    uint32_t PT1, PT2, offset[2];
+    uint32_t pool[MBEDTLS_HAVEGE_COLLECT_SIZE];
+    uint32_t WALK[8192];
 }
 mbedtls_havege_state;
 


### PR DESCRIPTION
The elements of the [HAVEGE](https://www.irisa.fr/caps/projects/hipsor/publications/havege-rr.pdf) state are manipulated with bitwise operations, with the expectations that the elements are 32-bit unsigned integers (or larger). But they are declared as `int`, and so the code has undefined behavior. Clang with Asan correctly points out some shifts that reach the sign bit.

Since these are supposed to be 32-bit unsigned integers, declare them as `uint32_t`.

This is technically an API break, since the type `mbedtls_havege_state` is exposed in a public header. However normal applications should not be affected.

Fix https://github.com/ARMmbed/mbedtls/issues/2598

PR extracted from https://github.com/ARMmbed/mbedtls/pull/2684 which combined this with other things needed to pass Clang+Asan with all configuration options.

Needs backports because the LTS branches have the same bug. We should probably make the backport more conservative with respect to the API.

This PR needs to be merged at the same time as updating the crypto submodule to contain https://github.com/ARMmbed/mbed-crypto/pull/149 since they both make the same incompatible change to `havege.h`. For testing on CI, I've included a submodule update which updates the submodule to https://github.com/ARMmbed/mbed-crypto/pull/149.
