### PR TITLE
Backport 2.7: test fixes not revealed by existing builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Bugfix
    * Enable Suite B with subset of ECP curves. Make sure the code compiles even
      if some curves are not defined. Fixes #1591 reported by dbedev.
    * Fix misuse of signed arithmetic in the HAVEGE module. #2598
+   * Make NV seed test support MBEDTLS_ENTROPY_FORCE_SHA256.
 
 Changes
    * Make `make clean` clean all programs always. Fixes #1862.

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -305,6 +305,10 @@ void entropy_nv_seed( char *read_seed_str )
 {
     mbedtls_sha512_context accumulator;
     mbedtls_entropy_context ctx;
+    int (*original_mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len ) =
+        mbedtls_nv_seed_read;
+    int (*original_mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len ) =
+        mbedtls_nv_seed_write;
 
     unsigned char header[2];
     unsigned char entropy[MBEDTLS_ENTROPY_BLOCK_SIZE];
@@ -373,7 +377,10 @@ void entropy_nv_seed( char *read_seed_str )
     TEST_ASSERT( memcmp( check_seed, buffer_seed, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
     TEST_ASSERT( memcmp( check_entropy, entropy, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
 
+exit:
     mbedtls_entropy_free( &ctx );
+    mbedtls_nv_seed_read = original_mbedtls_nv_seed_read;
+    mbedtls_nv_seed_write = original_mbedtls_nv_seed_write;
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_entropy.function
+++ b/tests/suites/test_suite_entropy.function
@@ -300,10 +300,19 @@ void entropy_nv_seed_std_io()
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_NV_SEED:MBEDTLS_PLATFORM_NV_SEED_ALT:MBEDTLS_ENTROPY_SHA512_ACCUMULATOR */
+/* BEGIN_CASE depends_on:MBEDTLS_MD_C:MBEDTLS_ENTROPY_NV_SEED:MBEDTLS_PLATFORM_NV_SEED_ALT */
 void entropy_nv_seed( char *read_seed_str )
 {
-    mbedtls_sha512_context accumulator;
+#if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
+    const mbedtls_md_info_t *md_info =
+        mbedtls_md_info_from_type( MBEDTLS_MD_SHA512 );
+#elif defined(MBEDTLS_ENTROPY_SHA256_ACCUMULATOR)
+    const mbedtls_md_info_t *md_info =
+        mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 );
+#else
+#error "Unsupported entropy accumulator"
+#endif
+    mbedtls_md_context_t accumulator;
     mbedtls_entropy_context ctx;
     int (*original_mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len ) =
         mbedtls_nv_seed_read;
@@ -320,18 +329,14 @@ void entropy_nv_seed( char *read_seed_str )
 
     memset( entropy, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
     memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
-    memset( buffer_seed, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
     memset( empty, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
     memset( check_seed, 2, MBEDTLS_ENTROPY_BLOCK_SIZE );
     memset( check_entropy, 3, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
-    // Set the initial NV seed to read
-    unhexify( read_seed, read_seed_str );
-    memcpy( buffer_seed, read_seed, MBEDTLS_ENTROPY_BLOCK_SIZE );
-
     // Make sure we read/write NV seed from our buffers
     mbedtls_platform_set_nv_seed( buffer_nv_seed_read, buffer_nv_seed_write );
 
+    mbedtls_md_init( &accumulator );
     mbedtls_entropy_init( &ctx );
     entropy_clear_sources( &ctx );
 
@@ -339,45 +344,57 @@ void entropy_nv_seed( char *read_seed_str )
                                              MBEDTLS_ENTROPY_BLOCK_SIZE,
                                              MBEDTLS_ENTROPY_SOURCE_STRONG ) == 0 );
 
+    // Set the initial NV seed to read.
+    // Get exactly MBEDTLS_ENTROPY_BLOCK_SIZE bytes from read_str.
+    TEST_ASSERT( strlen( read_seed ) / 2 >= MBEDTLS_ENTROPY_BLOCK_SIZE );
+    read_seed_str[MBEDTLS_ENTROPY_BLOCK_SIZE * 2] = '\0';
+    unhexify( read_seed, read_seed_str );
+    memcpy( buffer_seed, read_seed, MBEDTLS_ENTROPY_BLOCK_SIZE );
+
     // Do an entropy run
     TEST_ASSERT( mbedtls_entropy_func( &ctx, entropy, sizeof( entropy ) ) == 0 );
-
     // Determine what should have happened with manual entropy internal logic
-    // Only use the SHA-512 version to check
 
     // Init accumulator
     header[1] = MBEDTLS_ENTROPY_BLOCK_SIZE;
-    mbedtls_sha512_starts( &accumulator, 0 );
+    TEST_ASSERT( mbedtls_md_setup( &accumulator, md_info, 0 ) == 0 );
 
     // First run for updating write_seed
     header[0] = 0;
-    mbedtls_sha512_update( &accumulator, header, 2 );
-    mbedtls_sha512_update( &accumulator, read_seed, MBEDTLS_ENTROPY_BLOCK_SIZE );
-    mbedtls_sha512_finish( &accumulator, buf );
+    TEST_ASSERT( mbedtls_md_starts( &accumulator ) == 0 );
+    TEST_ASSERT( mbedtls_md_update( &accumulator, header, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_md_update( &accumulator,
+                                    read_seed, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
+    TEST_ASSERT( mbedtls_md_finish( &accumulator, buf ) == 0 );
 
-    memset( &accumulator, 0, sizeof( mbedtls_sha512_context ) );
-    mbedtls_sha512_starts( &accumulator, 0 );
-    mbedtls_sha512_update( &accumulator, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    TEST_ASSERT( mbedtls_md_starts( &accumulator ) == 0 );
+    TEST_ASSERT( mbedtls_md_update( &accumulator,
+                                    buf, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
 
-    mbedtls_sha512( buf, MBEDTLS_ENTROPY_BLOCK_SIZE, check_seed, 0 );
+    TEST_ASSERT( mbedtls_md( md_info, buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
+                             check_seed ) == 0 );
 
     // Second run for actual entropy (triggers mbedtls_entropy_update_nv_seed)
     header[0] = MBEDTLS_ENTROPY_SOURCE_MANUAL;
-    mbedtls_sha512_update( &accumulator, header, 2 );
-    mbedtls_sha512_update( &accumulator, empty, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    TEST_ASSERT( mbedtls_md_update( &accumulator, header, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_md_update( &accumulator,
+                                    empty, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
 
     header[0] = 0;
-    mbedtls_sha512_update( &accumulator, header, 2 );
-    mbedtls_sha512_update( &accumulator, check_seed, MBEDTLS_ENTROPY_BLOCK_SIZE );
-    mbedtls_sha512_finish( &accumulator, buf );
+    TEST_ASSERT( mbedtls_md_update( &accumulator, header, 2 ) == 0 );
+    TEST_ASSERT( mbedtls_md_update( &accumulator,
+                                    check_seed, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
+    TEST_ASSERT( mbedtls_md_finish( &accumulator, buf ) == 0 );
 
-    mbedtls_sha512( buf, MBEDTLS_ENTROPY_BLOCK_SIZE, check_entropy, 0 );
+    TEST_ASSERT( mbedtls_md( md_info, buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
+                             check_entropy ) == 0 );
 
     // Check result of both NV file and entropy received with the manual calculations
     TEST_ASSERT( memcmp( check_seed, buffer_seed, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
     TEST_ASSERT( memcmp( check_entropy, entropy, MBEDTLS_ENTROPY_BLOCK_SIZE ) == 0 );
 
 exit:
+    mbedtls_md_free( &accumulator );
     mbedtls_entropy_free( &ctx );
     mbedtls_nv_seed_read = original_mbedtls_nv_seed_read;
     mbedtls_nv_seed_write = original_mbedtls_nv_seed_write;


### PR DESCRIPTION
Backport of the applicable parts of https://github.com/ARMmbed/mbed-crypto/pull/144 (entropy tests).