### PR TITLE
tests: Limit log output to 10 GiB

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -15,6 +15,10 @@
 
 set -u
 
+# Limit the size of each log to 10 GiB, in case of failures with this script
+# where it may output seemingly unlimited length error logs.
+ulimit -f 20971520
+
 # initialise counters
 TESTS=0
 FAILED=0

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -21,6 +21,10 @@
 
 set -u
 
+# Limit the size of each log to 10 GiB, in case of failures with this script
+# where it may output seemingly unlimited length error logs.
+ulimit -f 20971520
+
 if cd $( dirname $0 ); then :; else
     echo "cd $( dirname $0 ) failed" >&2
     exit 1


### PR DESCRIPTION
Limit log output in compat.sh and ssl-opt.sh, in case of failures with these
scripts where they may output seemingly unlimited length error logs.


## Status
**READY**

## Requires Backporting
Yes - 2.16, 2.7

## Todos
- [ ] Tests
- ~[ ] Documentation~
- ~[ ] Changelog updated~
- [ ] Backported
