### PR TITLE
Backport 2.16: Fix uninitialized variable in x509_crt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,9 @@ Bugfix
    * Fix propagation of restart contexts in restartable EC operations.
      This could previously lead to segmentation faults in builds using an
      address-sanitizer and enabling but not using MBEDTLS_ECP_RESTARTABLE.
+   * Improve code clarity in x509_crt module, removing false-positive
+     uninitialized variable warnings on some recent toolchains (GCC8, etc).
+     Discovered and fixed by Andy Gross (Linaro), #2392.
 
 Changes
    * Make it easier to define MBEDTLS_PARAM_FAILED as assert (which config.h

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2087,15 +2087,13 @@ check_signature:
             continue;
         }
 
+        *r_parent = parent;
+        *r_signature_is_good = signature_is_good;
+
         break;
     }
 
-    if( parent != NULL )
-    {
-        *r_parent = parent;
-        *r_signature_is_good = signature_is_good;
-    }
-    else
+    if( parent == NULL )
     {
         *r_parent = fallback_parent;
         *r_signature_is_good = fallback_signature_is_good;


### PR DESCRIPTION
This patch fixes an issue we encountered with more stringent compiler
warnings.  The signature_is_good variable has a possibility of being
used uninitialized.  This patch moves the use of the variable to a
place where it cannot be used while uninitialized.

Signed-off-by: Andy Gross <andy.gross@linaro.org>

This is a backport to 2.16 of https://github.com/ARMmbed/mbedtls/pull/2795

Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
