### PR TITLE
[s11n 1/7] Refactor derive keys (side-port)

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -458,7 +458,7 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
     void (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
-    void (*calc_verify)(mbedtls_ssl_context *, unsigned char *);
+    void (*calc_verify)(const mbedtls_ssl_context *, unsigned char *);
     void (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
     mbedtls_ssl_tls_prf_cb *tls_prf;
 

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -458,7 +458,7 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
     void (*update_checksum)(mbedtls_ssl_context *, const unsigned char *, size_t);
-    void (*calc_verify)(const mbedtls_ssl_context *, unsigned char *);
+    void (*calc_verify)(const mbedtls_ssl_context *, unsigned char *, size_t *);
     void (*calc_finished)(mbedtls_ssl_context *, unsigned char *, int);
     mbedtls_ssl_tls_prf_cb *tls_prf;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3625,7 +3625,7 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
     unsigned char hash[48];
     unsigned char *hash_start = hash;
     mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
-    unsigned int hashlen;
+    size_t hashlen;
     void *rs_ctx = NULL;
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> write certificate verify" ) );
@@ -3674,7 +3674,7 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
 sign:
 #endif
 
-    ssl->handshake->calc_verify( ssl, hash );
+    ssl->handshake->calc_verify( ssl, hash, &hashlen );
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
@@ -3692,7 +3692,6 @@ sign:
          * sha_hash
          *     SHA(handshake_messages);
          */
-        hashlen = 36;
         md_alg = MBEDTLS_MD_NONE;
 
         /*

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -4361,7 +4361,10 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
     }
 
     /* Calculate hash and verify signature */
-    ssl->handshake->calc_verify( ssl, hash );
+    {
+        size_t dummy_hlen;
+        ssl->handshake->calc_verify( ssl, hash, &dummy_hlen );
+    }
 
     if( ( ret = mbedtls_pk_verify( peer_pk,
                            md_alg, hash_start, hashlen,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1521,7 +1521,7 @@ end:
  * - SSL/TLS minor version
  * - hash associated with the ciphersuite (only used by TLS 1.2)
  *
- * Ouputs:
+ * Outputs:
  * - the tls_prf, calc_verify and calc_finished members of handshake structure
  */
 static int ssl_set_handshake_prfs( mbedtls_ssl_handshake_params *handshake,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1578,7 +1578,7 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_handshake_params *handshake,
 }
 
 /*
- * Compute master secret
+ * Compute master secret if needed
  */
 static int ssl_compute_master( mbedtls_ssl_context *ssl )
 {
@@ -1595,134 +1595,123 @@ static int ssl_compute_master( mbedtls_ssl_context *ssl )
     unsigned char session_hash[48];
 #endif /* MBEDTLS_SSL_EXTENDED_MASTER_SECRET */
 
-    /*
-     * SSLv3:
-     *   master =
-     *     MD5( premaster + SHA1( 'A'   + premaster + randbytes ) ) +
-     *     MD5( premaster + SHA1( 'BB'  + premaster + randbytes ) ) +
-     *     MD5( premaster + SHA1( 'CCC' + premaster + randbytes ) )
-     *
-     * TLSv1+:
-     *   master = PRF( premaster, "master secret", randbytes )[0..47]
-     */
+    /* The label for the KDF used for key expansion.
+     * This is either "master secret" or "extended master secret"
+     * depending on whether the Extended Master Secret extension
+     * is used. */
+    char const *lbl = "master secret";
+
+    /* The salt for the KDF used for key expansion.
+     * - If the Extended Master Secret extension is not used,
+     *   this is ClientHello.Random + ServerHello.Random
+     *   (see Sect. 8.1 in RFC 5246).
+     * - If the Extended Master Secret extension is used,
+     *   this is the transcript of the handshake so far.
+     *   (see Sect. 4 in RFC 7627). */
+    unsigned char const *salt = handshake->randbytes;
+    size_t salt_len = 64;
+
     if( handshake->resume != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "no premaster (session resumed)" ) );
+        return( 0 );
     }
-    else
-    {
-        /* The label for the KDF used for key expansion.
-         * This is either "master secret" or "extended master secret"
-         * depending on whether the Extended Master Secret extension
-         * is used. */
-        char const *lbl = "master secret";
-
-        /* The salt for the KDF used for key expansion.
-         * - If the Extended Master Secret extension is not used,
-         *   this is ClientHello.Random + ServerHello.Random
-         *   (see Sect. 8.1 in RFC 5246).
-         * - If the Extended Master Secret extension is used,
-         *   this is the transcript of the handshake so far.
-         *   (see Sect. 4 in RFC 7627). */
-        unsigned char const *salt = handshake->randbytes;
-        size_t salt_len = 64;
 
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
-        if( ssl->handshake->extended_ms == MBEDTLS_SSL_EXTENDED_MS_ENABLED )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "using extended master secret" ) );
+    if( ssl->handshake->extended_ms == MBEDTLS_SSL_EXTENDED_MS_ENABLED )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "using extended master secret" ) );
 
-            lbl  = "extended master secret";
-            salt = session_hash;
-            ssl->handshake->calc_verify( ssl, session_hash );
+        lbl  = "extended master secret";
+        salt = session_hash;
+        ssl->handshake->calc_verify( ssl, session_hash );
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-            if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
-            {
+        if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+        {
 #if defined(MBEDTLS_SHA512_C)
-                if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-                {
-                    salt_len = 48;
-                }
-                else
-#endif /* MBEDTLS_SHA512_C */
-                    salt_len = 32;
+            if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+            {
+                salt_len = 48;
             }
             else
-#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
-                salt_len = 36;
-
-            MBEDTLS_SSL_DEBUG_BUF( 3, "session hash", session_hash, salt_len );
+#endif /* MBEDTLS_SHA512_C */
+                salt_len = 32;
         }
+        else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+            salt_len = 36;
+
+        MBEDTLS_SSL_DEBUG_BUF( 3, "session hash", session_hash, salt_len );
+    }
 #endif /* MBEDTLS_SSL_EXTENDED_MS_ENABLED */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO) &&          \
-    defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
-        if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK &&
-            ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
-            ssl_use_opaque_psk( ssl ) == 1 )
-        {
-            /* Perform PSK-to-MS expansion in a single step. */
-            psa_status_t status;
-            psa_algorithm_t alg;
-            psa_key_handle_t psk;
-            psa_key_derivation_operation_t derivation =
-                PSA_KEY_DERIVATION_OPERATION_INIT;
+defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
+    if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_PSK &&
+        ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        ssl_use_opaque_psk( ssl ) == 1 )
+    {
+        /* Perform PSK-to-MS expansion in a single step. */
+        psa_status_t status;
+        psa_algorithm_t alg;
+        psa_key_handle_t psk;
+        psa_key_derivation_operation_t derivation =
+            PSA_KEY_DERIVATION_OPERATION_INIT;
 
-            MBEDTLS_SSL_DEBUG_MSG( 2, ( "perform PSA-based PSK-to-MS expansion" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 2, ( "perform PSA-based PSK-to-MS expansion" ) );
 
-            psk = ssl->conf->psk_opaque;
-            if( ssl->handshake->psk_opaque != 0 )
-                psk = ssl->handshake->psk_opaque;
+        psk = ssl->conf->psk_opaque;
+        if( ssl->handshake->psk_opaque != 0 )
+            psk = ssl->handshake->psk_opaque;
 
-            if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-                alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_384);
-            else
-                alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
-
-            status = psa_key_derivation( &derivation, psk, alg,
-                                         salt, salt_len,
-                                         (unsigned char const *) lbl,
-                                         (size_t) strlen( lbl ),
-                                         master_secret_len );
-            if( status != PSA_SUCCESS )
-            {
-                psa_key_derivation_abort( &derivation );
-                return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-            }
-
-            status = psa_key_derivation_output_bytes( &derivation,
-                                                      session->master,
-                                                      master_secret_len );
-            if( status != PSA_SUCCESS )
-            {
-                psa_key_derivation_abort( &derivation );
-                return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-            }
-
-            status = psa_key_derivation_abort( &derivation );
-            if( status != PSA_SUCCESS )
-                return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-        }
+        if( ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+            alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_384);
         else
-#endif
+            alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
+
+        status = psa_key_derivation( &derivation, psk, alg,
+                                     salt, salt_len,
+                                     (unsigned char const *) lbl,
+                                     (size_t) strlen( lbl ),
+                                     master_secret_len );
+        if( status != PSA_SUCCESS )
         {
-            ret = handshake->tls_prf( handshake->premaster, handshake->pmslen,
-                                      lbl, salt, salt_len,
-                                      session->master,
-                                      master_secret_len );
-            if( ret != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_RET( 1, "prf", ret );
-                return( ret );
-            }
-
-            MBEDTLS_SSL_DEBUG_BUF( 3, "premaster secret",
-                                   handshake->premaster,
-                                   handshake->pmslen );
-
-            mbedtls_platform_zeroize( handshake->premaster,
-                                      sizeof(handshake->premaster) );
+            psa_key_derivation_abort( &derivation );
+            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
         }
+
+        status = psa_key_derivation_output_bytes( &derivation,
+                                                  session->master,
+                                                  master_secret_len );
+        if( status != PSA_SUCCESS )
+        {
+            psa_key_derivation_abort( &derivation );
+            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+        }
+
+        status = psa_key_derivation_abort( &derivation );
+        if( status != PSA_SUCCESS )
+            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+    }
+    else
+#endif
+    {
+        ret = handshake->tls_prf( handshake->premaster, handshake->pmslen,
+                                  lbl, salt, salt_len,
+                                  session->master,
+                                  master_secret_len );
+        if( ret != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "prf", ret );
+            return( ret );
+        }
+
+        MBEDTLS_SSL_DEBUG_BUF( 3, "premaster secret",
+                               handshake->premaster,
+                               handshake->pmslen );
+
+        mbedtls_platform_zeroize( handshake->premaster,
+                                  sizeof(handshake->premaster) );
     }
 
     return( 0 );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -855,25 +855,25 @@ static void ssl_update_checksum_md5sha1( mbedtls_ssl_context *, const unsigned c
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
-static void ssl_calc_verify_ssl( mbedtls_ssl_context *, unsigned char * );
+static void ssl_calc_verify_ssl( const mbedtls_ssl_context *, unsigned char * );
 static void ssl_calc_finished_ssl( mbedtls_ssl_context *, unsigned char *, int );
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
-static void ssl_calc_verify_tls( mbedtls_ssl_context *, unsigned char * );
+static void ssl_calc_verify_tls( const mbedtls_ssl_context *, unsigned char * );
 static void ssl_calc_finished_tls( mbedtls_ssl_context *, unsigned char *, int );
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA256_C)
 static void ssl_update_checksum_sha256( mbedtls_ssl_context *, const unsigned char *, size_t );
-static void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *,unsigned char * );
+static void ssl_calc_verify_tls_sha256( const mbedtls_ssl_context *,unsigned char * );
 static void ssl_calc_finished_tls_sha256( mbedtls_ssl_context *,unsigned char *, int );
 #endif
 
 #if defined(MBEDTLS_SHA512_C)
 static void ssl_update_checksum_sha384( mbedtls_ssl_context *, const unsigned char *, size_t );
-static void ssl_calc_verify_tls_sha384( mbedtls_ssl_context *, unsigned char * );
+static void ssl_calc_verify_tls_sha384( const mbedtls_ssl_context *, unsigned char * );
 static void ssl_calc_finished_tls_sha384( mbedtls_ssl_context *, unsigned char *, int );
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
@@ -1597,7 +1597,7 @@ static int ssl_compute_master( mbedtls_ssl_handshake_params *handshake,
                                int minor_ver,
                                mbedtls_md_type_t hash_alg,
                                unsigned char *master,
-                               mbedtls_ssl_context *ssl )
+                               const mbedtls_ssl_context *ssl )
 {
     int ret;
 
@@ -1774,7 +1774,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 }
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
-void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char hash[36] )
+void ssl_calc_verify_ssl( const mbedtls_ssl_context *ssl, unsigned char hash[36] )
 {
     mbedtls_md5_context md5;
     mbedtls_sha1_context sha1;
@@ -1823,7 +1823,7 @@ void ssl_calc_verify_ssl( mbedtls_ssl_context *ssl, unsigned char hash[36] )
 #endif /* MBEDTLS_SSL_PROTO_SSL3 */
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
-void ssl_calc_verify_tls( mbedtls_ssl_context *ssl, unsigned char hash[36] )
+void ssl_calc_verify_tls( const mbedtls_ssl_context *ssl, unsigned char hash[36] )
 {
     mbedtls_md5_context md5;
     mbedtls_sha1_context sha1;
@@ -1851,7 +1851,7 @@ void ssl_calc_verify_tls( mbedtls_ssl_context *ssl, unsigned char hash[36] )
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA256_C)
-void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char hash[32] )
+void ssl_calc_verify_tls_sha256( const mbedtls_ssl_context *ssl, unsigned char hash[32] )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;
@@ -1894,7 +1894,7 @@ void ssl_calc_verify_tls_sha256( mbedtls_ssl_context *ssl, unsigned char hash[32
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
-void ssl_calc_verify_tls_sha384( mbedtls_ssl_context *ssl, unsigned char hash[48] )
+void ssl_calc_verify_tls_sha384( const mbedtls_ssl_context *ssl, unsigned char hash[48] )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     size_t hash_size;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1027,6 +1027,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
 #if !defined(MBEDTLS_SSL_HW_RECORD_ACCEL) && \
     !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
     !defined(MBEDTLS_DEBUG_C)
+    ssl = NULL; /* make sure we don't use it except for those cases */
     (void) ssl;
 #endif
 
@@ -1625,6 +1626,7 @@ static int ssl_compute_master( mbedtls_ssl_handshake_params *handshake,
     !defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET) && \
     !(defined(MBEDTLS_USE_PSA_CRYPTO) &&            \
       defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED))
+    ssl = NULL; /* make sure we don't use it except for those cases */
     (void) ssl;
 #endif
 
@@ -2312,6 +2314,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
 
     /* The SSL context is only used for debugging purposes! */
 #if !defined(MBEDTLS_DEBUG_C)
+    ssl = NULL; /* make sure we don't use it except for debug */
     ((void) ssl);
 #endif
 
@@ -2741,6 +2744,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
     size_t add_data_len;
 
 #if !defined(MBEDTLS_DEBUG_C)
+    ssl = NULL; /* make sure we don't use it except for debug */
     ((void) ssl);
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1528,7 +1528,7 @@ end:
 }
 
 /*
- * Set appropriate PRF function and other SSL / TLS / TLS1.2 functions
+ * Set appropriate PRF function and other SSL / TLS 1.0/1.1 / TLS1.2 functions
  *
  * Inputs:
  * - SSL/TLS minor version

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -989,16 +989,23 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
  * Parameters:
  * - [in/out]: transform: structure to populate
  *      [in] must be just initialised with mbedtls_ssl_transform_init()
- *      [out] fully populate, ready for use by mbedtls_ssl_{en,de}crypt_buf()
+ *      [out] fully populated, ready for use by mbedtls_ssl_{en,de}crypt_buf()
  * - [in] session: used: ciphersuite, encrypt_then_mac, master, compression
  * - [in] tls_prf: pointer to PRF to use for key derivation
  * - [in] randbytes: buffer holding ServerHello.random + ClientHello.random
- * - [in] ssl: used members: minor_ver, conf->endpoint
+ * - [in] minor_ver: SSL/TLS minor version
+ * - [in] endpoint: client or server
+ * - [in] ssl: optionally used for:
+ *        - MBEDTLS_SSL_HW_RECORD_ACCEL: whole context
+ *        - MBEDTLS_SSL_EXPORT_KEYS: ssl->conf->{f,p}_export_keys
+ *        - MBEDTLS_DEBUG_C: ssl->conf->{f,p}_dbg
  */
 static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                    const mbedtls_ssl_session *session,
                                    ssl_tls_prf_t tls_prf,
                                    const unsigned char randbytes[64],
+                                   int minor_ver,
+                                   unsigned endpoint,
                                    const mbedtls_ssl_context *ssl )
 {
     int ret = 0;
@@ -1017,12 +1024,18 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     const mbedtls_cipher_info_t *cipher_info;
     const mbedtls_md_info_t *md_info;
 
+#if !defined(MBEDTLS_SSL_HW_RECORD_ACCEL) && \
+    !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
+    !defined(MBEDTLS_DEBUG_C)
+    (void) ssl;
+#endif
+
     /* Copy info about negotiated version and extensions */
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
     defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
     transform->encrypt_then_mac = session->encrypt_then_mac;
 #endif
-    transform->minor_ver = ssl->minor_ver;
+    transform->minor_ver = minor_ver;
 
     /*
      * Get various info structures
@@ -1188,14 +1201,14 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
             }
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1)
-            if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 ||
-                ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_1 )
+            if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 ||
+                minor_ver == MBEDTLS_SSL_MINOR_VERSION_1 )
                 ; /* No need to adjust minlen */
             else
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_1) || defined(MBEDTLS_SSL_PROTO_TLS1_2)
-            if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_2 ||
-                ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+            if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_2 ||
+                minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
             {
                 transform->minlen += transform->ivlen;
             }
@@ -1225,7 +1238,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
      * Finally setup the cipher contexts, IVs and MAC secrets.
      */
 #if defined(MBEDTLS_SSL_CLI_C)
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
+    if( endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
         key1 = keyblk + mac_key_len * 2;
         key2 = keyblk + mac_key_len * 2 + keylen;
@@ -1245,7 +1258,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     else
 #endif /* MBEDTLS_SSL_CLI_C */
 #if defined(MBEDTLS_SSL_SRV_C)
-    if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
+    if( endpoint == MBEDTLS_SSL_IS_SERVER )
     {
         key1 = keyblk + mac_key_len * 2 + keylen;
         key2 = keyblk + mac_key_len * 2;
@@ -1272,7 +1285,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
 
 #if defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
     {
         if( mac_key_len > sizeof( transform->mac_enc ) )
         {
@@ -1288,7 +1301,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
 #endif /* MBEDTLS_SSL_PROTO_SSL3 */
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
-    if( ssl->minor_ver >= MBEDTLS_SSL_MINOR_VERSION_1 )
+    if( minor_ver >= MBEDTLS_SSL_MINOR_VERSION_1 )
     {
         /* For HMAC-based ciphersuites, initialize the HMAC transforms.
            For AEAD-based ciphersuites, there is nothing to do here. */
@@ -1751,6 +1764,8 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                                   ssl->session_negotiate,
                                   ssl->handshake->tls_prf,
                                   ssl->handshake->randbytes,
+                                  ssl->minor_ver,
+                                  ssl->conf->endpoint,
                                   ssl );
     if( ret != 0 )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1060,53 +1060,6 @@ static int ssl_populate_transform( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
     /*
-     * Set appropriate PRF function and other SSL / TLS / TLS1.2 functions
-     */
-#if defined(MBEDTLS_SSL_PROTO_SSL3)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
-    {
-        handshake->tls_prf = ssl3_prf;
-        handshake->calc_verify = ssl_calc_verify_ssl;
-        handshake->calc_finished = ssl_calc_finished_ssl;
-    }
-    else
-#endif
-#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
-    if( ssl->minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 )
-    {
-        handshake->tls_prf = tls1_prf;
-        handshake->calc_verify = ssl_calc_verify_tls;
-        handshake->calc_finished = ssl_calc_finished_tls;
-    }
-    else
-#endif
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
-#if defined(MBEDTLS_SHA512_C)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
-        ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
-    {
-        handshake->tls_prf = tls_prf_sha384;
-        handshake->calc_verify = ssl_calc_verify_tls_sha384;
-        handshake->calc_finished = ssl_calc_finished_tls_sha384;
-    }
-    else
-#endif
-#if defined(MBEDTLS_SHA256_C)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
-    {
-        handshake->tls_prf = tls_prf_sha256;
-        handshake->calc_verify = ssl_calc_verify_tls_sha256;
-        handshake->calc_finished = ssl_calc_finished_tls_sha256;
-    }
-    else
-#endif
-#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-    }
-
-    /*
      * SSLv3:
      *   master =
      *     MD5( premaster + SHA1( 'A'   + premaster + randbytes ) ) +
@@ -1698,8 +1651,71 @@ end:
     return( ret );
 }
 
+static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
+{
+    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
+    const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
+    ciphersuite_info = handshake->ciphersuite_info;
+
+    /*
+     * Set appropriate PRF function and other SSL / TLS / TLS1.2 functions
+     */
+#if defined(MBEDTLS_SSL_PROTO_SSL3)
+    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
+    {
+        handshake->tls_prf = ssl3_prf;
+        handshake->calc_verify = ssl_calc_verify_ssl;
+        handshake->calc_finished = ssl_calc_finished_ssl;
+    }
+    else
+#endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
+    if( ssl->minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 )
+    {
+        handshake->tls_prf = tls1_prf;
+        handshake->calc_verify = ssl_calc_verify_tls;
+        handshake->calc_finished = ssl_calc_finished_tls;
+    }
+    else
+#endif
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#if defined(MBEDTLS_SHA512_C)
+    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+    {
+        handshake->tls_prf = tls_prf_sha384;
+        handshake->calc_verify = ssl_calc_verify_tls_sha384;
+        handshake->calc_finished = ssl_calc_finished_tls_sha384;
+    }
+    else
+#endif
+#if defined(MBEDTLS_SHA256_C)
+    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+    {
+        handshake->tls_prf = tls_prf_sha256;
+        handshake->calc_verify = ssl_calc_verify_tls_sha256;
+        handshake->calc_finished = ssl_calc_finished_tls_sha256;
+    }
+    else
+#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
+        return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+    }
+
+    return( 0 );
+}
+
+
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 {
+    int ret;
+
+    ret = ssl_set_handshake_prfs( ssl );
+    if( ret != 0 )
+        return( ret );
+
     return( ssl_populate_transform( ssl ) );
 }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1652,8 +1652,6 @@ static int ssl_compute_master( mbedtls_ssl_handshake_params *handshake,
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
     if( handshake->extended_ms == MBEDTLS_SSL_EXTENDED_MS_ENABLED )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "using extended master secret" ) );
-
         lbl  = "extended master secret";
         salt = session_hash;
         handshake->calc_verify( ssl, session_hash, &salt_len );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1460,24 +1460,10 @@ static int ssl_populate_transform( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 
+    /* Initialize Zlib contexts */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    // Initialize compression
-    //
     if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
     {
-        if( ssl->compress_buf == NULL )
-        {
-            MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );
-            ssl->compress_buf = mbedtls_calloc( 1, MBEDTLS_SSL_COMPRESS_BUFFER_LEN );
-            if( ssl->compress_buf == NULL )
-            {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "alloc(%d bytes) failed",
-                                    MBEDTLS_SSL_COMPRESS_BUFFER_LEN ) );
-                ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
-                goto end;
-            }
-        }
-
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Initializing zlib states" ) );
 
         memset( &transform->ctx_deflate, 0, sizeof( transform->ctx_deflate ) );
@@ -1756,6 +1742,22 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
     /* We no longer need Server/ClientHello.random values */
     mbedtls_platform_zeroize( ssl->handshake->randbytes,
                       sizeof( ssl->handshake->randbytes ) );
+
+    /* Allocate compression buffer */
+#if defined(MBEDTLS_ZLIB_SUPPORT)
+    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
+        ssl->compress_buf == NULL )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );
+        ssl->compress_buf = mbedtls_calloc( 1, MBEDTLS_SSL_COMPRESS_BUFFER_LEN );
+        if( ssl->compress_buf == NULL )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "alloc(%d bytes) failed",
+                                MBEDTLS_SSL_COMPRESS_BUFFER_LEN ) );
+            return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
+        }
+    }
+#endif
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= derive keys" ) );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1336,8 +1336,9 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                       session->master, keyblk,
                                       mac_key_len, keylen,
                                       iv_copy_len,
-                                      handshake->randbytes + 32,
-                                      handshake->randbytes,
+                                      /* work around bug in exporter type */
+                                      (unsigned char *) handshake->randbytes + 32,
+                                      (unsigned char *) handshake->randbytes,
                                       tls_prf_get_type( handshake->tls_prf ) );
     }
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1110,7 +1110,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ciphersuite = %s",
-                   mbedtls_ssl_get_ciphersuite_name( ciphersuite ) ) );
+                           mbedtls_ssl_get_ciphersuite_name( ciphersuite ) ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "master secret", master, 48 );
     MBEDTLS_SSL_DEBUG_BUF( 4, "random bytes", randbytes, 64 );
     MBEDTLS_SSL_DEBUG_BUF( 4, "key block", keyblk, 256 );
@@ -1810,7 +1810,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
         if( ssl->compress_buf == NULL )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "alloc(%d bytes) failed",
-                                MBEDTLS_SSL_COMPRESS_BUFFER_LEN ) );
+                                        MBEDTLS_SSL_COMPRESS_BUFFER_LEN ) );
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
         }
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -977,7 +977,13 @@ int  mbedtls_ssl_tls_prf( const mbedtls_tls_prf_types prf,
     return( tls_prf( secret, slen, label, random, rlen, dstbuf, dlen ) );
 }
 
-int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
+/*
+ * This function will ultimetaly only be responsible for populating a
+ * transform structure from data passed as explicit parameters.
+ *
+ * For now however it's doing rather more in a rather less explicit way.
+ */
+static int ssl_populate_transform( mbedtls_ssl_context *ssl )
 {
     int ret = 0;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1690,6 +1696,11 @@ end:
     mbedtls_platform_zeroize( handshake->randbytes,
                               sizeof( handshake->randbytes ) );
     return( ret );
+}
+
+int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
+{
+    return( ssl_populate_transform( ssl ) );
 }
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1651,17 +1651,26 @@ end:
     return( ret );
 }
 
-static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
+/*
+ * Set appropriate PRF function and other SSL / TLS / TLS1.2 functions
+ *
+ * Inputs:
+ * - SSL/TLS minor version
+ * - hash associated with the ciphersuite (only used by TLS 1.2)
+ *
+ * Ouputs:
+ * - the tls_prf, calc_verify and calc_finished members of handshake structure
+ */
+static int ssl_set_handshake_prfs( mbedtls_ssl_handshake_params *handshake,
+                                   int minor_ver,
+                                   mbedtls_md_type_t hash )
 {
-    mbedtls_ssl_handshake_params *handshake = ssl->handshake;
-    const mbedtls_ssl_ciphersuite_t *ciphersuite_info;
-    ciphersuite_info = handshake->ciphersuite_info;
+#if !defined(MBEDTLS_SSL_PROTO_TLS1_2) || !defined(MBEDTLS_SHA512_C)
+    (void) hash;
+#endif
 
-    /*
-     * Set appropriate PRF function and other SSL / TLS / TLS1.2 functions
-     */
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
     {
         handshake->tls_prf = ssl3_prf;
         handshake->calc_verify = ssl_calc_verify_ssl;
@@ -1670,7 +1679,7 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
     else
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1)
-    if( ssl->minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 )
+    if( minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 )
     {
         handshake->tls_prf = tls1_prf;
         handshake->calc_verify = ssl_calc_verify_tls;
@@ -1680,8 +1689,8 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
 #endif
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
 #if defined(MBEDTLS_SHA512_C)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
-        ciphersuite_info->mac == MBEDTLS_MD_SHA384 )
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        hash == MBEDTLS_MD_SHA384 )
     {
         handshake->tls_prf = tls_prf_sha384;
         handshake->calc_verify = ssl_calc_verify_tls_sha384;
@@ -1690,7 +1699,7 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
     else
 #endif
 #if defined(MBEDTLS_SHA256_C)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+    if( minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
     {
         handshake->tls_prf = tls_prf_sha256;
         handshake->calc_verify = ssl_calc_verify_tls_sha256;
@@ -1700,7 +1709,6 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
@@ -1711,10 +1719,17 @@ static int ssl_set_handshake_prfs( mbedtls_ssl_context *ssl )
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 {
     int ret;
+    const mbedtls_ssl_ciphersuite_t * const ciphersuite_info =
+        ssl->handshake->ciphersuite_info;
 
-    ret = ssl_set_handshake_prfs( ssl );
+    ret = ssl_set_handshake_prfs( ssl->handshake,
+                                  ssl->minor_ver,
+                                  ciphersuite_info->mac );
     if( ret != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "ssl_set_handshake_prfs", ret );
         return( ret );
+    }
 
     return( ssl_populate_transform( ssl ) );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1656,7 +1656,8 @@ static int ssl_compute_master( mbedtls_ssl_handshake_params *handshake,
         salt = session_hash;
         handshake->calc_verify( ssl, session_hash, &salt_len );
 
-        MBEDTLS_SSL_DEBUG_BUF( 3, "session hash", session_hash, salt_len );
+        MBEDTLS_SSL_DEBUG_BUF( 3, "session hash for extended master secret",
+                                  session_hash, salt_len );
     }
 #endif /* MBEDTLS_SSL_EXTENDED_MS_ENABLED */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -990,7 +990,11 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
  * - [in/out]: transform: structure to populate
  *      [in] must be just initialised with mbedtls_ssl_transform_init()
  *      [out] fully populated, ready for use by mbedtls_ssl_{en,de}crypt_buf()
- * - [in] session: used: ciphersuite, encrypt_then_mac, master, compression
+ * - [in] ciphersuite
+ * - [in] master
+ * - [in] encrypt_then_mac
+ * - [in] trunc_hmac
+ * - [in] compression
  * - [in] tls_prf: pointer to PRF to use for key derivation
  * - [in] randbytes: buffer holding ServerHello.random + ClientHello.random
  * - [in] minor_ver: SSL/TLS minor version
@@ -1001,7 +1005,17 @@ typedef int ssl_tls_prf_t(const unsigned char *, size_t, const char *,
  *        - MBEDTLS_DEBUG_C: ssl->conf->{f,p}_dbg
  */
 static int ssl_populate_transform( mbedtls_ssl_transform *transform,
-                                   const mbedtls_ssl_session *session,
+                                   int ciphersuite,
+                                   const unsigned char master[48],
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+                                   int encrypt_then_mac,
+#endif
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
+                                   int trunc_hmac,
+#endif
+#if defined(MBEDTLS_ZLIB_SUPPORT)
+                                   int compression,
+#endif
                                    ssl_tls_prf_t tls_prf,
                                    const unsigned char randbytes[64],
                                    int minor_ver,
@@ -1034,18 +1048,18 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     /* Copy info about negotiated version and extensions */
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC) && \
     defined(MBEDTLS_SSL_SOME_MODES_USE_MAC)
-    transform->encrypt_then_mac = session->encrypt_then_mac;
+    transform->encrypt_then_mac = encrypt_then_mac;
 #endif
     transform->minor_ver = minor_ver;
 
     /*
      * Get various info structures
      */
-    ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( session->ciphersuite );
+    ciphersuite_info = mbedtls_ssl_ciphersuite_from_id( ciphersuite );
     if( ciphersuite_info == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "ciphersuite info for %d not found",
-                                    session->ciphersuite ) );
+                                    ciphersuite ) );
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
@@ -1088,8 +1102,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     /*
      * Compute key block using the PRF
      */
-    ret = tls_prf( session->master, 48, "key expansion",
-                   randbytes, 64, keyblk, 256 );
+    ret = tls_prf( master, 48, "key expansion", randbytes, 64, keyblk, 256 );
     if( ret != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "prf", ret );
@@ -1097,8 +1110,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "ciphersuite = %s",
-                   mbedtls_ssl_get_ciphersuite_name( session->ciphersuite ) ) );
-    MBEDTLS_SSL_DEBUG_BUF( 3, "master secret", session->master, 48 );
+                   mbedtls_ssl_get_ciphersuite_name( ciphersuite ) ) );
+    MBEDTLS_SSL_DEBUG_BUF( 3, "master secret", master, 48 );
     MBEDTLS_SSL_DEBUG_BUF( 4, "random bytes", randbytes, 64 );
     MBEDTLS_SSL_DEBUG_BUF( 4, "key block", keyblk, 256 );
 
@@ -1160,7 +1173,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
          * (rfc 6066 page 13 or rfc 2104 section 4),
          * so we only need to adjust the length here.
          */
-        if( session->trunc_hmac == MBEDTLS_SSL_TRUNC_HMAC_ENABLED )
+        if( trunc_hmac == MBEDTLS_SSL_TRUNC_HMAC_ENABLED )
         {
             transform->maclen = MBEDTLS_SSL_TRUNCATED_HMAC_LEN;
 
@@ -1188,7 +1201,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
              * 2. IV except for SSL3 and TLS 1.0
              */
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-            if( session->encrypt_then_mac == MBEDTLS_SSL_ETM_ENABLED )
+            if( encrypt_then_mac == MBEDTLS_SSL_ETM_ENABLED )
             {
                 transform->minlen = transform->maclen
                                   + cipher_info->block_size;
@@ -1348,7 +1361,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     if( ssl->conf->f_export_keys != NULL )
     {
         ssl->conf->f_export_keys( ssl->conf->p_export_keys,
-                                  session->master, keyblk,
+                                  master, keyblk,
                                   mac_key_len, keylen,
                                   iv_copy_len );
     }
@@ -1356,7 +1369,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     if( ssl->conf->f_export_keys_ext != NULL )
     {
         ssl->conf->f_export_keys_ext( ssl->conf->p_export_keys,
-                                      session->master, keyblk,
+                                      master, keyblk,
                                       mac_key_len, keylen,
                                       iv_copy_len,
                                       /* work around bug in exporter type */
@@ -1491,7 +1504,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
 
     /* Initialize Zlib contexts */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
+    if( compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Initializing zlib states" ) );
 
@@ -1763,7 +1776,17 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     /* Populate transform structure */
     ret = ssl_populate_transform( ssl->transform_negotiate,
-                                  ssl->session_negotiate,
+                                  ssl->session_negotiate->ciphersuite,
+                                  ssl->session_negotiate->master,
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+                                  ssl->session_negotiate->encrypt_then_mac,
+#endif
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
+                                  ssl->session_negotiate->trunc_hmac,
+#endif
+#if defined(MBEDTLS_ZLIB_SUPPORT)
+                                  ssl->session_negotiate->compression,
+#endif
                                   ssl->handshake->tls_prf,
                                   ssl->handshake->randbytes,
                                   ssl->minor_ver,

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1939,8 +1939,8 @@ run_test    "Extended Master Secret: default" \
             -s "found extended master secret extension" \
             -s "server hello, adding extended master secret extension" \
             -c "found extended_master_secret extension" \
-            -c "using extended master secret" \
-            -s "using extended master secret"
+            -c "session hash" \
+            -s "session hash"
 
 run_test    "Extended Master Secret: client enabled, server disabled" \
             "$P_SRV debug_level=3 extended_ms=0" \
@@ -1950,8 +1950,8 @@ run_test    "Extended Master Secret: client enabled, server disabled" \
             -s "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "using extended master secret" \
-            -S "using extended master secret"
+            -C "session hash" \
+            -S "session hash"
 
 run_test    "Extended Master Secret: client disabled, server enabled" \
             "$P_SRV debug_level=3 extended_ms=1" \
@@ -1961,8 +1961,8 @@ run_test    "Extended Master Secret: client disabled, server enabled" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "using extended master secret" \
-            -S "using extended master secret"
+            -C "session hash" \
+            -S "session hash"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
 run_test    "Extended Master Secret: client SSLv3, server enabled" \
@@ -1973,8 +1973,8 @@ run_test    "Extended Master Secret: client SSLv3, server enabled" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "using extended master secret" \
-            -S "using extended master secret"
+            -C "session hash" \
+            -S "session hash"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
 run_test    "Extended Master Secret: client enabled, server SSLv3" \
@@ -1985,8 +1985,8 @@ run_test    "Extended Master Secret: client enabled, server SSLv3" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "using extended master secret" \
-            -S "using extended master secret"
+            -C "session hash" \
+            -S "session hash"
 
 # Tests for FALLBACK_SCSV
 
@@ -4782,8 +4782,8 @@ run_test    "PSK callback: opaque psk on client, no callback" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4796,8 +4796,8 @@ run_test    "PSK callback: opaque psk on client, no callback, SHA-384" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4810,8 +4810,8 @@ run_test    "PSK callback: opaque psk on client, no callback, EMS" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4824,8 +4824,8 @@ run_test    "PSK callback: opaque psk on client, no callback, SHA-384, EMS" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4838,8 +4838,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4852,8 +4852,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4865,8 +4865,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-128-CBC-SHA \
             psk_identity=foo psk=abc123 extended_ms=1" \
             0 \
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4880,8 +4880,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-256-CBC-SHA384 \
             psk_identity=foo psk=abc123 extended_ms=1" \
             0 \
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4896,8 +4896,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4910,8 +4910,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4923,8 +4923,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-128-CBC-SHA \
             psk_identity=abc psk=dead extended_ms=1" \
             0 \
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4938,8 +4938,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-256-CBC-SHA384 \
             psk_identity=abc psk=dead extended_ms=1" \
             0 \
-            -c "using extended master secret"\
-            -s "using extended master secret"\
+            -c "session hash"\
+            -s "session hash"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4954,8 +4954,8 @@ run_test    "PSK callback: raw psk on client, mismatching static raw PSK on serv
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4968,8 +4968,8 @@ run_test    "PSK callback: raw psk on client, mismatching static opaque PSK on s
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4981,8 +4981,8 @@ run_test    "PSK callback: raw psk on client, mismatching static opaque PSK on s
             psk_identity=def psk=beef" \
             0 \
             -C "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4994,8 +4994,8 @@ run_test    "PSK callback: raw psk on client, id-matching but wrong raw PSK on s
             psk_identity=def psk=beef" \
             0 \
             -C "skip PMS generation for opaque PSK"\
-            -C "using extended master secret"\
-            -S "using extended master secret"\
+            -C "session hash"\
+            -S "session hash"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1939,8 +1939,8 @@ run_test    "Extended Master Secret: default" \
             -s "found extended master secret extension" \
             -s "server hello, adding extended master secret extension" \
             -c "found extended_master_secret extension" \
-            -c "session hash" \
-            -s "session hash"
+            -c "session hash for extended master secret" \
+            -s "session hash for extended master secret"
 
 run_test    "Extended Master Secret: client enabled, server disabled" \
             "$P_SRV debug_level=3 extended_ms=0" \
@@ -1950,8 +1950,8 @@ run_test    "Extended Master Secret: client enabled, server disabled" \
             -s "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "session hash" \
-            -S "session hash"
+            -C "session hash for extended master secret" \
+            -S "session hash for extended master secret"
 
 run_test    "Extended Master Secret: client disabled, server enabled" \
             "$P_SRV debug_level=3 extended_ms=1" \
@@ -1961,8 +1961,8 @@ run_test    "Extended Master Secret: client disabled, server enabled" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "session hash" \
-            -S "session hash"
+            -C "session hash for extended master secret" \
+            -S "session hash for extended master secret"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
 run_test    "Extended Master Secret: client SSLv3, server enabled" \
@@ -1973,8 +1973,8 @@ run_test    "Extended Master Secret: client SSLv3, server enabled" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "session hash" \
-            -S "session hash"
+            -C "session hash for extended master secret" \
+            -S "session hash for extended master secret"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_SSL3
 run_test    "Extended Master Secret: client enabled, server SSLv3" \
@@ -1985,8 +1985,8 @@ run_test    "Extended Master Secret: client enabled, server SSLv3" \
             -S "found extended master secret extension" \
             -S "server hello, adding extended master secret extension" \
             -C "found extended_master_secret extension" \
-            -C "session hash" \
-            -S "session hash"
+            -C "session hash for extended master secret" \
+            -S "session hash for extended master secret"
 
 # Tests for FALLBACK_SCSV
 
@@ -4782,8 +4782,8 @@ run_test    "PSK callback: opaque psk on client, no callback" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4796,8 +4796,8 @@ run_test    "PSK callback: opaque psk on client, no callback, SHA-384" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4810,8 +4810,8 @@ run_test    "PSK callback: opaque psk on client, no callback, EMS" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4824,8 +4824,8 @@ run_test    "PSK callback: opaque psk on client, no callback, SHA-384, EMS" \
             0 \
             -c "skip PMS generation for opaque PSK"\
             -S "skip PMS generation for opaque PSK"\
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4838,8 +4838,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4852,8 +4852,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4865,8 +4865,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-128-CBC-SHA \
             psk_identity=foo psk=abc123 extended_ms=1" \
             0 \
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4880,8 +4880,8 @@ run_test    "PSK callback: raw psk on client, static opaque on server, no callba
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-256-CBC-SHA384 \
             psk_identity=foo psk=abc123 extended_ms=1" \
             0 \
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4896,8 +4896,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4910,8 +4910,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4923,8 +4923,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-128-CBC-SHA \
             psk_identity=abc psk=dead extended_ms=1" \
             0 \
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4938,8 +4938,8 @@ run_test    "PSK callback: raw psk on client, no static PSK on server, opaque PS
             "$P_CLI debug_level=3 min_version=tls1_2 force_ciphersuite=TLS-PSK-WITH-AES-256-CBC-SHA384 \
             psk_identity=abc psk=dead extended_ms=1" \
             0 \
-            -c "session hash"\
-            -s "session hash"\
+            -c "session hash for extended master secret"\
+            -s "session hash for extended master secret"\
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
             -S "SSL - None of the common ciphersuites is usable" \
@@ -4954,8 +4954,8 @@ run_test    "PSK callback: raw psk on client, mismatching static raw PSK on serv
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4968,8 +4968,8 @@ run_test    "PSK callback: raw psk on client, mismatching static opaque PSK on s
             0 \
             -C "skip PMS generation for opaque PSK"\
             -s "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4981,8 +4981,8 @@ run_test    "PSK callback: raw psk on client, mismatching static opaque PSK on s
             psk_identity=def psk=beef" \
             0 \
             -C "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"
@@ -4994,8 +4994,8 @@ run_test    "PSK callback: raw psk on client, id-matching but wrong raw PSK on s
             psk_identity=def psk=beef" \
             0 \
             -C "skip PMS generation for opaque PSK"\
-            -C "session hash"\
-            -S "session hash"\
+            -C "session hash for extended master secret"\
+            -S "session hash for extended master secret"\
             -S "SSL - None of the common ciphersuites is usable" \
             -S "SSL - Unknown identity received" \
             -S "SSL - Verification of the message MAC failed"


### PR DESCRIPTION
This is a side-port to development of PR https://github.com/ARMmbed/mbedtls-restricted/pull/563 that has already been merged to baremetal.

The primary goal of the PR is to extract a new function `ssl_populate_transform()` from existing function `ssl_derive_key()`. Later (see "background" below") this new function can be used to restore a tranform from serialised info (master secret, hello randoms, plus administrative data). In order to facilitate that future use, the function uses explicit arguments rather than accessing everything implicitly through the SSL context.

Along the way, the PR attempts small cleanups of related code, mostly along the lines of dividing stuff in smaller functions and trying to make it clear what parts of the (huge) SSL state are used or not by a particular function. However, as this is only a secondary goal, this is not pursued as far as it could be, in particular the final `ssl_populate_tranform()` a still a bit longer and more complex than desirable for a single function.

## Background

This is the first in a series of seven PRs implementing serialization of a full SSL context (not just the session), under some restrictions.

The five PRs in the series are:
 
1. [r563](https://github.com/ARMmbed/mbedtls-restricted/pull/563) -> #2764 Refactor derive keys __(this PR)__
2. [r568](https://github.com/ARMmbed/mbedtls-restricted/pull/568) -> #2766 Make session serialisation functions public
3. [r570](https://github.com/ARMmbed/mbedtls-restricted/pull/570) -> #2785 Make session format ABI-independent
4. [r567](https://github.com/ARMmbed/mbedtls-restricted/pull/567) -> #2788 Add version + config check to SSL tickets
5. [r572](https://github.com/ARMmbed/mbedtls-restricted/pull/572) -> #2789 Context serialisation: API and documentation
6. [r575](https://github.com/ARMmbed/mbedtls-restricted/pull/575) -> #2791 Serialization test
7. [r616](https://github.com/ARMmbed/mbedtls-restricted/pull/616) -> #2792 Implement context serialization

The full series is already merged in baremetal. It needs upstreaming for the benefit of the Could team, who will be the main user, and relies on upstream releases.

## Side-porting details

Side-porting was not trivial there were a number of conflicts due to PSA work in that part of the code. Also, some commits move code around, which git merge algorithm is unable to understand - when that's the case, the commit has been reconstructed manually to avoid accidentally reverting changes in the code that's moved.

The table shows how each side-ported commit was handled:

- (nothing) cherry-picking worked without conflict
- "r" manual rework after cherry-picking
- "R" the commit was reconstructed manually
- "-" the commit was removed, as it no longer made sense
- "+" this commit was added to work around a bug in an new API in development

| resolution | original commit | commit message |
|---| ---          | --- |
| r | 5ed5e90ec48e | Start splitting populate_transform() out of derive_keys() |
|   | 52aa520c9631 | Start extraction ssl_set_handshake_prfs() |
|   | aa3c7011934f | Fix signature of ssl_set_transform_prfs() |
| R | 7edd5876ceae | Start extracting ssl_compute_master() |
| R | dafe5227d444 | Reduce indentation in ssl_compute_master() |
| R | c28c8895e584 | Improve signature of ssl_compute_master() |
|   | ed3b7a949254 | Constify ssl_context param of calc_verify() |
| r | a575975280bc | Make calc_verify() return the length as well |
| - | bcf258e07731 | Remove duplicated branch in ssl_compute_master() |
| r | 707728dfca9f | Move handling of randbytes to derive_keys() |
| r | a1abb2609470 | Move compress_buf allocation to derive_keys |
| r | 12a3f445b6f2 | Start refining parameters of populate_transform() |
| + | [NEW]        | Work around bug in key exporter API |
| r | 0bcfbc3e04eb | Remove "handshake" input from populate_transform() |
|   | 1d10a98f56c7 | Partially rm 'ssl' input from populate_transform() |
|   | 86e48c213c89 | Enforce promise to not use whole ssl context |
|   | cf31216ace92 | Fix typo in comment |
| r | 84ef8bde6847 | Remove 'session' input from populate_tranform() |
| r | 5478e1e5ede5 | Remove redundant debug message. |
|   | 42c814fdc12f | Clarify comment about TLS versions |
|   | 762d011ece6d | Fix alignment issues |
| r | 9c5bcc9220cf | Use more specific name in debug message for testing |

## Review notes

Reviewers are strongly encouraged to review commit by commit, as the final diff is unlikely to make sense. Due to the amount of conflicts, doing the side-port yourself may not be the simplest review strategy; you might consider reviewing each commit here and checking the original commit to see if they do the same things.

