### PR TITLE
Add a linker flag to enable gcov in basic-build-test.sh

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -64,6 +64,7 @@ echo
 
 # Step 1 - Make and instrumented build for code coverage
 export CFLAGS=' --coverage -g3 -O0 '
+export LDFLAGS=' --coverage'
 make clean
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full


### PR DESCRIPTION
Once #1622 has been merged, the gcov configuration in basic-build-test.sh will no longer work, as it doesn't provide `--coverage` flag to the linker. This worked so far as whenever gcov was needed, the `CFLAGS` variable was present in the command line. #1622 adds a Makefile, which links some objects separately, which leads to failure of linking gcov.

This PR adds `--coverage` flag to the LDFLAGS along the one in CFLAGS, inside basic-build-test.sh