### PR TITLE
Change worktree_rev to HEAD for rev-parse

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -107,7 +107,7 @@ class AbiChecker(object):
         )
         self.log.debug(worktree_output.decode("utf-8"))
         version.commit = subprocess.check_output(
-            [self.git_command, "rev-parse", worktree_rev],
+            [self.git_command, "rev-parse", "HEAD"],
             cwd=git_worktree_path,
             stderr=subprocess.STDOUT
         ).decode("ascii").rstrip()


### PR DESCRIPTION
Due to how the checking script is run in docker, worktree_rev is
ambiguous when running rev-parse. We're running it in the checked
out worktree, so we can use HEAD instead, which is unambiguous.
