### PR TITLE
Make zeroize test independent of the zeroize.c size or structure

### DIFF
--- a/tests/scripts/test_zeroize.gdb
+++ b/tests/scripts/test_zeroize.gdb
@@ -43,7 +43,13 @@
 set confirm off
 
 file ./programs/test/zeroize
-break zeroize.c:100
+
+# Set breakpoint at the one line after the call to mbedtls_platform_zeroize()
+shell echo set \$zeroize_line = $(grep -n "mbedtls_platform_zeroize( buf, sizeof( buf ) )" ./programs/test/zeroize.c | cut -d: -f1) > zeroize_line.tmp
+source zeroize_line.tmp
+set $break_line = $zeroize_line + 1
+break zeroize.c:$break_line
+shell rm zeroize_line.tmp
 
 set args ./programs/test/zeroize.c
 run


### PR DESCRIPTION
The zeroization test is based on a scripted GDB run, which assumes
hard-coded line to break the execution for `mbedtls_platform_zeroize()` operation
evaluation.

The hardcoded break line has already had to be modified more than once
(due to changes made to `zeroize.c` program), surprising at least one of
the programmers. Therefore, this PR proposes inclusion of an automated
selection of the line for the said break point.