### PR TITLE
Backport 2.7: Test documented builds

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -835,12 +835,14 @@ component_test_platform_calloc_macro () {
 component_test_make_shared () {
     msg "build/test: make shared" # ~ 40s
     make SHARED=1 all check
+    ldd programs/util/strerror | grep libmbedcrypto
 }
 
 component_test_cmake_shared () {
     msg "build/test: cmake shared" # ~ 2min
     cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On .
     make
+    ldd programs/util/strerror | grep libmbedcrypto
     make test
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -837,6 +837,13 @@ component_test_make_shared () {
     make SHARED=1 all check
 }
 
+component_test_cmake_shared () {
+    msg "build/test: cmake shared" # ~ 2min
+    cmake -DUSE_SHARED_MBEDTLS_LIBRARY=On .
+    make
+    make test
+}
+
 component_build_mbedtls_config_file () {
     msg "build: make with MBEDTLS_CONFIG_FILE" # ~40s
     # Use the full config so as to catch a maximum of places where

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -837,6 +837,17 @@ component_test_make_shared () {
     make SHARED=1 all check
 }
 
+component_build_mbedtls_config_file () {
+    msg "build: make with MBEDTLS_CONFIG_FILE" # ~40s
+    # Use the full config so as to catch a maximum of places where
+    # the check of MBEDTLS_CONFIG_FILE might be missing.
+    scripts/config.pl full
+    sed 's!"check_config.h"!"mbedtls/check_config.h"!' <"$CONFIG_H" >full_config.h
+    echo '#error "MBEDTLS_CONFIG_FILE is not working"' >"$CONFIG_H"
+    make CFLAGS="-I '$PWD' -DMBEDTLS_CONFIG_FILE='\"full_config.h\"'"
+    rm -f full_config.h
+}
+
 component_test_m32_o0 () {
     # Build once with -O0, to compile out the i386 specific inline assembly
     msg "build: i386, make, gcc -O0 (ASan build)" # ~ 30s


### PR DESCRIPTION
Test build modes that we document.

I believe that with this PR, we're testing all the non-debug build modes that we document in `README.md` or `configs/README.txt`.

* `-DMBEDTLS_CONFIG_FILE="…"`
* Shared library build with cmake (we were only testing a shared library build with make)

Straightforward backport of #2728
