### PR TITLE
Backport 2.16: Fix misuse of signed ints in the HAVEGE module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,7 @@ Bugfix
    * Fix multiple X.509 functions previously returning ASN.1 low-level error
      codes to always wrap these codes into X.509 high level error codes before
      returning. Fixes #2431.
+   * Fix misuse of signed arithmetic in the HAVEGE module. #2598
 
 Changes
    * Return from various debugging routines immediately if the

--- a/library/havege.c
+++ b/library/havege.c
@@ -54,7 +54,7 @@
  * ------------------------------------------------------------------------
  */
 
-#define SWAP(X,Y) { int *T = (X); (X) = (Y); (Y) = T; }
+#define SWAP(X,Y) { unsigned *T = (X); (X) = (Y); (Y) = T; }
 
 #define TST1_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;
 #define TST2_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;
@@ -77,7 +77,7 @@
     PTX = (PT1 >> 18) & 7;                              \
     PT1 &= 0x1FFF;                                      \
     PT2 &= 0x1FFF;                                      \
-    CLK = (int) mbedtls_timing_hardclock();                            \
+    CLK = (unsigned) mbedtls_timing_hardclock();        \
                                                         \
     i = 0;                                              \
     A = &WALK[PT1    ]; RES[i++] ^= *A;                 \
@@ -100,7 +100,7 @@
                                                         \
     IN = (*A >> (5)) ^ (*A << (27)) ^ CLK;              \
     *A = (*B >> (6)) ^ (*B << (26)) ^ CLK;              \
-    *B = IN; CLK = (int) mbedtls_timing_hardclock();                   \
+    *B = IN; CLK = (unsigned) mbedtls_timing_hardclock(); \
     *C = (*C >> (7)) ^ (*C << (25)) ^ CLK;              \
     *D = (*D >> (8)) ^ (*D << (24)) ^ CLK;              \
                                                         \
@@ -151,19 +151,20 @@
     PT1 ^= (PT2 ^ 0x10) & 0x10;                         \
                                                         \
     for( n++, i = 0; i < 16; i++ )                      \
-        hs->pool[n % MBEDTLS_HAVEGE_COLLECT_SIZE] ^= RES[i];
+        POOL[n % MBEDTLS_HAVEGE_COLLECT_SIZE] ^= RES[i];
 
 /*
  * Entropy gathering function
  */
 static void havege_fill( mbedtls_havege_state *hs )
 {
-    int i, n = 0;
-    int  U1,  U2, *A, *B, *C, *D;
-    int PT1, PT2, *WALK, RES[16];
-    int PTX, PTY, CLK, PTEST, IN;
+    unsigned i, n = 0;
+    unsigned  U1,  U2, *A, *B, *C, *D;
+    unsigned PT1, PT2, *WALK, *POOL, RES[16];
+    unsigned PTX, PTY, CLK, PTEST, IN;
 
-    WALK = hs->WALK;
+    WALK = (unsigned *) hs->WALK;
+    POOL = (unsigned *) hs->pool;
     PT1  = hs->PT1;
     PT2  = hs->PT2;
 

--- a/library/havege.c
+++ b/library/havege.c
@@ -38,7 +38,18 @@
 #include "mbedtls/timing.h"
 #include "mbedtls/platform_util.h"
 
+#include <limits.h>
 #include <string.h>
+
+/* If int isn't capable of storing 2^32 distinct values, the code of this
+ * module may cause a processor trap or a miscalculation. If int is more
+ * than 32 bits, the code may not calculate the intended values. */
+#if INT_MIN + 1 != -0x7fffffff
+#error "The HAVEGE module requires int to be exactly 32 bits, with INT_MIN = -2^31."
+#endif
+#if UINT_MAX != 0xffffffff
+#error "The HAVEGE module requires unsigned to be exactly 32 bits."
+#endif
 
 /* ------------------------------------------------------------------------
  * On average, one iteration accesses two 8-word blocks in the havege WALK


### PR DESCRIPTION
The elements of the [HAVEGE](https://www.irisa.fr/caps/projects/hipsor/publications/havege-rr.pdf) state are manipulated with bitwise operations, with the expectations that the elements are 32-bit unsigned integers (or larger). But they are declared as `int`, and so the code has undefined behavior. Clang with Asan correctly points out some shifts that reach the sign bit.

Use `unsigned` internally, which violates strict aliasing rules but is less likely to be compiled in an unintended manner than overflowing a signed integer.

Backport of #2699 to fix #2598. Unlike https://github.com/ARMmbed/mbed-crypto/pull/149, this pull request doesn't change the API at all, since it's for a long-time support branch.
