### PR TITLE
crypto: Update submodule to 3f20efc03016

### DIFF
--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -222,7 +222,6 @@
     <ClCompile Include="..\..\crypto\library\md2.c" />
     <ClCompile Include="..\..\crypto\library\md4.c" />
     <ClCompile Include="..\..\crypto\library\md5.c" />
-    <ClCompile Include="..\..\crypto\library\md_wrap.c" />
     <ClCompile Include="..\..\crypto\library\memory_buffer_alloc.c" />
     <ClCompile Include="..\..\crypto\library\nist_kw.c" />
     <ClCompile Include="..\..\crypto\library\oid.c" />


### PR DESCRIPTION
This brings in the removal of md_wrap.c and regenerates the generated
files to accommodate the change.

Note that this will fix the Mbed Crypto PR job's TLS testing.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Todos
- [ ] Tests
- ~[ ] Documentation~
- ~[ ] Changelog updated~
- ~[ ] Backported~
