### PR TITLE
2.16: Don't call memset with NULL pointer in NIST KW test suite

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ Bugfix
    * Enable Suite B with subset of ECP curves. Make sure the code compiles even
      if some curves are not defined. Fixes #1591 reported by dbedev.
    * Fix misuse of signed arithmetic in the HAVEGE module. #2598
+   * Remove call to memset() with NULL buffer in NIST KW test suite.
+     This could previously lead to failure of the NIST KW test suite
+     in builds using address sanitizer.
 
 Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -162,17 +162,17 @@ void nist_kw_plaintext_lengths( int in_len, int out_len, int mode, int res )
     {
         plaintext = mbedtls_calloc( 1, in_len );
         TEST_ASSERT( plaintext != NULL );
+
+        memset( plaintext, 0, in_len );
     }
 
     if( out_len != 0 )
     {
         ciphertext = mbedtls_calloc( 1, output_len );
         TEST_ASSERT( ciphertext != NULL );
+
+        memset( ciphertext, 0, output_len );
     }
-
-    memset( plaintext, 0, in_len );
-    memset( ciphertext, 0, output_len );
-
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, MBEDTLS_CIPHER_ID_AES,
                                          key, 8 * sizeof( key ), 1 ) == 0 );
@@ -218,16 +218,16 @@ void nist_kw_ciphertext_lengths( int in_len, int out_len, int mode, int res )
     {
         plaintext = mbedtls_calloc( 1, output_len );
         TEST_ASSERT( plaintext != NULL );
+
+        memset( plaintext, 0, output_len );
     }
     if( in_len != 0 )
     {
         ciphertext = mbedtls_calloc( 1, in_len );
         TEST_ASSERT( ciphertext != NULL );
+
+        memset( ciphertext, 0, in_len );
     }
-
-    memset( plaintext, 0, output_len );
-    memset( ciphertext, 0, in_len );
-
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, MBEDTLS_CIPHER_ID_AES,
                                          key, 8 * sizeof( key ), 0 ) == 0 );


### PR DESCRIPTION
The NIST KW test suite contains test cases calling `memset()` with `NULL + 0-length` buffers, which is undefined behaviour and caught when run with AddressSanitizer. 