### PR TITLE
Update to PSA 1.0 beta 3

### DIFF
--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3315,9 +3315,9 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         ssl->handshake->pmslen =
             MBEDTLS_PSA_ECC_KEY_BYTES_OF_CURVE( handshake->ecdh_psa_curve );
 
-        status = psa_generator_read( &generator,
-                                     ssl->handshake->premaster,
-                                     ssl->handshake->pmslen );
+        status = psa_key_derivation_output_bytes( &generator,
+                                                  ssl->handshake->premaster,
+                                                  ssl->handshake->pmslen );
         if( status != PSA_SUCCESS )
         {
             psa_generator_abort( &generator );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3301,11 +3301,12 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         content_len = own_pubkey_ecpoint_len + 1;
 
         /* Compute ECDH shared secret. */
-        status = psa_key_agreement( &generator,
-                                    handshake->ecdh_psa_privkey,
-                                    handshake->ecdh_psa_peerkey,
-                                    handshake->ecdh_psa_peerkey_len,
-                                    PSA_ALG_ECDH( PSA_ALG_SELECT_RAW ) );
+        status = psa_key_derivation_key_agreement(
+                &generator,
+                handshake->ecdh_psa_privkey,
+                handshake->ecdh_psa_peerkey,
+                handshake->ecdh_psa_peerkey_len,
+                PSA_ALG_ECDH( PSA_ALG_SELECT_RAW ) );
         if( status != PSA_SUCCESS )
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3271,7 +3271,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
 
         /* Generate ECDH private key. */
         status = psa_generate_key( handshake->ecdh_psa_privkey,
-                          PSA_KEY_TYPE_ECC_KEYPAIR( handshake->ecdh_psa_curve ),
+                          PSA_KEY_TYPE_ECC_KEY_PAIR( handshake->ecdh_psa_curve ),
                           MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE( handshake->ecdh_psa_curve ),
                           NULL, 0 );
         if( status != PSA_SUCCESS )

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3229,7 +3229,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
     {
         psa_status_t status;
-        psa_key_attributes_t attributes;
+        psa_key_attributes_t key_attributes;
 
         mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
@@ -3262,18 +3262,19 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
          * yet support the provisioning of salt + label to the KDF.
          * For the time being, we therefore need to split the computation
          * of the ECDH secret and the application of the TLS 1.2 PRF. */
-        attributes = psa_key_attributes_init();
-        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
-        psa_set_key_algorithm( &attributes,
+        key_attributes = psa_key_attributes_init();
+        psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );
+        psa_set_key_algorithm( &key_attributes,
                                PSA_ALG_ECDH( PSA_ALG_SELECT_RAW ) );
-        psa_set_key_type( &attributes,
+        psa_set_key_type( &key_attributes,
                           PSA_KEY_TYPE_ECC_KEY_PAIR( handshake->ecdh_psa_curve )
                         );
         psa_set_key_bits( &key_attributes,
                           PSA_ECC_CURVE_BITS( handshake->ecdh_psa_curve ) );
 
         /* Generate ECDH private key. */
-        status = psa_generate_key( &attributes, handshake->ecdh_psa_privkey );
+        status = psa_generate_key( &key_attributes,
+                                   handshake->ecdh_psa_privkey );
         if( status != PSA_SUCCESS )
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3249,12 +3249,6 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
          * Generate EC private key for ECDHE exchange.
          */
 
-        /* Allocate a new key slot for the private key. */
-
-        status = psa_allocate_key( &handshake->ecdh_psa_privkey );
-        if( status != PSA_SUCCESS )
-            return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-
         /* The master secret is obtained from the shared ECDH secret by
          * applying the TLS 1.2 PRF with a specific salt and label. While
          * the PSA Crypto API encourages combining key agreement schemes

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3238,7 +3238,8 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         unsigned char *own_pubkey_ecpoint;
         size_t own_pubkey_ecpoint_len;
 
-        psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
+        psa_key_derivation_operation_t generator =
+            PSA_KEY_DERIVATION_OPERATION_INIT;
 
         header_len = 4;
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3320,11 +3320,11 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
                                                   ssl->handshake->pmslen );
         if( status != PSA_SUCCESS )
         {
-            psa_generator_abort( &generator );
+            psa_key_derivation_abort( &generator );
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
         }
 
-        status = psa_generator_abort( &generator );
+        status = psa_key_derivation_abort( &generator );
         if( status != PSA_SUCCESS )
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -632,7 +632,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     psa_algorithm_t alg;
     psa_key_policy_t policy;
     psa_key_handle_t master_slot;
-    psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
+    psa_crypto_generator_t generator = PSA_KEY_DERIVATION_OPERATION_INIT;
 
     if( ( status = psa_allocate_key( &master_slot ) ) != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
@@ -1108,7 +1108,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
             /* Perform PSK-to-MS expansion in a single step. */
             psa_status_t status;
             psa_algorithm_t alg;
-            psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
+            psa_crypto_generator_t generator = PSA_KEY_DERIVATION_OPERATION_INIT;
             psa_key_handle_t psk;
 
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "perform PSA-based PSK-to-MS expansion" ) );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -632,7 +632,8 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     psa_algorithm_t alg;
     psa_key_policy_t policy;
     psa_key_handle_t master_slot;
-    psa_crypto_generator_t generator = PSA_KEY_DERIVATION_OPERATION_INIT;
+    psa_key_derivation_operation_t generator =
+        PSA_KEY_DERIVATION_OPERATION_INIT;
 
     if( ( status = psa_allocate_key( &master_slot ) ) != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
@@ -1108,8 +1109,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
             /* Perform PSK-to-MS expansion in a single step. */
             psa_status_t status;
             psa_algorithm_t alg;
-            psa_crypto_generator_t generator = PSA_KEY_DERIVATION_OPERATION_INIT;
             psa_key_handle_t psk;
+            psa_key_derivation_operation_t generator =
+                PSA_KEY_DERIVATION_OPERATION_INIT;
 
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "perform PSA-based PSK-to-MS expansion" ) );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -630,7 +630,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
 {
     psa_status_t status;
     psa_algorithm_t alg;
-    psa_key_policy_t policy;
+    psa_key_attributes_t attributes;
     psa_key_handle_t master_slot;
     psa_key_derivation_operation_t generator =
         PSA_KEY_DERIVATION_OPERATION_INIT;
@@ -643,15 +643,12 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     else
         alg = PSA_ALG_TLS12_PRF(PSA_ALG_SHA_256);
 
-    policy = psa_key_policy_init();
-    psa_key_policy_set_usage( &policy,
-                              PSA_KEY_USAGE_DERIVE,
-                              alg );
-    status = psa_set_key_policy( master_slot, &policy );
-    if( status != PSA_SUCCESS )
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
+    attributes = psa_key_attributes_init();
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
+    psa_set_key_algorithm( &attributes, alg );
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
 
-    status = psa_import_key( master_slot, PSA_KEY_TYPE_DERIVE, secret, slen );
+    status = psa_import_key( &attributes, secret, slen, &master_slot );
     if( status != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -630,7 +630,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
 {
     psa_status_t status;
     psa_algorithm_t alg;
-    psa_key_attributes_t attributes;
+    psa_key_attributes_t key_attributes;
     psa_key_handle_t master_slot;
     psa_key_derivation_operation_t generator =
         PSA_KEY_DERIVATION_OPERATION_INIT;
@@ -643,12 +643,12 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     else
         alg = PSA_ALG_TLS12_PRF(PSA_ALG_SHA_256);
 
-    attributes = psa_key_attributes_init();
-    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
-    psa_set_key_algorithm( &attributes, alg );
-    psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
+    key_attributes = psa_key_attributes_init();
+    psa_set_key_usage_flags( &key_attributes, PSA_KEY_USAGE_DERIVE );
+    psa_set_key_algorithm( &key_attributes, alg );
+    psa_set_key_type( &key_attributes, PSA_KEY_TYPE_DERIVE );
 
-    status = psa_import_key( &attributes, secret, slen, &master_slot );
+    status = psa_import_key( &key_attributes, secret, slen, &master_slot );
     if( status != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -635,9 +635,6 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     psa_key_derivation_operation_t generator =
         PSA_KEY_DERIVATION_OPERATION_INIT;
 
-    if( ( status = psa_allocate_key( &master_slot ) ) != PSA_SUCCESS )
-        return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
-
     if( md_type == MBEDTLS_MD_SHA384 )
         alg = PSA_ALG_TLS12_PRF(PSA_ALG_SHA_384);
     else

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -668,7 +668,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     }
 
-    status = psa_generator_read( &generator, dstbuf, dlen );
+    status = psa_key_derivation_output_bytes( &generator, dstbuf, dlen );
     if( status != PSA_SUCCESS )
     {
         psa_generator_abort( &generator );
@@ -1135,8 +1135,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                 return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
             }
 
-            status = psa_generator_read( &generator, session->master,
-                                         master_secret_len );
+            status = psa_key_derivation_output_bytes( &generator,
+                                                      session->master,
+                                                      master_secret_len );
             if( status != PSA_SUCCESS )
             {
                 psa_generator_abort( &generator );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -663,7 +663,7 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
                                  dlen );
     if( status != PSA_SUCCESS )
     {
-        psa_generator_abort( &generator );
+        psa_key_derivation_abort( &generator );
         psa_destroy_key( master_slot );
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     }
@@ -671,12 +671,12 @@ static int tls_prf_generic( mbedtls_md_type_t md_type,
     status = psa_key_derivation_output_bytes( &generator, dstbuf, dlen );
     if( status != PSA_SUCCESS )
     {
-        psa_generator_abort( &generator );
+        psa_key_derivation_abort( &generator );
         psa_destroy_key( master_slot );
         return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
     }
 
-    status = psa_generator_abort( &generator );
+    status = psa_key_derivation_abort( &generator );
     if( status != PSA_SUCCESS )
     {
         psa_destroy_key( master_slot );
@@ -1131,7 +1131,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                                          master_secret_len );
             if( status != PSA_SUCCESS )
             {
-                psa_generator_abort( &generator );
+                psa_key_derivation_abort( &generator );
                 return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
             }
 
@@ -1140,11 +1140,11 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                                                       master_secret_len );
             if( status != PSA_SUCCESS )
             {
-                psa_generator_abort( &generator );
+                psa_key_derivation_abort( &generator );
                 return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
             }
 
-            status = psa_generator_abort( &generator );
+            status = psa_key_derivation_abort( &generator );
             if( status != PSA_SUCCESS )
                 return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
         }

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -238,6 +238,7 @@
     <ClCompile Include="..\..\crypto\library\platform_util.c" />
     <ClCompile Include="..\..\crypto\library\poly1305.c" />
     <ClCompile Include="..\..\crypto\library\psa_crypto.c" />
+    <ClCompile Include="..\..\crypto\library\psa_crypto_se.c" />
     <ClCompile Include="..\..\crypto\library\psa_crypto_slot_management.c" />
     <ClCompile Include="..\..\crypto\library\psa_crypto_storage.c" />
     <ClCompile Include="..\..\crypto\library\psa_its_file.c" />


### PR DESCRIPTION
## Description

This PR updates PSA API as used by Mbed TLS to version 1.0 beta 3. The only exception to this is the multipart key derivation API, which for now is turned off in Mbed Crypto as default.

(See https://armmbed.github.io/mbed-crypto/html/index.html in section Document History.)

Prerequisites:
- https://github.com/ARMmbed/mbed-crypto/pull/212

After the prerequisite has been merged, this PR still needs updating the submodule. I would like to rebase to have 1 commit updating the submodule, instead of 3.

## Status
**READY**

## Requires Backporting
 NO  

## Migrations
 NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Changelog updated
- [ ] Submodule updated
