### PR TITLE
Deref pointer when using sizeof in x509_get_other_name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -74,6 +74,7 @@ Bugfix
      irwir.
    * Enable Suite B with subset of ECP curves. Make sure the code compiles even
      if some curves are not defined. Fixes #1591 reported by dbedev.
+   * Fix partial zeroing in x509_get_other_name. Found and fixed by ekse, #2716.
 
 API Changes
    * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1687,7 +1687,7 @@ static int x509_get_other_name( const mbedtls_x509_buf *subject_alt_name,
 
     if( p + len >= end )
     {
-        mbedtls_platform_zeroize( other_name, sizeof( other_name ) );
+        mbedtls_platform_zeroize( other_name, sizeof( *other_name ) );
         return( MBEDTLS_ERR_X509_INVALID_EXTENSIONS +
                 MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
     }
@@ -1709,7 +1709,7 @@ static int x509_get_other_name( const mbedtls_x509_buf *subject_alt_name,
 
     if( p + len >= end )
     {
-        mbedtls_platform_zeroize( other_name, sizeof( other_name ) );
+        mbedtls_platform_zeroize( other_name, sizeof( *other_name ) );
         return( MBEDTLS_ERR_X509_INVALID_EXTENSIONS +
                 MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
     }
@@ -1725,7 +1725,7 @@ static int x509_get_other_name( const mbedtls_x509_buf *subject_alt_name,
     if( p != end )
     {
         mbedtls_platform_zeroize( other_name,
-                                  sizeof( other_name ) );
+                                  sizeof( *other_name ) );
         return( MBEDTLS_ERR_X509_INVALID_EXTENSIONS +
                 MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
     }


### PR DESCRIPTION
Fix for #2716.