### PR TITLE
Update with changes from the mbedtls-2.18 release branch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,34 +3,6 @@ mbed TLS ChangeLog (Sorted per branch, date)
 = mbed TLS x.x.x branch released xxxx-xx-xx
 
 Features
-   * Add the Any Policy certificate policy oid, as defined in
-     rfc 5280 section 4.2.1.4.
-   * It is now possible to use NIST key wrap mode via the mbedtls_cipher API.
-     Contributed by Jack Lloyd and Fortanix Inc.
-   * Add the Wi-SUN Field Area Network (FAN) device extended key usage.
-   * Add the oid certificate policy x509 extension.
-   * It is now possible to perform RSA PKCS v1.5 signatures with RIPEMD-160 digest.
-     Contributed by Jack Lloyd and Fortanix Inc.
-   * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,
-     and the used tls-prf.
-   * Add public API for tls-prf function, according to requested enum.
-   * Add support for parsing otherName entries in the Subject Alternative Name
-     X.509 certificate extension, specifically type hardware module name,
-     as defined in RFC 4108 section 5.
-   * Add support for parsing certificate policies extension, as defined in
-     RFC 5280 section 4.2.1.4. Currently, only the "Any Policy" policy is
-     supported.
-   * List all SAN types in the subject_alt_names field of the certificate.
-     Resolves #459.
-   * Add support for draft-05 of the Connection ID extension, as specified
-     in https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05.
-     The Connection ID extension allows to keep DTLS connections beyond the
-     lifetime of the underlying transport by adding a connection identifier
-     to the DTLS record header. This identifier can be used to associated an
-     incoming record with the correct connection data even after the peer has
-     changed its IP or port. The feature is enabled at compile-time by setting
-     MBEDTLS_SSL_DTLS_CONNECTION_ID (disabled by default), and at run-time
-     through the new APIs mbedtls_ssl_conf_cid() and mbedtls_ssl_set_cid().
    * Add new API functions mbedtls_ssl_session_save() and
      mbedtls_ssl_session_load() to allow serializing a session, for example to
      store it in non-volatile storage, and later using it for TLS session
@@ -42,40 +14,12 @@ Features
      option.
 
 API Changes
-   * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,
-     and the used tls-prf.
-   * Add public API for tls-prf function, according to requested enum.
    * Add DER-encoded test CRTs to library/certs.c, allowing
      the example programs ssl_server2 and ssl_client2 to be run
      if MBEDTLS_FS_IO and MBEDTLS_PEM_PARSE_C are unset. Fixes #2254.
    * The HAVEGE state type now uses uint32_t elements instead of int.
 
 Bugfix
-   * Fix private key DER output in the key_app_writer example. File contents
-     were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
-     Christian Walther in #2239.
-   * Fix potential memory leak in X.509 self test. Found and fixed by
-     Junhwan Park, #2106.
-   * Reduce stack usage of hkdf tests. Fixes #2195.
-   * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
-     used with negative inputs. Found by Guido Vranken in #2404. Credit to
-     OSS-Fuzz.
-   * Fix bugs in the AEAD test suite which would be exposed by ciphers which
-     either used both encrypt and decrypt key schedules, or which perform padding.
-     GCM and CCM were not affected. Fixed by Jack Lloyd.
-   * Fix incorrect default port number in ssl_mail_client example's usage.
-     Found and fixed by irwir. #2337
-   * Add psa_util.h to test/cpp_dummy_build to fix build_default_make_gcc_and_cxx.
-     Fixed by Peter Kolbus (Garmin). #2579
-   * Add missing parentheses around parameters in the definition of the
-     public macro MBEDTLS_X509_ID_FLAG. This could lead to invalid evaluation
-     in case operators binding less strongly than subtraction were used
-     for the parameter.
-   * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
-     sni entry parameter. Reported by inestlerode in #560.
-   * Set the next sequence of the subject_alt_name to NULL when deleting
-     sequence on failure. Found and fix suggested by Philippe Antoine.
-     Credit to OSS-Fuzz.
    * Fix missing bounds checks in X.509 parsing functions that could
      lead to successful parsing of ill-formed X.509 CRTs. Fixes #2437.
    * Fix multiple X.509 functions previously returning ASN.1 low-level error
@@ -105,22 +49,8 @@ Bugfix
    * Fix propagation of restart contexts in restartable EC operations.
      This could previously lead to segmentation faults in builds using an
      address-sanitizer and enabling but not using MBEDTLS_ECP_RESTARTABLE.
+
 Changes
-   * Server's RSA certificate in certs.c was SHA-1 signed. In the default
-     mbedTLS configuration only SHA-2 signed certificates are accepted.
-     This certificate is used in the demo server programs, which lead the
-     client programs to fail at the peer's certificate verification
-     due to an unacceptable hash signature. The certificate has been
-     updated to one that is SHA-256 signed. Fix contributed by
-     Illya Gerasymchuk.
-   * Return from various debugging routines immediately if the
-     provided SSL context is unset.
-   * Remove dead code from bignum.c in the default configuration.
-     Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
-   * Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh.
-     Contributed by Peter Kolbus (Garmin).
-   * Change wording in the `mbedtls_ssl_conf_max_frag_len()`'s documentation to
-     improve clarity. Fixes #2258.
    * Replace multiple uses of MD2 by SHA-256 in X.509 test suite. Fixes #821.
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h
      suggests). #2671
@@ -146,6 +76,97 @@ Changes
      cyber) in #2681.
    * Adds fuzz targets, especially for continuous fuzzing with OSS-Fuzz.
      Contributed by Philippe Antoine (Catena cyber).
+
+= mbed TLS 2.18.1 branch released 2019-07-12
+
+Bugfix
+   * Fix build failure when building with mingw on Windows by including
+     stdarg.h where needed. Fixes #2656.
+
+Changes
+   * Enable building of Mbed TLS as a CMake subproject. Suggested and fixed by
+     Ashley Duncan in #2609.
+
+= mbed TLS 2.18.0 branch released 2019-06-11
+
+Features
+   * Add the Any Policy certificate policy oid, as defined in
+     rfc 5280 section 4.2.1.4.
+   * It is now possible to use NIST key wrap mode via the mbedtls_cipher API.
+     Contributed by Jack Lloyd and Fortanix Inc.
+   * Add the Wi-SUN Field Area Network (FAN) device extended key usage.
+   * Add the oid certificate policy x509 extension.
+   * It is now possible to perform RSA PKCS v1.5 signatures with RIPEMD-160 digest.
+     Contributed by Jack Lloyd and Fortanix Inc.
+   * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,
+     and the used tls-prf.
+   * Add public API for tls-prf function, according to requested enum.
+   * Add support for parsing otherName entries in the Subject Alternative Name
+     X.509 certificate extension, specifically type hardware module name,
+     as defined in RFC 4108 section 5.
+   * Add support for parsing certificate policies extension, as defined in
+     RFC 5280 section 4.2.1.4. Currently, only the "Any Policy" policy is
+     supported.
+   * List all SAN types in the subject_alt_names field of the certificate.
+     Resolves #459.
+   * Add support for draft-05 of the Connection ID extension, as specified
+     in https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05.
+     The Connection ID extension allows to keep DTLS connections beyond the
+     lifetime of the underlying transport by adding a connection identifier
+     to the DTLS record header. This identifier can be used to associated an
+     incoming record with the correct connection data even after the peer has
+     changed its IP or port. The feature is enabled at compile-time by setting
+     MBEDTLS_SSL_DTLS_CONNECTION_ID (disabled by default), and at run-time
+     through the new APIs mbedtls_ssl_conf_cid() and mbedtls_ssl_set_cid().
+
+API Changes
+   * Extend the MBEDTLS_SSL_EXPORT_KEYS to export the handshake randbytes,
+     and the used tls-prf.
+   * Add public API for tls-prf function, according to requested enum.
+
+Bugfix
+   * Fix private key DER output in the key_app_writer example. File contents
+     were shifted by one byte, creating an invalid ASN.1 tag. Fixed by
+     Christian Walther in #2239.
+   * Fix potential memory leak in X.509 self test. Found and fixed by
+     Junhwan Park, #2106.
+   * Reduce stack usage of hkdf tests. Fixes #2195.
+   * Fix 1-byte buffer overflow in mbedtls_mpi_write_string() when
+     used with negative inputs. Found by Guido Vranken in #2404. Credit to
+     OSS-Fuzz.
+   * Fix bugs in the AEAD test suite which would be exposed by ciphers which
+     either used both encrypt and decrypt key schedules, or which perform padding.
+     GCM and CCM were not affected. Fixed by Jack Lloyd.
+   * Fix incorrect default port number in ssl_mail_client example's usage.
+     Found and fixed by irwir. #2337
+   * Add psa_util.h to test/cpp_dummy_build to fix build_default_make_gcc_and_cxx.
+     Fixed by Peter Kolbus (Garmin). #2579
+   * Add missing parentheses around parameters in the definition of the
+     public macro MBEDTLS_X509_ID_FLAG. This could lead to invalid evaluation
+     in case operators binding less strongly than subtraction were used
+     for the parameter.
+   * Add a check for MBEDTLS_X509_CRL_PARSE_C in ssl_server2, guarding the crl
+     sni entry parameter. Reported by inestlerode in #560.
+   * Set the next sequence of the subject_alt_name to NULL when deleting
+     sequence on failure. Found and fix suggested by Philippe Antoine.
+     Credit to OSS-Fuzz.
+
+Changes
+   * Server's RSA certificate in certs.c was SHA-1 signed. In the default
+     mbedTLS configuration only SHA-2 signed certificates are accepted.
+     This certificate is used in the demo server programs, which lead the
+     client programs to fail at the peer's certificate verification
+     due to an unacceptable hash signature. The certificate has been
+     updated to one that is SHA-256 signed. Fix contributed by
+     Illya Gerasymchuk.
+   * Return from various debugging routines immediately if the
+     provided SSL context is unset.
+   * Remove dead code from bignum.c in the default configuration.
+     Found by Coverity, reported and fixed by Peter Kolbus (Garmin). Fixes #2309.
+   * Add test for minimal value of MBEDTLS_MPI_WINDOW_SIZE to all.sh.
+     Contributed by Peter Kolbus (Garmin).
+   * Change wording in the `mbedtls_ssl_conf_max_frag_len()`'s documentation to
+     improve clarity. Fixes #2258.
 
 = mbed TLS 2.17.0 branch released 2019-03-19
 

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.17.0 source code documentation
+ * @mainpage mbed TLS v2.18.0 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.17.0"
+PROJECT_NAME           = "mbed TLS v2.18.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  17
+#define MBEDTLS_VERSION_MINOR  18
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02110000
-#define MBEDTLS_VERSION_STRING         "2.17.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.17.0"
+#define MBEDTLS_VERSION_NUMBER         0x02120000
+#define MBEDTLS_VERSION_STRING         "2.18.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.18.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -172,14 +172,14 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 if(USE_SHARED_MBEDTLS_LIBRARY)
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.17.0 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.18.0 SOVERSION 1)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.17.0 SOVERSION 12)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.18.0 SOVERSION 13)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${MBEDTLS_DIR}/include/

--- a/library/Makefile
+++ b/library/Makefile
@@ -35,8 +35,8 @@ LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
-SOEXT_TLS=so.12
-SOEXT_X509=so.0
+SOEXT_TLS=so.13
+SOEXT_X509=so.1
 SOEXT_CRYPTO=so.3
 
 # Set AR_DASH= (empty string) to use an ar implementation that does not accept

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.17.0"
+check_compiletime_version:"2.18.0"
 
 Check runtime library version
-check_runtime_version:"2.17.0"
+check_runtime_version:"2.18.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
Bring Mbed TLS 2.18.0 and 2.18.1 release changes back into the
development branch. We had branched to release 2.18.0 and 2.18.1 in
order to allow those releases to go out without having to block work on
the `development` branch.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- ~[ ] Documentation~
- [X] Changelog updated
- ~[ ] Backported~
