### PR TITLE
bn_mul.h: require at least ARMv6 to enable the ARM DSP code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,9 @@ Bugfix
      This previously limited the maximum size of DER encoded certificates
      in mbedtls_x509write_crt_der() to 2Kb. Reported by soccerGB in #2631.
    * Fix partial zeroing in x509_get_other_name. Found and fixed by ekse, #2716.
+   * Fix the build on ARMv5TE in ARM mode to not use assembly instructions
+     that are only available in Thumb mode. Fix contributed by Aurelien Jarno
+     in #2169.
 
 API Changes
    * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -642,7 +642,8 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif (__ARM_ARCH >= 6) && \
+    defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 
 #define MULADDC_INIT                            \
     asm(

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1088,9 +1088,14 @@ component_build_arm_none_eabi_gcc () {
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
 }
 
-component_build_arm_none_eabi_gcc_armel () {
+component_build_arm_none_eabi_gcc_arm5vte () {
     msg "build: arm-none-eabi-gcc -march=arm5vte, make" # ~ 10s
     scripts/config.pl baremetal
+    # Build for a target platform that's close to what Debian uses
+    # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
+    # See https://github.com/ARMmbed/mbedtls/pull/2169 and comments.
+    # It would be better to build with arm-linux-gnueabi-gcc but
+    # we don't have that on our CI at this time.
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1088,6 +1088,12 @@ component_build_arm_none_eabi_gcc () {
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
 }
 
+component_build_arm_none_eabi_gcc_armel () {
+    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    scripts/config.pl baremetal
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+}
+
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1089,9 +1089,9 @@ component_build_arm_none_eabi_gcc () {
 }
 
 component_build_arm_none_eabi_gcc_armel () {
-    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    msg "build: arm-none-eabi-gcc -march=arm5vte, make" # ~ 10s
     scripts/config.pl baremetal
-    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 }
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {


### PR DESCRIPTION
Fix the build on ARMv5TE in ARM mode. The assembly code in `bn_mul.h` uses DSP instructions that are not available on this particular architecture, so set the conditional compilation directives to exclude them.

Fix originally contributed in #2169 by @aurel32. I rebased to current development to facilitate testing and added a changelog entry and a non-regression test.

Needs backport to 2.16: #2778. The offending code is not present in 2.7.
