### PR TITLE
Fix some possibly-undefined variable warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Bugfix
    * Fix an unchecked call to mbedtls_md() in the x509write module.
    * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
      Jack Lloyd in #2859. Fix submitted by jiblime in #2963.
+   * Fix some false-positive uninitialized variable warnings. Fix contributed
+     by apple-ihack-geek in #2663.
 
 = mbed TLS 2.20.0 branch released 2020-01-15
 
@@ -86,8 +88,6 @@ Bugfix
    * mbedtls_ctr_drbg_set_entropy_len() and
      mbedtls_hmac_drbg_set_entropy_len() now work if you call them before
      mbedtls_ctr_drbg_seed() or mbedtls_hmac_drbg_seed().
-   * Fix some false-positive uninitialized variable warnings. Fix contributed
-     by apple-ihack-geek in #2663.
 
 Changes
    * Remove the technical possibility to define custom mbedtls_md_info
@@ -118,6 +118,10 @@ API Changes
    * Make client_random and server_random const in
      mbedtls_ssl_export_keys_ext_t, so that the key exporter is discouraged
      from modifying the client/server hello.
+
+Bugfix
+   * Fix some false-positive uninitialized variable warnings. Fix
+     contributed by apple-ihack-geek in #2663.
 
 = mbed TLS 2.19.0 branch released 2019-09-06
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,8 +14,8 @@ Bugfix
    * Fix an unchecked call to mbedtls_md() in the x509write module.
    * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
      Jack Lloyd in #2859. Fix submitted by jiblime in #2963.
-   * Fix some false-positive uninitialized variable warnings. Fix contributed
-     by apple-ihack-geek in #2663.
+   * Fix some false-positive uninitialized variable warnings in X.509. Fix
+     contributed by apple-ihack-geek in #2663.
 
 = mbed TLS 2.20.0 branch released 2020-01-15
 
@@ -120,7 +120,7 @@ API Changes
      from modifying the client/server hello.
 
 Bugfix
-   * Fix some false-positive uninitialized variable warnings. Fix
+   * Fix some false-positive uninitialized variable warnings in crypto. Fix
      contributed by apple-ihack-geek in #2663.
 
 = mbed TLS 2.19.0 branch released 2019-09-06

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -541,7 +541,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
 {
 #if defined(MBEDTLS_PEM_PARSE_C)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t use_len;
+    size_t use_len = 0;
     mbedtls_pem_context pem;
     int is_pem = 0;
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2538,7 +2538,7 @@ static int x509_crt_find_parent_in(
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_x509_crt *parent, *fallback_parent;
-    int signature_is_good, fallback_signature_is_good;
+    int signature_is_good = 0, fallback_signature_is_good;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
     /* did we have something in progress? */


### PR DESCRIPTION
Forward port of https://github.com/ARMmbed/mbedtls/pull/2663 contributed by @apple-ihack-geek. The runtime behavior was always correct, but some compilers warned that they weren't sure about it.

### Related PRs

- mbedtls-2.16 #2663 
- mbedtls-2.7 #2897 
- mbed-crypto https://github.com/ARMmbed/mbed-crypto/pull/284 (merged)