### PR TITLE
Fix fragile method for passing from ECDSA to ECP restart contexts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,9 @@ Bugfix
      This previously limited the maximum size of DER encoded certificates
      in mbedtls_x509write_crt_der() to 2Kb. Reported by soccerGB in #2631.
    * Fix partial zeroing in x509_get_other_name. Found and fixed by ekse, #2716.
+   * Fix propagation of restart contexts in restartable EC operations.
+     This could previously lead to segmentation faults in builds using an
+     address-sanitizer and enabling but not using MBEDTLS_ECP_RESTARTABLE.
 
 API Changes
    * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -172,11 +172,11 @@ static void ecdsa_restart_det_free( mbedtls_ecdsa_restart_det_ctx *ctx )
 }
 #endif /* MBEDTLS_ECDSA_DETERMINISTIC */
 
-#define ECDSA_RS_ECP    &rs_ctx->ecp
+#define ECDSA_RS_ECP    ( rs_ctx == NULL ? NULL : &rs_ctx->ecp )
 
 /* Utility macro for checking and updating ops budget */
 #define ECDSA_BUDGET( ops )   \
-    MBEDTLS_MPI_CHK( mbedtls_ecp_check_budget( grp, &rs_ctx->ecp, ops ) );
+    MBEDTLS_MPI_CHK( mbedtls_ecp_check_budget( grp, ECDSA_RS_ECP, ops ) );
 
 /* Call this when entering a function that needs its own sub-context */
 #define ECDSA_RS_ENTER( SUB )   do {                                 \


### PR DESCRIPTION
Forward-port of #2751 to `development`. Mirrored in Mbed Crypto as https://github.com/ARMmbed/mbed-crypto/pull/184.