### PR TITLE
Fix issues in ssl_tls.c

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.19.2 branch released xxxx-xx-xx
+
+Bugfix
+   * Fix an incorrect size in a debugging message. Reported and fix
+     submitted by irwir. Fixes #2717.
+   * Fix an unused variable warning when compiling without DTLS.
+     Reported and fix submitted by irwir. Fixes #2800.
+   * Remove a useless assignment. Reported and fix submitted by irwir.
+     Fixes #2801.
+
 = mbed TLS 2.19.1 branch released 2019-09-16
 
 Features

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6414,7 +6414,7 @@ static int ssl_get_next_record( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ssl->in_len = ssl->in_cid + rec.cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-    ssl->in_iv  = ssl->in_msg = ssl->in_len + 2;
+    ssl->in_iv  = ssl->in_len + 2;
 
     /* The record content type may change during decryption,
      * so re-read it. */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6568,16 +6568,9 @@ int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl )
 
 int mbedtls_ssl_send_fatal_handshake_failure( mbedtls_ssl_context *ssl )
 {
-    int ret;
-
-    if( ( ret = mbedtls_ssl_send_alert_message( ssl,
-                    MBEDTLS_SSL_ALERT_LEVEL_FATAL,
-                    MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE ) ) != 0 )
-    {
-        return( ret );
-    }
-
-    return( 0 );
+    return( mbedtls_ssl_send_alert_message( ssl,
+                  MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                  MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE ) );
 }
 
 int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7264,7 +7264,7 @@ static int ssl_remember_peer_crt_digest( mbedtls_ssl_context *ssl,
     if( ssl->session_negotiate->peer_cert_digest == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "alloc(%d bytes) failed",
-                                    sizeof( MBEDTLS_SSL_PEER_CERT_DIGEST_DFL_LEN ) ) );
+                                    MBEDTLS_SSL_PEER_CERT_DIGEST_DFL_LEN ) );
         mbedtls_ssl_send_alert_message( ssl,
                                         MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                         MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -120,7 +120,6 @@ int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
                               size_t buflen )
 {
     int ret = 0;
-    mbedtls_record rec;
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "=> mbedtls_ssl_check_record" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "record buffer", buf, buflen );
 
@@ -137,6 +136,8 @@ int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     else
     {
+        mbedtls_record rec;
+
         ret = ssl_parse_record_header( ssl, buf, buflen, &rec );
         if( ret != 0 )
         {


### PR DESCRIPTION
## Description
Fix issues:
Resolve #2717 - remove erroneous `sizeof` (the operator was applied to constant integer number)
Resolve #2800 - move declaration to avoid unused variable warning in case `MBEDTLS_SSL_PROTO_DTLS` was undefined
Resolve #2801 - remove repetitive assignment to `ssl->in_msg` (the first value was never used)
Additionally, `mbedtls_ssl_send_fatal_handshake_failure` was overcomplicated and could be written in one line.

## Status
**READY**

## Requires Backporting
NO  
Which branch?
development

## Migrations
NO

Edit Ron: Add the "Resolve" magic word to automatically close the issues once merged