### PR TITLE
Backport 2.7: tests: Limit each log to 10 GiB

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -15,6 +15,10 @@
 
 set -u
 
+# Limit the size of each log to 10 GiB, in case of failures with this script
+# where it may output seemingly unlimited length error logs.
+ulimit -f 20971520
+
 # initialise counters
 TESTS=0
 FAILED=0

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -21,6 +21,10 @@
 
 set -u
 
+# Limit the size of each log to 10 GiB, in case of failures with this script
+# where it may output seemingly unlimited length error logs.
+ulimit -f 20971520
+
 # default values, can be overridden by the environment
 : ${P_SRV:=../programs/ssl/ssl_server2}
 : ${P_CLI:=../programs/ssl/ssl_client2}


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2727/