### PR TITLE
Add lower bound check to function index lookup

### DIFF
--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -387,7 +387,7 @@ int execute_tests( int argc , const char ** argv )
     const char **test_files = NULL;
     int testfile_count = 0;
     int option_verbose = 0;
-    int function_id = 0;
+    size_t function_id = 0;
 
     /* Other Local variables */
     int arg_index = 1;
@@ -564,7 +564,7 @@ int execute_tests( int argc , const char ** argv )
                 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
-                function_id = strtol( params[0], NULL, 10 );
+                function_id = strtoul( params[0], NULL, 10 );
                 if ( (ret = check_test( function_id )) == DISPATCH_TEST_SUCCESS )
                 {
                     ret = convert_params( cnt - 1, params + 1, int_params );

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -177,7 +177,7 @@ void execute_function_ptr(TestWrapper_t fp, void **params)
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
  *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
  */
-int dispatch_test( int func_idx, void ** params )
+int dispatch_test( size_t func_idx, void ** params )
 {
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;
@@ -208,7 +208,7 @@ int dispatch_test( int func_idx, void ** params )
  *               DISPATCH_TEST_FN_NOT_FOUND if not found
  *               DISPATCH_UNSUPPORTED_SUITE if not compile time enabled.
  */
-int check_test( int func_idx )
+int check_test( size_t func_idx )
 {
     int ret = DISPATCH_TEST_SUCCESS;
     TestWrapper_t fp = NULL;


### PR DESCRIPTION
The common test suites code looks up the test function in an array via an index obtained from the input data. The index's upper bound has already been checked, but as a signed type it could have been negative, which was not tested for.

The PR adds the missing lower bound check.

[edited by mpg] Backport to 2.16: #3207 - no backport needed for 2.7 as the test code is different so this is not applicable.