### PR TITLE
Backport 2.16: Don't exclude DTLS1.2 in OpenSSL

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -216,14 +216,13 @@ filter_ciphersuites()
         G_CIPHERS=$( filter "$G_CIPHERS" )
     fi
 
-    # OpenSSL 1.0.1h doesn't support DTLS 1.2
-    if [ `minor_ver "$MODE"` -ge 3 ] && is_dtls "$MODE"; then
+    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check what OpenSSL
+    # supports from the s_server help. (The s_client help isn't
+    # accurate as of 1.0.2g: it supports DTLS 1.2 but doesn't list it.
+    # But the s_server help seems to be accurate.)
+    if ! $OPENSSL_CMD s_server -help 2>&1 | grep -q "^ *-$MODE "; then
+        M_CIPHERS=""
         O_CIPHERS=""
-        case "$PEER" in
-            [Oo]pen*)
-                M_CIPHERS=""
-                ;;
-        esac
     fi
 
     # For GnuTLS client -> mbed TLS server,


### PR DESCRIPTION
Exclude DTLS 1.2 only with older OpenSSL. Backport of #2779.