### PR TITLE
Added mbedtls_net_close

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,10 @@ Features
      changed its IP or port. The feature is enabled at compile-time by setting
      MBEDTLS_SSL_DTLS_CONNECTION_ID (disabled by default), and at run-time
      through the new APIs mbedtls_ssl_conf_cid() and mbedtls_ssl_set_cid().
+   * Add mbedtls_net_close(), enabling the building of forking servers where
+     the parent process closes the client socket and continue accepting, and
+     the child process closes the listening socket and handles the client
+     socket. Contributed by Robert Larsen in #2803.
 
 API Changes
    * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -258,6 +258,13 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
                       uint32_t timeout );
 
 /**
+ * \brief          Closes down the connection and free associated data
+ *
+ * \param ctx      The context to close
+ */
+void mbedtls_net_close( mbedtls_net_context *ctx );
+
+/**
  * \brief          Gracefully shutdown the connection and free associated data
  *
  * \param ctx      The context to free

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -652,6 +652,19 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
 }
 
 /*
+ * Close the connection
+ */
+void mbedtls_net_close( mbedtls_net_context *ctx )
+{
+    if( ctx->fd == -1 )
+        return;
+
+    close( ctx->fd );
+
+    ctx->fd = -1;
+}
+
+/*
  * Gracefully close the connection
  */
 void mbedtls_net_free( mbedtls_net_context *ctx )

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -254,6 +254,7 @@ int main( void )
         if( pid != 0 )
         {
             mbedtls_printf( " ok\n" );
+            mbedtls_net_close( &client_fd );
 
             if( ( ret = mbedtls_ctr_drbg_reseed( &ctr_drbg,
                                          (const unsigned char *) "parent",
@@ -266,7 +267,7 @@ int main( void )
             continue;
         }
 
-        mbedtls_net_init( &listen_fd );
+        mbedtls_net_close( &listen_fd );
 
         pid = getpid();
 


### PR DESCRIPTION
When building a forking server the parent process should close the client socket and continue accepting, while the child process should close the listening socket and handle the client socket.

Overwriting the file descriptor does not close it, so `mbedtls_net_init` is not enough.
`mbedtls_net_shutdown` will close down the socket for writes which also affects the child process so this cannot be used either.

The forking server simply overwrites the socket file descriptor in userspace which does not disassociate the socket from the process as can be seen here:
```
$ ./ssl_fork_server >/dev/null &
[1] 25071
$ for i in {1..10}; do timeout .1 nc localhost 4433; done
$ ls -l /proc/$(pidof ssl_fork_server)/fd | grep socket
lrwx------ 1 user user 64 Aug 23 10:53 10 -> socket:[69247]
lrwx------ 1 user user 64 Aug 23 10:53 11 -> socket:[69248]
lrwx------ 1 user user 64 Aug 23 10:53 12 -> socket:[69249]
lrwx------ 1 user user 64 Aug 23 10:53 13 -> socket:[69250]
lrwx------ 1 user user 64 Aug 23 10:53 3 -> socket:[69233]
lrwx------ 1 user user 64 Aug 23 10:53 4 -> socket:[69234]
lrwx------ 1 user user 64 Aug 23 10:53 5 -> socket:[69240]
lrwx------ 1 user user 64 Aug 23 10:53 6 -> socket:[69241]
lrwx------ 1 user user 64 Aug 23 10:53 7 -> socket:[69243]
lrwx------ 1 user user 64 Aug 23 10:53 8 -> socket:[69244]
lrwx------ 1 user user 64 Aug 23 10:53 9 -> socket:[69245]
$
```
This is bad. When connecting the child process will inherit all these file descriptors and can thus communicate with all clients as if it was the server. All it takes is a RCE vulnerability and some socket finding shellcode.

After having applied this PR you get this result:
```
$ ./ssl_fork_server >/dev/null &
[1] 25192
$ for i in {1..10}; do timeout .1 nc localhost 4433; done
$ ls -l /proc/$(pidof ssl_fork_server)/fd | grep socket
lrwx------ 1 user user 64 Aug 23 10:54 3 -> socket:[71874]
$
```