### PR TITLE
Backport 2.16: Change worktree_rev to HEAD for rev-parse

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -107,7 +107,7 @@ class AbiChecker(object):
         )
         self.log.debug(worktree_output.decode("utf-8"))
         version.commit = subprocess.check_output(
-            [self.git_command, "rev-parse", worktree_rev],
+            [self.git_command, "rev-parse", "HEAD"],
             cwd=git_worktree_path,
             stderr=subprocess.STDOUT
         ).decode("ascii").rstrip()


### PR DESCRIPTION
Backport for 2.16 of #2760 