### PR TITLE
Improve clarity of a memory operation call

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6802,7 +6802,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( peer_crt->raw.len != crt_buf_len )
         return( -1 );
 
-    return( memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
+    return( memcmp( peer_crt->raw.p, crt_buf, peer_crt->raw.len ) );
 }
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,


### PR DESCRIPTION
One of `memcmp` calls may not be clearly valid due to the value used as the size argument. This PR choses another variable for that purpose. This happens right after an equality test, which guarantees that the code is effective equivalent after the change.

However, the new `memcmp` call no longer uses a value derived from external input.