### PR TITLE
Backport 2.16: bn_mul.h: require at least ARMv6 to enable the ARM DSP code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ Bugfix
    * Enable Suite B with subset of ECP curves. Make sure the code compiles even
      if some curves are not defined. Fixes #1591 reported by dbedev.
    * Fix misuse of signed arithmetic in the HAVEGE module. #2598
+   * Fix the build on ARMv5TE in ARM mode to not use assembly instructions
+     that are only available in Thumb mode. Fix contributed by Aurelien Jarno
+     in #2169.
 
 Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -642,7 +642,8 @@
            "r6", "r7", "r8", "r9", "cc"         \
          );
 
-#elif defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
+#elif (__ARM_ARCH >= 6) && \
+    defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)
 
 #define MULADDC_INIT                            \
     asm(

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1081,9 +1081,9 @@ component_build_arm_none_eabi_gcc () {
 }
 
 component_build_arm_none_eabi_gcc_armel () {
-    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    msg "build: arm-none-eabi-gcc -march=arm5vte, make" # ~ 10s
     scripts/config.pl baremetal
-    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 }
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1080,6 +1080,12 @@ component_build_arm_none_eabi_gcc () {
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
 }
 
+component_build_arm_none_eabi_gcc_armel () {
+    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    scripts/config.pl baremetal
+    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+}
+
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1080,9 +1080,14 @@ component_build_arm_none_eabi_gcc () {
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
 }
 
-component_build_arm_none_eabi_gcc_armel () {
+component_build_arm_none_eabi_gcc_arm5vte () {
     msg "build: arm-none-eabi-gcc -march=arm5vte, make" # ~ 10s
     scripts/config.pl baremetal
+    # Build for a target platform that's close to what Debian uses
+    # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
+    # See https://github.com/ARMmbed/mbedtls/pull/2169 and comments.
+    # It would be better to build with arm-linux-gnueabi-gcc but
+    # we don't have that on our CI at this time.
     make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 }
 


### PR DESCRIPTION
Fix the build on ARMv5TE in ARM mode. The assembly code in `bn_mul.h` uses DSP instructions that are not available on this particular architecture, so set the conditional compilation directives to exclude them.

Fix originally contributed in #2169 by @aurel32. I rebased to mbedtls-2.16 to facilitate testing and added a changelog entry and a non-regression test.