### PR TITLE
Backport [mbedtls-2.7] : Init function variable to avoid compiler warning

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1353,7 +1353,7 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                          int (*f_rng)(void *, unsigned char *, size_t),
                          void *p_rng )
 {
-    int ret;
+    int ret = MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
     unsigned char w, m_is_odd, p_eq_g, pre_len, i;
     size_t d;
     unsigned char k[COMB_MAX_D + 1];


### PR DESCRIPTION
Issue : https://github.com/ARMmbed/mbedtls/issues/2340

https://github.com/ARMmbed/mbed-crypto/pull/228