### PR TITLE
[baremetal] Inline PK functions

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -260,10 +260,6 @@ MBEDTLS_PK_INLINABLE_API mbedtls_pk_handle_t mbedtls_pk_info_from_type(
  */
 MBEDTLS_PK_INLINABLE_API void mbedtls_pk_init( mbedtls_pk_context *ctx );
 
-// Work in progress: further functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Free the components of a #mbedtls_pk_context.
  *
@@ -289,6 +285,10 @@ void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
  */
 void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
+// Work in progress: further functions not inlinable so far
+#undef MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API
 
 /**
  * \brief           Initialize a PK context with the information given
@@ -630,6 +630,15 @@ static inline void mbedtls_pk_init( mbedtls_pk_context *ctx )
 
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
 }
+
+static inline void mbedtls_pk_free( mbedtls_pk_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
+}
+
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 
 #if defined(MBEDTLS_PK_PARSE_C)

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -615,10 +615,6 @@ MBEDTLS_PK_INLINABLE_API int mbedtls_pk_check_pair(
 MBEDTLS_PK_INLINABLE_API int mbedtls_pk_debug(
         const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
 
-// Work in progress: following functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Access the type name
  *
@@ -706,6 +702,26 @@ MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_debug_internal(
 
     return( mbedtls_pk_info_debug_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx, items ) );
 }
+
+/* Access the PK type name */
+MBEDTLS_ALWAYS_INLINE static inline const char *mbedtls_pk_get_name_internal(
+        const mbedtls_pk_context *ctx )
+{
+    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
+        return( "invalid PK" );
+
+    return( mbedtls_pk_info_name( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+}
+
+/* Access the PK type */
+MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t mbedtls_pk_get_type_internal(
+        const mbedtls_pk_context *ctx )
+{
+    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
+        return( MBEDTLS_PK_NONE );
+
+    return( mbedtls_pk_info_type( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+}
 /*
  * Definitions of inline API functions
  */
@@ -766,6 +782,16 @@ static inline int mbedtls_pk_check_pair( const mbedtls_pk_context *pub,
 static inline int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
 {
     return( mbedtls_pk_debug_internal( ctx, items ) );
+}
+
+static inline const char *mbedtls_pk_get_name( const mbedtls_pk_context *ctx )
+{
+    return( mbedtls_pk_get_name_internal( ctx ) );
+}
+
+static inline mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx )
+{
+    return( mbedtls_pk_get_type_internal( ctx ) );
 }
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -49,9 +49,7 @@
 #include "tinycrypt/ecc.h"
 #endif
 
-#if defined(MBEDTLS_PK_SINGLE_TYPE)
-#include "pk_internal.h"
-#endif
+/* pk_internal included later as is depends on some types defined below */
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)
@@ -156,6 +154,12 @@ typedef struct
     uint8_t private_key[NUM_ECC_BYTES];
     uint8_t public_key[2*NUM_ECC_BYTES];
 } mbedtls_uecc_keypair;
+#endif
+
+/* This needs to come after the declaration of mbedtls_uecc_keypair
+ * and before the first use of MBEDTLS_PK_INFO_CONTEXT(). */
+#if defined(MBEDTLS_PK_SINGLE_TYPE)
+#include "pk_internal.h"
 #endif
 
 /**

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -187,8 +187,22 @@ typedef struct
 } mbedtls_uecc_keypair;
 #endif
 
-/* This needs to come after the declaration of all types
- * (mbedtls_uecc_keypair, mbedtls_pk_rsa_alt_ types)
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+/**
+ * \brief           Context for resuming operations
+ */
+typedef struct
+{
+    mbedtls_pk_handle_t         pk_info; /**< Public key information         */
+    void *                      rs_ctx;  /**< Underlying restart context     */
+} mbedtls_pk_restart_ctx;
+#else /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+/* Now we can declare functions that take a pointer to that */
+typedef void mbedtls_pk_restart_ctx;
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
+/* This needs to come after the declaration of most types
+ * (mbedtls_uecc_keypair, mbedtls_pk_rsa_alt_xxx, mbedtls_pk_restart_ctx)
  * and before the first use of MBEDTLS_PK_INFO_CONTEXT(). */
 #include "pk_internal.h"
 
@@ -207,20 +221,6 @@ typedef struct mbedtls_pk_context
     void *                      pk_ctx;  /**< Underlying public key context  */
 #endif
 } mbedtls_pk_context;
-
-#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
-/**
- * \brief           Context for resuming operations
- */
-typedef struct
-{
-    mbedtls_pk_handle_t         pk_info; /**< Public key information         */
-    void *                      rs_ctx;  /**< Underlying restart context     */
-} mbedtls_pk_restart_ctx;
-#else /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
-/* Now we can declare functions that take a pointer to that */
-typedef void mbedtls_pk_restart_ctx;
-#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 #if defined(MBEDTLS_RSA_C)
 /**

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -76,6 +76,16 @@
 /* MBEDTLS_ERR_PK_HW_ACCEL_FAILED is deprecated and should not be used. */
 #define MBEDTLS_ERR_PK_HW_ACCEL_FAILED     -0x3880  /**< PK hardware accelerator failed. */
 
+/*
+ * Make some API functions inline if only a single type is available.
+ * WIP: currently no effect. */
+#if defined(MBEDTLS_PK_SINGLE_TYPE)
+//#define MBEDTLS_PK_INLINABLE_API MBEDTLS_ALWAYS_INLINE static inline
+#define MBEDTLS_PK_INLINABLE_API
+#else
+#define MBEDTLS_PK_INLINABLE_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -240,7 +250,8 @@ typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
  *
  * \return          The PK info associated with the type or NULL if not found.
  */
-mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
+MBEDTLS_PK_INLINABLE_API mbedtls_pk_handle_t mbedtls_pk_info_from_type(
+        mbedtls_pk_type_t pk_type );
 
 /**
  * \brief           Initialize a #mbedtls_pk_context (as NONE).
@@ -248,7 +259,7 @@ mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
  * \param ctx       The context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_pk_init( mbedtls_pk_context *ctx );
+MBEDTLS_PK_INLINABLE_API void mbedtls_pk_init( mbedtls_pk_context *ctx );
 
 /**
  * \brief           Free the components of a #mbedtls_pk_context.
@@ -256,7 +267,7 @@ void mbedtls_pk_init( mbedtls_pk_context *ctx );
  * \param ctx       The context to clear. It must have been initialized.
  *                  If this is \c NULL, this function does nothing.
  */
-void mbedtls_pk_free( mbedtls_pk_context *ctx );
+MBEDTLS_PK_INLINABLE_API void mbedtls_pk_free( mbedtls_pk_context *ctx );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /**
@@ -291,7 +302,8 @@ void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
  * \note            For contexts holding an RSA-alt key, use
  *                  \c mbedtls_pk_setup_rsa_alt() instead.
  */
-int mbedtls_pk_setup( mbedtls_pk_context *ctx, mbedtls_pk_handle_t info );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_setup( mbedtls_pk_context *ctx,
+                                               mbedtls_pk_handle_t info );
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /**
@@ -322,7 +334,8 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
  *
  * \return          Key size in bits, or 0 on error
  */
-size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx );
+MBEDTLS_PK_INLINABLE_API size_t mbedtls_pk_get_bitlen(
+        const mbedtls_pk_context *ctx );
 
 /**
  * \brief           Get the length in bytes of the underlying key
@@ -348,7 +361,8 @@ static inline size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
  *                  been initialized but not set up, or that has been
  *                  cleared with mbedtls_pk_free().
  */
-int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_can_do( const mbedtls_pk_context *ctx,
+                                                mbedtls_pk_type_t type );
 
 /**
  * \brief           Verify signature (including padding if relevant).
@@ -374,9 +388,9 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
  *
  * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
  */
-int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
-               const unsigned char *hash, size_t hash_len,
-               const unsigned char *sig, size_t sig_len );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_verify( mbedtls_pk_context *ctx,
+        mbedtls_md_type_t md_alg, const unsigned char *hash, size_t hash_len,
+        const unsigned char *sig, size_t sig_len );
 
 /**
  * \brief           Restartable version of \c mbedtls_pk_verify()
@@ -398,11 +412,11 @@ int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
  * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
-int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
-               mbedtls_md_type_t md_alg,
-               const unsigned char *hash, size_t hash_len,
-               const unsigned char *sig, size_t sig_len,
-               mbedtls_pk_restart_ctx *rs_ctx );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_verify_restartable(
+        mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+        const unsigned char *hash, size_t hash_len,
+        const unsigned char *sig, size_t sig_len,
+        mbedtls_pk_restart_ctx *rs_ctx );
 
 /**
  * \brief           Verify signature, with options.
@@ -433,10 +447,11 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
  *                  to a mbedtls_pk_rsassa_pss_options structure,
  *                  otherwise it must be NULL.
  */
-int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
-                   mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
-                   const unsigned char *hash, size_t hash_len,
-                   const unsigned char *sig, size_t sig_len );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_verify_ext(
+        mbedtls_pk_type_t type, const void *options,
+        mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+        const unsigned char *hash, size_t hash_len,
+        const unsigned char *sig, size_t sig_len );
 
 /**
  * \brief           Make signature, including padding if relevant.
@@ -467,10 +482,10 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
  *                  \p sig buffer size must be of at least
  *                  `max(MBEDTLS_ECDSA_MAX_LEN, MBEDTLS_MPI_MAX_SIZE)` bytes.
  */
-int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
-             const unsigned char *hash, size_t hash_len,
-             unsigned char *sig, size_t *sig_len,
-             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_sign( mbedtls_pk_context *ctx,
+        mbedtls_md_type_t md_alg, const unsigned char *hash, size_t hash_len,
+        unsigned char *sig, size_t *sig_len,
+        int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
 
 /**
  * \brief           Restartable version of \c mbedtls_pk_sign()
@@ -499,12 +514,12 @@ int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
  * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
-int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
-             mbedtls_md_type_t md_alg,
-             const unsigned char *hash, size_t hash_len,
-             unsigned char *sig, size_t *sig_len,
-             int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
-             mbedtls_pk_restart_ctx *rs_ctx );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_sign_restartable(
+        mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+        const unsigned char *hash, size_t hash_len,
+        unsigned char *sig, size_t *sig_len,
+        int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
+        mbedtls_pk_restart_ctx *rs_ctx );
 
 /**
  * \brief           Decrypt message (including padding if relevant).
@@ -523,7 +538,7 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
  *
  * \return          0 on success, or a specific error code.
  */
-int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
                 const unsigned char *input, size_t ilen,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
@@ -544,7 +559,7 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
  *
  * \return          0 on success, or a specific error code.
  */
-int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 const unsigned char *input, size_t ilen,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
@@ -557,7 +572,8 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
  *
  * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
  */
-int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_check_pair(
+        const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
 
 /**
  * \brief           Export debug information
@@ -567,7 +583,8 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_conte
  *
  * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
  */
-int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
+MBEDTLS_PK_INLINABLE_API int mbedtls_pk_debug(
+        const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
 
 /**
  * \brief           Access the type name
@@ -576,7 +593,8 @@ int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *item
  *
  * \return          Type name on success, or "invalid PK"
  */
-const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
+MBEDTLS_PK_INLINABLE_API const char * mbedtls_pk_get_name(
+        const mbedtls_pk_context *ctx );
 
 /**
  * \brief           Get the key type
@@ -586,7 +604,8 @@ const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
  * \return          Type on success.
  * \return          #MBEDTLS_PK_NONE for a context that has not been set up.
  */
-mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx );
+MBEDTLS_PK_INLINABLE_API mbedtls_pk_type_t mbedtls_pk_get_type(
+        const mbedtls_pk_context *ctx );
 
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -78,10 +78,9 @@
 
 /*
  * Make some API functions inline if only a single type is available.
- * WIP: currently no effect. */
+ */
 #if defined(MBEDTLS_PK_SINGLE_TYPE)
-//#define MBEDTLS_PK_INLINABLE_API MBEDTLS_ALWAYS_INLINE static inline
-#define MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API MBEDTLS_ALWAYS_INLINE static inline
 #else
 #define MBEDTLS_PK_INLINABLE_API
 #endif
@@ -252,6 +251,10 @@ typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
  */
 MBEDTLS_PK_INLINABLE_API mbedtls_pk_handle_t mbedtls_pk_info_from_type(
         mbedtls_pk_type_t pk_type );
+
+// Work in progress: further functions not inlinable so far
+#undef MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API
 
 /**
  * \brief           Initialize a #mbedtls_pk_context (as NONE).
@@ -606,6 +609,22 @@ MBEDTLS_PK_INLINABLE_API const char * mbedtls_pk_get_name(
  */
 MBEDTLS_PK_INLINABLE_API mbedtls_pk_type_t mbedtls_pk_get_type(
         const mbedtls_pk_context *ctx );
+
+/*
+ * Implementation of inline API functions
+ */
+#if defined(MBEDTLS_PK_SINGLE_TYPE)
+
+static inline mbedtls_pk_handle_t mbedtls_pk_info_from_type(
+        mbedtls_pk_type_t pk_type )
+{
+    if( pk_type == MBEDTLS_PK_INFO_TYPE( MBEDTLS_PK_SINGLE_TYPE ) )
+        return( MBEDTLS_PK_UNIQUE_VALID_HANDLE );
+
+    return( MBEDTLS_PK_INVALID_HANDLE );
+}
+
+#endif /* MBEDTLS_PK_SINGLE_TYPE */
 
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -252,10 +252,6 @@ typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
 MBEDTLS_PK_INLINABLE_API mbedtls_pk_handle_t mbedtls_pk_info_from_type(
         mbedtls_pk_type_t pk_type );
 
-// Work in progress: further functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Initialize a #mbedtls_pk_context (as NONE).
  *
@@ -263,6 +259,10 @@ MBEDTLS_PK_INLINABLE_API mbedtls_pk_handle_t mbedtls_pk_info_from_type(
  *                  This must not be \c NULL.
  */
 MBEDTLS_PK_INLINABLE_API void mbedtls_pk_init( mbedtls_pk_context *ctx );
+
+// Work in progress: further functions not inlinable so far
+#undef MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API
 
 /**
  * \brief           Free the components of a #mbedtls_pk_context.
@@ -624,6 +624,12 @@ static inline mbedtls_pk_handle_t mbedtls_pk_info_from_type(
     return( MBEDTLS_PK_INVALID_HANDLE );
 }
 
+static inline void mbedtls_pk_init( mbedtls_pk_context *ctx )
+{
+    MBEDTLS_PK_VALIDATE( ctx != NULL );
+
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
+}
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 
 #if defined(MBEDTLS_PK_PARSE_C)

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -346,10 +346,6 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
                          mbedtls_pk_rsa_alt_key_len_func key_len_func );
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
-// Work in progress: further functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Get the size in bits of the underlying key
  *
@@ -371,12 +367,6 @@ static inline size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
 {
     return( ( mbedtls_pk_get_bitlen( ctx ) + 7 ) / 8 );
 }
-
-// Work in progress: previous functions not inlinable so far
-#if defined(MBEDTLS_PK_SINGLE_TYPE)
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API MBEDTLS_ALWAYS_INLINE static inline
-#endif
 
 /**
  * \brief           Tell if a context can do the operation given by type
@@ -644,9 +634,7 @@ MBEDTLS_PK_INLINABLE_API mbedtls_pk_type_t mbedtls_pk_get_type(
  * Internal definitions - for inlining purposes - do no use directly!
  */
 
-/*
- * Tell if a PK can do the operations of the given type
- */
+/* Tell if a PK can do the operations of the given type */
 MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_can_do_internal(
         const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 {
@@ -659,6 +647,17 @@ MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_can_do_internal(
     return( mbedtls_pk_info_can_do( MBEDTLS_PK_CTX_INFO( ctx ), type ) );
 }
 
+/* Get key size in bits */
+MBEDTLS_ALWAYS_INLINE static inline size_t mbedtls_pk_get_bitlen_internal(
+        const mbedtls_pk_context *ctx )
+{
+    /* For backward compatibility, accept NULL or a context that
+     * isn't set up yet, and return a fake value that should be safe. */
+    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
+        return( 0 );
+
+    return( mbedtls_pk_info_get_bitlen( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx ) );
+}
 
 /*
  * Definitions of inline API functions
@@ -704,6 +703,11 @@ static inline int mbedtls_pk_can_do(
         const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 {
     return( mbedtls_pk_can_do_internal( ctx, type ) );
+}
+
+static inline size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
+{
+    return( mbedtls_pk_get_bitlen_internal( ctx ) );
 }
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -604,10 +604,6 @@ MBEDTLS_PK_INLINABLE_API int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
 MBEDTLS_PK_INLINABLE_API int mbedtls_pk_check_pair(
         const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
 
-// Work in progress: following functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Export debug information
  *
@@ -618,6 +614,10 @@ MBEDTLS_PK_INLINABLE_API int mbedtls_pk_check_pair(
  */
 MBEDTLS_PK_INLINABLE_API int mbedtls_pk_debug(
         const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
+
+// Work in progress: following functions not inlinable so far
+#undef MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API
 
 /**
  * \brief           Access the type name
@@ -696,6 +696,16 @@ MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_check_pair_internal(
                 pub->pk_ctx, prv->pk_ctx ) );
 }
 
+/* Export debug information */
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_debug_internal(
+        const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
+{
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
+        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+
+    return( mbedtls_pk_info_debug_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx, items ) );
+}
 /*
  * Definitions of inline API functions
  */
@@ -751,6 +761,11 @@ static inline int mbedtls_pk_check_pair( const mbedtls_pk_context *pub,
                                          const mbedtls_pk_context *prv )
 {
     return( mbedtls_pk_check_pair_internal( pub, prv ) );
+}
+
+static inline int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
+{
+    return( mbedtls_pk_debug_internal( ctx, items ) );
 }
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -286,10 +286,6 @@ void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
 void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
-// Work in progress: further functions not inlinable so far
-#undef MBEDTLS_PK_INLINABLE_API
-#define MBEDTLS_PK_INLINABLE_API
-
 /**
  * \brief           Initialize a PK context with the information given
  *                  and allocates the type-specific PK subcontext.
@@ -329,6 +325,10 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
                          mbedtls_pk_rsa_alt_sign_func sign_func,
                          mbedtls_pk_rsa_alt_key_len_func key_len_func );
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+// Work in progress: further functions not inlinable so far
+#undef MBEDTLS_PK_INLINABLE_API
+#define MBEDTLS_PK_INLINABLE_API
 
 /**
  * \brief           Get the size in bits of the underlying key
@@ -639,6 +639,16 @@ static inline void mbedtls_pk_free( mbedtls_pk_context *ctx )
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
 }
 
+static inline int mbedtls_pk_setup( mbedtls_pk_context *ctx,
+                                    mbedtls_pk_handle_t info )
+{
+    (void) ctx;
+
+    if( info == MBEDTLS_PK_INVALID_HANDLE )
+        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+
+    return( 0 );
+}
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 
 #if defined(MBEDTLS_PK_PARSE_C)

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -59,17 +59,17 @@
 #define MBEDTLS_PK_INFO_ECKEY_CONTEXT           mbedtls_uecc_keypair
 #define MBEDTLS_PK_INFO_ECKEY_TYPE              MBEDTLS_PK_ECKEY
 #define MBEDTLS_PK_INFO_ECKEY_NAME              "EC"
-#define MBEDTLS_PK_INFO_ECKEY_GET_BITLEN        uecc_eckey_get_bitlen
-#define MBEDTLS_PK_INFO_ECKEY_CAN_DO            uecc_eckey_can_do
-#define MBEDTLS_PK_INFO_ECKEY_VERIFY_FUNC       uecc_eckey_verify_wrap
-#define MBEDTLS_PK_INFO_ECKEY_SIGN_FUNC         uecc_eckey_sign_wrap
+#define MBEDTLS_PK_INFO_ECKEY_GET_BITLEN        mbedtls_uecc_eckey_get_bitlen
+#define MBEDTLS_PK_INFO_ECKEY_CAN_DO            mbedtls_uecc_eckey_can_do
+#define MBEDTLS_PK_INFO_ECKEY_VERIFY_FUNC       mbedtls_uecc_eckey_verify_wrap
+#define MBEDTLS_PK_INFO_ECKEY_SIGN_FUNC         mbedtls_uecc_eckey_sign_wrap
 #define MBEDTLS_PK_INFO_ECKEY_DECRYPT_FUNC      NULL
 #define MBEDTLS_PK_INFO_ECKEY_DECRYPT_OMIT      1
 #define MBEDTLS_PK_INFO_ECKEY_ENCRYPT_FUNC      NULL
 #define MBEDTLS_PK_INFO_ECKEY_ENCRYPT_OMIT      1
-#define MBEDTLS_PK_INFO_ECKEY_CHECK_PAIR_FUNC   uecc_eckey_check_pair
-#define MBEDTLS_PK_INFO_ECKEY_CTX_ALLOC_FUNC    uecc_eckey_alloc_wrap
-#define MBEDTLS_PK_INFO_ECKEY_CTX_FREE_FUNC     uecc_eckey_free_wrap
+#define MBEDTLS_PK_INFO_ECKEY_CHECK_PAIR_FUNC   mbedtls_uecc_eckey_check_pair
+#define MBEDTLS_PK_INFO_ECKEY_CTX_ALLOC_FUNC    mbedtls_uecc_eckey_alloc_wrap
+#define MBEDTLS_PK_INFO_ECKEY_CTX_FREE_FUNC     mbedtls_uecc_eckey_free_wrap
 #define MBEDTLS_PK_INFO_ECKEY_DEBUG_FUNC        NULL
 #define MBEDTLS_PK_INFO_ECKEY_DEBUG_OMIT        1
 #endif /* MBEDTLS_USE_TINYCRYPT */

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -255,6 +255,8 @@ struct mbedtls_pk_info_t
 #define MBEDTLS_PK_CTX_IS_VALID( ctx )  \
     ( MBEDTLS_PK_CTX_INFO( (ctx) ) != MBEDTLS_PK_INVALID_HANDLE )
 
+#define MBEDTLS_PK_WRAPPER MBEDTLS_ALWAYS_INLINE static inline
+
 /*
  * Internal wrappers around ECC functions - based on TinyCrypt
  */
@@ -267,13 +269,14 @@ int mbedtls_uecc_sign_asn1( const mbedtls_uecc_keypair *keypair,
                    const unsigned char *hash, size_t hash_len,
                    unsigned char *sig, size_t *sig_len );
 
-static size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
+MBEDTLS_PK_WRAPPER size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
 {
     (void) ctx;
     return( (size_t) ( NUM_ECC_BYTES * 8 ) );
 }
 
-static int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
+MBEDTLS_PK_WRAPPER int mbedtls_uecc_eckey_check_pair( const void *pub,
+                                                      const void *prv )
 {
     const mbedtls_uecc_keypair *uecc_pub =
         (const mbedtls_uecc_keypair *) pub;
@@ -290,13 +293,14 @@ static int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
     return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 }
 
-static int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
+MBEDTLS_PK_WRAPPER int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
 {
     return( type == MBEDTLS_PK_ECDSA ||
             type == MBEDTLS_PK_ECKEY );
 }
 
-static int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
+MBEDTLS_PK_WRAPPER int mbedtls_uecc_eckey_verify_wrap( void *ctx,
+                       mbedtls_md_type_t md_alg,
                        const unsigned char *hash, size_t hash_len,
                        const unsigned char *sig, size_t sig_len )
 {
@@ -306,7 +310,8 @@ static int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     return( mbedtls_uecc_verify_asn1( keypair, hash, hash_len, sig, sig_len ) );
 }
 
-static int mbedtls_uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
+MBEDTLS_PK_WRAPPER int mbedtls_uecc_eckey_sign_wrap( void *ctx,
+                   mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -35,12 +35,6 @@
 
 #include "string.h"
 
-/* Parameter validation macros based on platform_util.h */
-#define MBEDTLS_PK_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
-#define MBEDTLS_PK_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 /*
  * PK information macro definitions
  */
@@ -243,17 +237,6 @@ struct mbedtls_pk_info_t
 }
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
-
-/*
- * Macros to access pk_info
- */
-#if defined(MBEDTLS_PK_SINGLE_TYPE)
-#define MBEDTLS_PK_CTX_INFO( ctx )      MBEDTLS_PK_UNIQUE_VALID_HANDLE
-#else
-#define MBEDTLS_PK_CTX_INFO( ctx )      ( (ctx)->pk_info )
-#endif
-#define MBEDTLS_PK_CTX_IS_VALID( ctx )  \
-    ( MBEDTLS_PK_CTX_INFO( (ctx) ) != MBEDTLS_PK_INVALID_HANDLE )
 
 #define MBEDTLS_PK_WRAPPER MBEDTLS_ALWAYS_INLINE static inline
 

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -640,4 +640,28 @@ MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_hashlen_helper(
     return( 0 );
 }
 
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+/*
+ * Helper to set up a restart context if needed
+ */
+static inline int mbedtls_pk_restart_setup( mbedtls_pk_restart_ctx *ctx,
+                             mbedtls_pk_handle_t info )
+{
+    /* Don't do anything if already set up or invalid */
+    if( ctx == NULL || MBEDTLS_PK_CTX_IS_VALID( ctx ) )
+        return( 0 );
+
+    /* Should never happen when we're called */
+    if( info->rs_alloc_func == NULL || info->rs_free_func == NULL )
+        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
+
+    if( ( ctx->rs_ctx = info->rs_alloc_func() ) == NULL )
+        return( MBEDTLS_ERR_PK_ALLOC_FAILED );
+
+    ctx->pk_info = info;
+
+    return( 0 );
+}
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -33,6 +33,12 @@
 
 #include "pk.h"
 
+/* Parameter validation macros based on platform_util.h */
+#define MBEDTLS_PK_VALIDATE_RET( cond )    \
+    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
+#define MBEDTLS_PK_VALIDATE( cond )        \
+    MBEDTLS_INTERNAL_VALIDATE( cond )
+
 /*
  * PK information macro definitions
  */

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -619,4 +619,25 @@ extern const mbedtls_pk_info_t mbedtls_rsa_alt_info;
 #endif
 #endif /* MBEDTLS_PK_SINGLE_TYPE */
 
+/*
+ * Helper for mbedtls_pk_sign and mbedtls_pk_verify
+ */
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_hashlen_helper(
+        mbedtls_md_type_t md_alg, size_t *hash_len )
+{
+    mbedtls_md_handle_t md_info;
+
+    if( *hash_len != 0 )
+        return( 0 );
+
+    if( ( md_info = mbedtls_md_info_from_type( md_alg ) ) ==
+        MBEDTLS_MD_INVALID_HANDLE )
+    {
+        return( -1 );
+    }
+
+    *hash_len = mbedtls_md_get_size( md_info );
+    return( 0 );
+}
+
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/library/pk.c
+++ b/library/pk.c
@@ -1343,16 +1343,9 @@ void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx )
 /*
  * Get pk_info structure from type
  */
+#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
 {
-#if defined(MBEDTLS_PK_SINGLE_TYPE)
-    if( pk_type == MBEDTLS_PK_INFO_TYPE( MBEDTLS_PK_SINGLE_TYPE ) )
-        return( MBEDTLS_PK_UNIQUE_VALID_HANDLE );
-
-    return( MBEDTLS_PK_INVALID_HANDLE );
-
-#else /* MBEDTLS_PK_SINGLE_TYPE */
-
     switch( pk_type ) {
 #if defined(MBEDTLS_RSA_C)
         case MBEDTLS_PK_RSA:
@@ -1379,8 +1372,8 @@ mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
         default:
             return( NULL );
     }
-#endif /* MBEDTLS_PK_SINGLE_TYPE */
 }
+#endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Initialise context

--- a/library/pk.c
+++ b/library/pk.c
@@ -1389,18 +1389,15 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_conte
                 pub->pk_ctx, prv->pk_ctx ) );
 }
 
+#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 /*
  * Get key size in bits
  */
 size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
 {
-    /* For backward compatibility, accept NULL or a context that
-     * isn't set up yet, and return a fake value that should be safe. */
-    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( 0 );
-
-    return( mbedtls_pk_info_get_bitlen( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx ) );
+    return( mbedtls_pk_get_bitlen_internal( ctx ) );
 }
+#endif /* ! MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Export debug information

--- a/library/pk.c
+++ b/library/pk.c
@@ -59,12 +59,6 @@
 #include <limits.h>
 #include <stdint.h>
 
-/* Parameter validation macros based on platform_util.h */
-#define PK_VALIDATE_RET( cond )    \
-    MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_PK_BAD_INPUT_DATA )
-#define PK_VALIDATE( cond )        \
-    MBEDTLS_INTERNAL_VALIDATE( cond )
-
 /*
  * Internal wrappers around RSA functions
  */
@@ -1285,7 +1279,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_debug_func(
  */
 void mbedtls_pk_init( mbedtls_pk_context *ctx )
 {
-    PK_VALIDATE( ctx != NULL );
+    MBEDTLS_PK_VALIDATE( ctx != NULL );
 
 #if !defined(MBEDTLS_PK_SINGLE_TYPE)
     ctx->pk_info = MBEDTLS_PK_INVALID_HANDLE;
@@ -1317,7 +1311,7 @@ void mbedtls_pk_free( mbedtls_pk_context *ctx )
  */
 void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx )
 {
-    PK_VALIDATE( ctx != NULL );
+    MBEDTLS_PK_VALIDATE( ctx != NULL );
     ctx->pk_info = NULL;
     ctx->rs_ctx = NULL;
 }
@@ -1380,7 +1374,7 @@ mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
  */
 int mbedtls_pk_setup( mbedtls_pk_context *ctx, mbedtls_pk_handle_t info )
 {
-    PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
     if( info == MBEDTLS_PK_INVALID_HANDLE )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -1411,7 +1405,7 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
     mbedtls_rsa_alt_context *rsa_alt;
     mbedtls_pk_handle_t info = &mbedtls_rsa_alt_info;
 
-    PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
     if( MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -1498,10 +1492,10 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
                const unsigned char *sig, size_t sig_len,
                mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
+    MBEDTLS_PK_VALIDATE_RET( sig != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )
@@ -1553,10 +1547,10 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
+    MBEDTLS_PK_VALIDATE_RET( sig != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -1618,10 +1612,10 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
              mbedtls_pk_restart_ctx *rs_ctx )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ( md_alg == MBEDTLS_MD_NONE && hash_len == 0 ) ||
                      hash != NULL );
-    PK_VALIDATE_RET( sig != NULL );
+    MBEDTLS_PK_VALIDATE_RET( sig != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) ||
         pk_hashlen_helper( md_alg, &hash_len ) != 0 )
@@ -1674,10 +1668,10 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( input != NULL || ilen == 0 );
-    PK_VALIDATE_RET( output != NULL || osize == 0 );
-    PK_VALIDATE_RET( olen != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( input != NULL || ilen == 0 );
+    MBEDTLS_PK_VALIDATE_RET( output != NULL || osize == 0 );
+    MBEDTLS_PK_VALIDATE_RET( olen != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -1694,10 +1688,10 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
-    PK_VALIDATE_RET( ctx != NULL );
-    PK_VALIDATE_RET( input != NULL || ilen == 0 );
-    PK_VALIDATE_RET( output != NULL || osize == 0 );
-    PK_VALIDATE_RET( olen != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( input != NULL || ilen == 0 );
+    MBEDTLS_PK_VALIDATE_RET( output != NULL || osize == 0 );
+    MBEDTLS_PK_VALIDATE_RET( olen != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -1711,8 +1705,8 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
  */
 int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv )
 {
-    PK_VALIDATE_RET( pub != NULL );
-    PK_VALIDATE_RET( prv != NULL );
+    MBEDTLS_PK_VALIDATE_RET( pub != NULL );
+    MBEDTLS_PK_VALIDATE_RET( prv != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( pub ) || !MBEDTLS_PK_CTX_IS_VALID( prv ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -1752,7 +1746,7 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
  */
 int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
 {
-    PK_VALIDATE_RET( ctx != NULL );
+    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -1361,35 +1361,16 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 input, ilen, output, olen, osize, f_rng, p_rng ) );
 }
 
+#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 /*
  * Check public-private key pair
  */
-int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv )
+int mbedtls_pk_check_pair( const mbedtls_pk_context *pub,
+                           const mbedtls_pk_context *prv )
 {
-    MBEDTLS_PK_VALIDATE_RET( pub != NULL );
-    MBEDTLS_PK_VALIDATE_RET( prv != NULL );
-
-    if( !MBEDTLS_PK_CTX_IS_VALID( pub ) || !MBEDTLS_PK_CTX_IS_VALID( prv ) )
-        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-
-#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-    if( mbedtls_pk_info_type( prv->pk_info ) == MBEDTLS_PK_RSA_ALT )
-    {
-        if( mbedtls_pk_info_type( pub->pk_info ) != MBEDTLS_PK_RSA )
-            return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-    }
-    else
-#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
-    {
-        if( MBEDTLS_PK_CTX_INFO( pub ) != MBEDTLS_PK_CTX_INFO( prv ) )
-            return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-    }
-
-    return( mbedtls_pk_info_check_pair_func( MBEDTLS_PK_CTX_INFO( prv ),
-                pub->pk_ctx, prv->pk_ctx ) );
+    return( mbedtls_pk_check_pair_internal( pub, prv ) );
 }
 
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 /*
  * Get key size in bits
  */

--- a/library/pk.c
+++ b/library/pk.c
@@ -1272,8 +1272,6 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_debug_func(
     return( 0 );
 }
 
-#endif /* MBEDTLS_PK_SINGLE_TYPE */
-
 /*
  * Initialise a mbedtls_pk_context
  */
@@ -1281,13 +1279,11 @@ void mbedtls_pk_init( mbedtls_pk_context *ctx )
 {
     MBEDTLS_PK_VALIDATE( ctx != NULL );
 
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
     ctx->pk_info = MBEDTLS_PK_INVALID_HANDLE;
     ctx->pk_ctx = NULL;
-#else
-    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
-#endif
 }
+
+#endif /* MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Free (the components of) a mbedtls_pk_context

--- a/library/pk.c
+++ b/library/pk.c
@@ -1378,19 +1378,15 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
 {
     return( mbedtls_pk_get_bitlen_internal( ctx ) );
 }
-#endif /* ! MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Export debug information
  */
 int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items )
 {
-    MBEDTLS_PK_VALIDATE_RET( ctx != NULL );
-    if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-
-    return( mbedtls_pk_info_debug_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx, items ) );
+    return( mbedtls_pk_debug_internal( ctx, items ) );
 }
+#endif /* ! MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Access the PK type name

--- a/library/pk.c
+++ b/library/pk.c
@@ -537,13 +537,13 @@ static int extract_ecdsa_sig( unsigned char **p, const unsigned char *end,
     return( 0 );
 }
 
-static size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
+size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
 {
     (void) ctx;
     return( (size_t) ( NUM_ECC_BYTES * 8 ) );
 }
 
-static int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
+int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
 {
     const mbedtls_uecc_keypair *uecc_pub =
         (const mbedtls_uecc_keypair *) pub;
@@ -560,13 +560,13 @@ static int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
     return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 }
 
-static int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
+int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
 {
     return( type == MBEDTLS_PK_ECDSA ||
             type == MBEDTLS_PK_ECKEY );
 }
 
-static int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
+int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                        const unsigned char *hash, size_t hash_len,
                        const unsigned char *sig, size_t sig_len )
 {
@@ -681,7 +681,7 @@ static int pk_ecdsa_sig_asn1_from_uecc( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
-static int mbedtls_uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
+int mbedtls_uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
@@ -998,280 +998,7 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
 };
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
-/*
- * Access to members of the pk_info structure. When a single PK type is
- * hardcoded, these should have zero runtime cost; otherwise, the usual
- * dynamic dispatch based on pk_info is used.
- *
- * For function members, don't make a getter, but a function that directly
- * calls the method, so that we can entirely get rid of function pointers
- * when hardcoding a single PK - some compilers optimize better that way.
- *
- * Not implemented for members that are only present in builds with
- * MBEDTLS_ECP_RESTARTABLE for now, as the main target for this is builds
- * with MBEDTLS_USE_TINYCRYPT, which don't have MBEDTLS_ECP_RESTARTABLE.
- */
-#if defined(MBEDTLS_PK_SINGLE_TYPE)
-
-MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t mbedtls_pk_info_type(
-    mbedtls_pk_handle_t info )
-{
-    (void) info;
-    return( MBEDTLS_PK_INFO_TYPE( MBEDTLS_PK_SINGLE_TYPE ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline const char * mbedtls_pk_info_name(
-    mbedtls_pk_handle_t info )
-{
-    (void) info;
-    return( MBEDTLS_PK_INFO_NAME( MBEDTLS_PK_SINGLE_TYPE ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline size_t mbedtls_pk_info_get_bitlen(
-    mbedtls_pk_handle_t info, const void *ctx )
-{
-    (void) info;
-    return( MBEDTLS_PK_INFO_GET_BITLEN( MBEDTLS_PK_SINGLE_TYPE )( ctx ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_can_do(
-    mbedtls_pk_handle_t info, mbedtls_pk_type_t type )
-{
-    (void) info;
-    return( MBEDTLS_PK_INFO_CAN_DO( MBEDTLS_PK_SINGLE_TYPE )( type ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_verify_func(
-    mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
-    const unsigned char *hash, size_t hash_len,
-    const unsigned char *sig, size_t sig_len )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_VERIFY_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) ctx;
-    (void) md_alg;
-    (void) hash;
-    (void) hash_len;
-    (void) sig;
-    (void) sig_len;
-    return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-#else
-    return( MBEDTLS_PK_INFO_VERIFY_FUNC( MBEDTLS_PK_SINGLE_TYPE )(
-                ctx, md_alg, hash, hash_len, sig, sig_len ) );
-#endif
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_sign_func(
-    mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
-    const unsigned char *hash, size_t hash_len,
-    unsigned char *sig, size_t *sig_len,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_SIGN_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) ctx;
-    (void) md_alg;
-    (void) hash;
-    (void) hash_len;
-    (void) sig;
-    (void) sig_len;
-    (void) f_rng;
-    (void) p_rng;
-    return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-#else
-    return( MBEDTLS_PK_INFO_SIGN_FUNC( MBEDTLS_PK_SINGLE_TYPE )(
-                ctx, md_alg, hash, hash_len, sig, sig_len, f_rng, p_rng ) );
-#endif
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_decrypt_func(
-    mbedtls_pk_handle_t info, void *ctx,
-    const unsigned char *input, size_t ilen,
-    unsigned char *output, size_t *olen, size_t osize,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_DECRYPT_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) ctx;
-    (void) input;
-    (void) ilen;
-    (void) output;
-    (void) olen;
-    (void) osize;
-    (void) f_rng;
-    (void) p_rng;
-    return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-#else
-    return( MBEDTLS_PK_INFO_DECRYPT_FUNC( MBEDTLS_PK_SINGLE_TYPE )(
-                ctx, input, ilen, output, olen, osize, f_rng, p_rng ) );
-#endif
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_encrypt_func(
-    mbedtls_pk_handle_t info, void *ctx,
-    const unsigned char *input, size_t ilen,
-    unsigned char *output, size_t *olen, size_t osize,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_ENCRYPT_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) ctx;
-    (void) input;
-    (void) ilen;
-    (void) output;
-    (void) olen;
-    (void) osize;
-    (void) f_rng;
-    (void) p_rng;
-    return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-#else
-    return( MBEDTLS_PK_INFO_ENCRYPT_FUNC( MBEDTLS_PK_SINGLE_TYPE )(
-                ctx, input, ilen, output, olen, osize, f_rng, p_rng ) );
-#endif
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_check_pair_func(
-    mbedtls_pk_handle_t info, const void *pub, const void *prv )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_CHECK_PAIR_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) pub;
-    (void) prv;
-    return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-#else
-    return( MBEDTLS_PK_INFO_CHECK_PAIR_FUNC( MBEDTLS_PK_SINGLE_TYPE )(
-                pub, prv ) );
-#endif
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_debug_func(
-    mbedtls_pk_handle_t info,
-    const void *ctx, mbedtls_pk_debug_item *items )
-{
-    (void) info;
-#if MBEDTLS_PK_INFO_DEBUG_OMIT( MBEDTLS_PK_SINGLE_TYPE )
-    (void) ctx;
-    (void) items;
-    return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-#else
-    return( MBEDTLS_PK_INFO_DEBUG_FUNC( MBEDTLS_PK_SINGLE_TYPE )( ctx, items ) );
-#endif
-}
-
-#else /* MBEDTLS_PK_SINGLE_TYPE */
-
-MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t mbedtls_pk_info_type(
-    mbedtls_pk_handle_t info )
-{
-    return( info->type );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline const char * mbedtls_pk_info_name(
-    mbedtls_pk_handle_t info )
-{
-    return( info->name );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline size_t mbedtls_pk_info_get_bitlen(
-    mbedtls_pk_handle_t info, const void *ctx )
-{
-    return( info->get_bitlen( ctx ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_can_do(
-    mbedtls_pk_handle_t info, mbedtls_pk_type_t type )
-{
-    return( info->can_do( type ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_verify_func(
-    mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
-    const unsigned char *hash, size_t hash_len,
-    const unsigned char *sig, size_t sig_len )
-{
-    if( info->verify_func == NULL )
-        return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-
-    return( info->verify_func( ctx, md_alg, hash, hash_len, sig, sig_len ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_sign_func(
-    mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
-    const unsigned char *hash, size_t hash_len,
-    unsigned char *sig, size_t *sig_len,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    if( info->sign_func == NULL )
-        return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-
-    return( info->sign_func( ctx, md_alg, hash, hash_len, sig, sig_len,
-                             f_rng, p_rng ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_decrypt_func(
-    mbedtls_pk_handle_t info, void *ctx,
-    const unsigned char *input, size_t ilen,
-    unsigned char *output, size_t *olen, size_t osize,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    if( info->decrypt_func == NULL )
-        return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-
-    return( info->decrypt_func( ctx, input, ilen, output, olen, osize,
-                                f_rng, p_rng ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_encrypt_func(
-    mbedtls_pk_handle_t info, void *ctx,
-    const unsigned char *input, size_t ilen,
-    unsigned char *output, size_t *olen, size_t osize,
-    int (*f_rng)(void *, unsigned char *, size_t),
-    void *p_rng )
-{
-    if( info->encrypt_func == NULL )
-        return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-
-    return( info->encrypt_func( ctx, input, ilen, output, olen, osize,
-                                f_rng, p_rng ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_check_pair_func(
-    mbedtls_pk_handle_t info, const void *pub, const void *prv )
-{
-    if( info->check_pair_func == NULL )
-        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-
-    return( info->check_pair_func( pub, prv ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline void *mbedtls_pk_info_ctx_alloc_func(
-    mbedtls_pk_handle_t info )
-{
-    return( info->ctx_alloc_func( ) );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline void mbedtls_pk_info_ctx_free_func(
-    mbedtls_pk_handle_t info, void *ctx )
-{
-    info->ctx_free_func( ctx );
-}
-
-MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_debug_func(
-    mbedtls_pk_handle_t info,
-    const void *ctx, mbedtls_pk_debug_item *items )
-{
-    if( info->debug_func == NULL )
-        return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
-
-    info->debug_func( ctx, items );
-    return( 0 );
-}
-
+#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 /*
  * Initialise a mbedtls_pk_context
  */

--- a/library/pk.c
+++ b/library/pk.c
@@ -537,13 +537,13 @@ static int extract_ecdsa_sig( unsigned char **p, const unsigned char *end,
     return( 0 );
 }
 
-static size_t uecc_eckey_get_bitlen( const void *ctx )
+static size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
 {
     (void) ctx;
     return( (size_t) ( NUM_ECC_BYTES * 8 ) );
 }
 
-static int uecc_eckey_check_pair( const void *pub, const void *prv )
+static int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
 {
     const mbedtls_uecc_keypair *uecc_pub =
         (const mbedtls_uecc_keypair *) pub;
@@ -560,13 +560,13 @@ static int uecc_eckey_check_pair( const void *pub, const void *prv )
     return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 }
 
-static int uecc_eckey_can_do( mbedtls_pk_type_t type )
+static int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
 {
     return( type == MBEDTLS_PK_ECDSA ||
             type == MBEDTLS_PK_ECKEY );
 }
 
-static int uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
+static int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
                        const unsigned char *hash, size_t hash_len,
                        const unsigned char *sig, size_t sig_len )
 {
@@ -681,7 +681,7 @@ static int pk_ecdsa_sig_asn1_from_uecc( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
-static int uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
+static int mbedtls_uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
@@ -726,12 +726,12 @@ static int uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 }
 
 #if !defined(MBEDTLS_PK_SINGLE_TYPE)
-static void *uecc_eckey_alloc_wrap( void )
+static void *mbedtls_uecc_eckey_alloc_wrap( void )
 {
     return( mbedtls_calloc( 1, sizeof( mbedtls_uecc_keypair ) ) );
 }
 
-static void uecc_eckey_free_wrap( void *ctx )
+static void mbedtls_uecc_eckey_free_wrap( void *ctx )
 {
     if( ctx == NULL )
         return;

--- a/library/pk.c
+++ b/library/pk.c
@@ -679,63 +679,9 @@ int mbedtls_uecc_sign_asn1( const mbedtls_uecc_keypair *keypair,
 
 /*
  * Internal wrappers around ECC functions - based on TinyCrypt
+ * Most of them are defined in pk_internal.h, here are the remaining ones.
  */
-#if defined(MBEDTLS_USE_TINYCRYPT)
-size_t mbedtls_uecc_eckey_get_bitlen( const void *ctx )
-{
-    (void) ctx;
-    return( (size_t) ( NUM_ECC_BYTES * 8 ) );
-}
-
-int mbedtls_uecc_eckey_check_pair( const void *pub, const void *prv )
-{
-    const mbedtls_uecc_keypair *uecc_pub =
-        (const mbedtls_uecc_keypair *) pub;
-    const mbedtls_uecc_keypair *uecc_prv =
-        (const mbedtls_uecc_keypair *) prv;
-
-    if( memcmp( uecc_pub->public_key,
-                uecc_prv->public_key,
-                2 * NUM_ECC_BYTES ) == 0 )
-    {
-        return( 0 );
-    }
-
-    return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-}
-
-int mbedtls_uecc_eckey_can_do( mbedtls_pk_type_t type )
-{
-    return( type == MBEDTLS_PK_ECDSA ||
-            type == MBEDTLS_PK_ECKEY );
-}
-
-int mbedtls_uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
-                       const unsigned char *hash, size_t hash_len,
-                       const unsigned char *sig, size_t sig_len )
-{
-    const mbedtls_uecc_keypair *keypair = (const mbedtls_uecc_keypair *) ctx;
-
-    ((void) md_alg);
-    return( mbedtls_uecc_verify_asn1( keypair, hash, hash_len, sig, sig_len ) );
-}
-
-int mbedtls_uecc_eckey_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
-                   const unsigned char *hash, size_t hash_len,
-                   unsigned char *sig, size_t *sig_len,
-                   int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
-{
-    const mbedtls_uecc_keypair *keypair = (const mbedtls_uecc_keypair *) ctx;
-
-    /* uECC owns its rng function pointer */
-    (void) f_rng;
-    (void) p_rng;
-    (void) md_alg;
-
-    return( mbedtls_uecc_sign_asn1( keypair, hash, hash_len, sig, sig_len ) );
-}
-
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
+#if defined(MBEDTLS_USE_TINYCRYPT) && !defined(MBEDTLS_PK_SINGLE_TYPE)
 static void *mbedtls_uecc_eckey_alloc_wrap( void )
 {
     return( mbedtls_calloc( 1, sizeof( mbedtls_uecc_keypair ) ) );
@@ -749,13 +695,10 @@ static void mbedtls_uecc_eckey_free_wrap( void *ctx )
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_uecc_keypair ) );
     mbedtls_free( ctx );
 }
-#endif /* MBEDTLS_PK_SINGLE_TYPE */
 
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 const mbedtls_pk_info_t mbedtls_uecc_eckey_info =
                         MBEDTLS_PK_INFO( MBEDTLS_PK_INFO_ECKEY );
-#endif
-#endif /* MBEDTLS_USE_TINYCRYPT */
+#endif /* MBEDTLS_USE_TINYCRYPT && !MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Internal wrappers around ECDSA functions

--- a/library/pk.c
+++ b/library/pk.c
@@ -1100,30 +1100,6 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 
 #endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
-#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
-/*
- * Helper to set up a restart context if needed
- */
-static int pk_restart_setup( mbedtls_pk_restart_ctx *ctx,
-                             mbedtls_pk_handle_t info )
-{
-    /* Don't do anything if already set up or invalid */
-    if( ctx == NULL || MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( 0 );
-
-    /* Should never happen when we're called */
-    if( info->rs_alloc_func == NULL || info->rs_free_func == NULL )
-        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-
-    if( ( ctx->rs_ctx = info->rs_alloc_func() ) == NULL )
-        return( MBEDTLS_ERR_PK_ALLOC_FAILED );
-
-    ctx->pk_info = info;
-
-    return( 0 );
-}
-#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
-
 /*
  * Verify a signature (restartable)
  */
@@ -1150,7 +1126,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
     {
         int ret;
 
-        if( ( ret = pk_restart_setup( rs_ctx, ctx->pk_info ) ) != 0 )
+        if( ( ret = mbedtls_pk_restart_setup( rs_ctx, ctx->pk_info ) ) != 0 )
             return( ret );
 
         ret = ctx->pk_info->verify_rs_func( ctx->pk_ctx,
@@ -1270,7 +1246,7 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
     {
         int ret;
 
-        if( ( ret = pk_restart_setup( rs_ctx, ctx->pk_info ) ) != 0 )
+        if( ( ret = mbedtls_pk_restart_setup( rs_ctx, ctx->pk_info ) ) != 0 )
             return( ret );
 
         ret = ctx->pk_info->sign_rs_func( ctx->pk_ctx, md_alg,

--- a/library/pk.c
+++ b/library/pk.c
@@ -1100,26 +1100,6 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 
 #endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
-/*
- * Helper for mbedtls_pk_sign and mbedtls_pk_verify
- */
-static inline int pk_hashlen_helper( mbedtls_md_type_t md_alg, size_t *hash_len )
-{
-    mbedtls_md_handle_t md_info;
-
-    if( *hash_len != 0 )
-        return( 0 );
-
-    if( ( md_info = mbedtls_md_info_from_type( md_alg ) ) ==
-        MBEDTLS_MD_INVALID_HANDLE )
-    {
-        return( -1 );
-    }
-
-    *hash_len = mbedtls_md_get_size( md_info );
-    return( 0 );
-}
-
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /*
  * Helper to set up a restart context if needed
@@ -1159,7 +1139,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
     MBEDTLS_PK_VALIDATE_RET( sig != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) ||
-        pk_hashlen_helper( md_alg, &hash_len ) != 0 )
+        mbedtls_pk_hashlen_helper( md_alg, &hash_len ) != 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
@@ -1279,7 +1259,7 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
     MBEDTLS_PK_VALIDATE_RET( sig != NULL );
 
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) ||
-        pk_hashlen_helper( md_alg, &hash_len ) != 0 )
+        mbedtls_pk_hashlen_helper( md_alg, &hash_len ) != 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)

--- a/library/pk.c
+++ b/library/pk.c
@@ -1283,8 +1283,6 @@ void mbedtls_pk_init( mbedtls_pk_context *ctx )
     ctx->pk_ctx = NULL;
 }
 
-#endif /* MBEDTLS_PK_SINGLE_TYPE */
-
 /*
  * Free (the components of) a mbedtls_pk_context
  */
@@ -1293,10 +1291,8 @@ void mbedtls_pk_free( mbedtls_pk_context *ctx )
     if( ctx == NULL )
         return;
 
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
     if( MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         pk_info_ctx_free_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx );
-#endif
 
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
 }
@@ -1333,7 +1329,6 @@ void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx )
 /*
  * Get pk_info structure from type
  */
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
 mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
 {
     switch( pk_type ) {
@@ -1363,6 +1358,7 @@ mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
             return( NULL );
     }
 }
+
 #endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
 /*

--- a/library/pk.c
+++ b/library/pk.c
@@ -27,7 +27,6 @@
 
 #if defined(MBEDTLS_PK_C)
 #include "mbedtls/pk.h"
-#include "mbedtls/pk_internal.h"
 
 #if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 #include "mbedtls/rsa.h"
@@ -1091,21 +1090,15 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
 }
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
-#endif /* !MBEDTLS_PK_SINGLE_TYPE */
-
 /*
  * Tell if a PK can do the operations of the given type
  */
 int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
 {
-    /* A context with null pk_info is not set up yet and can't do anything.
-     * For backward compatibility, also accept NULL instead of a context
-     * pointer. */
-    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( 0 );
-
-    return( mbedtls_pk_info_can_do( MBEDTLS_PK_CTX_INFO( ctx ), type ) );
+    return( mbedtls_pk_can_do_internal( ctx, type ) );
 }
+
+#endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Helper for mbedtls_pk_sign and mbedtls_pk_verify

--- a/library/pk.c
+++ b/library/pk.c
@@ -1359,8 +1359,6 @@ mbedtls_pk_handle_t mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type )
     }
 }
 
-#endif /* !MBEDTLS_PK_SINGLE_TYPE */
-
 /*
  * Initialise context
  */
@@ -1370,7 +1368,6 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, mbedtls_pk_handle_t info )
     if( info == MBEDTLS_PK_INVALID_HANDLE )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-#if !defined(MBEDTLS_PK_SINGLE_TYPE)
     if( ctx->pk_info != NULL )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
@@ -1378,9 +1375,6 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, mbedtls_pk_handle_t info )
 
     if( ( ctx->pk_ctx = pk_info_ctx_alloc_func( info ) ) == NULL )
         return( MBEDTLS_ERR_PK_ALLOC_FAILED );
-#else
-    (void) ctx;
-#endif
 
     return( 0 );
 }
@@ -1416,6 +1410,8 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
     return( 0 );
 }
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
+#endif /* !MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Tell if a PK can do the operations of the given type

--- a/library/pk.c
+++ b/library/pk.c
@@ -1386,17 +1386,13 @@ int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *item
 {
     return( mbedtls_pk_debug_internal( ctx, items ) );
 }
-#endif /* ! MBEDTLS_PK_SINGLE_TYPE */
 
 /*
  * Access the PK type name
  */
 const char *mbedtls_pk_get_name( const mbedtls_pk_context *ctx )
 {
-    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( "invalid PK" );
-
-    return( mbedtls_pk_info_name( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+    return( mbedtls_pk_get_name_internal( ctx ) );
 }
 
 /*
@@ -1404,10 +1400,8 @@ const char *mbedtls_pk_get_name( const mbedtls_pk_context *ctx )
  */
 mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx )
 {
-    if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        return( MBEDTLS_PK_NONE );
-
-    return( mbedtls_pk_info_type( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+    return( mbedtls_pk_get_type_internal( ctx ) );
 }
+#endif /* ! MBEDTLS_PK_SINGLE_TYPE */
 
 #endif /* MBEDTLS_PK_C */

--- a/library/pk.c
+++ b/library/pk.c
@@ -1013,35 +1013,35 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
  */
 #if defined(MBEDTLS_PK_SINGLE_TYPE)
 
-MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t pk_info_type(
+MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t mbedtls_pk_info_type(
     mbedtls_pk_handle_t info )
 {
     (void) info;
     return( MBEDTLS_PK_INFO_TYPE( MBEDTLS_PK_SINGLE_TYPE ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline const char * pk_info_name(
+MBEDTLS_ALWAYS_INLINE static inline const char * mbedtls_pk_info_name(
     mbedtls_pk_handle_t info )
 {
     (void) info;
     return( MBEDTLS_PK_INFO_NAME( MBEDTLS_PK_SINGLE_TYPE ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline size_t pk_info_get_bitlen(
+MBEDTLS_ALWAYS_INLINE static inline size_t mbedtls_pk_info_get_bitlen(
     mbedtls_pk_handle_t info, const void *ctx )
 {
     (void) info;
     return( MBEDTLS_PK_INFO_GET_BITLEN( MBEDTLS_PK_SINGLE_TYPE )( ctx ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_can_do(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_can_do(
     mbedtls_pk_handle_t info, mbedtls_pk_type_t type )
 {
     (void) info;
     return( MBEDTLS_PK_INFO_CAN_DO( MBEDTLS_PK_SINGLE_TYPE )( type ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_verify_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_verify_func(
     mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
     const unsigned char *hash, size_t hash_len,
     const unsigned char *sig, size_t sig_len )
@@ -1061,7 +1061,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_verify_func(
 #endif
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_sign_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_sign_func(
     mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
     const unsigned char *hash, size_t hash_len,
     unsigned char *sig, size_t *sig_len,
@@ -1085,7 +1085,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_sign_func(
 #endif
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_decrypt_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_decrypt_func(
     mbedtls_pk_handle_t info, void *ctx,
     const unsigned char *input, size_t ilen,
     unsigned char *output, size_t *olen, size_t osize,
@@ -1109,7 +1109,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_decrypt_func(
 #endif
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_encrypt_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_encrypt_func(
     mbedtls_pk_handle_t info, void *ctx,
     const unsigned char *input, size_t ilen,
     unsigned char *output, size_t *olen, size_t osize,
@@ -1133,7 +1133,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_encrypt_func(
 #endif
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_check_pair_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_check_pair_func(
     mbedtls_pk_handle_t info, const void *pub, const void *prv )
 {
     (void) info;
@@ -1147,7 +1147,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_check_pair_func(
 #endif
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_debug_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_debug_func(
     mbedtls_pk_handle_t info,
     const void *ctx, mbedtls_pk_debug_item *items )
 {
@@ -1163,31 +1163,31 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_debug_func(
 
 #else /* MBEDTLS_PK_SINGLE_TYPE */
 
-MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t pk_info_type(
+MBEDTLS_ALWAYS_INLINE static inline mbedtls_pk_type_t mbedtls_pk_info_type(
     mbedtls_pk_handle_t info )
 {
     return( info->type );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline const char * pk_info_name(
+MBEDTLS_ALWAYS_INLINE static inline const char * mbedtls_pk_info_name(
     mbedtls_pk_handle_t info )
 {
     return( info->name );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline size_t pk_info_get_bitlen(
+MBEDTLS_ALWAYS_INLINE static inline size_t mbedtls_pk_info_get_bitlen(
     mbedtls_pk_handle_t info, const void *ctx )
 {
     return( info->get_bitlen( ctx ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_can_do(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_can_do(
     mbedtls_pk_handle_t info, mbedtls_pk_type_t type )
 {
     return( info->can_do( type ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_verify_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_verify_func(
     mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
     const unsigned char *hash, size_t hash_len,
     const unsigned char *sig, size_t sig_len )
@@ -1198,7 +1198,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_verify_func(
     return( info->verify_func( ctx, md_alg, hash, hash_len, sig, sig_len ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_sign_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_sign_func(
     mbedtls_pk_handle_t info, void *ctx, mbedtls_md_type_t md_alg,
     const unsigned char *hash, size_t hash_len,
     unsigned char *sig, size_t *sig_len,
@@ -1212,7 +1212,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_sign_func(
                              f_rng, p_rng ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_decrypt_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_decrypt_func(
     mbedtls_pk_handle_t info, void *ctx,
     const unsigned char *input, size_t ilen,
     unsigned char *output, size_t *olen, size_t osize,
@@ -1226,7 +1226,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_decrypt_func(
                                 f_rng, p_rng ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_encrypt_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_encrypt_func(
     mbedtls_pk_handle_t info, void *ctx,
     const unsigned char *input, size_t ilen,
     unsigned char *output, size_t *olen, size_t osize,
@@ -1240,7 +1240,7 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_encrypt_func(
                                 f_rng, p_rng ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_check_pair_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_check_pair_func(
     mbedtls_pk_handle_t info, const void *pub, const void *prv )
 {
     if( info->check_pair_func == NULL )
@@ -1249,19 +1249,19 @@ MBEDTLS_ALWAYS_INLINE static inline int pk_info_check_pair_func(
     return( info->check_pair_func( pub, prv ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline void *pk_info_ctx_alloc_func(
+MBEDTLS_ALWAYS_INLINE static inline void *mbedtls_pk_info_ctx_alloc_func(
     mbedtls_pk_handle_t info )
 {
     return( info->ctx_alloc_func( ) );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline void pk_info_ctx_free_func(
+MBEDTLS_ALWAYS_INLINE static inline void mbedtls_pk_info_ctx_free_func(
     mbedtls_pk_handle_t info, void *ctx )
 {
     info->ctx_free_func( ctx );
 }
 
-MBEDTLS_ALWAYS_INLINE static inline int pk_info_debug_func(
+MBEDTLS_ALWAYS_INLINE static inline int mbedtls_pk_info_debug_func(
     mbedtls_pk_handle_t info,
     const void *ctx, mbedtls_pk_debug_item *items )
 {
@@ -1292,7 +1292,7 @@ void mbedtls_pk_free( mbedtls_pk_context *ctx )
         return;
 
     if( MBEDTLS_PK_CTX_IS_VALID( ctx ) )
-        pk_info_ctx_free_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx );
+        mbedtls_pk_info_ctx_free_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx );
 
     mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
 }
@@ -1373,7 +1373,7 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, mbedtls_pk_handle_t info )
 
     ctx->pk_info = info;
 
-    if( ( ctx->pk_ctx = pk_info_ctx_alloc_func( info ) ) == NULL )
+    if( ( ctx->pk_ctx = mbedtls_pk_info_ctx_alloc_func( info ) ) == NULL )
         return( MBEDTLS_ERR_PK_ALLOC_FAILED );
 
     return( 0 );
@@ -1424,7 +1424,7 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type )
     if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( 0 );
 
-    return( pk_info_can_do( MBEDTLS_PK_CTX_INFO( ctx ), type ) );
+    return( mbedtls_pk_info_can_do( MBEDTLS_PK_CTX_INFO( ctx ), type ) );
 }
 
 /*
@@ -1512,7 +1512,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
     (void) rs_ctx;
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
-    return( pk_info_verify_func( MBEDTLS_PK_CTX_INFO( ctx ),
+    return( mbedtls_pk_info_verify_func( MBEDTLS_PK_CTX_INFO( ctx ),
                 ctx->pk_ctx, md_alg, hash, hash_len, sig, sig_len ) );
 }
 
@@ -1632,7 +1632,7 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
     (void) rs_ctx;
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
-    return( pk_info_sign_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
+    return( mbedtls_pk_info_sign_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
                 md_alg, hash, hash_len, sig, sig_len, f_rng, p_rng ) );
 }
 
@@ -1664,7 +1664,7 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    return( pk_info_decrypt_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
+    return( mbedtls_pk_info_decrypt_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
                 input, ilen, output, olen, osize, f_rng, p_rng ) );
 }
 
@@ -1684,7 +1684,7 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    return( pk_info_encrypt_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
+    return( mbedtls_pk_info_encrypt_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx,
                 input, ilen, output, olen, osize, f_rng, p_rng ) );
 }
 
@@ -1700,9 +1700,9 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_conte
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-    if( pk_info_type( prv->pk_info ) == MBEDTLS_PK_RSA_ALT )
+    if( mbedtls_pk_info_type( prv->pk_info ) == MBEDTLS_PK_RSA_ALT )
     {
-        if( pk_info_type( pub->pk_info ) != MBEDTLS_PK_RSA )
+        if( mbedtls_pk_info_type( pub->pk_info ) != MBEDTLS_PK_RSA )
             return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
     }
     else
@@ -1712,7 +1712,7 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_conte
             return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
     }
 
-    return( pk_info_check_pair_func( MBEDTLS_PK_CTX_INFO( prv ),
+    return( mbedtls_pk_info_check_pair_func( MBEDTLS_PK_CTX_INFO( prv ),
                 pub->pk_ctx, prv->pk_ctx ) );
 }
 
@@ -1726,7 +1726,7 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
     if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( 0 );
 
-    return( pk_info_get_bitlen( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx ) );
+    return( mbedtls_pk_info_get_bitlen( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx ) );
 }
 
 /*
@@ -1738,7 +1738,7 @@ int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *item
     if( !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
 
-    return( pk_info_debug_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx, items ) );
+    return( mbedtls_pk_info_debug_func( MBEDTLS_PK_CTX_INFO( ctx ), ctx->pk_ctx, items ) );
 }
 
 /*
@@ -1749,7 +1749,7 @@ const char *mbedtls_pk_get_name( const mbedtls_pk_context *ctx )
     if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( "invalid PK" );
 
-    return( pk_info_name( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+    return( mbedtls_pk_info_name( MBEDTLS_PK_CTX_INFO( ctx ) ) );
 }
 
 /*
@@ -1760,7 +1760,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx )
     if( ctx == NULL || !MBEDTLS_PK_CTX_IS_VALID( ctx ) )
         return( MBEDTLS_PK_NONE );
 
-    return( pk_info_type( MBEDTLS_PK_CTX_INFO( ctx ) ) );
+    return( mbedtls_pk_info_type( MBEDTLS_PK_CTX_INFO( ctx ) ) );
 }
 
 #endif /* MBEDTLS_PK_C */


### PR DESCRIPTION
## Description

This PR aims at decreasing the cost of the PK layer when only one key type is enabled, by making the generic function inline, so that client code can directly call the relevant underlying function. For example, instead of "client -> `pk_sign()` -> `uecc_sign_wrap()`" we want the more direct "client -> `uecc_sign_wrap()` in the generated code, with the client's source code remaining unchanged.

__Note to gatekeeper:__ This is based on https://github.com/ARMmbed/mbedtls/pull/2835

_Note:_ this is similar to the second part of ARMmbed/mbedtls-restricted#654 which changed the MD layer. Specifically, the same general design is followed, on purpose. (The first part was #2835.)

| | GCC | ARMC5 | ARMC6 |
| --- | --- | --- | --- |
| `libmbedcrypto.a` before | 20915 | 21379 | 24531 |
| `libmbedcrypto.a` after |  |  |  |
| gain in bytes Crypt |  |  |  |
| `libmbedx509.a` before | 5341 | 5522 | 6344 |
| `libmbedx509.a` after |  |  |  |
| gain in bytes X.509 |  |  |  |
| `libmbedtls.a` before | 15177 | 16515 | 18973 |
| `libmbedtls.a` after |  |  |  |
| gain in bytes TLS |  |  |  |
| total before | 41433 | 43416 | 49848 |
| total after |  |  |  |
| gain in total |  |  |  |

## Migrations

No API change, but the ABI is changed when `MBEDTLS_PK_SINGLE_TYPE` is enabled, as functions that are currently part of the ABI are made static inline (hence not visible by the linker).