### PR TITLE
Fix the license header of hkdf

### DIFF
--- a/include/mbedtls/hkdf.h
+++ b/include/mbedtls/hkdf.h
@@ -7,22 +7,22 @@
  *          specified by RFC 5869.
  */
 /*
- * Copyright (C) 2016-2018, ARM Limited, All Rights Reserved
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright (C) 2016-2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
- * This file is part of mbed TLS (https://tls.mbed.org)
+ *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 #ifndef MBEDTLS_HKDF_H
 #define MBEDTLS_HKDF_H


### PR DESCRIPTION
## Description
Change the license header of `hkdf.h` to a format the that script
`apache_to_gpl.pl` knows how to parse.


## Status
**READY**

## Requires Backporting

Yes 
`mbedtls-2.16`

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


