### PR TITLE
ssl: Disallow modification of hello.random by export

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -970,7 +970,8 @@ struct mbedtls_ssl_config
      *  tls_prf and random bytes. Should replace f_export_keys    */
     int (*f_export_keys_ext)( void *, const unsigned char *,
                 const unsigned char *, size_t, size_t, size_t,
-                unsigned char[32], unsigned char[32], mbedtls_tls_prf_types );
+                const unsigned char[32], const unsigned char[32],
+                mbedtls_tls_prf_types );
     void *p_export_keys;            /*!< context for key export callback    */
 #endif
 
@@ -1925,8 +1926,8 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
                                            size_t maclen,
                                            size_t keylen,
                                            size_t ivlen,
-                                           unsigned char client_random[32],
-                                           unsigned char server_random[32],
+                                           const unsigned char client_random[32],
+                                           const unsigned char server_random[32],
                                            mbedtls_tls_prf_types tls_prf_type );
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1427,9 +1427,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                       master, keyblk,
                                       mac_key_len, keylen,
                                       iv_copy_len,
-                                      /* work around bug in exporter type */
-                                      (unsigned char *) randbytes + 32,
-                                      (unsigned char *) randbytes,
+                                      randbytes + 32,
+                                      randbytes,
                                       tls_prf_get_type( tls_prf ) );
     }
 #endif

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -526,8 +526,8 @@ static int eap_tls_key_derivation ( void *p_expkey,
                                     size_t maclen,
                                     size_t keylen,
                                     size_t ivlen,
-                                    unsigned char client_random[32],
-                                    unsigned char server_random[32],
+                                    const unsigned char client_random[32],
+                                    const unsigned char server_random[32],
                                     mbedtls_tls_prf_types tls_prf_type )
 {
     eap_tls_keys *keys = (eap_tls_keys *)p_expkey;
@@ -553,8 +553,8 @@ static int nss_keylog_export( void *p_expkey,
                               size_t maclen,
                               size_t keylen,
                               size_t ivlen,
-                              unsigned char client_random[32],
-                              unsigned char server_random[32],
+                              const unsigned char client_random[32],
+                              const unsigned char server_random[32],
                               mbedtls_tls_prf_types tls_prf_type )
 {
     char nss_keylog_line[ 200 ];

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -637,8 +637,8 @@ static int eap_tls_key_derivation ( void *p_expkey,
                                     size_t maclen,
                                     size_t keylen,
                                     size_t ivlen,
-                                    unsigned char client_random[32],
-                                    unsigned char server_random[32],
+                                    const unsigned char client_random[32],
+                                    const unsigned char server_random[32],
                                     mbedtls_tls_prf_types tls_prf_type )
 {
     eap_tls_keys *keys = (eap_tls_keys *)p_expkey;
@@ -664,8 +664,8 @@ static int nss_keylog_export( void *p_expkey,
                               size_t maclen,
                               size_t keylen,
                               size_t ivlen,
-                              unsigned char client_random[32],
-                              unsigned char server_random[32],
+                              const unsigned char client_random[32],
+                              const unsigned char server_random[32],
                               mbedtls_tls_prf_types tls_prf_type )
 {
     char nss_keylog_line[ 200 ];


### PR DESCRIPTION
Make client_random and server_random const in
mbedtls_ssl_export_keys_ext_t, so that the key exporter is discouraged
from modifying the client/server hello.

Fixes #2759

## Status
**READY**

## Requires Backporting
NO  


## Migrations
If there is any API change, what's the incentive and logic for it.
YES - but not for any released versions. We want to update the API to something sane before this API is released for the first time.