### PR TITLE
Bump Mbed TLS version to 2.19.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.19.1 branch released 2019-09-16
+
+Features
+   * Add nss_keylog to ssl_client2 and ssl_server2, enabling easier analysis of
+     TLS sessions with tools like Wireshark.
+
+API Changes
+   * Make client_random and server_random const in
+     mbedtls_ssl_export_keys_ext_t, so that the key exporter is discouraged
+     from modifying the client/server hello.
+
 = mbed TLS 2.19.0 branch released 2019-09-06
 
 Security

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.19.0 source code documentation
+ * @mainpage mbed TLS v2.19.1 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.19.0"
+PROJECT_NAME           = "mbed TLS v2.19.1"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -40,16 +40,16 @@
  */
 #define MBEDTLS_VERSION_MAJOR  2
 #define MBEDTLS_VERSION_MINOR  19
-#define MBEDTLS_VERSION_PATCH  0
+#define MBEDTLS_VERSION_PATCH  1
 
 /**
  * The single version number has the following structure:
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02130000
-#define MBEDTLS_VERSION_STRING         "2.19.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.19.0"
+#define MBEDTLS_VERSION_NUMBER         0x02130100
+#define MBEDTLS_VERSION_STRING         "2.19.1"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.19.1"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -174,14 +174,14 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 if(USE_SHARED_MBEDTLS_LIBRARY)
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.19.0 SOVERSION 1)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.19.1 SOVERSION 1)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.19.0 SOVERSION 13)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.19.1 SOVERSION 13)
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${MBEDTLS_DIR}/include/

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.19.0"
+check_compiletime_version:"2.19.1"
 
 Check runtime library version
-check_runtime_version:"2.19.0"
+check_runtime_version:"2.19.1"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
## Description

Update ChangeLog and version number for 2.19.1, which includes a late-breaking API change.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Todos
- ~[ ] Tests~
- ~[ ] Documentation~
- [X] Changelog updated
- ~[ ] Backported~