### PR TITLE
Backport 2.16: Changelog entry for test certificates update

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Bugfix
    * Enable Suite B with subset of ECP curves. Make sure the code compiles even
      if some curves are not defined. Fixes #1591 reported by dbedev.
    * Fix misuse of signed arithmetic in the HAVEGE module. #2598
+   * Update test certificates that were about to expire. Reported by
+     Bernhard M. Wiedemann in #2357.
 
 Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h


### PR DESCRIPTION
Add changelog entry for #2419 to acknowledge #2357. Backport of #2773.