### PR TITLE
Fix potential resource leak in sslserver2 example

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -721,6 +721,7 @@ static int nss_keylog_export( void *p_expkey,
         if( fwrite( nss_keylog_line, 1, len, f ) != len )
         {
             ret = -1;
+            fclose( f );
             goto exit;
         }
 


### PR DESCRIPTION
One of the execution paths in sslserver2 doesn't release a file handle.