### PR TITLE
[Baremetal] Use mbedtls_platform_memcmp for memory comparison

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -130,11 +130,13 @@
  */
 #define MBEDTLS_OID_CMP(oid_str, oid_buf)                                   \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf)->len ) ||                \
-          memcmp( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
+          mbedtls_platform_memcmp( (oid_str), (oid_buf)->p,                 \
+          (oid_buf)->len) != 0 )
 
 #define MBEDTLS_OID_CMP_RAW(oid_str, oid_buf, oid_buf_len)                  \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf_len) ) ||                 \
-          memcmp( (oid_str), (oid_buf), (oid_buf_len) ) != 0 )
+          mbedtls_platform_memcmp( (oid_str), (oid_buf),                    \
+          (oid_buf_len) ) != 0 )
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/compat-1.3.h
+++ b/include/mbedtls/compat-1.3.h
@@ -2231,7 +2231,7 @@
 #define rsa_rsassa_pss_verify_ext mbedtls_rsa_rsassa_pss_verify_ext
 #define rsa_self_test mbedtls_rsa_self_test
 #define rsa_set_padding mbedtls_rsa_set_padding
-#define safer_memcmp mbedtls_ssl_safer_memcmp
+#define safer_memcmp mbedtls_platform_memcmp
 #define set_alarm mbedtls_set_alarm
 #define sha1 mbedtls_sha1
 #define sha1_context mbedtls_sha1_context

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,6 +3683,14 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
+/**
+ * Uncomment the macro to let Mbed TLS use a platform implementation of
+ * global RNG.
+ *
+ * By default the global RNG function will be a no-op.
+ */
+//#define MBEDTLS_PLATFORM_GLOBAL_RNG
+
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -170,7 +170,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
-size_t mbedtls_random_in_range( size_t num );
+size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,6 +164,14 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+void mbedtls_platform_memset( void *ptr, int value, size_t num );
+
+void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+
+int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
+
+size_t mbedtls_random_in_range( size_t num );
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -228,7 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  * \param num   Max-value for the generated random number.
  *
  */ 
-size_t mbedtls_platform_random_in_range( size_t num );
+uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -225,8 +225,9 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
  *
- * \param num   Max-value for the generated random number.
- *
+ * \param num   Max-value for the generated random number, exclusive.
+ *              The generated number will be on range [0, num).
+ * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,12 +164,70 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+/**
+ * \brief       Secure memset
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memset. It starts by initialising the given memory area
+ *              from random tail location with random data. After tail is
+ *              initialised, the remaining head of the buffer is initialised
+ *              with random data. After initialisation, the original memset
+ *              is performed
+ *
+ * \param ptr   Buffer to be set.
+ * \param value Value to be used when setting the buffer.
+ * \param num   The length of the buffer in bytes.
+ * 
+ */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 
+/**
+ * \brief       Secure memcpy
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcpy. It starts by initialising the given memory area
+ *              with random data. After initialisation, the original memcpy
+ *              is performed by starting first copying from random tail
+ *              location of the buffer. After tail has been copied, the
+ *              remaining head is copied as well.
+ *
+ * \param dst   Destination buffer where the data is being copied to.
+ * \param src   Source buffer where the data is being copied from.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
+/**
+ * \brief       Secure memcmp
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcmp. It starts comparing from a random offset and goes
+ *              through the tail part of buffers first byte by byte. After
+ *              that it starts going through the head part of buffer. In the
+ *              end, the number of equal bytes is compared to the length of the
+ *              buffers, thus making the function a fixed time memcmp.
+ *
+ * \param buf1  First buffer to compare.
+ * \param buf2  Second buffer to compare against.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
+/**
+ * \brief       A global RNG-function
+ *
+ *              This function is meant to provide a global RNG to be used
+ *              throughout Mbed TLS for hardening the library. It is used
+ *              for generating a random delay, random data or random offset
+ *              for utility functions. It is not meant to be a
+ *              cryptographically secure RNG, but provide an RNG for utility
+ *              functions.
+ *
+ * \param num   Max-value for the generated random number.
+ *
+ */ 
 size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -212,6 +212,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      0 if the buffers were equal.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
@@ -227,6 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).
+ *
  * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -177,7 +177,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
- * 
+ *
  */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -230,7 +230,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              The generated number will be on range [0, num).
  *
  * \return      The generated random number.
- */ 
+ */
 uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1159,26 +1159,6 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
                               const mbedtls_ssl_session *src );
 
-/* constant-time buffer comparison */
-static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
-{
-    size_t i;
-    volatile const unsigned char *A = (volatile const unsigned char *) a;
-    volatile const unsigned char *B = (volatile const unsigned char *) b;
-    volatile unsigned char diff = 0;
-
-    for( i = 0; i < n; i++ )
-    {
-        /* Read volatile data in order before computing diff.
-         * This avoids IAR compiler warning:
-         * 'the order of volatile accesses is undefined ..' */
-        unsigned char x = A[i], y = B[i];
-        diff |= x ^ y;
-    }
-
-    return( diff );
-}
-
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
 int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -431,7 +431,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *
     while( list != NULL )
     {
         if( list->oid.len == len &&
-            memcmp( list->oid.p, oid, len ) == 0 )
+            mbedtls_platform_memcmp( list->oid.p, oid, len ) == 0 )
         {
             break;
         }

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -70,26 +70,6 @@
 #define CIPHER_VALIDATE( cond )        \
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
-#if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
-/* Compare the contents of two buffers in constant time.
- * Returns 0 if the contents are bitwise identical, otherwise returns
- * a non-zero value.
- * This is currently only used by GCM and ChaCha20+Poly1305.
- */
-static int mbedtls_constant_time_memcmp( const void *v1, const void *v2, size_t len )
-{
-    const unsigned char *p1 = (const unsigned char*) v1;
-    const unsigned char *p2 = (const unsigned char*) v2;
-    size_t i;
-    unsigned char diff;
-
-    for( diff = 0, i = 0; i < len; i++ )
-        diff |= p1[i] ^ p2[i];
-
-    return( (int)diff );
-}
-#endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
-
 static int supported_init = 0;
 
 const int *mbedtls_cipher_list( void )
@@ -960,8 +940,7 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
             return( ret );
         }
 
-        /* Check the tag in "constant-time" */
-        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+        if( mbedtls_platform_memcmp( tag, check_tag, tag_len ) != 0 )
             return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
 
         return( 0 );
@@ -982,8 +961,7 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
             return( ret );
         }
 
-        /* Check the tag in "constant-time" */
-        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+        if( mbedtls_platform_memcmp( tag, check_tag, tag_len ) != 0 )
             return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
 
         return( 0 );

--- a/library/oid.c
+++ b/library/oid.c
@@ -75,7 +75,8 @@
         if( p == NULL || oid == NULL ) return( NULL );                  \
         while( cur->asn1 != NULL ) {                                    \
             if( cur->asn1_len == oid->len &&                            \
-                memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {          \
+                mbedtls_platform_memcmp( cur->asn1, oid->p, oid->len )  \
+                == 0 ) {                                                \
                 return( p );                                            \
             }                                                           \
             p++;                                                        \

--- a/library/pk.c
+++ b/library/pk.c
@@ -556,7 +556,7 @@ static int uecc_eckey_check_pair( const void *pub, const void *prv )
     const mbedtls_uecc_keypair *uecc_prv =
         (const mbedtls_uecc_keypair *) prv;
 
-    if( memcmp( uecc_pub->public_key,
+    if( mbedtls_platform_memcmp( uecc_pub->public_key,
                 uecc_prv->public_key,
                 2 * NUM_ECC_BYTES ) == 0 )
     {

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,9 +88,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( (void *) ( (unsigned char *) ptr + start_offset ), data,
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), (int) data,
             ( num - start_offset ) );
-    memset( (void *) ptr, data, start_offset );
+    memset( (void *) ptr, (int) data, start_offset );
 
     /* Perform the original memset */
     memset( ptr, value, num );
@@ -103,7 +103,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize initial data to prevent leakage while copying */
     size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
-    memset( (void *) dst, data, num );
+    memset( (void *) dst, (int) data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),
             (void *) ( (unsigned char *) src + start_offset ),
             ( num - start_offset ) );

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_platform_random_in_range( size_t num )
+uint32_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -112,7 +112,9 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 {
-    volatile unsigned int equal = 0;
+    volatile const unsigned char *A = (volatile const unsigned char *) buf1;
+    volatile const unsigned char *B = (volatile const unsigned char *) buf2;
+    volatile unsigned char diff = 0;
 
     size_t i = num;
 
@@ -120,22 +122,17 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
     for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
-    if ( equal == num )
-    {
-        return 0;
-    }
-
-    return 1;
+    return( diff );
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,15 +82,15 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
-            ( num - startOffset ) );
-    memset( ( void * ) ptr, data, startOffset );
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+            ( num - start_offset ) );
+    memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
     memset( ptr, value, num );
@@ -99,15 +99,15 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
-    memset( ( void * ) dst, data, num );
-    memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
-            ( void * ) ( ( unsigned char * ) src + startOffset ),
-            ( num - startOffset ) );
-    memcpy( ( void * ) dst, ( void * ) src, startOffset );
+    memset( (void *) dst, data, num );
+    memcpy( (void *) ( (unsigned char *) dst + start_offset ),
+            (void *) ( (unsigned char *) src + start_offset ),
+            ( num - start_offset ) );
+    memcpy( (void *) dst, (void *) src, start_offset );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
@@ -116,18 +116,18 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
 
-    for( i = startOffset; i < num; i++ )
+    for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
-    for( i = 0; i < startOffset; i++ )
+    for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
     if ( equal == num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,8 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ptr + startOffset ), value, ( num - startOffset ) );
+    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
+            ( num - startOffset ) );
     memset( ( void * ) ptr, data, startOffset );
 
     /* Perform the original memset */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -137,12 +137,13 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return 1;
 }
 
-//TODO: This is a stub implementation of the global RNG function.
+#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 size_t mbedtls_random_in_range( size_t num )
 {
     (void) num;
     return 0;
 }
+#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_random_in_range( size_t num )
+size_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), data,
             ( num - start_offset ) );
     memset( (void *) ptr, data, start_offset );
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1152,9 +1152,9 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len * 2 ||
             buf[0] !=     ssl->verify_data_len * 2 ||
-            mbedtls_ssl_safer_memcmp( buf + 1,
+            mbedtls_platform_memcmp( buf + 1,
                           ssl->own_verify_data, ssl->verify_data_len ) != 0 ||
-            mbedtls_ssl_safer_memcmp( buf + 1 + ssl->verify_data_len,
+            mbedtls_platform_memcmp( buf + 1 + ssl->verify_data_len,
                           ssl->peer_verify_data, ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -229,7 +229,8 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     if( ret != 0 )
         return( ret );
 
-    if( mbedtls_ssl_safer_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
+    if( mbedtls_platform_memcmp( cookie + 4, ref_hmac,
+                                 sizeof( ref_hmac ) ) != 0 )
         return( -1 );
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -160,7 +160,7 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len ||
             buf[0] !=     ssl->verify_data_len ||
-            mbedtls_ssl_safer_memcmp( buf + 1, ssl->peer_verify_data,
+            mbedtls_platform_memcmp( buf + 1, ssl->peer_verify_data,
                           ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );
@@ -4089,7 +4089,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
         /* Identity is not a big secret since clients send it in the clear,
          * but treat it carefully anyway, just in case */
         if( n != ssl->conf->psk_identity_len ||
-            mbedtls_ssl_safer_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
+            mbedtls_platform_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
         {
             ret = MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY;
         }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2883,7 +2883,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
      * Match record's CID with incoming CID.
      */
     if( rec->cid_len != transform->in_cid_len ||
-        memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 )
+        mbedtls_platform_memcmp( rec->cid, transform->in_cid,
+                                 rec->cid_len ) != 0 )
     {
         return( MBEDTLS_ERR_SSL_UNEXPECTED_CID );
     }
@@ -3083,7 +3084,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
              *
              * Afterwards, we know that data + data_len is followed by at
              * least maclen Bytes, which justifies the call to
-             * mbedtls_ssl_safer_memcmp() below.
+             * mbedtls_platform_memcmp() below.
              *
              * Further, we still know that data_len > minlen */
             rec->data_len -= transform->maclen;
@@ -3105,7 +3106,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                                    transform->maclen );
 
             /* Compare expected MAC with MAC at the end of the record. */
-            if( mbedtls_ssl_safer_memcmp( data + rec->data_len, mac_expect,
+            if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
                                           transform->maclen ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "message mac does not match" ) );
@@ -3444,7 +3445,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         MBEDTLS_SSL_DEBUG_BUF( 4, "message  mac", data + rec->data_len, transform->maclen );
 #endif
 
-        if( mbedtls_ssl_safer_memcmp( data + rec->data_len, mac_expect,
+        if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
                                       transform->maclen ) != 0 )
         {
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
@@ -6872,7 +6873,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( peer_crt->raw.len != crt_buf_len )
         return( -1 );
 
-    return( memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
+    return( mbedtls_platform_memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
 }
 #elif defined(MBEDTLS_SSL_RENEGOTIATION)
 static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
@@ -6903,7 +6904,8 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( ret != 0 )
         return( -1 );
 
-    return( memcmp( tmp_digest, peer_cert_digest, digest_len ) );
+    return( mbedtls_platform_memcmp( tmp_digest, peer_cert_digest,
+                                     digest_len ) );
 }
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE && MBEDTLS_SSL_RENEGOTIATION */
 #endif /* MBEDTLS_SSL_RENEGOTIATION && MBEDTLS_SSL_CLI_C */
@@ -7086,7 +7088,8 @@ static int ssl_srv_check_client_no_crt_notification( mbedtls_ssl_context *ssl )
     if( ssl->in_hslen   == 3 + mbedtls_ssl_hs_hdr_len( ssl ) &&
         ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE    &&
         ssl->in_msg[0]  == MBEDTLS_SSL_HS_CERTIFICATE   &&
-        memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 )
+        memcmp( ssl->in_msg +
+                mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "TLSv1 client has no certificate" ) );
         return( 0 );
@@ -7913,8 +7916,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_HS_FINISHED );
     }
 
-    if( mbedtls_ssl_safer_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
-                      buf, hash_len ) != 0 )
+    if( mbedtls_platform_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
+                                 buf, hash_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
         mbedtls_ssl_pend_fatal_alert( ssl,
@@ -9961,8 +9964,8 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( (size_t)( end - p ) < sizeof( ssl_serialized_session_header ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        if( memcmp( p, ssl_serialized_session_header,
-                    sizeof( ssl_serialized_session_header ) ) != 0 )
+        if( mbedtls_platform_memcmp( p, ssl_serialized_session_header,
+            sizeof( ssl_serialized_session_header ) ) != 0 )
         {
             return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );
         }
@@ -11448,7 +11451,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < sizeof( ssl_serialized_context_header ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    if( memcmp( p, ssl_serialized_context_header,
+    if( mbedtls_platform_memcmp( p, ssl_serialized_context_header,
                 sizeof( ssl_serialized_context_header ) ) != 0 )
     {
         return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );
@@ -11615,7 +11618,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
             for( cur = ssl->conf->alpn_list; *cur != NULL; cur++ )
             {
                 if( strlen( *cur ) == alpn_len &&
-                    memcmp( p, cur, alpn_len ) == 0 )
+                    mbedtls_platform_memcmp( p, cur, alpn_len ) == 0 )
                 {
                     ssl->alpn_chosen = *cur;
                     break;

--- a/library/x509.c
+++ b/library/x509.c
@@ -589,7 +589,7 @@ int mbedtls_x509_name_cmp_raw( mbedtls_x509_buf_raw const *a,
             goto exit;
 
         if( oid[0].len != oid[1].len ||
-            memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
+            mbedtls_platform_memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
         {
             return( 1 );
         }

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1316,7 +1316,8 @@ static int x509_crt_parse_frame( unsigned char *start,
      *    signature field in the sequence tbsCertificate (Section 4.1.2.3).
      */
     if( outer_sig_alg.len != inner_sig_alg_len ||
-        memcmp( outer_sig_alg.p, inner_sig_alg_start, inner_sig_alg_len ) != 0 )
+        mbedtls_platform_memcmp( outer_sig_alg.p, inner_sig_alg_start,
+                                 inner_sig_alg_len ) != 0 )
     {
         return( MBEDTLS_ERR_X509_SIG_MISMATCH );
     }
@@ -2588,8 +2589,8 @@ static int x509_crt_check_ext_key_usage_cb( void *ctx,
         return( 1 );
     }
 
-    if( data_len == cb_ctx->oid_len && memcmp( data, cb_ctx->oid,
-                                               data_len ) == 0 )
+    if( data_len == cb_ctx->oid_len &&
+        mbedtls_platform_memcmp( data, cb_ctx->oid, data_len ) == 0 )
     {
         return( 1 );
     }
@@ -3173,7 +3174,8 @@ static int x509_crt_check_ee_locally_trusted(
     for( cur = trust_ca; cur != NULL; cur = cur->next )
     {
         if( crt->raw.len == cur->raw.len &&
-            memcmp( crt->raw.p, cur->raw.p, crt->raw.len ) == 0 )
+            mbedtls_platform_memcmp( crt->raw.p, cur->raw.p,
+                                     crt->raw.len ) == 0 )
         {
             return( 0 );
         }

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,6 +2666,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
+#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
+    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
+
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {


### PR DESCRIPTION
## Description

Use mbedtls_platform_memcmp to compare memory in baremetal configured code blocks.

* Change larger memcmp() calls to use to mbedtls_platform_memcmp in baremetal
  configured code blocks. Small memcmp's still use original memcmp function.
    
* Replace mbedtls_ssl_safer_memcmp with mbedtls_platform_memcmp
    
* Replace mbedtls_constant_time_memcmp with mbedtls_platform_memcmp

This PR is made on top of https://github.com/ARMmbed/mbedtls/pull/2870

__Impact on code-size:__

| | GCC | ARMC5 | ARMC6 |
| --- | --- | --- | --- |
| `libmbedtls.a` before | 15177 | 16519| 17162|
| `libmbedtls.a` after | 15109 | 16463  | 17126 |
| `libmbedcrypto.a` before | 20915 | 21387| 23477|
| `libmbedcrypto.a` after | 20979  | 21551| 23589 |
| `libmbedx509.a` before | 5345| 5522| 5960|
| `libmbedx509.a` after | 5345 | 5522 | 5951 |
| gain in bytes TLS | 68 | 56 | 36 |
| gain in bytes X.509 | == | == | 9 |
| gain in bytes Crypto | -64 | -164 | -112 |
| gain Total | 4 | -108 | -85 |


## Status
**IN DEVELOPMENT**