### PR TITLE
Backport 2.16: Check for zero length and NULL buffer pointer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ Bugfix
    * Fix propagation of restart contexts in restartable EC operations.
      This could previously lead to segmentation faults in builds using an
      address-sanitizer and enabling but not using MBEDTLS_ECP_RESTARTABLE.
+   * Zero length buffer check for undefined behavior in
+     mbedtls_platform_zeroize(). Fixes ARMmbed/mbed-crypto#49.
 
 Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -72,7 +72,10 @@ static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
 
 void mbedtls_platform_zeroize( void *buf, size_t len )
 {
-    memset_func( buf, 0, len );
+    MBEDTLS_INTERNAL_VALIDATE( len == 0 || buf != NULL );
+
+    if( len > 0 )
+        memset_func( buf, 0, len );
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 


### PR DESCRIPTION
In reference to issue https://github.com/ARMmbed/mbed-crypto/issues/49

Straight forward backport of https://github.com/ARMmbed/mbed-crypto/pull/222

