### PR TITLE
Test with MBEDTLS_ECP_RESTARTABLE

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -819,7 +819,7 @@ component_test_no_use_psa_crypto_full_cmake_asan() {
     msg "build: cmake, full config + MBEDTLS_USE_PSA_CRYPTO, ASan"
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-    scripts/config.pl unset MBEDTLS_ECP_RESTARTABLE  # restartable ECC not supported through PSA
+    scripts/config.pl set MBEDTLS_ECP_RESTARTABLE  # not using PSA, so enable restartable ECC
     scripts/config.pl set MBEDTLS_PSA_CRYPTO_C
     scripts/config.pl unset MBEDTLS_USE_PSA_CRYPTO
     scripts/config.pl unset MBEDTLS_PSA_ITS_FILE_C


### PR DESCRIPTION
We accidentally disabled testing with MBEDTLS_ECP_RESTARTABLE. Re-enable
testing with restartable ECP when MBEDTLS_USE_PSA_CRYPTO is not set.
    
Fixes 971dea37453c ("Enable USE_PSA_CRYPTO with config.pl full")

Internal Reference: https://jira.arm.com/browse/IOTSSL-2848

## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Todos
- [ ] Tests
- ~[ ] Documentation~
- ~[ ] Changelog updated~
- ~[ ] Backported~
