### PR TITLE
[Baremetal] Add FI/SCA compliant versions of mem-functions

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,14 +3683,6 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
-/**
- * Uncomment the macro to let Mbed TLS use a platform implementation of
- * global RNG.
- *
- * By default the global RNG function will be a no-op.
- */
-//#define MBEDTLS_PLATFORM_GLOBAL_RNG
-
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,6 +3683,14 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
+/**
+ * Uncomment the macro to let Mbed TLS use a platform implementation of
+ * global RNG.
+ *
+ * By default the global RNG function will be a no-op.
+ */
+//#define MBEDTLS_PLATFORM_GLOBAL_RNG
+
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -170,7 +170,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
-size_t mbedtls_random_in_range( size_t num );
+size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,6 +164,14 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+void mbedtls_platform_memset( void *ptr, int value, size_t num );
+
+void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+
+int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
+
+size_t mbedtls_random_in_range( size_t num );
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -228,7 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  * \param num   Max-value for the generated random number.
  *
  */ 
-size_t mbedtls_platform_random_in_range( size_t num );
+uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -225,8 +225,9 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
  *
- * \param num   Max-value for the generated random number.
- *
+ * \param num   Max-value for the generated random number, exclusive.
+ *              The generated number will be on range [0, num).
+ * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -178,8 +178,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
  *
+ * \return      The value of \p ptr.
  */
-void mbedtls_platform_memset( void *ptr, int value, size_t num );
+void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 
 /**
  * \brief       Secure memcpy
@@ -195,8 +196,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num );
  * \param src   Source buffer where the data is being copied from.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      The value of \p dst.
  */
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 /**
  * \brief       Secure memcmp

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,12 +164,70 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+/**
+ * \brief       Secure memset
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memset. It starts by initialising the given memory area
+ *              from random tail location with random data. After tail is
+ *              initialised, the remaining head of the buffer is initialised
+ *              with random data. After initialisation, the original memset
+ *              is performed
+ *
+ * \param ptr   Buffer to be set.
+ * \param value Value to be used when setting the buffer.
+ * \param num   The length of the buffer in bytes.
+ * 
+ */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 
+/**
+ * \brief       Secure memcpy
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcpy. It starts by initialising the given memory area
+ *              with random data. After initialisation, the original memcpy
+ *              is performed by starting first copying from random tail
+ *              location of the buffer. After tail has been copied, the
+ *              remaining head is copied as well.
+ *
+ * \param dst   Destination buffer where the data is being copied to.
+ * \param src   Source buffer where the data is being copied from.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
+/**
+ * \brief       Secure memcmp
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcmp. It starts comparing from a random offset and goes
+ *              through the tail part of buffers first byte by byte. After
+ *              that it starts going through the head part of buffer. In the
+ *              end, the number of equal bytes is compared to the length of the
+ *              buffers, thus making the function a fixed time memcmp.
+ *
+ * \param buf1  First buffer to compare.
+ * \param buf2  Second buffer to compare against.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
+/**
+ * \brief       A global RNG-function
+ *
+ *              This function is meant to provide a global RNG to be used
+ *              throughout Mbed TLS for hardening the library. It is used
+ *              for generating a random delay, random data or random offset
+ *              for utility functions. It is not meant to be a
+ *              cryptographically secure RNG, but provide an RNG for utility
+ *              functions.
+ *
+ * \param num   Max-value for the generated random number.
+ *
+ */ 
 size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -212,6 +212,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      0 if the buffers were equal.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
@@ -227,6 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).
+ *
  * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -177,7 +177,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
- * 
+ *
  */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -219,7 +219,7 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
 /**
- * \brief       A global RNG-function
+ * \brief       RNG-function for getting a random in given range.
  *
  *              This function is meant to provide a global RNG to be used
  *              throughout Mbed TLS for hardening the library. It is used
@@ -227,6 +227,12 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              for utility functions. It is not meant to be a
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
+ *
+ * \note        Currently the function is dependent of hardware providing an
+ *              rng with MBEDTLS_ENTROPY_HARDWARE_ALT. By default, 0 is
+ *              returned.
+ *
+ * \note        If the given range is [0, 0), 0 is returned.
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -230,7 +230,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              The generated number will be on range [0, num).
  *
  * \return      The generated random number.
- */ 
+ */
 uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -167,12 +167,11 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 /**
  * \brief       Secure memset
  *
- *              This function is meant to provide a more secure way to do
- *              memset. It starts by initialising the given memory area
- *              from random tail location with random data. After tail is
- *              initialised, the remaining head of the buffer is initialised
- *              with random data. After initialisation, the original memset
- *              is performed
+ *              This is a constant-time version of memset(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the buffer is
+ *              initialised with random data and the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
@@ -185,12 +184,11 @@ void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 /**
  * \brief       Secure memcpy
  *
- *              This function is meant to provide a more secure way to do
- *              memcpy. It starts by initialising the given memory area
- *              with random data. After initialisation, the original memcpy
- *              is performed by starting first copying from random tail
- *              location of the buffer. After tail has been copied, the
- *              remaining head is copied as well.
+ *              This is a constant-time version of memcpy(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the buffer is
+ *              initialised with random data and the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param dst   Destination buffer where the data is being copied to.
  * \param src   Source buffer where the data is being copied from.
@@ -203,18 +201,17 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 /**
  * \brief       Secure memcmp
  *
- *              This function is meant to provide a more secure way to do
- *              memcmp. It starts comparing from a random offset and goes
- *              through the tail part of buffers first byte by byte. After
- *              that it starts going through the head part of buffer. In the
- *              end, the number of equal bytes is compared to the length of the
- *              buffers, thus making the function a fixed time memcmp.
+ *              This is a constant-time version of memcmp(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param buf1  First buffer to compare.
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
- * \return      0 if the buffers were equal.
+ * \return      0 if the buffers were equal or an unspecified non-zero value
+ *              otherwise.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -79,7 +79,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
-void mbedtls_platform_memset( void *ptr, int value, size_t num )
+void *mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -93,10 +93,10 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
-    memset( ptr, value, num );
+    return( memset( ptr, value, num ) );
 }
 
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -107,7 +107,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),
             (void *) ( (unsigned char *) src + start_offset ),
             ( num - start_offset ) );
-    memcpy( (void *) dst, (void *) src, start_offset );
+    return( memcpy( (void *) dst, (void *) src, start_offset ) );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -38,6 +38,10 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/threading.h"
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+#include "mbedtls/entropy_poll.h"
+#endif
+
 #include <stddef.h>
 #include <string.h>
 
@@ -135,13 +139,20 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return( diff );
 }
 
-#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 uint32_t mbedtls_platform_random_in_range( size_t num )
 {
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     (void) num;
     return 0;
+#else
+    uint32_t result = 0;
+    size_t olen = 0;
+
+    mbedtls_hardware_poll( NULL, (unsigned char *) &result, sizeof( result ),
+                           &olen );
+    return( result % num );
+#endif
 }
-#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_platform_random_in_range( size_t num )
+uint32_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -112,7 +112,9 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 {
-    volatile unsigned int equal = 0;
+    volatile const unsigned char *A = (volatile const unsigned char *) buf1;
+    volatile const unsigned char *B = (volatile const unsigned char *) buf2;
+    volatile unsigned char diff = 0;
 
     size_t i = num;
 
@@ -120,22 +122,17 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
     for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
-    if ( equal == num )
-    {
-        return 0;
-    }
-
-    return 1;
+    return( diff );
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,15 +82,15 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
-            ( num - startOffset ) );
-    memset( ( void * ) ptr, data, startOffset );
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+            ( num - start_offset ) );
+    memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
     memset( ptr, value, num );
@@ -99,15 +99,15 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
-    memset( ( void * ) dst, data, num );
-    memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
-            ( void * ) ( ( unsigned char * ) src + startOffset ),
-            ( num - startOffset ) );
-    memcpy( ( void * ) dst, ( void * ) src, startOffset );
+    memset( (void *) dst, data, num );
+    memcpy( (void *) ( (unsigned char *) dst + start_offset ),
+            (void *) ( (unsigned char *) src + start_offset ),
+            ( num - start_offset ) );
+    memcpy( (void *) dst, (void *) src, start_offset );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
@@ -116,18 +116,18 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
 
-    for( i = startOffset; i < num; i++ )
+    for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
-    for( i = 0; i < startOffset; i++ )
+    for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
     if ( equal == num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,8 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ptr + startOffset ), value, ( num - startOffset ) );
+    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
+            ( num - startOffset ) );
     memset( ( void * ) ptr, data, startOffset );
 
     /* Perform the original memset */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -137,12 +137,13 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return 1;
 }
 
-//TODO: This is a stub implementation of the global RNG function.
+#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 size_t mbedtls_random_in_range( size_t num )
 {
     (void) num;
     return 0;
 }
+#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_random_in_range( size_t num )
+size_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), data,
             ( num - start_offset ) );
     memset( (void *) ptr, data, start_offset );
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -150,7 +150,17 @@ uint32_t mbedtls_platform_random_in_range( size_t num )
 
     mbedtls_hardware_poll( NULL, (unsigned char *) &result, sizeof( result ),
                            &olen );
-    return( result % num );
+
+    if( num == 0 )
+    {
+        result = 0;
+    }
+    else
+    {
+        result %= num;
+    }
+
+    return( result );
 #endif
 }
 

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -80,6 +80,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -82,6 +82,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -52,6 +52,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 static int generic_wrapper( mbedtls_md_handle_t md_info, char *filename, unsigned char *sum )
 {

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -48,6 +48,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -72,6 +72,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -69,6 +69,18 @@ int main( void )
  */
 #define GENERATOR "4"
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char **argv )
 {

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -72,6 +72,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -100,6 +100,18 @@ static void dump_pubkey( const char *title, mbedtls_ecdsa_context *key )
 #define dump_pubkey( a, b )
 #endif
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -137,6 +137,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -74,6 +74,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -99,6 +99,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/mpi_demo.c
+++ b/programs/pkey/mpi_demo.c
@@ -50,6 +50,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -60,6 +60,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -61,6 +61,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -61,6 +61,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * For the currently used signature algorithms the buffer to store any signature

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -57,6 +57,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -59,6 +59,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -59,6 +59,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -64,6 +64,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -56,6 +56,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -60,6 +60,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -55,6 +55,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -60,6 +60,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -51,6 +51,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -54,6 +54,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -109,6 +109,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret, len;

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -118,6 +118,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret, len;

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -180,6 +180,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = exit_ok;

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,6 +2666,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
+#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
+    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
+
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,14 +2666,6 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
-#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
-    {
-        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
-        return( 0 );
-    }
-#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
-
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -99,6 +99,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = 1, len;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -925,6 +925,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 0, len, tail_len, i, written, frags, retry_left;

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -116,6 +116,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = 1, len, cnt = 0, pid;

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -375,6 +375,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1, len;

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -111,6 +111,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret, len;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1536,6 +1536,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 0, len, written, frags, exchanges_left;

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -258,6 +258,18 @@ typedef struct {
          rsa, dhm, ecdsa, ecdh;
 } todo_list;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -279,6 +279,19 @@ const selftest_t selftests[] =
 };
 #endif /* MBEDTLS_SELF_TEST */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
 #if defined(MBEDTLS_SELF_TEST)

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -59,19 +59,6 @@ void usage( void )
     mbedtls_printf( "       zeroize <FILE>\n" );
 }
 
-#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
-int mbedtls_hardware_poll( void *data, unsigned char *output,
-                           size_t len, size_t *olen )
-{
-    size_t i;
-    (void) data;
-    for( i = 0; i < len; ++i )
-        output[i] = rand();
-    *olen = len;
-    return( 0 );
-}
-#endif
-
 int main( int argc, char** argv )
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;
@@ -112,3 +99,16 @@ int main( int argc, char** argv )
 
     return( exit_code );
 }
+
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -59,6 +59,19 @@ void usage( void )
     mbedtls_printf( "       zeroize <FILE>\n" );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char** argv )
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -165,6 +165,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -154,6 +154,19 @@ int write_certificate_request( mbedtls_x509write_csr *req, const char *output_fi
     return( 0 );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -214,6 +214,19 @@ int write_certificate( mbedtls_x509write_cert *crt, const char *output_file,
     return( 0 );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -72,6 +72,19 @@ struct options
     const char *filename;       /* filename of the certificate file     */
 } opt;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -72,6 +72,19 @@ struct options
     const char *filename;       /* filename of the certificate request  */
 } opt;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1561,6 +1561,16 @@ component_test_baremetal () {
     if_build_succeeded tests/ssl-opt.sh --filter "^Default, DTLS$"
 }
 
+component_test_hardware_entropy () {
+    msg "build: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
+    scripts/config.pl set MBEDTLS_ENTROPY_HARDWARE_ALT
+    make CFLAGS='-Werror -O1'
+
+    msg "test: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
+    if_build_succeeded make test
+    if_build_succeeded tests/ssl-opt.sh --filter "^Default, DTLS$"
+}
+
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
     scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -561,6 +561,16 @@ static int uecc_rng_wrapper( uint8_t *dest, unsigned int size )
 }
 #endif /* MBEDTLS_USE_TINYCRYPT */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    (void) data;
+    *olen = len;
+    return( rnd_std_rand( NULL, output, len ) );
+}
+#endif
+
 /**
  * This function only returns zeros
  *


### PR DESCRIPTION
## Description
Add FI/SCA compliant versions for memcmp, memcpy and memset. These functions should be used in global scope wherever mem-functions are used with secrets.
Adhering to the standards requires also a global RNG that can be used inside the global functions.

## Status
**REVIEW**

Impact on size with the baremetal config with ARM-GCC_6.3.1 and ARMC5_5.06 by running `scripts/baremetal.sh --rom --gcc --armc5`

With `MBEDTLS_ENTROPY_HARDWARE_ALT` enabled

-- | ARM-GCC | ARMCC-5
-- | -- | --
Before | 42191 | 43428
After | 42287 | 43576
Gained | 94 | 148

