### PR TITLE
Backport 2.7: Check for zero length and NULL buffer pointer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Bugfix
    * Update test certificates that were about to expire. Reported by
      Bernhard M. Wiedemann in #2357.
    * Make NV seed test support MBEDTLS_ENTROPY_FORCE_SHA256.
+   * Fix `mbedtls_zeroize()` to check for zero length.
 
 Changes
    * Make `make clean` clean all programs always. Fixes #1862.

--- a/library/aes.c
+++ b/library/aes.c
@@ -55,8 +55,15 @@
 #if !defined(MBEDTLS_AES_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -48,8 +48,15 @@
 #if !defined(MBEDTLS_ARC4_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx )

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -44,8 +44,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -64,8 +64,15 @@ static void mbedtls_mpi_zeroize( mbedtls_mpi_uint *v, size_t n ) {
 }
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #define ciL    (sizeof(mbedtls_mpi_uint))         /* chars in limb  */

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -40,8 +40,15 @@
 #if !defined(MBEDTLS_BLOWFISH_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -49,8 +49,15 @@
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -52,8 +52,15 @@
 #if !defined(MBEDTLS_CCM_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #define CCM_ENCRYPT 0

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -57,8 +57,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 static int supported_init = 0;

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -68,8 +68,15 @@
 #if !defined(MBEDTLS_CMAC_ALT) || defined(MBEDTLS_SELF_TEST)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -50,8 +50,15 @@
 #endif /* MBEDTLS_SELF_TEST */
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/des.c
+++ b/library/des.c
@@ -49,8 +49,15 @@
 #if !defined(MBEDTLS_DES_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -59,8 +59,15 @@
 
 #if !defined(MBEDTLS_DHM_ALT)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -73,8 +73,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -60,8 +60,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #define ENTROPY_MAX_LOOP    256     /**< Maximum amount to loop before error */

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -81,8 +81,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/havege.c
+++ b/library/havege.c
@@ -51,8 +51,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /* ------------------------------------------------------------------------

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -51,8 +51,15 @@
 #endif /* MBEDTLS_PLATFORM_C */
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/md.c
+++ b/library/md.c
@@ -49,8 +49,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/md2.c
+++ b/library/md2.c
@@ -49,8 +49,15 @@
 #if !defined(MBEDTLS_MD2_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 static const unsigned char PI_SUBST[256] =

--- a/library/md4.c
+++ b/library/md4.c
@@ -49,8 +49,15 @@
 #if !defined(MBEDTLS_MD4_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/md5.c
+++ b/library/md5.c
@@ -48,8 +48,15 @@
 #if !defined(MBEDTLS_MD5_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -43,8 +43,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #define MAGIC1       0xFF00AA55

--- a/library/pem.c
+++ b/library/pem.c
@@ -46,8 +46,15 @@
 
 #if defined(MBEDTLS_PEM_PARSE_C)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 void mbedtls_pem_init( mbedtls_pem_context *ctx )

--- a/library/pk.c
+++ b/library/pk.c
@@ -43,8 +43,15 @@
 #include <stdint.h>
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -54,8 +54,15 @@
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 #endif
 

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -48,8 +48,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #if defined(MBEDTLS_ASN1_PARSE_C)

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -63,8 +63,15 @@
 #if defined(MBEDTLS_FS_IO) || \
     defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 #endif
 

--- a/library/platform.c
+++ b/library/platform.c
@@ -32,8 +32,15 @@
 #if defined(MBEDTLS_ENTROPY_NV_SEED) && \
     !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS) && defined(MBEDTLS_FS_IO)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 #endif
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -72,8 +72,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx )

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -71,8 +71,15 @@
 #if !defined(MBEDTLS_RSA_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 #if defined(MBEDTLS_PKCS1_V15)

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -48,8 +48,15 @@
 #if !defined(MBEDTLS_SHA1_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -51,8 +51,15 @@
 #if !defined(MBEDTLS_SHA256_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -57,8 +57,15 @@
 #if !defined(MBEDTLS_SHA512_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -49,8 +49,15 @@
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 #endif
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -44,8 +44,15 @@
 #include <string.h>
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -51,8 +51,15 @@
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 #endif
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -40,8 +40,15 @@
 #include <string.h>
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -54,8 +54,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /* Length of the "epoch" field in the record header */

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -67,8 +67,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -76,8 +76,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -61,8 +61,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -45,8 +45,15 @@
 #endif /* MBEDTLS_PEM_WRITE_C */
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx )

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -44,8 +44,15 @@
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx )

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -43,8 +43,15 @@
 #if !defined(MBEDTLS_XTEA_ALT)
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 /*

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -74,8 +74,15 @@ int main( void )
 #else
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 int main( int argc, char *argv[] )

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -76,8 +76,15 @@ int main( void )
 #else
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+static void mbedtls_zeroize( void *v, size_t n )
+{
+    if( n > 0 )
+    {
+        volatile unsigned char *p = (unsigned char*)v;
+
+        while( n-- )
+            *p++ = 0;
+    }
 }
 
 int main( int argc, char *argv[] )


### PR DESCRIPTION
In reference to issue https://github.com/ARMmbed/mbed-crypto/issues/49

Backport of https://github.com/ARMmbed/mbed-crypto/pull/222