### PR TITLE
Backport [mbedtls-2.16] : Init function variable to avoid compiler warning

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2004,7 +2004,7 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                          void *p_rng,
                          mbedtls_ecp_restart_ctx *rs_ctx )
 {
-    int ret;
+    int ret = MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
     unsigned char w, p_eq_g, i;
     size_t d;
     unsigned char T_size, T_ok;


### PR DESCRIPTION
Issue : https://github.com/ARMmbed/mbedtls/issues/2340

https://github.com/ARMmbed/mbed-crypto/pull/228