### PR TITLE
Backport 2.18: CMake subproject and stdarg.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ else()
     project("mbed TLS" C)
 endif()
 
+set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
 option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.18.1 branch released 2019-07-12
+
+Changes
+   * Enable building of Mbed TLS as a CMake subproject. Suggested and fixed by
+     Ashley Duncan in #2609.
+
 = mbed TLS 2.18.0 branch released 2019-06-11
 
 Features

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS 2.18.1 branch released 2019-07-12
 
+Bugfix
+   * Fix build failure when building with mingw on Windows by including
+     stdarg.h where needed. Fixes #2656.
+
 Changes
    * Enable building of Mbed TLS as a CMake subproject. Suggested and fixed by
      Ashley Duncan in #2609.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Regarding variables, also note that if you set CFLAGS when invoking cmake,
 your value of CFLAGS doesn't override the content provided by cmake (depending
 on the build mode as seen above), it's merely prepended to it.
 
+#### Mbed TLS as a subproject
+
+Mbed TLS, like Mbed Crypto, supports being built as a CMake subproject. One can
+use `add_subdirectory()` from a parent CMake project to include Mbed TLS as a
+subproject.
+
 ### Microsoft Visual Studio
 
 The build files for Microsoft Visual Studio are generated for Visual Studio 2010.

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -256,6 +256,7 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
  *   the destination buffer is too short.
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
+#include <stdarg.h>
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
 int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );
 #endif

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -151,15 +151,15 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
     target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
     target_include_directories(${mbedx509_static_target}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
     target_include_directories(${mbedtls_static_target}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/
         )
 
 
@@ -175,15 +175,15 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     set_target_properties(mbedx509 PROPERTIES VERSION 2.18.0 SOVERSION 1)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
     set_target_properties(mbedtls PROPERTIES VERSION 2.18.0 SOVERSION 13)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
       install(TARGETS mbedtls mbedx509
               DESTINATION ${LIB_INSTALL_DIR}

--- a/programs/test/cmake_subproject/.gitignore
+++ b/programs/test/cmake_subproject/.gitignore
@@ -1,0 +1,3 @@
+build
+Makefile
+cmake_subproject

--- a/programs/test/cmake_subproject/CMakeLists.txt
+++ b/programs/test/cmake_subproject/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.6)
+
+# We use the parent Mbed TLS directory as the MBEDTLS_DIR for this test. Other
+# projects that use Mbed TLS as a subproject are likely to add by their own
+# relative paths.
+set(MBEDTLS_DIR ../../../)
+
+# Add Mbed TLS as a subdirectory.
+add_subdirectory(${MBEDTLS_DIR} build)
+
+# Link against all the Mbed TLS libraries.
+set(libs
+    mbedtls
+    mbedcrypto
+    mbedx509
+)
+
+add_executable(cmake_subproject cmake_subproject.c)
+target_link_libraries(cmake_subproject ${libs})

--- a/programs/test/cmake_subproject/cmake_subproject.c
+++ b/programs/test/cmake_subproject/cmake_subproject.c
@@ -1,0 +1,56 @@
+/*
+ *  Simple program to test that CMake builds with Mbed TLS as a subdirectory
+ *  work correctly.
+ *
+ *  Copyright (C) 2006-2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_fprintf         fprintf
+#define mbedtls_printf          printf
+#define mbedtls_exit            exit
+#define MBEDTLS_EXIT_SUCCESS    EXIT_SUCCESS
+#define MBEDTLS_EXIT_FAILURE    EXIT_FAILURE
+#endif /* MBEDTLS_PLATFORM_C */
+
+#include "mbedtls/version.h"
+
+/* The main reason to build this is for testing the CMake build, so the program
+ * doesn't need to do very much. It calls a single library function to ensure
+ * linkage works, but that is all. */
+int main()
+{
+    /* This version string is 18 bytes long, as advised by version.h. */
+    char version[18];
+
+    mbedtls_version_get_string_full( version );
+
+    mbedtls_printf( "Built against %s\n", version );
+
+    return( 0 );
+}

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -242,6 +242,11 @@ cleanup()
     git checkout -- Makefile library/Makefile programs/Makefile tests/Makefile
     cd ..
 
+    # Remove any artifacts from the component_test_cmake_as_subdirectory test.
+    rm -rf programs/test/cmake_subproject/build
+    rm -f programs/test/cmake_subproject/Makefile
+    rm -f programs/test/cmake_subproject/cmake_subproject
+
     if [ -f "$CONFIG_BAK" ]; then
         mv "$CONFIG_BAK" "$CONFIG_H"
     fi
@@ -1245,6 +1250,19 @@ component_test_cmake_out_of_source () {
     fi
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+    unset MBEDTLS_ROOT_DIR
+}
+
+component_test_cmake_as_subdirectory () {
+    msg "build: cmake 'as-subdirectory' build"
+    MBEDTLS_ROOT_DIR="$PWD"
+
+    cd programs/test/cmake_subproject
+    cmake .
+    make
+    if_build_succeeded ./cmake_subproject
+
+    cd "$MBEDTLS_ROOT_DIR"
     unset MBEDTLS_ROOT_DIR
 }
 


### PR DESCRIPTION
This PR aims to make Mbed TLS 2.18.1 comprising:
- Minimal cherry-pick from https://github.com/ARMmbed/mbedtls/pull/2711 for including `stdarg.h` where needed
- Cherry-pick of all commits from https://github.com/ARMmbed/mbedtls/pull/2706 to enable building Mbed TLS as a CMake subproject

Cherry-pick is used because #2711 and #2706 are based on commits beyond 2.18.0 and would bring in too many other changes if merged. The aim is to bring in the two above mentioned changes without anything else.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests
- ~[ ] Documentation~
- [x] Changelog updated
- ~[ ] Backported~
