### PR TITLE
Fix warning in PSK parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.19.2 branch released xxxx-xx-xx
+
+Bugfix
+   * Remove a spurious check in ssl_parse_client_psk_identity that triggered
+     a warning with some compilers. Fix contributed by irwir in #2856.
+
 = mbed TLS 2.19.1 branch released 2019-09-16
 
 Features

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2339,7 +2339,7 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
                                       unsigned char *end )
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-    size_t  len;
+    uint16_t  len;
     ((void) ssl);
 
     /*
@@ -2356,7 +2356,7 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
     len = (*p)[0] << 8 | (*p)[1];
     *p += 2;
 
-    if( end - (*p) < (int) len )
+    if( end - (*p) < len )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message "
                                     "(psk_identity_hint length)" ) );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3810,7 +3810,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
                                           const unsigned char *end )
 {
     int ret = 0;
-    size_t n;
+    uint16_t n;
 
     if( ssl_conf_has_psk_or_cb( ssl->conf ) == 0 )
     {
@@ -3830,7 +3830,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
     n = ( (*p)[0] << 8 ) | (*p)[1];
     *p += 2;
 
-    if( n < 1 || n > 65535 || n > (size_t) ( end - *p ) )
+    if( n == 0 || n > end - *p )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
         return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );


### PR DESCRIPTION
## Description
The algorithm in [RFC4279](https://tools.ietf.org/html/rfc4279#section-3) requires 16-bit value, and nothing more than 16 bits could be obtained from combining two 8-bit values.
Therefore it would be appropriate to use `uint16_t` instead of _possibly_ too wide `size_t`.
Then the range check (`n > 65535`) could go away together with the warning.

The same type change applies to `ssl_cli.c`, even though the mentioned check was in `ssl_srv.c` only.

## Status
**READY**

## Requires Backporting
NO  
Which branch?
Development

## Migrations
NO