### PR TITLE
[Baremetal] Use mbedtls_platform_memcpy for memory copy

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1846,7 +1846,7 @@ int mbedtls_aes_self_test( int verbose )
 #endif
     mbedtls_aes_context ctx;
 
-    mbedtls_platform_memset( key, 0, 32 );
+    memset( key, 0, 32 );
     mbedtls_aes_init( &ctx );
 
     /*
@@ -1878,7 +1878,7 @@ int mbedtls_aes_self_test( int verbose )
         }
 #endif /* MBEDTLS_AES_ONLY_ENCRYPT */
 
-        mbedtls_platform_memset( buf, 0, 16 );
+        memset( buf, 0, 16 );
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
@@ -1956,9 +1956,9 @@ int mbedtls_aes_self_test( int verbose )
         }
 #endif /* MBEDTLS_AES_ONLY_ENCRYPT */
 
-        mbedtls_platform_memset( iv , 0, 16 );
-        mbedtls_platform_memset( prv, 0, 16 );
-        mbedtls_platform_memset( buf, 0, 16 );
+        memset( iv , 0, 16 );
+        memset( prv, 0, 16 );
+        memset( buf, 0, 16 );
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
@@ -2272,8 +2272,8 @@ int mbedtls_aes_self_test( int verbose )
         }
 #endif /* MBEDTLS_AES_ONLY_ENCRYPT */
 
-        mbedtls_platform_memset( key, 0, sizeof( key ) );
-        mbedtls_platform_memcpy( key, aes_test_xts_key[u], 32 );
+        memset( key, 0, sizeof( key ) );
+        memcpy( key, aes_test_xts_key[u], 32 );
         data_unit = aes_test_xts_data_unit[u];
 
         len = sizeof( *aes_test_xts_ct32 );

--- a/library/aes.c
+++ b/library/aes.c
@@ -1113,13 +1113,13 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, 16 );
+            mbedtls_platform_memcpy( temp, input, 16 );
             mbedtls_aes_crypt_ecb( ctx, mode, input, output );
 
             for( i = 0; i < 16; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, 16 );
+            mbedtls_platform_memcpy( iv, temp, 16 );
 
             input  += 16;
             output += 16;
@@ -1134,7 +1134,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_aes_crypt_ecb( ctx, mode, output, output );
-            memcpy( iv, output, 16 );
+            mbedtls_platform_memcpy( iv, output, 16 );
 
             input  += 16;
             output += 16;
@@ -1251,7 +1251,7 @@ int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
              * and this tweak for the lefover bytes. Save the current tweak for
              * the leftovers and then update the current tweak for use on this,
              * the last full block. */
-            memcpy( prev_tweak, tweak, sizeof( tweak ) );
+            mbedtls_platform_memcpy( prev_tweak, tweak, sizeof( tweak ) );
             mbedtls_gf128mul_x_ble( tweak, tweak );
         }
 
@@ -1393,7 +1393,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
     AES_VALIDATE_RET( output != NULL );
     while( length-- )
     {
-        memcpy( ov, iv, 16 );
+        mbedtls_platform_memcpy( ov, iv, 16 );
         mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
 
         if( mode == MBEDTLS_AES_DECRYPT )
@@ -1404,7 +1404,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
         if( mode == MBEDTLS_AES_ENCRYPT )
             ov[16] = c;
 
-        memcpy( iv, ov + 1, 16 );
+        mbedtls_platform_memcpy( iv, ov + 1, 16 );
     }
 
     return( 0 );
@@ -1992,9 +1992,9 @@ int mbedtls_aes_self_test( int verbose )
             {
                 unsigned char tmp[16];
 
-                memcpy( tmp, prv, 16 );
-                memcpy( prv, buf, 16 );
-                memcpy( buf, tmp, 16 );
+                mbedtls_platform_memcpy( tmp, prv, 16 );
+                mbedtls_platform_memcpy( prv, buf, 16 );
+                mbedtls_platform_memcpy( buf, tmp, 16 );
             }
 
             ret = mbedtls_aes_crypt_cbc( &ctx, mode, 16, iv, buf, buf );
@@ -2069,12 +2069,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            memcpy( buf, aes_test_cfb128_ct[u], 64 );
+            mbedtls_platform_memcpy( buf, aes_test_cfb128_ct[u], 64 );
             aes_tests = aes_test_cfb128_pt;
         }
         else
         {
-            memcpy( buf, aes_test_cfb128_pt, 64 );
+            mbedtls_platform_memcpy( buf, aes_test_cfb128_pt, 64 );
             aes_tests = aes_test_cfb128_ct[u];
         }
 
@@ -2148,12 +2148,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            memcpy( buf, aes_test_ofb_ct[u], 64 );
+            mbedtls_platform_memcpy( buf, aes_test_ofb_ct[u], 64 );
             aes_tests = aes_test_ofb_pt;
         }
         else
         {
-            memcpy( buf, aes_test_ofb_pt, 64 );
+            mbedtls_platform_memcpy( buf, aes_test_ofb_pt, 64 );
             aes_tests = aes_test_ofb_ct[u];
         }
 
@@ -2215,12 +2215,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            memcpy( buf, aes_test_ctr_ct[u], len );
+            mbedtls_platform_memcpy( buf, aes_test_ctr_ct[u], len );
             aes_tests = aes_test_ctr_pt[u];
         }
         else
         {
-            memcpy( buf, aes_test_ctr_pt[u], len );
+            mbedtls_platform_memcpy( buf, aes_test_ctr_pt[u], len );
             aes_tests = aes_test_ctr_ct[u];
         }
 
@@ -2273,7 +2273,7 @@ int mbedtls_aes_self_test( int verbose )
 #endif /* MBEDTLS_AES_ONLY_ENCRYPT */
 
         mbedtls_platform_memset( key, 0, sizeof( key ) );
-        memcpy( key, aes_test_xts_key[u], 32 );
+        mbedtls_platform_memcpy( key, aes_test_xts_key[u], 32 );
         data_unit = aes_test_xts_data_unit[u];
 
         len = sizeof( *aes_test_xts_ct32 );
@@ -2283,7 +2283,7 @@ int mbedtls_aes_self_test( int verbose )
             ret = mbedtls_aes_xts_setkey_dec( &ctx_xts, key, 256 );
             if( ret != 0)
                 goto exit;
-            memcpy( buf, aes_test_xts_ct32[u], len );
+            mbedtls_platform_memcpy( buf, aes_test_xts_ct32[u], len );
             aes_tests = aes_test_xts_pt32[u];
         }
         else
@@ -2291,7 +2291,7 @@ int mbedtls_aes_self_test( int verbose )
             ret = mbedtls_aes_xts_setkey_enc( &ctx_xts, key, 256 );
             if( ret != 0)
                 goto exit;
-            memcpy( buf, aes_test_xts_pt32[u], len );
+            mbedtls_platform_memcpy( buf, aes_test_xts_pt32[u], len );
             aes_tests = aes_test_xts_ct32[u];
         }
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1992,9 +1992,9 @@ int mbedtls_aes_self_test( int verbose )
             {
                 unsigned char tmp[16];
 
-                mbedtls_platform_memcpy( tmp, prv, 16 );
-                mbedtls_platform_memcpy( prv, buf, 16 );
-                mbedtls_platform_memcpy( buf, tmp, 16 );
+                memcpy( tmp, prv, 16 );
+                memcpy( prv, buf, 16 );
+                memcpy( buf, tmp, 16 );
             }
 
             ret = mbedtls_aes_crypt_cbc( &ctx, mode, 16, iv, buf, buf );
@@ -2069,12 +2069,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            mbedtls_platform_memcpy( buf, aes_test_cfb128_ct[u], 64 );
+            memcpy( buf, aes_test_cfb128_ct[u], 64 );
             aes_tests = aes_test_cfb128_pt;
         }
         else
         {
-            mbedtls_platform_memcpy( buf, aes_test_cfb128_pt, 64 );
+            memcpy( buf, aes_test_cfb128_pt, 64 );
             aes_tests = aes_test_cfb128_ct[u];
         }
 
@@ -2148,12 +2148,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            mbedtls_platform_memcpy( buf, aes_test_ofb_ct[u], 64 );
+            memcpy( buf, aes_test_ofb_ct[u], 64 );
             aes_tests = aes_test_ofb_pt;
         }
         else
         {
-            mbedtls_platform_memcpy( buf, aes_test_ofb_pt, 64 );
+            memcpy( buf, aes_test_ofb_pt, 64 );
             aes_tests = aes_test_ofb_ct[u];
         }
 
@@ -2215,12 +2215,12 @@ int mbedtls_aes_self_test( int verbose )
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
-            mbedtls_platform_memcpy( buf, aes_test_ctr_ct[u], len );
+            memcpy( buf, aes_test_ctr_ct[u], len );
             aes_tests = aes_test_ctr_pt[u];
         }
         else
         {
-            mbedtls_platform_memcpy( buf, aes_test_ctr_pt[u], len );
+            memcpy( buf, aes_test_ctr_pt[u], len );
             aes_tests = aes_test_ctr_ct[u];
         }
 
@@ -2283,7 +2283,7 @@ int mbedtls_aes_self_test( int verbose )
             ret = mbedtls_aes_xts_setkey_dec( &ctx_xts, key, 256 );
             if( ret != 0)
                 goto exit;
-            mbedtls_platform_memcpy( buf, aes_test_xts_ct32[u], len );
+            memcpy( buf, aes_test_xts_ct32[u], len );
             aes_tests = aes_test_xts_pt32[u];
         }
         else
@@ -2291,7 +2291,7 @@ int mbedtls_aes_self_test( int verbose )
             ret = mbedtls_aes_xts_setkey_enc( &ctx_xts, key, 256 );
             if( ret != 0)
                 goto exit;
-            mbedtls_platform_memcpy( buf, aes_test_xts_pt32[u], len );
+            memcpy( buf, aes_test_xts_pt32[u], len );
             aes_tests = aes_test_xts_ct32[u];
         }
 

--- a/library/aesni.c
+++ b/library/aesni.c
@@ -39,6 +39,7 @@
 #endif
 
 #include "mbedtls/aesni.h"
+#include "mbedtls/platform_util.h"
 
 #include <string.h>
 
@@ -261,7 +262,7 @@ void mbedtls_aesni_inverse_key( unsigned char *invkey,
     unsigned char *ik = invkey;
     const unsigned char *fk = fwdkey + 16 * nr;
 
-    memcpy( ik, fk, 16 );
+    mbedtls_platform_memcpy( ik, fk, 16 );
 
     for( fk -= 16, ik += 16; fk > fwdkey; fk -= 16, ik += 16 )
         asm( "movdqu (%0), %%xmm0       \n\t"
@@ -271,7 +272,7 @@ void mbedtls_aesni_inverse_key( unsigned char *invkey,
              : "r" (fk), "r" (ik)
              : "memory", "xmm0" );
 
-    memcpy( ik, fk, 16 );
+    mbedtls_platform_memcpy( ik, fk, 16 );
 }
 
 /*

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -169,7 +169,7 @@ int mbedtls_arc4_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  ARC4 test #%d: ", i + 1 );
 
-        mbedtls_platform_memcpy( ibuf, arc4_test_pt[i], 8 );
+        memcpy( ibuf, arc4_test_pt[i], 8 );
 
         mbedtls_arc4_setup( &ctx, arc4_test_key[i], 8 );
         mbedtls_arc4_crypt( &ctx, 8, ibuf, obuf );

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -169,7 +169,7 @@ int mbedtls_arc4_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  ARC4 test #%d: ", i + 1 );
 
-        memcpy( ibuf, arc4_test_pt[i], 8 );
+        mbedtls_platform_memcpy( ibuf, arc4_test_pt[i], 8 );
 
         mbedtls_arc4_setup( &ctx, arc4_test_key[i], 8 );
         mbedtls_arc4_crypt( &ctx, 8, ibuf, obuf );

--- a/library/aria.c
+++ b/library/aria.c
@@ -1047,8 +1047,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CTR-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
-        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
+        memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
+        memset( buf, 0x55, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_ctr( &ctx, 48, &j, iv, blk,
             aria_test2_pt, buf );
@@ -1059,8 +1059,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CTR-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
-        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
+        memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
+        memset( buf, 0xAA, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_ctr( &ctx, 48, &j, iv, blk,
             aria_test2_ctr_ct[i], buf );

--- a/library/aria.c
+++ b/library/aria.c
@@ -986,8 +986,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CBC-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
+        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        memset( buf, 0x55, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, iv,
             aria_test2_pt, buf );
         if( memcmp( buf, aria_test2_cbc_ct[i], 48 ) != 0 )
@@ -997,8 +997,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CBC-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_dec( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
+        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        memset( buf, 0xAA, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, 48, iv,
             aria_test2_cbc_ct[i], buf );
         if( memcmp( buf, aria_test2_pt, 48 ) != 0 )
@@ -1016,8 +1016,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CFB-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
+        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        memset( buf, 0x55, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, &j, iv,
             aria_test2_pt, buf );
@@ -1028,8 +1028,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CFB-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
+        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        memset( buf, 0xAA, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT, 48, &j,
             iv, aria_test2_cfb_ct[i], buf );

--- a/library/aria.c
+++ b/library/aria.c
@@ -640,13 +640,13 @@ int mbedtls_aria_crypt_cbc( mbedtls_aria_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, MBEDTLS_ARIA_BLOCKSIZE );
+            mbedtls_platform_memcpy( temp, input, MBEDTLS_ARIA_BLOCKSIZE );
             mbedtls_aria_crypt_ecb( ctx, input, output );
 
             for( i = 0; i < MBEDTLS_ARIA_BLOCKSIZE; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, MBEDTLS_ARIA_BLOCKSIZE );
+            mbedtls_platform_memcpy( iv, temp, MBEDTLS_ARIA_BLOCKSIZE );
 
             input  += MBEDTLS_ARIA_BLOCKSIZE;
             output += MBEDTLS_ARIA_BLOCKSIZE;
@@ -661,7 +661,7 @@ int mbedtls_aria_crypt_cbc( mbedtls_aria_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_aria_crypt_ecb( ctx, output, output );
-            memcpy( iv, output, MBEDTLS_ARIA_BLOCKSIZE );
+            mbedtls_platform_memcpy( iv, output, MBEDTLS_ARIA_BLOCKSIZE );
 
             input  += MBEDTLS_ARIA_BLOCKSIZE;
             output += MBEDTLS_ARIA_BLOCKSIZE;
@@ -986,7 +986,7 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CBC-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
         mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, iv,
             aria_test2_pt, buf );
@@ -997,7 +997,7 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CBC-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_dec( &ctx, aria_test2_key, 128 + 64 * i );
-        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
         mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, 48, iv,
             aria_test2_cbc_ct[i], buf );
@@ -1016,7 +1016,7 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CFB-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
         mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, &j, iv,
@@ -1028,7 +1028,7 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CFB-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
+        mbedtls_platform_memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
         mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT, 48, &j,

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -124,7 +124,7 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
 
     len = size;
     (*p) -= len;
-    memcpy( *p, buf, len );
+    mbedtls_platform_memcpy( *p, buf, len );
 
     return( (int) len );
 }
@@ -312,7 +312,7 @@ int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
         byte_len--;
         *--( *p ) = buf[byte_len] & ~( ( 0x1 << unused_bits ) - 1 );
         ( *p ) -= byte_len;
-        memcpy( *p, buf, byte_len );
+        mbedtls_platform_memcpy( *p, buf, byte_len );
     }
 
     /* Write unused bits */
@@ -384,7 +384,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
             return( NULL );
         }
 
-        memcpy( cur->oid.p, oid, oid_len );
+        mbedtls_platform_memcpy( cur->oid.p, oid, oid_len );
 
         cur->val.len = val_len;
         cur->val.p = mbedtls_calloc( 1, val_len );
@@ -415,7 +415,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
     }
 
     if( val != NULL )
-        memcpy( cur->val.p, val, val_len );
+        mbedtls_platform_memcpy( cur->val.p, val, val_len );
 
     return( cur );
 }

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -132,7 +132,7 @@ int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs )
 
         if( X->p != NULL )
         {
-            memcpy( p, X->p, X->n * ciL );
+            mbedtls_platform_memcpy( p, X->p, X->n * ciL );
             mbedtls_mpi_zeroize( X->p, X->n );
             mbedtls_free( X->p );
         }
@@ -174,7 +174,7 @@ int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs )
 
     if( X->p != NULL )
     {
-        memcpy( p, X->p, i * ciL );
+        mbedtls_platform_memcpy( p, X->p, i * ciL );
         mbedtls_mpi_zeroize( X->p, X->n );
         mbedtls_free( X->p );
     }
@@ -220,7 +220,7 @@ int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y )
         mbedtls_platform_memset( X->p + i, 0, ( X->n - i ) * ciL );
     }
 
-    memcpy( X->p, Y->p, i * ciL );
+    mbedtls_platform_memcpy( X->p, Y->p, i * ciL );
 
 cleanup:
 
@@ -236,9 +236,9 @@ void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y )
     MPI_VALIDATE( X != NULL );
     MPI_VALIDATE( Y != NULL );
 
-    memcpy( &T,  X, sizeof( mbedtls_mpi ) );
-    memcpy(  X,  Y, sizeof( mbedtls_mpi ) );
-    memcpy(  Y, &T, sizeof( mbedtls_mpi ) );
+    mbedtls_platform_memcpy( &T,  X, sizeof( mbedtls_mpi ) );
+    mbedtls_platform_memcpy(  X,  Y, sizeof( mbedtls_mpi ) );
+    mbedtls_platform_memcpy(  Y, &T, sizeof( mbedtls_mpi ) );
 }
 
 /*
@@ -848,12 +848,12 @@ int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf, size_t bu
     }
     MBEDTLS_MPI_CHK( mbedtls_mpi_lset( X, 0 ) );
 
-    /* Avoid calling `memcpy` with NULL source argument,
+    /* Avoid calling `mbedtls_platform_memcpy` with NULL source argument,
      * even if buflen is 0. */
     if( buf != NULL )
     {
         Xp = (unsigned char*) X->p;
-        memcpy( Xp + overhead, buf, buflen );
+        mbedtls_platform_memcpy( Xp + overhead, buf, buflen );
 
         mpi_bigendian_to_host( X->p, limbs );
     }
@@ -1817,7 +1817,7 @@ static int mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi 
         *d++ = u0; d[n + 1] = 0;
     }
 
-    memcpy( A->p, d, ( n + 1 ) * ciL );
+    mbedtls_platform_memcpy( A->p, d, ( n + 1 ) * ciL );
 
     if( mbedtls_mpi_cmp_abs( A, N ) >= 0 )
         mpi_sub_hlp( n, N->p, A->p );
@@ -1913,10 +1913,10 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
         MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( &RR, &RR, N ) );
 
         if( _RR != NULL )
-            memcpy( _RR, &RR, sizeof( mbedtls_mpi ) );
+            mbedtls_platform_memcpy( _RR, &RR, sizeof( mbedtls_mpi ) );
     }
     else
-        memcpy( &RR, _RR, sizeof( mbedtls_mpi ) );
+        mbedtls_platform_memcpy( &RR, _RR, sizeof( mbedtls_mpi ) );
 
     /*
      * W[1] = A * R^2 * R^-1 mod N = A * R mod N

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -293,13 +293,13 @@ int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, MBEDTLS_BLOWFISH_BLOCKSIZE );
+            mbedtls_platform_memcpy( temp, input, MBEDTLS_BLOWFISH_BLOCKSIZE );
             mbedtls_blowfish_crypt_ecb( ctx, mode, input, output );
 
             for( i = 0; i < MBEDTLS_BLOWFISH_BLOCKSIZE;i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, MBEDTLS_BLOWFISH_BLOCKSIZE );
+            mbedtls_platform_memcpy( iv, temp, MBEDTLS_BLOWFISH_BLOCKSIZE );
 
             input  += MBEDTLS_BLOWFISH_BLOCKSIZE;
             output += MBEDTLS_BLOWFISH_BLOCKSIZE;
@@ -314,7 +314,7 @@ int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_blowfish_crypt_ecb( ctx, mode, output, output );
-            memcpy( iv, output, MBEDTLS_BLOWFISH_BLOCKSIZE );
+            mbedtls_platform_memcpy( iv, output, MBEDTLS_BLOWFISH_BLOCKSIZE );
 
             input  += MBEDTLS_BLOWFISH_BLOCKSIZE;
             output += MBEDTLS_BLOWFISH_BLOCKSIZE;

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -593,13 +593,13 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, 16 );
+            mbedtls_platform_memcpy( temp, input, 16 );
             mbedtls_camellia_crypt_ecb( ctx, mode, input, output );
 
             for( i = 0; i < 16; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, 16 );
+            mbedtls_platform_memcpy( iv, temp, 16 );
 
             input  += 16;
             output += 16;
@@ -614,7 +614,7 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_camellia_crypt_ecb( ctx, mode, output, output );
-            memcpy( iv, output, 16 );
+            mbedtls_platform_memcpy( iv, output, 16 );
 
             input  += 16;
             output += 16;
@@ -962,16 +962,16 @@ int mbedtls_camellia_self_test( int verbose )
                          (v == MBEDTLS_CAMELLIA_DECRYPT) ? "dec" : "enc");
 
     for( i = 0; i < CAMELLIA_TESTS_ECB; i++ ) {
-        memcpy( key, camellia_test_ecb_key[u][i], 16 + 8 * u );
+        mbedtls_platform_memcpy( key, camellia_test_ecb_key[u][i], 16 + 8 * u );
 
         if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
             mbedtls_camellia_setkey_dec( &ctx, key, 128 + u * 64 );
-            memcpy( src, camellia_test_ecb_cipher[u][i], 16 );
-            memcpy( dst, camellia_test_ecb_plain[i], 16 );
+            mbedtls_platform_memcpy( src, camellia_test_ecb_cipher[u][i], 16 );
+            mbedtls_platform_memcpy( dst, camellia_test_ecb_plain[i], 16 );
         } else { /* MBEDTLS_CAMELLIA_ENCRYPT */
             mbedtls_camellia_setkey_enc( &ctx, key, 128 + u * 64 );
-            memcpy( src, camellia_test_ecb_plain[i], 16 );
-            memcpy( dst, camellia_test_ecb_cipher[u][i], 16 );
+            mbedtls_platform_memcpy( src, camellia_test_ecb_plain[i], 16 );
+            mbedtls_platform_memcpy( dst, camellia_test_ecb_cipher[u][i], 16 );
         }
 
         mbedtls_camellia_crypt_ecb( &ctx, v, src, buf );
@@ -1005,9 +1005,9 @@ int mbedtls_camellia_self_test( int verbose )
             mbedtls_printf( "  CAMELLIA-CBC-%3d (%s): ", 128 + u * 64,
                              ( v == MBEDTLS_CAMELLIA_DECRYPT ) ? "dec" : "enc" );
 
-        memcpy( src, camellia_test_cbc_iv, 16 );
-        memcpy( dst, camellia_test_cbc_iv, 16 );
-        memcpy( key, camellia_test_cbc_key[u], 16 + 8 * u );
+        mbedtls_platform_memcpy( src, camellia_test_cbc_iv, 16 );
+        mbedtls_platform_memcpy( dst, camellia_test_cbc_iv, 16 );
+        mbedtls_platform_memcpy( key, camellia_test_cbc_key[u], 16 + 8 * u );
 
         if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
             mbedtls_camellia_setkey_dec( &ctx, key, 128 + u * 64 );
@@ -1018,13 +1018,13 @@ int mbedtls_camellia_self_test( int verbose )
         for( i = 0; i < CAMELLIA_TESTS_CBC; i++ ) {
 
             if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
-                memcpy( iv , src, 16 );
-                memcpy( src, camellia_test_cbc_cipher[u][i], 16 );
-                memcpy( dst, camellia_test_cbc_plain[i], 16 );
+                mbedtls_platform_memcpy( iv , src, 16 );
+                mbedtls_platform_memcpy( src, camellia_test_cbc_cipher[u][i], 16 );
+                mbedtls_platform_memcpy( dst, camellia_test_cbc_plain[i], 16 );
             } else { /* MBEDTLS_CAMELLIA_ENCRYPT */
-                memcpy( iv , dst, 16 );
-                memcpy( src, camellia_test_cbc_plain[i], 16 );
-                memcpy( dst, camellia_test_cbc_cipher[u][i], 16 );
+                mbedtls_platform_memcpy( iv , dst, 16 );
+                mbedtls_platform_memcpy( src, camellia_test_cbc_plain[i], 16 );
+                mbedtls_platform_memcpy( dst, camellia_test_cbc_cipher[u][i], 16 );
             }
 
             mbedtls_camellia_crypt_cbc( &ctx, v, 16, iv, src, buf );
@@ -1059,8 +1059,8 @@ int mbedtls_camellia_self_test( int verbose )
             mbedtls_printf( "  CAMELLIA-CTR-128 (%s): ",
                              ( v == MBEDTLS_CAMELLIA_DECRYPT ) ? "dec" : "enc" );
 
-        memcpy( nonce_counter, camellia_test_ctr_nonce_counter[u], 16 );
-        memcpy( key, camellia_test_ctr_key[u], 16 );
+        mbedtls_platform_memcpy( nonce_counter, camellia_test_ctr_nonce_counter[u], 16 );
+        mbedtls_platform_memcpy( key, camellia_test_ctr_key[u], 16 );
 
         offset = 0;
         mbedtls_camellia_setkey_enc( &ctx, key, 128 );
@@ -1068,7 +1068,7 @@ int mbedtls_camellia_self_test( int verbose )
         if( v == MBEDTLS_CAMELLIA_DECRYPT )
         {
             len = camellia_test_ctr_len[u];
-            memcpy( buf, camellia_test_ctr_ct[u], len );
+            mbedtls_platform_memcpy( buf, camellia_test_ctr_ct[u], len );
 
             mbedtls_camellia_crypt_ctr( &ctx, len, &offset, nonce_counter, stream_block,
                                 buf, buf );
@@ -1084,7 +1084,7 @@ int mbedtls_camellia_self_test( int verbose )
         else
         {
             len = camellia_test_ctr_len[u];
-            memcpy( buf, camellia_test_ctr_pt[u], len );
+            mbedtls_platform_memcpy( buf, camellia_test_ctr_pt[u], len );
 
             mbedtls_camellia_crypt_ctr( &ctx, len, &offset, nonce_counter, stream_block,
                                 buf, buf );

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -962,16 +962,16 @@ int mbedtls_camellia_self_test( int verbose )
                          (v == MBEDTLS_CAMELLIA_DECRYPT) ? "dec" : "enc");
 
     for( i = 0; i < CAMELLIA_TESTS_ECB; i++ ) {
-        mbedtls_platform_memcpy( key, camellia_test_ecb_key[u][i], 16 + 8 * u );
+        memcpy( key, camellia_test_ecb_key[u][i], 16 + 8 * u );
 
         if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
             mbedtls_camellia_setkey_dec( &ctx, key, 128 + u * 64 );
-            mbedtls_platform_memcpy( src, camellia_test_ecb_cipher[u][i], 16 );
-            mbedtls_platform_memcpy( dst, camellia_test_ecb_plain[i], 16 );
+            memcpy( src, camellia_test_ecb_cipher[u][i], 16 );
+            memcpy( dst, camellia_test_ecb_plain[i], 16 );
         } else { /* MBEDTLS_CAMELLIA_ENCRYPT */
             mbedtls_camellia_setkey_enc( &ctx, key, 128 + u * 64 );
-            mbedtls_platform_memcpy( src, camellia_test_ecb_plain[i], 16 );
-            mbedtls_platform_memcpy( dst, camellia_test_ecb_cipher[u][i], 16 );
+            memcpy( src, camellia_test_ecb_plain[i], 16 );
+            memcpy( dst, camellia_test_ecb_cipher[u][i], 16 );
         }
 
         mbedtls_camellia_crypt_ecb( &ctx, v, src, buf );
@@ -1005,9 +1005,9 @@ int mbedtls_camellia_self_test( int verbose )
             mbedtls_printf( "  CAMELLIA-CBC-%3d (%s): ", 128 + u * 64,
                              ( v == MBEDTLS_CAMELLIA_DECRYPT ) ? "dec" : "enc" );
 
-        mbedtls_platform_memcpy( src, camellia_test_cbc_iv, 16 );
-        mbedtls_platform_memcpy( dst, camellia_test_cbc_iv, 16 );
-        mbedtls_platform_memcpy( key, camellia_test_cbc_key[u], 16 + 8 * u );
+        memcpy( src, camellia_test_cbc_iv, 16 );
+        memcpy( dst, camellia_test_cbc_iv, 16 );
+        memcpy( key, camellia_test_cbc_key[u], 16 + 8 * u );
 
         if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
             mbedtls_camellia_setkey_dec( &ctx, key, 128 + u * 64 );
@@ -1018,13 +1018,13 @@ int mbedtls_camellia_self_test( int verbose )
         for( i = 0; i < CAMELLIA_TESTS_CBC; i++ ) {
 
             if( v == MBEDTLS_CAMELLIA_DECRYPT ) {
-                mbedtls_platform_memcpy( iv , src, 16 );
-                mbedtls_platform_memcpy( src, camellia_test_cbc_cipher[u][i], 16 );
-                mbedtls_platform_memcpy( dst, camellia_test_cbc_plain[i], 16 );
+                memcpy( iv , src, 16 );
+                memcpy( src, camellia_test_cbc_cipher[u][i], 16 );
+                memcpy( dst, camellia_test_cbc_plain[i], 16 );
             } else { /* MBEDTLS_CAMELLIA_ENCRYPT */
-                mbedtls_platform_memcpy( iv , dst, 16 );
-                mbedtls_platform_memcpy( src, camellia_test_cbc_plain[i], 16 );
-                mbedtls_platform_memcpy( dst, camellia_test_cbc_cipher[u][i], 16 );
+                memcpy( iv , dst, 16 );
+                memcpy( src, camellia_test_cbc_plain[i], 16 );
+                memcpy( dst, camellia_test_cbc_cipher[u][i], 16 );
             }
 
             mbedtls_camellia_crypt_cbc( &ctx, v, 16, iv, src, buf );
@@ -1059,8 +1059,8 @@ int mbedtls_camellia_self_test( int verbose )
             mbedtls_printf( "  CAMELLIA-CTR-128 (%s): ",
                              ( v == MBEDTLS_CAMELLIA_DECRYPT ) ? "dec" : "enc" );
 
-        mbedtls_platform_memcpy( nonce_counter, camellia_test_ctr_nonce_counter[u], 16 );
-        mbedtls_platform_memcpy( key, camellia_test_ctr_key[u], 16 );
+        memcpy( nonce_counter, camellia_test_ctr_nonce_counter[u], 16 );
+        memcpy( key, camellia_test_ctr_key[u], 16 );
 
         offset = 0;
         mbedtls_camellia_setkey_enc( &ctx, key, 128 );
@@ -1068,7 +1068,7 @@ int mbedtls_camellia_self_test( int verbose )
         if( v == MBEDTLS_CAMELLIA_DECRYPT )
         {
             len = camellia_test_ctr_len[u];
-            mbedtls_platform_memcpy( buf, camellia_test_ctr_ct[u], len );
+            memcpy( buf, camellia_test_ctr_ct[u], len );
 
             mbedtls_camellia_crypt_ctr( &ctx, len, &offset, nonce_counter, stream_block,
                                 buf, buf );
@@ -1084,7 +1084,7 @@ int mbedtls_camellia_self_test( int verbose )
         else
         {
             len = camellia_test_ctr_len[u];
-            mbedtls_platform_memcpy( buf, camellia_test_ctr_pt[u], len );
+            memcpy( buf, camellia_test_ctr_pt[u], len );
 
             mbedtls_camellia_crypt_ctr( &ctx, len, &offset, nonce_counter, stream_block,
                                 buf, buf );

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -951,7 +951,7 @@ int mbedtls_camellia_self_test( int verbose )
 
     mbedtls_camellia_context ctx;
 
-    mbedtls_platform_memset( key, 0, 32 );
+    memset( key, 0, 32 );
 
     for( j = 0; j < 6; j++ ) {
         u = j >> 1;

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -495,9 +495,9 @@ int mbedtls_ccm_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  CCM-AES #%u: ", (unsigned int) i + 1 );
 
-        mbedtls_platform_memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
-        mbedtls_platform_memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
-        mbedtls_platform_memcpy( plaintext, msg, msg_len[i] );
+        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+        memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
+        memcpy( plaintext, msg, msg_len[i] );
 
         ret = mbedtls_ccm_encrypt_and_tag( &ctx, msg_len[i],
                                            iv, iv_len[i], ad, add_len[i],

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -512,7 +512,7 @@ int mbedtls_ccm_self_test( int verbose )
 
             return( 1 );
         }
-        mbedtls_platform_memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
 
         ret = mbedtls_ccm_auth_decrypt( &ctx, msg_len[i],
                                         iv, iv_len[i], ad, add_len[i],

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -201,7 +201,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     b[0] |= ( ( tag_len - 2 ) / 2 ) << 3;
     b[0] |= q - 1;
 
-    memcpy( b + 1, iv, iv_len );
+    mbedtls_platform_memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
         b[15-i] = (unsigned char)( len_left & 0xFF );
@@ -229,7 +229,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         b[1] = (unsigned char)( ( add_len      ) & 0xFF );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
-        memcpy( b + 2, src, use_len );
+        mbedtls_platform_memcpy( b + 2, src, use_len );
         len_left -= use_len;
         src += use_len;
 
@@ -240,7 +240,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
             use_len = len_left > 16 ? 16 : len_left;
 
             mbedtls_platform_memset( b, 0, 16 );
-            memcpy( b, src, use_len );
+            mbedtls_platform_memcpy( b, src, use_len );
             UPDATE_CBC_MAC;
 
             len_left -= use_len;
@@ -259,7 +259,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
      * 2 .. 0   q - 1
      */
     ctr[0] = q - 1;
-    memcpy( ctr + 1, iv, iv_len );
+    mbedtls_platform_memcpy( ctr + 1, iv, iv_len );
     mbedtls_platform_memset( ctr + 1 + iv_len, 0, q );
     ctr[15] = 1;
 
@@ -280,7 +280,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         if( mode == CCM_ENCRYPT )
         {
             mbedtls_platform_memset( b, 0, 16 );
-            memcpy( b, src, use_len );
+            mbedtls_platform_memcpy( b, src, use_len );
             UPDATE_CBC_MAC;
         }
 
@@ -289,7 +289,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         if( mode == CCM_DECRYPT )
         {
             mbedtls_platform_memset( b, 0, 16 );
-            memcpy( b, dst, use_len );
+            mbedtls_platform_memcpy( b, dst, use_len );
             UPDATE_CBC_MAC;
         }
 
@@ -313,7 +313,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         ctr[15-i] = 0;
 
     CTR_CRYPT( y, y, 16 );
-    memcpy( tag, y, tag_len );
+    mbedtls_platform_memcpy( tag, y, tag_len );
 
     return( 0 );
 }
@@ -497,7 +497,7 @@ int mbedtls_ccm_self_test( int verbose )
 
         mbedtls_platform_memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
         mbedtls_platform_memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
-        memcpy( plaintext, msg, msg_len[i] );
+        mbedtls_platform_memcpy( plaintext, msg, msg_len[i] );
 
         ret = mbedtls_ccm_encrypt_and_tag( &ctx, msg_len[i],
                                            iv, iv_len[i], ad, add_len[i],

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -148,7 +148,7 @@ static void chacha20_block( const uint32_t initial_state[16],
     uint32_t working_state[16];
     size_t i;
 
-    memcpy( working_state,
+    mbedtls_platform_memcpy( working_state,
             initial_state,
             CHACHA20_BLOCK_SIZE_BYTES );
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -286,7 +286,7 @@ int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
 
     if ( actual_iv_size != 0 )
     {
-        memcpy( ctx->iv, iv, actual_iv_size );
+        mbedtls_platform_memcpy( ctx->iv, iv, actual_iv_size );
         ctx->iv_size = actual_iv_size;
     }
 
@@ -422,7 +422,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
              ( ctx->operation == MBEDTLS_ENCRYPT &&
                 ilen < block_size - ctx->unprocessed_len ) )
         {
-            memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
+            mbedtls_platform_memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
                     ilen );
 
             ctx->unprocessed_len += ilen;
@@ -436,7 +436,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
         {
             copy_len = block_size - ctx->unprocessed_len;
 
-            memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
+            mbedtls_platform_memcpy( &( ctx->unprocessed_data[ctx->unprocessed_len] ), input,
                     copy_len );
 
             if( 0 != ( ret = ctx->cipher_info->base->cbc_func( ctx->cipher_ctx,
@@ -476,7 +476,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
                 copy_len = block_size;
             }
 
-            memcpy( ctx->unprocessed_data, &( input[ilen - copy_len] ),
+            mbedtls_platform_memcpy( ctx->unprocessed_data, &( input[ilen - copy_len] ),
                     copy_len );
 
             ctx->unprocessed_len += copy_len;

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -260,7 +260,7 @@ int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
     if( cmac_ctx->unprocessed_len > 0 &&
         ilen > block_size - cmac_ctx->unprocessed_len )
     {
-        memcpy( &cmac_ctx->unprocessed_block[cmac_ctx->unprocessed_len],
+        mbedtls_platform_memcpy( &cmac_ctx->unprocessed_block[cmac_ctx->unprocessed_len],
                 input,
                 block_size - cmac_ctx->unprocessed_len );
 
@@ -297,7 +297,7 @@ int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
     /* If there is data left over that wasn't aligned to a block */
     if( ilen > 0 )
     {
-        memcpy( &cmac_ctx->unprocessed_block[cmac_ctx->unprocessed_len],
+        mbedtls_platform_memcpy( &cmac_ctx->unprocessed_block[cmac_ctx->unprocessed_len],
                 input,
                 ilen );
         cmac_ctx->unprocessed_len += ilen;
@@ -352,7 +352,7 @@ int mbedtls_cipher_cmac_finish( mbedtls_cipher_context_t *ctx,
         goto exit;
     }
 
-    memcpy( output, state, block_size );
+    mbedtls_platform_memcpy( output, state, block_size );
 
 exit:
     /* Wipe the generated keys on the stack, and any other transients to avoid
@@ -446,7 +446,7 @@ int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_length,
     if( key_length == MBEDTLS_AES_BLOCK_SIZE )
     {
         /* Use key as is */
-        memcpy( int_key, key, MBEDTLS_AES_BLOCK_SIZE );
+        mbedtls_platform_memcpy( int_key, key, MBEDTLS_AES_BLOCK_SIZE );
     }
     else
     {

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -185,7 +185,7 @@ static int block_cipher_df( unsigned char *output,
     *p++ = ( data_len       ) & 0xff;
     p += 3;
     *p++ = MBEDTLS_CTR_DRBG_SEEDLEN;
-    memcpy( p, data, data_len );
+    mbedtls_platform_memcpy( p, data, data_len );
     p[data_len] = 0x80;
 
     buf_len = MBEDTLS_CTR_DRBG_BLOCKSIZE + 8 + data_len + 1;
@@ -221,7 +221,7 @@ static int block_cipher_df( unsigned char *output,
             }
         }
 
-        memcpy( tmp + j, chain, MBEDTLS_CTR_DRBG_BLOCKSIZE );
+        mbedtls_platform_memcpy( tmp + j, chain, MBEDTLS_CTR_DRBG_BLOCKSIZE );
 
         /*
          * Update IV
@@ -245,7 +245,7 @@ static int block_cipher_df( unsigned char *output,
         {
             goto exit;
         }
-        memcpy( p, iv, MBEDTLS_CTR_DRBG_BLOCKSIZE );
+        mbedtls_platform_memcpy( p, iv, MBEDTLS_CTR_DRBG_BLOCKSIZE );
         p += MBEDTLS_CTR_DRBG_BLOCKSIZE;
     }
 exit:
@@ -312,7 +312,7 @@ static int ctr_drbg_update_internal( mbedtls_ctr_drbg_context *ctx,
      */
     if( ( ret = mbedtls_aes_setkey_enc( &ctx->aes_ctx, tmp, MBEDTLS_CTR_DRBG_KEYBITS ) ) != 0 )
         goto exit;
-    memcpy( ctx->counter, tmp + MBEDTLS_CTR_DRBG_KEYSIZE, MBEDTLS_CTR_DRBG_BLOCKSIZE );
+    mbedtls_platform_memcpy( ctx->counter, tmp + MBEDTLS_CTR_DRBG_KEYSIZE, MBEDTLS_CTR_DRBG_BLOCKSIZE );
 
 exit:
     mbedtls_platform_zeroize( tmp, sizeof( tmp ) );
@@ -405,7 +405,7 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
      */
     if( additional && len )
     {
-        memcpy( seed + seedlen, additional, len );
+        mbedtls_platform_memcpy( seed + seedlen, additional, len );
         seedlen += len;
     }
 
@@ -504,7 +504,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
         /*
          * Copy random block to destination
          */
-        memcpy( p, tmp, use_len );
+        mbedtls_platform_memcpy( p, tmp, use_len );
         p += use_len;
         output_len -= use_len;
     }
@@ -649,7 +649,7 @@ static int ctr_drbg_self_test_entropy( void *data, unsigned char *buf,
                                        size_t len )
 {
     const unsigned char *p = data;
-    memcpy( buf, p + test_offset, len );
+    mbedtls_platform_memcpy( buf, p + test_offset, len );
     test_offset += len;
     return( 0 );
 }

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -649,7 +649,7 @@ static int ctr_drbg_self_test_entropy( void *data, unsigned char *buf,
                                        size_t len )
 {
     const unsigned char *p = data;
-    mbedtls_platform_memcpy( buf, p + test_offset, len );
+    memcpy( buf, p + test_offset, len );
     test_offset += len;
     return( 0 );
 }

--- a/library/debug.c
+++ b/library/debug.c
@@ -355,7 +355,7 @@ static void debug_print_line_by_line( const mbedtls_ssl_context *ssl, int level,
             if( len > DEBUG_BUF_SIZE - 1 )
                 len = DEBUG_BUF_SIZE - 1;
 
-            memcpy( str, start, len );
+            mbedtls_platform_memcpy( str, start, len );
             str[len] = '\0';
 
             debug_send_line( ssl, level, file, line, str );

--- a/library/des.c
+++ b/library/des.c
@@ -896,7 +896,7 @@ int mbedtls_des_self_test( int verbose )
                              ( u == 0 ) ? ' ' : '3', 56 + u * 56,
                              ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
 
-        mbedtls_platform_memcpy( buf, des3_test_buf, 8 );
+        memcpy( buf, des3_test_buf, 8 );
 
         switch( i )
         {
@@ -969,9 +969,9 @@ int mbedtls_des_self_test( int verbose )
                              ( u == 0 ) ? ' ' : '3', 56 + u * 56,
                              ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
 
-        mbedtls_platform_memcpy( iv,  des3_test_iv,  8 );
-        mbedtls_platform_memcpy( prv, des3_test_iv,  8 );
-        mbedtls_platform_memcpy( buf, des3_test_buf, 8 );
+        memcpy( iv,  des3_test_iv,  8 );
+        memcpy( prv, des3_test_iv,  8 );
+        memcpy( buf, des3_test_buf, 8 );
 
         switch( i )
         {
@@ -1024,12 +1024,12 @@ int mbedtls_des_self_test( int verbose )
                 else
                     mbedtls_des3_crypt_cbc( &ctx3, v, 8, iv, buf, buf );
 
-                mbedtls_platform_memcpy( tmp, prv, 8 );
-                mbedtls_platform_memcpy( prv, buf, 8 );
-                mbedtls_platform_memcpy( buf, tmp, 8 );
+                memcpy( tmp, prv, 8 );
+                memcpy( prv, buf, 8 );
+                memcpy( buf, tmp, 8 );
             }
 
-            mbedtls_platform_memcpy( buf, prv, 8 );
+            memcpy( buf, prv, 8 );
         }
 
         if( ( v == MBEDTLS_DES_DECRYPT &&

--- a/library/des.c
+++ b/library/des.c
@@ -684,7 +684,7 @@ int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_des_crypt_ecb( ctx, output, output );
-            memcpy( iv, output, 8 );
+            mbedtls_platform_memcpy( iv, output, 8 );
 
             input  += 8;
             output += 8;
@@ -695,13 +695,13 @@ int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, 8 );
+            mbedtls_platform_memcpy( temp, input, 8 );
             mbedtls_des_crypt_ecb( ctx, input, output );
 
             for( i = 0; i < 8; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, 8 );
+            mbedtls_platform_memcpy( iv, temp, 8 );
 
             input  += 8;
             output += 8;
@@ -783,7 +783,7 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_des3_crypt_ecb( ctx, output, output );
-            memcpy( iv, output, 8 );
+            mbedtls_platform_memcpy( iv, output, 8 );
 
             input  += 8;
             output += 8;
@@ -794,13 +794,13 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, 8 );
+            mbedtls_platform_memcpy( temp, input, 8 );
             mbedtls_des3_crypt_ecb( ctx, input, output );
 
             for( i = 0; i < 8; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, 8 );
+            mbedtls_platform_memcpy( iv, temp, 8 );
 
             input  += 8;
             output += 8;
@@ -896,7 +896,7 @@ int mbedtls_des_self_test( int verbose )
                              ( u == 0 ) ? ' ' : '3', 56 + u * 56,
                              ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
 
-        memcpy( buf, des3_test_buf, 8 );
+        mbedtls_platform_memcpy( buf, des3_test_buf, 8 );
 
         switch( i )
         {
@@ -969,9 +969,9 @@ int mbedtls_des_self_test( int verbose )
                              ( u == 0 ) ? ' ' : '3', 56 + u * 56,
                              ( v == MBEDTLS_DES_DECRYPT ) ? "dec" : "enc" );
 
-        memcpy( iv,  des3_test_iv,  8 );
-        memcpy( prv, des3_test_iv,  8 );
-        memcpy( buf, des3_test_buf, 8 );
+        mbedtls_platform_memcpy( iv,  des3_test_iv,  8 );
+        mbedtls_platform_memcpy( prv, des3_test_iv,  8 );
+        mbedtls_platform_memcpy( buf, des3_test_buf, 8 );
 
         switch( i )
         {
@@ -1024,12 +1024,12 @@ int mbedtls_des_self_test( int verbose )
                 else
                     mbedtls_des3_crypt_cbc( &ctx3, v, 8, iv, buf, buf );
 
-                memcpy( tmp, prv, 8 );
-                memcpy( prv, buf, 8 );
-                memcpy( buf, tmp, 8 );
+                mbedtls_platform_memcpy( tmp, prv, 8 );
+                mbedtls_platform_memcpy( prv, buf, 8 );
+                mbedtls_platform_memcpy( buf, tmp, 8 );
             }
 
-            memcpy( buf, prv, 8 );
+            mbedtls_platform_memcpy( buf, prv, 8 );
         }
 
         if( ( v == MBEDTLS_DES_DECRYPT &&

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -722,7 +722,7 @@ static int ecdsa_signature_to_asn1( const mbedtls_mpi *r, const mbedtls_mpi *s,
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( &p, buf,
                                        MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) );
 
-    memcpy( sig, p, len );
+    mbedtls_platform_memcpy( sig, p, len );
     *slen = len;
 
     return( 0 );

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -1104,7 +1104,7 @@ int mbedtls_ecjpake_self_test( int verbose )
     TEST_ASSERT( len == sizeof( ecjpake_test_pms ) );
     TEST_ASSERT( memcmp( buf, ecjpake_test_pms, len ) == 0 );
 
-    mbedtls_platform_memset( buf, 0, len ); /* Avoid interferences with next step */
+    memset( buf, 0, len ); /* Avoid interferences with next step */
 
     /* Client derives PMS */
     TEST_ASSERT( mbedtls_ecjpake_derive_secret( &cli,

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -983,7 +983,7 @@ static int ecjpake_lgc( void *p, unsigned char *out, size_t len )
     {
         size_t use_len = len > 4 ? 4 : len;
         x = 1664525 * x + 1013904223;
-        mbedtls_platform_memcpy( out, &x, use_len );
+        memcpy( out, &x, use_len );
         out += use_len;
         len -= use_len;
     }

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -225,7 +225,7 @@ static int ecjpake_hash( mbedtls_md_handle_t md_info,
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    memcpy( p, id, id_len );
+    mbedtls_platform_memcpy( p, id, id_len );
     p += id_len;
 
     /* Compute hash */
@@ -983,7 +983,7 @@ static int ecjpake_lgc( void *p, unsigned char *out, size_t len )
     {
         size_t use_len = len > 4 ? 4 : len;
         x = 1664525 * x + 1013904223;
-        memcpy( out, &x, use_len );
+        mbedtls_platform_memcpy( out, &x, use_len );
         out += use_len;
         len -= use_len;
     }

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -1202,7 +1202,7 @@ static int ecp_mod_p521( mbedtls_mpi *N )
     if( M.n > P521_WIDTH + 1 )
         M.n = P521_WIDTH + 1;
     M.p = Mp;
-    memcpy( Mp, N->p + P521_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
+    mbedtls_platform_memcpy( Mp, N->p + P521_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, 521 % ( 8 * sizeof( mbedtls_mpi_uint ) ) ) );
 
     /* N = A0 */
@@ -1249,7 +1249,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
     M.p = Mp;
     mbedtls_platform_memset( Mp, 0, sizeof Mp );
-    memcpy( Mp, N->p + P255_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
+    mbedtls_platform_memcpy( Mp, N->p + P255_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, 255 % ( 8 * sizeof( mbedtls_mpi_uint ) ) ) );
     M.n++; /* Make room for multiplication by 19 */
 
@@ -1307,7 +1307,7 @@ static int ecp_mod_p448( mbedtls_mpi *N )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
     M.p = Mp;
     mbedtls_platform_memset( Mp, 0, sizeof( Mp ) );
-    memcpy( Mp, N->p + P448_WIDTH, M.n * sizeof( mbedtls_mpi_uint ) );
+    mbedtls_platform_memcpy( Mp, N->p + P448_WIDTH, M.n * sizeof( mbedtls_mpi_uint ) );
 
     /* N = A0 */
     for( i = P448_WIDTH; i < N->n; i++ )
@@ -1319,7 +1319,7 @@ static int ecp_mod_p448( mbedtls_mpi *N )
     /* Q = B1, N += B1 */
     Q = M;
     Q.p = Qp;
-    memcpy( Qp, Mp, sizeof( Qp ) );
+    mbedtls_platform_memcpy( Qp, Mp, sizeof( Qp ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &Q, 224 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( N, N, &Q ) );
 
@@ -1375,7 +1375,7 @@ static inline int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t 
     if( M.n > p_limbs + adjust )
         M.n = p_limbs + adjust;
     mbedtls_platform_memset( Mp, 0, sizeof Mp );
-    memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
+    mbedtls_platform_memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
     if( shift != 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, shift ) );
     M.n += R.n; /* Make room for multiplication by R */
@@ -1397,7 +1397,7 @@ static inline int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t 
     if( M.n > p_limbs + adjust )
         M.n = p_limbs + adjust;
     mbedtls_platform_memset( Mp, 0, sizeof Mp );
-    memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
+    mbedtls_platform_memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
     if( shift != 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, shift ) );
     M.n += R.n; /* Make room for multiplication by R */

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -424,7 +424,7 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     for( i = 0; i < ctx->source_count; i++ )
         ctx->source[i].size = 0;
 
-    memcpy( output, buf, len );
+    mbedtls_platform_memcpy( output, buf, len );
 
     ret = 0;
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -37,6 +37,7 @@
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
+#include "mbedtls/platform_util.h"
 
 #if defined(MBEDTLS_TIMING_C)
 #include "mbedtls/timing.h"
@@ -188,7 +189,7 @@ int mbedtls_hardclock_poll( void *data,
     if( len < sizeof(unsigned long) )
         return( 0 );
 
-    memcpy( output, &timer, sizeof(unsigned long) );
+    mbedtls_platform_memcpy( output, &timer, sizeof(unsigned long) );
     *olen = sizeof(unsigned long);
 
     return( 0 );
@@ -227,7 +228,7 @@ int mbedtls_nv_seed_poll( void *data,
     if( len < use_len )
       use_len = len;
 
-    memcpy( output, buf, use_len );
+    mbedtls_platform_memcpy( output, buf, use_len );
     *olen = use_len;
 
     return( 0 );

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -307,7 +307,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
 
     if( iv_len == 12 )
     {
-        memcpy( ctx->y, iv, iv_len );
+        mbedtls_platform_memcpy( ctx->y, iv, iv_len );
         ctx->y[15] = 1;
     }
     else
@@ -440,7 +440,7 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     if( tag_len > 16 || tag_len < 4 )
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
 
-    memcpy( tag, ctx->base_ectr, tag_len );
+    mbedtls_platform_memcpy( tag, ctx->base_ectr, tag_len );
 
     if( orig_len || orig_add_len )
     {

--- a/library/havege.c
+++ b/library/havege.c
@@ -241,7 +241,7 @@ int mbedtls_havege_random( void *p_rng, unsigned char *buf, size_t len )
         val  = hs->pool[hs->offset[0]++];
         val ^= hs->pool[hs->offset[1]++];
 
-        memcpy( p, &val, use_len );
+        mbedtls_platform_memcpy( p, &val, use_len );
 
         len -= use_len;
         p += use_len;

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -177,7 +177,7 @@ int mbedtls_hkdf_expand( mbedtls_md_handle_t md, const unsigned char *prk,
         }
 
         num_to_copy = i != n ? hash_len : okm_len - where;
-        memcpy( okm + where, t, num_to_copy );
+        mbedtls_platform_memcpy( okm + where, t, num_to_copy );
         where += hash_len;
         t_len = hash_len;
     }

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -547,7 +547,7 @@ static int hmac_drbg_self_test_entropy( void *data,
                                         unsigned char *buf, size_t len )
 {
     const unsigned char *p = data;
-    mbedtls_platform_memcpy( buf, p + test_offset, len );
+    memcpy( buf, p + test_offset, len );
     test_offset += len;
     return( 0 );
 }

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -213,7 +213,7 @@ static int hmac_drbg_reseed_core( mbedtls_hmac_drbg_context *ctx,
     /* 1. Concatenate entropy and additional data if any */
     if( additional != NULL && len != 0 )
     {
-        memcpy( seed + seedlen, additional, len );
+        mbedtls_platform_memcpy( seed + seedlen, additional, len );
         seedlen += len;
     }
 
@@ -375,7 +375,7 @@ int mbedtls_hmac_drbg_random_with_add( void *p_rng,
         if( ( ret = mbedtls_md_hmac_finish( &ctx->md_ctx, ctx->V ) ) != 0 )
             goto exit;
 
-        memcpy( out, ctx->V, use_len );
+        mbedtls_platform_memcpy( out, ctx->V, use_len );
         out += use_len;
         left -= use_len;
     }
@@ -547,7 +547,7 @@ static int hmac_drbg_self_test_entropy( void *data,
                                         unsigned char *buf, size_t len )
 {
     const unsigned char *p = data;
-    memcpy( buf, p + test_offset, len );
+    mbedtls_platform_memcpy( buf, p + test_offset, len );
     test_offset += len;
     return( 0 );
 }

--- a/library/md2.c
+++ b/library/md2.c
@@ -180,7 +180,7 @@ int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
         else
             fill = ilen;
 
-        memcpy( ctx->buffer + ctx->left, input, fill );
+        mbedtls_platform_memcpy( ctx->buffer + ctx->left, input, fill );
 
         ctx->left += fill;
         input += fill;
@@ -224,11 +224,11 @@ int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
     if( ( ret = mbedtls_internal_md2_process( ctx ) ) != 0 )
         return( ret );
 
-    memcpy( ctx->buffer, ctx->cksum, 16 );
+    mbedtls_platform_memcpy( ctx->buffer, ctx->cksum, 16 );
     if( ( ret = mbedtls_internal_md2_process( ctx ) ) != 0 )
         return( ret );
 
-    memcpy( output, ctx->state, 16 );
+    mbedtls_platform_memcpy( output, ctx->state, 16 );
 
     return( 0 );
 }

--- a/library/md4.c
+++ b/library/md4.c
@@ -271,7 +271,7 @@ int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left),
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left),
                 (void *) input, fill );
 
         if( ( ret = mbedtls_internal_md4_process( ctx, ctx->buffer ) ) != 0 )
@@ -293,7 +293,7 @@ int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
 
     if( ilen > 0 )
     {
-        memcpy( (void *) (ctx->buffer + left),
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left),
                 (void *) input, ilen );
     }
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -277,7 +277,7 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, fill );
         if( ( ret = mbedtls_internal_md5_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
@@ -297,7 +297,7 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
 
     if( ilen > 0 )
     {
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, ilen );
     }
 
     return( 0 );

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -408,7 +408,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
             if( buf_size < *ip_len )
                 return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
 
-            memcpy( client_ip, &addr4->sin_addr.s_addr, *ip_len );
+            mbedtls_platform_memcpy( client_ip, &addr4->sin_addr.s_addr, *ip_len );
         }
         else
         {
@@ -418,7 +418,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
             if( buf_size < *ip_len )
                 return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
 
-            memcpy( client_ip, &addr6->sin6_addr.s6_addr, *ip_len);
+            mbedtls_platform_memcpy( client_ip, &addr6->sin6_addr.s6_addr, *ip_len);
         }
     }
 

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -221,7 +221,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
         }
 
-        memcpy( output, NIST_KW_ICV1, KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memcpy( output, NIST_KW_ICV1, KW_SEMIBLOCK_LENGTH );
         memmove( output + KW_SEMIBLOCK_LENGTH, input, in_len );
     }
     else
@@ -249,11 +249,11 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
         }
 
-        memcpy( output, NIST_KW_ICV2, KW_SEMIBLOCK_LENGTH / 2 );
+        mbedtls_platform_memcpy( output, NIST_KW_ICV2, KW_SEMIBLOCK_LENGTH / 2 );
         PUT_UINT32_BE( ( in_len & 0xffffffff ), output,
                        KW_SEMIBLOCK_LENGTH / 2 );
 
-        memcpy( output + KW_SEMIBLOCK_LENGTH, input, in_len );
+        mbedtls_platform_memcpy( output + KW_SEMIBLOCK_LENGTH, input, in_len );
         mbedtls_platform_memset( output + KW_SEMIBLOCK_LENGTH + in_len, 0, padlen );
     }
     semiblocks = ( ( in_len + padlen ) / KW_SEMIBLOCK_LENGTH ) + 1;
@@ -263,7 +263,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
     if( mode == MBEDTLS_KW_MODE_KWP
         && in_len <= KW_SEMIBLOCK_LENGTH )
     {
-        memcpy( inbuff, output, 16 );
+        mbedtls_platform_memcpy( inbuff, output, 16 );
         ret = mbedtls_cipher_update( &ctx->cipher_ctx,
                                      inbuff, 16, output, &olen );
         if( ret != 0 )
@@ -283,18 +283,18 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
         /* Calculate intermediate values */
         for( t = 1; t <= s; t++ )
         {
-            memcpy( inbuff, A, KW_SEMIBLOCK_LENGTH );
-            memcpy( inbuff + KW_SEMIBLOCK_LENGTH, R2, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( inbuff, A, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( inbuff + KW_SEMIBLOCK_LENGTH, R2, KW_SEMIBLOCK_LENGTH );
 
             ret = mbedtls_cipher_update( &ctx->cipher_ctx,
                                          inbuff, 16, outbuff, &olen );
             if( ret != 0 )
                 goto cleanup;
 
-            memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
             calc_a_xor_t( A, t );
 
-            memcpy( R2, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( R2, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
             R2 += KW_SEMIBLOCK_LENGTH;
             if( R2 >= output + ( semiblocks * KW_SEMIBLOCK_LENGTH ) )
                 R2 = output + KW_SEMIBLOCK_LENGTH;
@@ -342,7 +342,7 @@ static int unwrap( mbedtls_nist_kw_context *ctx,
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
     }
 
-    memcpy( A, input, KW_SEMIBLOCK_LENGTH );
+    mbedtls_platform_memcpy( A, input, KW_SEMIBLOCK_LENGTH );
     memmove( output, input + KW_SEMIBLOCK_LENGTH, ( semiblocks - 1 ) * KW_SEMIBLOCK_LENGTH );
 
     /* Calculate intermediate values */
@@ -350,18 +350,18 @@ static int unwrap( mbedtls_nist_kw_context *ctx,
     {
         calc_a_xor_t( A, t );
 
-        memcpy( inbuff, A, KW_SEMIBLOCK_LENGTH );
-        memcpy( inbuff + KW_SEMIBLOCK_LENGTH, R, KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memcpy( inbuff, A, KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memcpy( inbuff + KW_SEMIBLOCK_LENGTH, R, KW_SEMIBLOCK_LENGTH );
 
         ret = mbedtls_cipher_update( &ctx->cipher_ctx,
                                      inbuff, 16, outbuff, &olen );
         if( ret != 0 )
             goto cleanup;
 
-        memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
 
         /* Set R as LSB64 of outbuff */
-        memcpy( R, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memcpy( R, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
 
         if( R == output )
             R = output + ( semiblocks - 2 ) * KW_SEMIBLOCK_LENGTH;
@@ -455,8 +455,8 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
             if( ret != 0 )
                 goto cleanup;
 
-            memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
-            memcpy( output, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( A, outbuff, KW_SEMIBLOCK_LENGTH );
+            mbedtls_platform_memcpy( output, outbuff + KW_SEMIBLOCK_LENGTH, KW_SEMIBLOCK_LENGTH );
             mbedtls_platform_zeroize( outbuff, sizeof( outbuff ) );
             *out_len = KW_SEMIBLOCK_LENGTH;
         }

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -34,6 +34,7 @@
 #if defined(MBEDTLS_PADLOCK_C)
 
 #include "mbedtls/padlock.h"
+#include "mbedtls/platform_util.h"
 
 #include <string.h>
 

--- a/library/padlock.c
+++ b/library/padlock.c
@@ -90,7 +90,7 @@ int mbedtls_padlock_xcryptecb( mbedtls_aes_context *ctx,
 
     rk  = ctx->rk;
     blk = MBEDTLS_PADLOCK_ALIGN16( buf );
-    memcpy( blk, input, 16 );
+    mbedtls_platform_memcpy( blk, input, 16 );
 
      ctrl = blk + 4;
     *ctrl = 0x80 | ctx->nr | ( ( ctx->nr + ( mode^1 ) - 10 ) << 9 );
@@ -109,7 +109,7 @@ int mbedtls_padlock_xcryptecb( mbedtls_aes_context *ctx,
          :  "m" (ebx), "m" (ctrl), "m" (rk), "m" (blk)
          : "memory", "ecx", "edx", "esi", "edi" );
 
-    memcpy( output, blk, 16 );
+    mbedtls_platform_memcpy( output, blk, 16 );
 
     return( 0 );
 }
@@ -137,7 +137,7 @@ int mbedtls_padlock_xcryptcbc( mbedtls_aes_context *ctx,
 
     rk = ctx->rk;
     iw = MBEDTLS_PADLOCK_ALIGN16( buf );
-    memcpy( iw, iv, 16 );
+    mbedtls_platform_memcpy( iw, iv, 16 );
 
      ctrl = iw + 4;
     *ctrl = 0x80 | ctx->nr | ( ( ctx->nr + ( mode ^ 1 ) - 10 ) << 9 );
@@ -160,7 +160,7 @@ int mbedtls_padlock_xcryptcbc( mbedtls_aes_context *ctx,
             "m"  (rk), "m" (input), "m" (output), "m" (iw)
          : "memory", "eax", "ecx", "edx", "esi", "edi" );
 
-    memcpy( iv, iw, 16 );
+    mbedtls_platform_memcpy( iv, iw, 16 );
 
     return( 0 );
 }

--- a/library/pem.c
+++ b/library/pem.c
@@ -103,11 +103,11 @@ static int pem_pbkdf1( unsigned char *key, size_t keylen,
 
     if( keylen <= 16 )
     {
-        memcpy( key, md5sum, keylen );
+        mbedtls_platform_memcpy( key, md5sum, keylen );
         goto exit;
     }
 
-    memcpy( key, md5sum, 16 );
+    mbedtls_platform_memcpy( key, md5sum, 16 );
 
     /*
      * key[16..23] = MD5(key[ 0..15] || pwd || IV])
@@ -127,7 +127,7 @@ static int pem_pbkdf1( unsigned char *key, size_t keylen,
     if( keylen < 32 )
         use_len = keylen - 16;
 
-    memcpy( key + 16, md5sum, use_len );
+    mbedtls_platform_memcpy( key + 16, md5sum, use_len );
 
 exit:
     mbedtls_md5_free( &md5_ctx );
@@ -463,21 +463,21 @@ int mbedtls_pem_write_buffer( const char *header, const char *footer,
         return( ret );
     }
 
-    memcpy( p, header, strlen( header ) );
+    mbedtls_platform_memcpy( p, header, strlen( header ) );
     p += strlen( header );
     c = encode_buf;
 
     while( use_len )
     {
         len = ( use_len > 64 ) ? 64 : use_len;
-        memcpy( p, c, len );
+        mbedtls_platform_memcpy( p, c, len );
         use_len -= len;
         p += len;
         c += len;
         *p++ = '\n';
     }
 
-    memcpy( p, footer, strlen( footer ) );
+    mbedtls_platform_memcpy( p, footer, strlen( footer ) );
     p += strlen( footer );
 
     *p++ = '\0';

--- a/library/pk.c
+++ b/library/pk.c
@@ -512,7 +512,7 @@ static int extract_ecdsa_sig_int( unsigned char **from, const unsigned char *end
 
     padding_len = to_len - unpadded_len;
     memset( to, 0x00, padding_len );
-    memcpy( to + padding_len, *from, unpadded_len );
+    mbedtls_platform_memcpy( to + padding_len, *from, unpadded_len );
     ( *from ) += unpadded_len;
 
     return( 0 );

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -219,7 +219,7 @@ int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
         *p++ = (unsigned char) ( 0x04 + oid_size );
         *p++ = MBEDTLS_ASN1_OID;
         *p++ = oid_size & 0xFF;
-        memcpy( p, oid, oid_size );
+        mbedtls_platform_memcpy( p, oid, oid_size );
         p += oid_size;
         *p++ = MBEDTLS_ASN1_NULL;
         *p++ = 0x00;
@@ -227,7 +227,7 @@ int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
         *p++ = hashlen;
     }
 
-    memcpy( p, hash, hashlen );
+    mbedtls_platform_memcpy( p, hash, hashlen );
 
     if( pkcs11h_certificate_signAny( ctx->pkcs11h_cert, CKM_RSA_PKCS, sig,
             asn_len + hashlen, sig, &sig_len ) != CKR_OK )

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -239,7 +239,7 @@ static void pkcs12_fill_buffer( unsigned char *data, size_t data_len,
     while( data_len > 0 )
     {
         use_len = ( data_len > fill_len ) ? fill_len : data_len;
-        memcpy( p, filler, use_len );
+        mbedtls_platform_memcpy( p, filler, use_len );
         p += use_len;
         data_len -= use_len;
     }
@@ -315,7 +315,7 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
         }
 
         use_len = ( datalen > hlen ) ? hlen : datalen;
-        memcpy( p, hash_output, use_len );
+        mbedtls_platform_memcpy( p, hash_output, use_len );
         datalen -= use_len;
         p += use_len;
 

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -189,7 +189,7 @@ int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
     mbedtls_md_init( &md_ctx );
     mbedtls_cipher_init( &cipher_ctx );
 
-    memcpy( iv, enc_scheme_params.p, enc_scheme_params.len );
+    mbedtls_platform_memcpy( iv, enc_scheme_params.p, enc_scheme_params.len );
 
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 1 ) ) != 0 )
         goto exit;
@@ -256,7 +256,7 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
         if( ( ret = mbedtls_md_hmac_finish( ctx, work ) ) != 0 )
             return( ret );
 
-        memcpy( md1, work, md_size );
+        mbedtls_platform_memcpy( md1, work, md_size );
 
         for( i = 1; i < iteration_count; i++ )
         {
@@ -278,7 +278,7 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
         }
 
         use_len = ( key_length < md_size ) ? key_length : md_size;
-        memcpy( out_p, work, use_len );
+        mbedtls_platform_memcpy( out_p, work, use_len );
 
         key_length -= (uint32_t) use_len;
         out_p += use_len;

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -561,7 +561,7 @@ static int uecc_public_key_read_binary( mbedtls_uecc_keypair *uecc_keypair,
     if( buf[0] != 0x04 )
         return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
 
-    memcpy( uecc_keypair->public_key, buf + 1, 2 * NUM_ECC_BYTES );
+    mbedtls_platform_memcpy( uecc_keypair->public_key, buf + 1, 2 * NUM_ECC_BYTES );
 
     return( 0 );
 }
@@ -918,7 +918,7 @@ static int pk_parse_key_sec1_der( mbedtls_uecc_keypair *keypair,
     if( ( ret = mbedtls_asn1_get_tag( &p, end, &len, MBEDTLS_ASN1_OCTET_STRING ) ) != 0 )
         return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT + ret );
 
-    memcpy( keypair->private_key, p, len );
+    mbedtls_platform_memcpy( keypair->private_key, p, len );
 
     p += len;
 
@@ -1521,7 +1521,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
         if( ( key_copy = mbedtls_calloc( 1, keylen ) ) == NULL )
             return( MBEDTLS_ERR_PK_ALLOC_FAILED );
 
-        memcpy( key_copy, key, keylen );
+        mbedtls_platform_memcpy( key_copy, key, keylen );
 
         ret = pk_parse_key_pkcs8_encrypted_der( pk, key_copy, keylen,
                                                 pwd, pwdlen );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -116,7 +116,7 @@ static int pk_write_ec_pubkey( unsigned char **p, unsigned char *start,
 
     *p -= len;
     (*p)[0] = 0x04;
-    memcpy( *p + 1, uecc->public_key, 2 * NUM_ECC_BYTES );
+    mbedtls_platform_memcpy( *p + 1, uecc->public_key, 2 * NUM_ECC_BYTES );
 
     return( (int) len );
 }
@@ -180,7 +180,7 @@ static int pk_write_ec_pubkey( unsigned char **p, unsigned char *start,
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
     *p -= len;
-    memcpy( *p, buf, len );
+    mbedtls_platform_memcpy( *p, buf, len );
 
     return( (int) len );
 }

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -211,7 +211,7 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
 
     if( lt != NULL )
     {
-        memcpy( tm_buf, lt, sizeof( struct tm ) );
+        mbedtls_platform_memcpy( tm_buf, lt, sizeof( struct tm ) );
     }
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -211,7 +211,7 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
 
     if( lt != NULL )
     {
-        mbedtls_platform_memcpy( tm_buf, lt, sizeof( struct tm ) );
+        memcpy( tm_buf, lt, sizeof( struct tm ) );
     }
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -346,7 +346,7 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
             /* Not enough data to complete the block.
              * Store this data with the other leftovers.
              */
-            memcpy( &ctx->queue[ctx->queue_len],
+            mbedtls_platform_memcpy( &ctx->queue[ctx->queue_len],
                     input,
                     ilen );
 
@@ -357,7 +357,7 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
         else
         {
             /* Enough data to produce a complete block */
-            memcpy( &ctx->queue[ctx->queue_len],
+            mbedtls_platform_memcpy( &ctx->queue[ctx->queue_len],
                     input,
                     queue_free_len );
 
@@ -384,7 +384,7 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
     {
         /* Store partial block */
         ctx->queue_len = remaining;
-        memcpy( ctx->queue, &input[offset], remaining );
+        mbedtls_platform_memcpy( ctx->queue, &input[offset], remaining );
     }
 
     return( 0 );

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -520,7 +520,7 @@ int mbedtls_ripemd160_self_test( int verbose )
     int i, ret = 0;
     unsigned char output[20];
 
-    mbedtls_platform_memset( output, 0, sizeof output );
+    memset( output, 0, sizeof output );
 
     for( i = 0; i < TESTS; i++ )
     {

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -340,7 +340,7 @@ int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, fill );
 
         if( ( ret = mbedtls_internal_ripemd160_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
@@ -361,7 +361,7 @@ int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
 
     if( ilen > 0 )
     {
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, ilen );
     }
 
     return( 0 );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2623,7 +2623,7 @@ int mbedtls_rsa_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "passed\n  PKCS#1 encryption : " );
 
-    mbedtls_platform_memcpy( rsa_plaintext, RSA_PT, PT_LEN );
+    memcpy( rsa_plaintext, RSA_PT, PT_LEN );
 
     if( mbedtls_rsa_pkcs1_encrypt( &rsa, myrand, NULL, MBEDTLS_RSA_PUBLIC,
                                    PT_LEN, rsa_plaintext,

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1171,7 +1171,7 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     p += hlen;
     p += olen - 2 * hlen - 2 - ilen;
     *p++ = 1;
-    memcpy( p, input, ilen );
+    mbedtls_platform_memcpy( p, input, ilen );
 
     mbedtls_md_init( &md_ctx );
     if( ( ret = mbedtls_md_setup( &md_ctx, md_info, 0 ) ) != 0 )
@@ -1263,7 +1263,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
     }
 
     *p++ = 0;
-    memcpy( p, input, ilen );
+    mbedtls_platform_memcpy( p, input, ilen );
 
     return( ( mode == MBEDTLS_RSA_PUBLIC )
             ? mbedtls_rsa_public(  ctx, output, output )
@@ -1441,7 +1441,7 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
     }
 
     *olen = ilen - (p - buf);
-    memcpy( output, p, *olen );
+    mbedtls_platform_memcpy( output, p, *olen );
     ret = 0;
 
 cleanup:
@@ -1695,7 +1695,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
 
     /* Finally copy the decrypted plaintext plus trailing zeros
      * into the output buffer. */
-    memcpy( output, buf + ilen - plaintext_max_size, plaintext_max_size );
+    mbedtls_platform_memcpy( output, buf + ilen - plaintext_max_size, plaintext_max_size );
 
     /* Report the amount of data we copied to the output buffer. In case
      * of errors (bad padding or output too large), the value of *olen
@@ -1825,7 +1825,7 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;
     p += olen - hlen - slen - 2;
     *p++ = 0x01;
-    memcpy( p, salt, slen );
+    mbedtls_platform_memcpy( p, salt, slen );
     p += slen;
 
     mbedtls_md_init( &md_ctx );
@@ -1965,7 +1965,7 @@ static int rsa_rsassa_pkcs1_v15_encode( mbedtls_md_type_t md_alg,
     /* Are we signing raw data? */
     if( md_alg == MBEDTLS_MD_NONE )
     {
-        memcpy( p, hash, hashlen );
+        mbedtls_platform_memcpy( p, hash, hashlen );
         return( 0 );
     }
 
@@ -1988,13 +1988,13 @@ static int rsa_rsassa_pkcs1_v15_encode( mbedtls_md_type_t md_alg,
     *p++ = (unsigned char)( 0x04 + oid_size );
     *p++ = MBEDTLS_ASN1_OID;
     *p++ = (unsigned char) oid_size;
-    memcpy( p, oid, oid_size );
+    mbedtls_platform_memcpy( p, oid, oid_size );
     p += oid_size;
     *p++ = MBEDTLS_ASN1_NULL;
     *p++ = 0x00;
     *p++ = MBEDTLS_ASN1_OCTET_STRING;
     *p++ = (unsigned char) hashlen;
-    memcpy( p, hash, hashlen );
+    mbedtls_platform_memcpy( p, hash, hashlen );
     p += hashlen;
 
     /* Just a sanity-check, should be automatic
@@ -2078,7 +2078,7 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
         goto cleanup;
     }
 
-    memcpy( sig, sig_try, ctx->len );
+    mbedtls_platform_memcpy( sig, sig_try, ctx->len );
 
 cleanup:
     mbedtls_free( sig_try );
@@ -2623,7 +2623,7 @@ int mbedtls_rsa_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "passed\n  PKCS#1 encryption : " );
 
-    memcpy( rsa_plaintext, RSA_PT, PT_LEN );
+    mbedtls_platform_memcpy( rsa_plaintext, RSA_PT, PT_LEN );
 
     if( mbedtls_rsa_pkcs1_encrypt( &rsa, myrand, NULL, MBEDTLS_RSA_PUBLIC,
                                    PT_LEN, rsa_plaintext,

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -523,7 +523,7 @@ int mbedtls_sha1_self_test( int verbose )
 
         if( i == 2 )
         {
-            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
+            memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -328,7 +328,7 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, fill );
 
         if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
@@ -348,7 +348,7 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
     }
 
     if( ilen > 0 )
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, ilen );
 
     return( 0 );
 }

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -527,7 +527,7 @@ int mbedtls_sha256_self_test( int verbose )
 
         if( j == 2 )
         {
-            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
+            memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -280,7 +280,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, fill );
 
         if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
@@ -300,7 +300,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
     }
 
     if( ilen > 0 )
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, ilen );
 
     return( 0 );
 }

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -585,7 +585,7 @@ int mbedtls_sha512_self_test( int verbose )
 
         if( j == 2 )
         {
-            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
+            memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -326,7 +326,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
 
     if( left && ilen >= fill )
     {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, fill );
 
         if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
@@ -346,7 +346,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
     }
 
     if( ilen > 0 )
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
+        mbedtls_platform_memcpy( (void *) (ctx->buffer + left), input, ilen );
 
     return( 0 );
 }

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -290,7 +290,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
             goto exit;
         }
 
-        memcpy( cur->peer_cert.p,
+        mbedtls_platform_memcpy( cur->peer_cert.p,
                 cur->session.peer_cert->raw.p,
                 cur->session.peer_cert->raw.len );
         cur->peer_cert.len = session->peer_cert->raw.len;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -440,7 +440,8 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     p = mbedtls_platform_put_uint16_be( p, ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
-    mbedtls_platform_memcpy( p, ssl->own_cid, ssl->own_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( p, ssl->own_cid, ssl->own_cid_len );
 
     *olen = ssl->own_cid_len + 5;
 }
@@ -1272,7 +1273,8 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
 
     ssl->handshake->cid_in_use = MBEDTLS_SSL_CID_ENABLED;
     ssl->handshake->peer_cid_len = (uint8_t) peer_cid_len;
-    mbedtls_platform_memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as peer_cid is public */
+    memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Use of CID extension negotiated" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Server CID", buf, peer_cid_len );
@@ -1848,7 +1850,8 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         ssl->session_negotiate->compression = comp;
 #endif
         ssl->session_negotiate->id_len = n;
-        mbedtls_platform_memcpy( ssl->session_negotiate->id, buf + 35, n );
+        /* Not using more secure mbedtls_platform_memcpy as id is public */
+        memcpy( ssl->session_negotiate->id, buf + 35, n );
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "%s session has been resumed",

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -111,7 +111,7 @@ static void ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
 
     p = mbedtls_platform_put_uint16_be( p, hostname_len );
 
-    memcpy( p, ssl->hostname, hostname_len );
+    mbedtls_platform_memcpy( p, ssl->hostname, hostname_len );
 
     *olen = hostname_len + 9;
 }
@@ -150,7 +150,7 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
     *p++ = ssl->verify_data_len & 0xFF;
 
-    memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
+    mbedtls_platform_memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
 
     *olen = 5 + ssl->verify_data_len;
 }
@@ -375,7 +375,7 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
             return;
         }
 
-        memcpy( ssl->handshake->ecjpake_cache, p + 2, kkpp_len );
+        mbedtls_platform_memcpy( ssl->handshake->ecjpake_cache, p + 2, kkpp_len );
         ssl->handshake->ecjpake_cache_len = kkpp_len;
     }
     else
@@ -390,7 +390,7 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
             return;
         }
 
-        memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
+        mbedtls_platform_memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
     p = mbedtls_platform_put_uint16_be( p, kkpp_len );
@@ -440,7 +440,7 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     p = mbedtls_platform_put_uint16_be( p, ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
-    memcpy( p, ssl->own_cid, ssl->own_cid_len );
+    mbedtls_platform_memcpy( p, ssl->own_cid, ssl->own_cid_len );
 
     *olen = ssl->own_cid_len + 5;
 }
@@ -614,7 +614,7 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "sending session ticket of length %d", tlen ) );
 
-    memcpy( p, ssl->session_negotiate->ticket, tlen );
+    mbedtls_platform_memcpy( p, ssl->session_negotiate->ticket, tlen );
 
     *olen += tlen;
 }
@@ -663,7 +663,7 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     for( cur = ssl->conf->alpn_list; *cur != NULL; cur++ )
     {
         *p = (unsigned char)( strlen( *cur ) & 0xFF );
-        memcpy( p + 1, *cur, *p );
+        mbedtls_platform_memcpy( p + 1, *cur, *p );
         p += 1 + *p;
     }
 
@@ -838,7 +838,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         return( ret );
     }
 
-    memcpy( p, ssl->handshake->randbytes, 32 );
+    mbedtls_platform_memcpy( p, ssl->handshake->randbytes, 32 );
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, random bytes", p, 32 );
     p += 32;
 
@@ -918,7 +918,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
                               ssl->handshake->verify_cookie_len );
 
             *p++ = ssl->handshake->verify_cookie_len;
-            memcpy( p, ssl->handshake->verify_cookie,
+            mbedtls_platform_memcpy( p, ssl->handshake->verify_cookie,
                        ssl->handshake->verify_cookie_len );
             p += ssl->handshake->verify_cookie_len;
         }
@@ -1272,7 +1272,7 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
 
     ssl->handshake->cid_in_use = MBEDTLS_SSL_CID_ENABLED;
     ssl->handshake->peer_cid_len = (uint8_t) peer_cid_len;
-    memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
+    mbedtls_platform_memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Use of CID extension negotiated" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Server CID", buf, peer_cid_len );
@@ -1558,7 +1558,7 @@ static int ssl_parse_hello_verify_request( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
-    memcpy( ssl->handshake->verify_cookie, p, cookie_len );
+    mbedtls_platform_memcpy( ssl->handshake->verify_cookie, p, cookie_len );
     ssl->handshake->verify_cookie_len = cookie_len;
 
     /* Start over at ClientHello */
@@ -1717,7 +1717,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, current time: %lu",
         (unsigned long)mbedtls_platform_get_uint32_be( &buf[2] ) ) );
 
-    memcpy( ssl->handshake->randbytes + 32, buf + 2, 32 );
+    mbedtls_platform_memcpy( ssl->handshake->randbytes + 32, buf + 2, 32 );
 
     n = buf[34];
 
@@ -1848,7 +1848,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         ssl->session_negotiate->compression = comp;
 #endif
         ssl->session_negotiate->id_len = n;
-        memcpy( ssl->session_negotiate->id, buf + 35, n );
+        mbedtls_platform_memcpy( ssl->session_negotiate->id, buf + 35, n );
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "%s session has been resumed",
@@ -2553,7 +2553,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         mbedtls_uecc_keypair *peer_key =
             mbedtls_pk_uecc( *peer_pk );
 
-        memcpy( ssl->handshake->ecdh_peerkey,
+        mbedtls_platform_memcpy( ssl->handshake->ecdh_peerkey,
                 peer_key->public_key,
                 sizeof( ssl->handshake->ecdh_peerkey ) );
 #else /* MBEDTLS_USE_TINYCRYPT */
@@ -3652,7 +3652,7 @@ static int ssl_out_client_key_exchange_write( mbedtls_ssl_context *ssl,
 
         p = mbedtls_platform_put_uint16_be( p, n );
 
-        memcpy( p, ssl->conf->psk_identity, n );
+        mbedtls_platform_memcpy( p, ssl->conf->psk_identity, n );
         p += ssl->conf->psk_identity_len;
 
 #if defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
@@ -4106,7 +4106,7 @@ static int ssl_parse_new_session_ticket( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
     }
 
-    memcpy( ticket, msg + 6, ticket_len );
+    mbedtls_platform_memcpy( ticket, msg + 6, ticket_len );
 
     ssl->session_negotiate->ticket = ticket;
     ssl->session_negotiate->ticket_len = ticket_len;

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -144,7 +144,7 @@ static int ssl_cookie_hmac( mbedtls_md_context_t *hmac_ctx,
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    memcpy( *p, hmac_out, COOKIE_HMAC_LEN );
+    mbedtls_platform_memcpy( *p, hmac_out, COOKIE_HMAC_LEN );
     *p += COOKIE_HMAC_LEN;
 
     return( 0 );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -63,7 +63,7 @@ int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
     if( ( ssl->cli_id = mbedtls_calloc( 1, ilen ) ) == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-    memcpy( ssl->cli_id, info, ilen );
+    mbedtls_platform_memcpy( ssl->cli_id, info, ilen );
     ssl->cli_id_len = ilen;
 
     return( 0 );
@@ -485,7 +485,7 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
 
     ssl->handshake->cid_in_use = MBEDTLS_SSL_CID_ENABLED;
     ssl->handshake->peer_cid_len = (uint8_t) peer_cid_len;
-    memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
+    mbedtls_platform_memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Use of CID extension negotiated" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Client CID", buf, peer_cid_len );
@@ -615,10 +615,10 @@ static int ssl_parse_session_ticket_ext( mbedtls_ssl_context *ssl,
      * inform them we're accepting the ticket  (RFC 5077 section 3.4)
      */
     session.id_len = ssl->session_negotiate->id_len;
-    memcpy( &session.id, ssl->session_negotiate->id, session.id_len );
+    mbedtls_platform_memcpy( &session.id, ssl->session_negotiate->id, session.id_len );
 
     mbedtls_ssl_session_free( ssl->session_negotiate );
-    memcpy( ssl->session_negotiate, &session, sizeof( mbedtls_ssl_session ) );
+    mbedtls_platform_memcpy( ssl->session_negotiate, &session, sizeof( mbedtls_ssl_session ) );
 
     /* Zeroize instead of free as we copied the content */
     mbedtls_platform_zeroize( &session, sizeof( mbedtls_ssl_session ) );
@@ -1218,11 +1218,11 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     ssl->session_negotiate->id_len = sess_len;
     memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
-    memcpy( ssl->session_negotiate->id, p, ssl->session_negotiate->id_len );
+    mbedtls_platform_memcpy( ssl->session_negotiate->id, p, ssl->session_negotiate->id_len );
 
     p += sess_len;
     memset( ssl->handshake->randbytes, 0, 64 );
-    memcpy( ssl->handshake->randbytes + 32 - chal_len, p, chal_len );
+    mbedtls_platform_memcpy( ssl->handshake->randbytes + 32 - chal_len, p, chal_len );
 
     /*
      * Check for TLS_EMPTY_RENEGOTIATION_INFO_SCSV
@@ -1484,7 +1484,7 @@ read_record_header:
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO );
         }
 
-        memcpy( ssl->cur_out_ctr + 2, ssl->in_ctr + 2, 6 );
+        mbedtls_platform_memcpy( ssl->cur_out_ctr + 2, ssl->in_ctr + 2, 6 );
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
         if( mbedtls_ssl_dtls_replay_check( ssl ) != 0 )
@@ -1717,7 +1717,7 @@ read_record_header:
      */
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, random bytes", buf + 2, 32 );
 
-    memcpy( ssl->handshake->randbytes, buf + 2, 32 );
+    mbedtls_platform_memcpy( ssl->handshake->randbytes, buf + 2, 32 );
 
     /*
      * Check the session ID length and save session ID
@@ -1738,7 +1738,7 @@ read_record_header:
     ssl->session_negotiate->id_len = sess_len;
     memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
-    memcpy( ssl->session_negotiate->id, buf + 35,
+    mbedtls_platform_memcpy( ssl->session_negotiate->id, buf + 35,
             ssl->session_negotiate->id_len );
 
     /*
@@ -2391,7 +2391,7 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     ext_len = (size_t) ssl->own_cid_len + 1;
     p = mbedtls_platform_put_uint16_be( p, ext_len );
     *p++ = (uint8_t) ssl->own_cid_len;
-    memcpy( p, ssl->own_cid, ssl->own_cid_len );
+    mbedtls_platform_memcpy( p, ssl->own_cid, ssl->own_cid_len );
 
     *olen = ssl->own_cid_len + 5;
 }
@@ -2520,9 +2520,9 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
         *p++ = ( ssl->verify_data_len * 2 + 1 ) & 0xFF;
         *p++ = ssl->verify_data_len * 2 & 0xFF;
 
-        memcpy( p, ssl->peer_verify_data, ssl->verify_data_len );
+        mbedtls_platform_memcpy( p, ssl->peer_verify_data, ssl->verify_data_len );
         p += ssl->verify_data_len;
-        memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
+        mbedtls_platform_memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
         p += ssl->verify_data_len;
     }
     else
@@ -2664,7 +2664,7 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     buf[6] = (unsigned char)( ( ( *olen - 7 )      ) & 0xFF );
 
-    memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
+    mbedtls_platform_memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
 #endif /* MBEDTLS_ECDH_C || MBEDTLS_ECDSA_C */
 
@@ -2811,7 +2811,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     p += 28;
 
-    memcpy( ssl->handshake->randbytes + 32, buf + 6, 32 );
+    mbedtls_platform_memcpy( ssl->handshake->randbytes + 32, buf + 6, 32 );
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "server hello, random bytes", buf + 6, 32 );
 
@@ -2887,7 +2887,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
      *   44+n . 43+n+m  extensions
      */
     *p++ = (unsigned char) ssl->session_negotiate->id_len;
-    memcpy( p, ssl->session_negotiate->id, ssl->session_negotiate->id_len );
+    mbedtls_platform_memcpy( p, ssl->session_negotiate->id, ssl->session_negotiate->id_len );
     p += ssl->session_negotiate->id_len;
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, session id len.: %d", n ) );
@@ -3161,7 +3161,7 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
             }
 
             p = mbedtls_platform_put_uint16_be( p, dn_size );
-            memcpy( p, frame->subject_raw.p, dn_size );
+            mbedtls_platform_memcpy( p, frame->subject_raw.p, dn_size );
             p += dn_size;
 
             MBEDTLS_SSL_DEBUG_BUF( 3, "requested DN", p - dn_size, dn_size );
@@ -3203,7 +3203,7 @@ static int ssl_get_ecdh_params_from_cert( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH );
     }
 
-    memcpy( ssl->handshake->ecdh_privkey,
+    mbedtls_platform_memcpy( ssl->handshake->ecdh_privkey,
             own_key->private_key,
             sizeof( ssl->handshake->ecdh_privkey ) );
 
@@ -3420,7 +3420,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
             dig_signed = ssl->out_msg + ssl->out_msglen;
 #endif
 
-            memcpy( ssl->out_msg + ssl->out_msglen,
+            mbedtls_platform_memcpy( ssl->out_msg + ssl->out_msglen,
                     ecdh_param_hdr, sizeof( ecdh_param_hdr ) );
             ssl->out_msglen += sizeof( ecdh_param_hdr );
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -63,7 +63,8 @@ int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
     if( ( ssl->cli_id = mbedtls_calloc( 1, ilen ) ) == NULL )
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-    mbedtls_platform_memcpy( ssl->cli_id, info, ilen );
+    /* Not using more secure mbedtls_platform_memcpy as id is public*/
+    memcpy( ssl->cli_id, info, ilen );
     ssl->cli_id_len = ilen;
 
     return( 0 );
@@ -485,7 +486,8 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
 
     ssl->handshake->cid_in_use = MBEDTLS_SSL_CID_ENABLED;
     ssl->handshake->peer_cid_len = (uint8_t) peer_cid_len;
-    mbedtls_platform_memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as peer_cid is is public */
+    memcpy( ssl->handshake->peer_cid, buf, peer_cid_len );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Use of CID extension negotiated" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Client CID", buf, peer_cid_len );
@@ -1738,7 +1740,8 @@ read_record_header:
     ssl->session_negotiate->id_len = sess_len;
     memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
-    mbedtls_platform_memcpy( ssl->session_negotiate->id, buf + 35,
+    /* Not using more secure mbedtls_platform_memcpy as id is public */
+    memcpy( ssl->session_negotiate->id, buf + 35,
             ssl->session_negotiate->id_len );
 
     /*
@@ -2391,7 +2394,8 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     ext_len = (size_t) ssl->own_cid_len + 1;
     p = mbedtls_platform_put_uint16_be( p, ext_len );
     *p++ = (uint8_t) ssl->own_cid_len;
-    mbedtls_platform_memcpy( p, ssl->own_cid, ssl->own_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( p, ssl->own_cid, ssl->own_cid_len );
 
     *olen = ssl->own_cid_len + 5;
 }
@@ -2887,7 +2891,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
      *   44+n . 43+n+m  extensions
      */
     *p++ = (unsigned char) ssl->session_negotiate->id_len;
-    mbedtls_platform_memcpy( p, ssl->session_negotiate->id, ssl->session_negotiate->id_len );
+    /* Not using more secure mbedtls_platform_memcpy as id is public */
+    memcpy( p, ssl->session_negotiate->id, ssl->session_negotiate->id_len );
     p += ssl->session_negotiate->id_len;
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, session id len.: %d", n ) );

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -208,7 +208,7 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
 
     *ticket_lifetime = ctx->ticket_lifetime;
 
-    memcpy( key_name, key->name, 4 );
+    mbedtls_platform_memcpy( key_name, key->name, 4 );
 
     if( ( ret = ctx->f_rng( ctx->p_rng, iv, 12 ) ) != 0 )
         goto cleanup;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -299,7 +299,8 @@ int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    mbedtls_platform_memcpy( ssl->own_cid, own_cid, own_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( ssl->own_cid, own_cid, own_cid_len );
     /* Truncation is not an issue here because
      * MBEDTLS_SSL_CID_IN_LEN_MAX at most 255. */
     ssl->own_cid_len = (uint8_t) own_cid_len;
@@ -335,7 +336,8 @@ int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
         *peer_cid_len = ssl->transform_in->out_cid_len;
         if( peer_cid != NULL )
         {
-            mbedtls_platform_memcpy( peer_cid, ssl->transform_in->out_cid,
+            /* Not using more secure mbedtls_platform_memcpy as cid is public */
+            memcpy( peer_cid, ssl->transform_in->out_cid,
                     ssl->transform_in->out_cid_len );
         }
     }
@@ -1317,12 +1319,14 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Copy CIDs into SSL transform" ) );
 
         transform->in_cid_len = ssl->own_cid_len;
-        mbedtls_platform_memcpy( transform->in_cid, ssl->own_cid, ssl->own_cid_len );
+        /* Not using more secure mbedtls_platform_memcpy as cid is public */
+        memcpy( transform->in_cid, ssl->own_cid, ssl->own_cid_len );
         MBEDTLS_SSL_DEBUG_BUF( 3, "Incoming CID", transform->in_cid,
                                transform->in_cid_len );
 
         transform->out_cid_len = ssl->handshake->peer_cid_len;
-        mbedtls_platform_memcpy( transform->out_cid, ssl->handshake->peer_cid,
+        /* Not using more secure mbedtls_platform_memcpy as cid is public */
+        memcpy( transform->out_cid, ssl->handshake->peer_cid,
                 ssl->handshake->peer_cid_len );
         MBEDTLS_SSL_DEBUG_BUF( 3, "Outgoing CID", transform->out_cid,
                                transform->out_cid_len );
@@ -2479,7 +2483,8 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
      * Add CID information
      */
     rec->cid_len = transform->out_cid_len;
-    mbedtls_platform_memcpy( rec->cid, transform->out_cid, transform->out_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( rec->cid, transform->out_cid, transform->out_cid_len );
     MBEDTLS_SSL_DEBUG_BUF( 3, "CID", rec->cid, rec->cid_len );
 
     if( rec->cid_len != 0 )
@@ -4540,7 +4545,8 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
             /* Update the record content type and CID. */
             ssl->out_msgtype = rec.type;
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID )
-            mbedtls_platform_memcpy( ssl->out_cid, rec.cid, rec.cid_len );
+            /* Not using more secure mbedtls_platform_memcpy as cid is public */
+            memcpy( ssl->out_cid, rec.cid, rec.cid_len );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
             ssl->out_msglen = len = rec.data_len;
             (void)mbedtls_platform_put_uint16_be( ssl->out_len, rec.data_len );
@@ -5328,7 +5334,8 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
         /* configured CID len is guaranteed at most 255, see
          * MBEDTLS_SSL_CID_OUT_LEN_MAX in check_config.h */
         rec->cid_len = (uint8_t) rec_hdr_cid_len;
-        mbedtls_platform_memcpy( rec->cid, buf + rec_hdr_cid_offset, rec_hdr_cid_len );
+        /* Not using more secure mbedtls_platform_memcpy as cid is public */
+        memcpy( rec->cid, buf + rec_hdr_cid_offset, rec_hdr_cid_len );
     }
     else
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
@@ -5372,7 +5379,8 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
     if( MBEDTLS_SSL_TRANSPORT_IS_DTLS( ssl->conf->transport ) )
     {
         /* Copy explicit record sequence number from input buffer. */
-        mbedtls_platform_memcpy( &rec->ctr[0], buf + rec_hdr_ctr_offset,
+        /* Not using more secure mbedtls_platform_memcpy as sequence number is public */
+        memcpy( &rec->ctr[0], buf + rec_hdr_ctr_offset,
                 rec_hdr_ctr_len );
     }
     MBEDTLS_SSL_TRANSPORT_ELSE
@@ -5380,7 +5388,8 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_PROTO_TLS)
     {
         /* Copy implicit record sequence number from SSL context structure. */
-        mbedtls_platform_memcpy( &rec->ctr[0], ssl->in_ctr, rec_hdr_ctr_len );
+        /* Not using more secure mbedtls_platform_memcpy as sequence number is public */
+        memcpy( &rec->ctr[0], ssl->in_ctr, rec_hdr_ctr_len );
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS */
 
@@ -9019,7 +9028,8 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
         if( ssl->hostname == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        mbedtls_platform_memcpy( ssl->hostname, hostname, hostname_len );
+        /* Not using more secure mbedtls_platform_memcpy as hostname is public in initial handshake */
+        memcpy( ssl->hostname, hostname, hostname_len );
 
         ssl->hostname[hostname_len] = '\0';
     }
@@ -9828,7 +9838,8 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 #endif
 
         *p++ = (unsigned char)( session->id_len & 0xFF );
-        mbedtls_platform_memcpy( p, session->id, 32 );
+        /* Not using more secure mbedtls_platform_memcpy as session id is public */
+        memcpy( p, session->id, 32 );
         p += 32;
 
         mbedtls_platform_memcpy( p, session->master, 48 );
@@ -10055,7 +10066,8 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 #endif
 
     session->id_len = *p++;
-    mbedtls_platform_memcpy( session->id, p, 32 );
+    /* Not using more secure mbedtls_platform_memcpy as session id is public */
+    memcpy( session->id, p, 32 );
     p += 32;
 
     mbedtls_platform_memcpy( session->master, p, 48 );
@@ -11313,11 +11325,13 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     if( used <= buf_len )
     {
         *p++ = ssl->transform->in_cid_len;
-        mbedtls_platform_memcpy( p, ssl->transform->in_cid, ssl->transform->in_cid_len );
+        /* Not using more secure mbedtls_platform_memcpy as cid is public */
+        memcpy( p, ssl->transform->in_cid, ssl->transform->in_cid_len );
         p += ssl->transform->in_cid_len;
 
         *p++ = ssl->transform->out_cid_len;
-        mbedtls_platform_memcpy( p, ssl->transform->out_cid, ssl->transform->out_cid_len );
+        /* Not using more secure mbedtls_platform_memcpy as cid is public */
+        memcpy( p, ssl->transform->out_cid, ssl->transform->out_cid_len );
         p += ssl->transform->out_cid_len;
     }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
@@ -11554,7 +11568,8 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < ssl->transform->in_cid_len + 1u )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    mbedtls_platform_memcpy( ssl->transform->in_cid, p, ssl->transform->in_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( ssl->transform->in_cid, p, ssl->transform->in_cid_len );
     p += ssl->transform->in_cid_len;
 
     ssl->transform->out_cid_len = *p++;
@@ -11562,7 +11577,8 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < ssl->transform->out_cid_len )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    mbedtls_platform_memcpy( ssl->transform->out_cid, p, ssl->transform->out_cid_len );
+    /* Not using more secure mbedtls_platform_memcpy as cid is public */
+    memcpy( ssl->transform->out_cid, p, ssl->transform->out_cid_len );
     p += ssl->transform->out_cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -89,7 +89,7 @@ int mbedtls_ssl_ecdh_read_peerkey( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    memcpy( ssl->handshake->ecdh_peerkey, *p + 2, 2 * NUM_ECC_BYTES );
+    mbedtls_platform_memcpy( ssl->handshake->ecdh_peerkey, *p + 2, 2 * NUM_ECC_BYTES );
 
     *p += secp256r1_uncompressed_point_length;
     return( 0 );
@@ -299,7 +299,7 @@ int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }
 
-    memcpy( ssl->own_cid, own_cid, own_cid_len );
+    mbedtls_platform_memcpy( ssl->own_cid, own_cid, own_cid_len );
     /* Truncation is not an issue here because
      * MBEDTLS_SSL_CID_IN_LEN_MAX at most 255. */
     ssl->own_cid_len = (uint8_t) own_cid_len;
@@ -335,7 +335,7 @@ int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
         *peer_cid_len = ssl->transform_in->out_cid_len;
         if( peer_cid != NULL )
         {
-            memcpy( peer_cid, ssl->transform_in->out_cid,
+            mbedtls_platform_memcpy( peer_cid, ssl->transform_in->out_cid,
                     ssl->transform_in->out_cid_len );
         }
     }
@@ -516,7 +516,7 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
                               const mbedtls_ssl_session *src )
 {
     mbedtls_ssl_session_free( dst );
-    memcpy( dst, src, sizeof( mbedtls_ssl_session ) );
+    mbedtls_platform_memcpy( dst, src, sizeof( mbedtls_ssl_session ) );
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 
@@ -547,7 +547,7 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
         if( dst->peer_cert_digest == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        memcpy( dst->peer_cert_digest, src->peer_cert_digest,
+        mbedtls_platform_memcpy( dst->peer_cert_digest, src->peer_cert_digest,
                 src->peer_cert_digest_len );
         dst->peer_cert_digest_type = src->peer_cert_digest_type;
         dst->peer_cert_digest_len = src->peer_cert_digest_len;
@@ -563,7 +563,7 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
         if( dst->ticket == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        memcpy( dst->ticket, src->ticket, src->ticket_len );
+        mbedtls_platform_memcpy( dst->ticket, src->ticket, src->ticket_len );
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
@@ -674,8 +674,8 @@ MBEDTLS_NO_INLINE static int tls1_prf( const unsigned char *secret, size_t slen,
     S2 = secret + slen - hs;
 
     nb = strlen( label );
-    memcpy( tmp + 20, label, nb );
-    memcpy( tmp + 20 + nb, random, rlen );
+    mbedtls_platform_memcpy( tmp + 20, label, nb );
+    mbedtls_platform_memcpy( tmp + 20 + nb, random, rlen );
     nb += rlen;
 
     /*
@@ -787,8 +787,8 @@ int tls_prf_generic( mbedtls_md_type_t md_type,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
     nb = strlen( label );
-    memcpy( tmp + md_len, label, nb );
-    memcpy( tmp + md_len + nb, random, rlen );
+    mbedtls_platform_memcpy( tmp + md_len, label, nb );
+    mbedtls_platform_memcpy( tmp + md_len + nb, random, rlen );
     nb += rlen;
 
     /*
@@ -1277,7 +1277,7 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
 #endif /* !MBEDTLS_SSL_CONF_FIXED_MINOR_VER */
 
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
-    memcpy( transform->randbytes, randbytes, sizeof( transform->randbytes ) );
+    mbedtls_platform_memcpy( transform->randbytes, randbytes, sizeof( transform->randbytes ) );
 #endif
 
     /*
@@ -1317,12 +1317,12 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Copy CIDs into SSL transform" ) );
 
         transform->in_cid_len = ssl->own_cid_len;
-        memcpy( transform->in_cid, ssl->own_cid, ssl->own_cid_len );
+        mbedtls_platform_memcpy( transform->in_cid, ssl->own_cid, ssl->own_cid_len );
         MBEDTLS_SSL_DEBUG_BUF( 3, "Incoming CID", transform->in_cid,
                                transform->in_cid_len );
 
         transform->out_cid_len = ssl->handshake->peer_cid_len;
-        memcpy( transform->out_cid, ssl->handshake->peer_cid,
+        mbedtls_platform_memcpy( transform->out_cid, ssl->handshake->peer_cid,
                 ssl->handshake->peer_cid_len );
         MBEDTLS_SSL_DEBUG_BUF( 3, "Outgoing CID", transform->out_cid,
                                transform->out_cid_len );
@@ -1445,8 +1445,8 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
          */
         iv_copy_len = ( transform->fixed_ivlen ) ?
                             transform->fixed_ivlen : transform->ivlen;
-        memcpy( transform->iv_enc, key2 + keylen,  iv_copy_len );
-        memcpy( transform->iv_dec, key2 + keylen + iv_copy_len,
+        mbedtls_platform_memcpy( transform->iv_enc, key2 + keylen,  iv_copy_len );
+        mbedtls_platform_memcpy( transform->iv_dec, key2 + keylen + iv_copy_len,
                 iv_copy_len );
     }
     else
@@ -1465,8 +1465,8 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
          */
         iv_copy_len = ( transform->fixed_ivlen ) ?
                             transform->fixed_ivlen : transform->ivlen;
-        memcpy( transform->iv_dec, key1 + keylen,  iv_copy_len );
-        memcpy( transform->iv_enc, key1 + keylen + iv_copy_len,
+        mbedtls_platform_memcpy( transform->iv_dec, key1 + keylen,  iv_copy_len );
+        mbedtls_platform_memcpy( transform->iv_enc, key1 + keylen + iv_copy_len,
                 iv_copy_len );
     }
     else
@@ -1486,8 +1486,8 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
             return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
 
-        memcpy( transform->mac_enc, mac_enc, mac_key_len );
-        memcpy( transform->mac_dec, mac_dec, mac_key_len );
+        mbedtls_platform_memcpy( transform->mac_enc, mac_enc, mac_key_len );
+        mbedtls_platform_memcpy( transform->mac_dec, mac_dec, mac_key_len );
     }
     else
 #endif /* MBEDTLS_SSL_PROTO_SSL3 */
@@ -1896,9 +1896,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
      * - key derivation wants server+client (RFC 5246 6.3) */
     {
         unsigned char tmp[64];
-        memcpy( tmp, ssl->handshake->randbytes, 64 );
-        memcpy( ssl->handshake->randbytes, tmp + 32, 32 );
-        memcpy( ssl->handshake->randbytes + 32, tmp, 32 );
+        mbedtls_platform_memcpy( tmp, ssl->handshake->randbytes, 64 );
+        mbedtls_platform_memcpy( ssl->handshake->randbytes, tmp + 32, 32 );
+        mbedtls_platform_memcpy( ssl->handshake->randbytes + 32, tmp, 32 );
         mbedtls_platform_zeroize( tmp, sizeof( tmp ) );
     }
 
@@ -2211,7 +2211,7 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
     if( end < p || (size_t)( end - p ) < psk_len )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    memcpy( p, psk, psk_len );
+    mbedtls_platform_memcpy( p, psk, psk_len );
     p += psk_len;
 
     ssl->handshake->pmslen = p - ssl->handshake->premaster;
@@ -2243,7 +2243,7 @@ static void ssl_mac( mbedtls_md_context_t *md_ctx,
     else
         padlen = 40;
 
-    memcpy( header, ctr, 8 );
+    mbedtls_platform_memcpy( header, ctr, 8 );
     header[8] = (unsigned char) type;
     (void)mbedtls_platform_put_uint16_be( &header[9], len );
 
@@ -2388,14 +2388,14 @@ static void ssl_extract_add_data_from_record( unsigned char* add_data,
      *                         length_of_DTLSInnerPlaintext;
      */
 
-    memcpy( add_data, rec->ctr, sizeof( rec->ctr ) );
+    mbedtls_platform_memcpy( add_data, rec->ctr, sizeof( rec->ctr ) );
     add_data[8] = rec->type;
-    memcpy( add_data + 9, rec->ver, sizeof( rec->ver ) );
+    mbedtls_platform_memcpy( add_data + 9, rec->ver, sizeof( rec->ver ) );
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     if( rec->cid_len != 0 )
     {
-        memcpy( add_data + 11, rec->cid, rec->cid_len );
+        mbedtls_platform_memcpy( add_data + 11, rec->cid, rec->cid_len );
         add_data[11 + rec->cid_len + 0] = rec->cid_len;
         (void)mbedtls_platform_put_uint16_be( &add_data[11 + rec->cid_len + 1],
                                               rec->data_len );
@@ -2479,7 +2479,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
      * Add CID information
      */
     rec->cid_len = transform->out_cid_len;
-    memcpy( rec->cid, transform->out_cid, transform->out_cid_len );
+    mbedtls_platform_memcpy( rec->cid, transform->out_cid, transform->out_cid_len );
     MBEDTLS_SSL_DEBUG_BUF( 3, "CID", rec->cid, rec->cid_len );
 
     if( rec->cid_len != 0 )
@@ -2529,7 +2529,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
             unsigned char mac[SSL_MAC_MAX_BYTES];
             ssl_mac( &transform->md_ctx_enc, transform->mac_enc,
                      data, rec->data_len, rec->ctr, rec->type, mac );
-            memcpy( data + rec->data_len, mac, transform->maclen );
+            mbedtls_platform_memcpy( data + rec->data_len, mac, transform->maclen );
         }
         else
 #endif
@@ -2550,7 +2550,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
             mbedtls_md_hmac_finish( &transform->md_ctx_enc, mac );
             mbedtls_md_hmac_reset( &transform->md_ctx_enc );
 
-            memcpy( data + rec->data_len, mac, transform->maclen );
+            mbedtls_platform_memcpy( data + rec->data_len, mac, transform->maclen );
         }
         else
 #endif
@@ -2624,18 +2624,18 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
         if( transform->ivlen == 12 && transform->fixed_ivlen == 4 )
         {
             /* GCM and CCM: fixed || explicit (=seqnum) */
-            memcpy( iv, transform->iv_enc, transform->fixed_ivlen );
-            memcpy( iv + transform->fixed_ivlen, rec->ctr,
+            mbedtls_platform_memcpy( iv, transform->iv_enc, transform->fixed_ivlen );
+            mbedtls_platform_memcpy( iv + transform->fixed_ivlen, rec->ctr,
                     explicit_iv_len );
             /* Prefix record content with explicit IV. */
-            memcpy( data - explicit_iv_len, rec->ctr, explicit_iv_len );
+            mbedtls_platform_memcpy( data - explicit_iv_len, rec->ctr, explicit_iv_len );
         }
         else if( transform->ivlen == 12 && transform->fixed_ivlen == 12 )
         {
             /* ChachaPoly: fixed XOR sequence number */
             unsigned char i;
 
-            memcpy( iv, transform->iv_enc, transform->fixed_ivlen );
+            mbedtls_platform_memcpy( iv, transform->iv_enc, transform->fixed_ivlen );
 
             for( i = 0; i < 8; i++ )
                 iv[i+4] ^= rec->ctr[i];
@@ -2739,7 +2739,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
             if( ret != 0 )
                 return( ret );
 
-            memcpy( data - transform->ivlen, transform->iv_enc,
+            mbedtls_platform_memcpy( data - transform->ivlen, transform->iv_enc,
                     transform->ivlen );
 
         }
@@ -2774,7 +2774,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
             /*
              * Save IV in SSL3 and TLS1
              */
-            memcpy( transform->iv_enc, transform->cipher_ctx_enc.iv,
+            mbedtls_platform_memcpy( transform->iv_enc, transform->cipher_ctx_enc.iv,
                     transform->ivlen );
         }
         else
@@ -2818,7 +2818,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
             mbedtls_md_hmac_finish( &transform->md_ctx_enc, mac );
             mbedtls_md_hmac_reset( &transform->md_ctx_enc );
 
-            memcpy( data + rec->data_len, mac, transform->maclen );
+            mbedtls_platform_memcpy( data + rec->data_len, mac, transform->maclen );
 
             rec->data_len += transform->maclen;
             post_avail -= transform->maclen;
@@ -2942,9 +2942,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             /* GCM and CCM: fixed || explicit */
 
             /* Fixed */
-            memcpy( iv, transform->iv_dec, transform->fixed_ivlen );
+            mbedtls_platform_memcpy( iv, transform->iv_dec, transform->fixed_ivlen );
             /* Explicit */
-            memcpy( iv + transform->fixed_ivlen, data, 8 );
+            mbedtls_platform_memcpy( iv + transform->fixed_ivlen, data, 8 );
         }
         else
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CCM_C */
@@ -2954,7 +2954,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             /* ChachaPoly: fixed XOR sequence number */
             unsigned char i;
 
-            memcpy( iv, transform->iv_dec, transform->fixed_ivlen );
+            mbedtls_platform_memcpy( iv, transform->iv_dec, transform->fixed_ivlen );
 
             for( i = 0; i < 8; i++ )
                 iv[i+4] ^= rec->ctr[i];
@@ -3138,7 +3138,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                 MBEDTLS_SSL_MINOR_VERSION_2 ) )
         {
             /* Safe because data_len >= minlen + ivlen = 2 * ivlen. */
-            memcpy( transform->iv_dec, data, transform->ivlen );
+            mbedtls_platform_memcpy( transform->iv_dec, data, transform->ivlen );
 
             data += transform->ivlen;
             rec->data_offset += transform->ivlen;
@@ -3174,7 +3174,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
              * of the records; in other words, IVs are maintained across
              * record decryptions.
              */
-            memcpy( transform->iv_dec, transform->cipher_ctx_dec.iv,
+            mbedtls_platform_memcpy( transform->iv_dec, transform->cipher_ctx_dec.iv,
                     transform->ivlen );
         }
 #endif
@@ -3505,7 +3505,7 @@ static int ssl_compress_buf( mbedtls_ssl_context *ssl )
     if( len_pre == 0 )
         return( 0 );
 
-    memcpy( msg_pre, ssl->out_msg, len_pre );
+    mbedtls_platform_memcpy( msg_pre, ssl->out_msg, len_pre );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "before compression: msglen = %d, ",
                    ssl->out_msglen ) );
@@ -3552,7 +3552,7 @@ static int ssl_decompress_buf( mbedtls_ssl_context *ssl )
     if( len_pre == 0 )
         return( 0 );
 
-    memcpy( msg_pre, ssl->in_msg, len_pre );
+    mbedtls_platform_memcpy( msg_pre, ssl->in_msg, len_pre );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "before decompression: msglen = %d, ",
                    ssl->in_msglen ) );
@@ -3959,7 +3959,7 @@ static int ssl_flight_append( mbedtls_ssl_context *ssl )
     }
 
     /* Copy current handshake message with headers */
-    memcpy( msg->p, ssl->out_msg, ssl->out_msglen );
+    mbedtls_platform_memcpy( msg->p, ssl->out_msg, ssl->out_msglen );
     msg->len = ssl->out_msglen;
     msg->type = ssl->out_msgtype;
     msg->next = NULL;
@@ -4024,9 +4024,9 @@ static void ssl_swap_epochs( mbedtls_ssl_context *ssl )
     ssl->handshake->alt_transform_out = tmp_transform;
 
     /* Swap epoch + sequence_number */
-    memcpy( tmp_out_ctr,                 ssl->cur_out_ctr,            8 );
-    memcpy( ssl->cur_out_ctr,            ssl->handshake->alt_out_ctr, 8 );
-    memcpy( ssl->handshake->alt_out_ctr, tmp_out_ctr,                 8 );
+    mbedtls_platform_memcpy( tmp_out_ctr,                 ssl->cur_out_ctr,            8 );
+    mbedtls_platform_memcpy( ssl->cur_out_ctr,            ssl->handshake->alt_out_ctr, 8 );
+    mbedtls_platform_memcpy( ssl->handshake->alt_out_ctr, tmp_out_ctr,                 8 );
 
     /* Adjust to the newly activated transform */
     ssl_update_out_pointers( ssl, ssl->transform_out );
@@ -4119,7 +4119,7 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
                 continue;
             }
 
-            memcpy( ssl->out_msg, cur->p, cur->len );
+            mbedtls_platform_memcpy( ssl->out_msg, cur->p, cur->len );
             ssl->out_msglen  = cur->len;
             ssl->out_msgtype = cur->type;
 
@@ -4159,7 +4159,7 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
             /* Messages are stored with handshake headers as if not fragmented,
              * copy beginning of headers then fill fragmentation fields.
              * Handshake headers: type(1) len(3) seq(2) f_off(3) f_len(3) */
-            memcpy( ssl->out_msg, cur->p, 6 );
+            mbedtls_platform_memcpy( ssl->out_msg, cur->p, 6 );
 
             (void)mbedtls_platform_put_uint24_be( &ssl->out_msg[6], frag_off );
             (void)mbedtls_platform_put_uint24_be( &ssl->out_msg[9],
@@ -4168,7 +4168,7 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
             MBEDTLS_SSL_DEBUG_BUF( 3, "handshake header", ssl->out_msg, 12 );
 
             /* Copy the handshake message content and set records fields */
-            memcpy( ssl->out_msg + 12, p, cur_hs_frag_len );
+            mbedtls_platform_memcpy( ssl->out_msg + 12, p, cur_hs_frag_len );
             ssl->out_msglen = cur_hs_frag_len + 12;
             ssl->out_msgtype = cur->type;
 
@@ -4401,7 +4401,7 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Handshake hashes are computed without fragmentation,
              * so set frag_offset = 0 and frag_len = hs_len for now */
             mbedtls_platform_memset( ssl->out_msg + 6, 0x00, 3 );
-            memcpy( ssl->out_msg + 9, ssl->out_msg + 1, 3 );
+            mbedtls_platform_memcpy( ssl->out_msg + 9, ssl->out_msg + 1, 3 );
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
@@ -4499,7 +4499,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
                                    mbedtls_ssl_get_minor_ver( ssl ),
                                    ssl->conf->transport, ssl->out_hdr + 1 );
 
-        memcpy( ssl->out_ctr, ssl->cur_out_ctr, 8 );
+        mbedtls_platform_memcpy( ssl->out_ctr, ssl->cur_out_ctr, 8 );
         (void)mbedtls_platform_put_uint16_be( ssl->out_len, len );
 
         if( ssl->transform_out != NULL )
@@ -4512,7 +4512,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
             rec.data_len    = ssl->out_msglen;
             rec.data_offset = ssl->out_msg - rec.buf;
 
-            memcpy( &rec.ctr[0], ssl->out_ctr, 8 );
+            mbedtls_platform_memcpy( &rec.ctr[0], ssl->out_ctr, 8 );
             mbedtls_ssl_write_version( mbedtls_ssl_get_major_ver( ssl ),
                                        mbedtls_ssl_get_minor_ver( ssl ),
                                        ssl->conf->transport, rec.ver );
@@ -4540,7 +4540,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
             /* Update the record content type and CID. */
             ssl->out_msgtype = rec.type;
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID )
-            memcpy( ssl->out_cid, rec.cid, rec.cid_len );
+            mbedtls_platform_memcpy( ssl->out_cid, rec.cid, rec.cid_len );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
             ssl->out_msglen = len = rec.data_len;
             (void)mbedtls_platform_put_uint16_be( ssl->out_len, rec.data_len );
@@ -5103,7 +5103,7 @@ static int ssl_check_dtls_clihlo_cookie(
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
     /* Copy most fields and adapt others */
-    memcpy( obuf, in, 25 );
+    mbedtls_platform_memcpy( obuf, in, 25 );
     obuf[13] = MBEDTLS_SSL_HS_HELLO_VERIFY_REQUEST;
     obuf[25] = 0xfe;
     obuf[26] = 0xff;
@@ -5328,7 +5328,7 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
         /* configured CID len is guaranteed at most 255, see
          * MBEDTLS_SSL_CID_OUT_LEN_MAX in check_config.h */
         rec->cid_len = (uint8_t) rec_hdr_cid_len;
-        memcpy( rec->cid, buf + rec_hdr_cid_offset, rec_hdr_cid_len );
+        mbedtls_platform_memcpy( rec->cid, buf + rec_hdr_cid_offset, rec_hdr_cid_len );
     }
     else
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
@@ -5372,7 +5372,7 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
     if( MBEDTLS_SSL_TRANSPORT_IS_DTLS( ssl->conf->transport ) )
     {
         /* Copy explicit record sequence number from input buffer. */
-        memcpy( &rec->ctr[0], buf + rec_hdr_ctr_offset,
+        mbedtls_platform_memcpy( &rec->ctr[0], buf + rec_hdr_ctr_offset,
                 rec_hdr_ctr_len );
     }
     MBEDTLS_SSL_TRANSPORT_ELSE
@@ -5380,7 +5380,7 @@ static int ssl_parse_record_header( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_PROTO_TLS)
     {
         /* Copy implicit record sequence number from SSL context structure. */
-        memcpy( &rec->ctr[0], ssl->in_ctr, rec_hdr_ctr_len );
+        mbedtls_platform_memcpy( &rec->ctr[0], ssl->in_ctr, rec_hdr_ctr_len );
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS */
 
@@ -5834,7 +5834,7 @@ static int ssl_load_buffered_message( mbedtls_ssl_context *ssl )
         ssl->in_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
         ssl->in_hslen   = msg_len + 12;
         ssl->in_msglen  = msg_len + 12;
-        memcpy( ssl->in_msg, hs_buf->data, ssl->in_hslen );
+        mbedtls_platform_memcpy( ssl->in_msg, hs_buf->data, ssl->in_hslen );
 
         ret = 0;
         goto exit;
@@ -6022,9 +6022,9 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
 
                 /* Prepare final header: copy msg_type, length and message_seq,
                  * then add standardised fragment_offset and fragment_length */
-                memcpy( hs_buf->data, ssl->in_msg, 6 );
+                mbedtls_platform_memcpy( hs_buf->data, ssl->in_msg, 6 );
                 mbedtls_platform_memset( hs_buf->data + 6, 0, 3 );
-                memcpy( hs_buf->data + 9, hs_buf->data + 1, 3 );
+                mbedtls_platform_memcpy( hs_buf->data + 9, hs_buf->data + 1, 3 );
 
                 hs_buf->is_valid = 1;
 
@@ -6057,7 +6057,7 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
 
                 MBEDTLS_SSL_DEBUG_MSG( 2, ( "adding fragment, offset = %d, length = %d",
                                             frag_off, frag_len ) );
-                memcpy( msg + frag_off, ssl->in_msg + 12, frag_len );
+                mbedtls_platform_memcpy( msg + frag_off, ssl->in_msg + 12, frag_len );
 
                 if( hs_buf->is_fragmented )
                 {
@@ -6246,7 +6246,7 @@ static int ssl_load_buffered_record( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
 
-    memcpy( ssl->in_hdr, rec, rec_len );
+    mbedtls_platform_memcpy( ssl->in_hdr, rec, rec_len );
     ssl->in_left = rec_len;
     ssl->next_record_offset = 0;
 
@@ -6304,7 +6304,7 @@ static int ssl_buffer_future_record( mbedtls_ssl_context *ssl,
         return( 0 );
     }
 
-    memcpy( hs->buffering.future_record.data, rec->buf, rec->buf_len );
+    mbedtls_platform_memcpy( hs->buffering.future_record.data, rec->buf, rec->buf_len );
 
     hs->buffering.total_bytes_buffered += rec->buf_len;
     return( 0 );
@@ -6850,7 +6850,7 @@ int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl )
 
         (void)mbedtls_platform_put_uint24_be( &ssl->out_msg[i], n );
 
-        i += 3; memcpy( ssl->out_msg + i, crt->raw.p, n );
+        i += 3; mbedtls_platform_memcpy( ssl->out_msg + i, crt->raw.p, n );
         i += n; crt = crt->next;
     }
 
@@ -7770,7 +7770,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     ssl->verify_data_len = hash_len;
-    memcpy( ssl->own_verify_data, ssl->out_msg + 4, hash_len );
+    mbedtls_platform_memcpy( ssl->own_verify_data, ssl->out_msg + 4, hash_len );
 #endif
 
     ssl->out_msglen  = 4 + hash_len;
@@ -7816,7 +7816,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 
         /* Remember current epoch settings for resending */
         ssl->handshake->alt_transform_out = ssl->transform_out;
-        memcpy( ssl->handshake->alt_out_ctr, ssl->cur_out_ctr, 8 );
+        mbedtls_platform_memcpy( ssl->handshake->alt_out_ctr, ssl->cur_out_ctr, 8 );
 
         /* Set sequence_number to zero */
         memset( ssl->cur_out_ctr + 2, 0, 6 );
@@ -7944,7 +7944,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     ssl->verify_data_len = hash_len;
-    memcpy( ssl->peer_verify_data, buf, hash_len );
+    mbedtls_platform_memcpy( ssl->peer_verify_data, buf, hash_len );
 #endif
 
 #if !defined(MBEDTLS_SSL_NO_SESSION_RESUMPTION)
@@ -8848,8 +8848,8 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
     conf->psk_len = psk_len;
     conf->psk_identity_len = psk_identity_len;
 
-    memcpy( conf->psk, psk, conf->psk_len );
-    memcpy( conf->psk_identity, psk_identity, conf->psk_identity_len );
+    mbedtls_platform_memcpy( conf->psk, psk, conf->psk_len );
+    mbedtls_platform_memcpy( conf->psk_identity, psk_identity, conf->psk_identity_len );
 
     return( 0 );
 }
@@ -8875,7 +8875,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
     ssl->handshake->psk_len = psk_len;
-    memcpy( ssl->handshake->psk, psk, ssl->handshake->psk_len );
+    mbedtls_platform_memcpy( ssl->handshake->psk, psk, ssl->handshake->psk_len );
 
     return( 0 );
 }
@@ -9019,7 +9019,7 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
         if( ssl->hostname == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        memcpy( ssl->hostname, hostname, hostname_len );
+        mbedtls_platform_memcpy( ssl->hostname, hostname, hostname_len );
 
         ssl->hostname[hostname_len] = '\0';
     }
@@ -9188,7 +9188,7 @@ void mbedtls_ssl_conf_renegotiation_enforced( mbedtls_ssl_config *conf, int max_
 void mbedtls_ssl_conf_renegotiation_period( mbedtls_ssl_config *conf,
                                    const unsigned char period[8] )
 {
-    memcpy( conf->renego_period, period, 8 );
+    mbedtls_platform_memcpy( conf->renego_period, period, 8 );
 }
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
@@ -9763,7 +9763,7 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
         if( used <= buf_len )
         {
-            memcpy( p, ssl_serialized_session_header,
+            mbedtls_platform_memcpy( p, ssl_serialized_session_header,
                     sizeof( ssl_serialized_session_header ) );
             p += sizeof( ssl_serialized_session_header );
         }
@@ -9828,10 +9828,10 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 #endif
 
         *p++ = (unsigned char)( session->id_len & 0xFF );
-        memcpy( p, session->id, 32 );
+        mbedtls_platform_memcpy( p, session->id, 32 );
         p += 32;
 
-        memcpy( p, session->master, 48 );
+        mbedtls_platform_memcpy( p, session->master, 48 );
         p += 48;
         p = mbedtls_platform_put_uint32_be( p, session->verify_result );
     }
@@ -9854,7 +9854,7 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
         if( session->peer_cert != NULL )
         {
-            memcpy( p, session->peer_cert->raw.p, cert_len );
+            mbedtls_platform_memcpy( p, session->peer_cert->raw.p, cert_len );
             p += cert_len;
         }
     }
@@ -9868,7 +9868,7 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
         {
             *p++ = (unsigned char) session->peer_cert_digest_type;
             *p++ = (unsigned char) session->peer_cert_digest_len;
-            memcpy( p, session->peer_cert_digest,
+            mbedtls_platform_memcpy( p, session->peer_cert_digest,
                     session->peer_cert_digest_len );
             p += session->peer_cert_digest_len;
         }
@@ -9897,7 +9897,7 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
         if( session->ticket != NULL )
         {
-            memcpy( p, session->ticket, session->ticket_len );
+            mbedtls_platform_memcpy( p, session->ticket, session->ticket_len );
             p += session->ticket_len;
         }
 
@@ -10055,10 +10055,10 @@ static int ssl_session_load( mbedtls_ssl_session *session,
 #endif
 
     session->id_len = *p++;
-    memcpy( session->id, p, 32 );
+    mbedtls_platform_memcpy( session->id, p, 32 );
     p += 32;
 
-    memcpy( session->master, p, 48 );
+    mbedtls_platform_memcpy( session->master, p, 48 );
     p += 48;
 
     session->verify_result = (uint32_t)mbedtls_platform_get_uint32_be( p );
@@ -10143,7 +10143,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( session->peer_cert_digest == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        memcpy( session->peer_cert_digest, p,
+        mbedtls_platform_memcpy( session->peer_cert_digest, p,
                 session->peer_cert_digest_len );
         p += session->peer_cert_digest_len;
     }
@@ -10169,7 +10169,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( session->ticket == NULL )
             return( MBEDTLS_ERR_SSL_ALLOC_FAILED );
 
-        memcpy( session->ticket, p, session->ticket_len );
+        mbedtls_platform_memcpy( session->ticket, p, session->ticket_len );
         p += session->ticket_len;
     }
 
@@ -10740,7 +10740,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     n = ( len < ssl->in_msglen )
         ? len : ssl->in_msglen;
 
-    memcpy( buf, ssl->in_offt, n );
+    mbedtls_platform_memcpy( buf, ssl->in_offt, n );
     ssl->in_msglen -= n;
 
     if( ssl->in_msglen == 0 )
@@ -10826,7 +10826,7 @@ static int ssl_write_real( mbedtls_ssl_context *ssl,
          */
         ssl->out_msglen  = len;
         ssl->out_msgtype = MBEDTLS_SSL_MSG_APPLICATION_DATA;
-        memcpy( ssl->out_msg, buf, len );
+        mbedtls_platform_memcpy( ssl->out_msg, buf, len );
 
         if( ( ret = mbedtls_ssl_write_record( ssl, SSL_FORCE_FLUSH ) ) != 0 )
         {
@@ -11272,7 +11272,7 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
 
     if( used <= buf_len )
     {
-        memcpy( p, ssl_serialized_context_header,
+        mbedtls_platform_memcpy( p, ssl_serialized_context_header,
                 sizeof( ssl_serialized_context_header ) );
         p += sizeof( ssl_serialized_context_header );
     }
@@ -11303,7 +11303,7 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += sizeof( ssl->transform->randbytes );
     if( used <= buf_len )
     {
-        memcpy( p, ssl->transform->randbytes,
+        mbedtls_platform_memcpy( p, ssl->transform->randbytes,
            sizeof( ssl->transform->randbytes ) );
         p += sizeof( ssl->transform->randbytes );
     }
@@ -11313,11 +11313,11 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     if( used <= buf_len )
     {
         *p++ = ssl->transform->in_cid_len;
-        memcpy( p, ssl->transform->in_cid, ssl->transform->in_cid_len );
+        mbedtls_platform_memcpy( p, ssl->transform->in_cid, ssl->transform->in_cid_len );
         p += ssl->transform->in_cid_len;
 
         *p++ = ssl->transform->out_cid_len;
-        memcpy( p, ssl->transform->out_cid, ssl->transform->out_cid_len );
+        mbedtls_platform_memcpy( p, ssl->transform->out_cid, ssl->transform->out_cid_len );
         p += ssl->transform->out_cid_len;
     }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
@@ -11368,7 +11368,7 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 8;
     if( used <= buf_len )
     {
-        memcpy( p, ssl->cur_out_ctr, 8 );
+        mbedtls_platform_memcpy( p, ssl->cur_out_ctr, 8 );
         p += 8;
     }
 
@@ -11393,7 +11393,7 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
 
             if( ssl->alpn_chosen != NULL )
             {
-                memcpy( p, ssl->alpn_chosen, alpn_len );
+                mbedtls_platform_memcpy( p, ssl->alpn_chosen, alpn_len );
                 p += alpn_len;
             }
         }
@@ -11554,7 +11554,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < ssl->transform->in_cid_len + 1u )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    memcpy( ssl->transform->in_cid, p, ssl->transform->in_cid_len );
+    mbedtls_platform_memcpy( ssl->transform->in_cid, p, ssl->transform->in_cid_len );
     p += ssl->transform->in_cid_len;
 
     ssl->transform->out_cid_len = *p++;
@@ -11562,7 +11562,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < ssl->transform->out_cid_len )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    memcpy( ssl->transform->out_cid, p, ssl->transform->out_cid_len );
+    mbedtls_platform_memcpy( ssl->transform->out_cid, p, ssl->transform->out_cid_len );
     p += ssl->transform->out_cid_len;
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
@@ -11612,7 +11612,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < 8 )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    memcpy( ssl->cur_out_ctr, p, 8 );
+    mbedtls_platform_memcpy( ssl->cur_out_ctr, p, 8 );
     p += 8;
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/library/version.c
+++ b/library/version.c
@@ -28,6 +28,8 @@
 #if defined(MBEDTLS_VERSION_C)
 
 #include "mbedtls/version.h"
+#include "mbedtls/platform_util.h"
+
 #include <string.h>
 
 unsigned int mbedtls_version_get_number( void )
@@ -37,13 +39,13 @@ unsigned int mbedtls_version_get_number( void )
 
 void mbedtls_version_get_string( char *string )
 {
-    memcpy( string, MBEDTLS_VERSION_STRING,
+    mbedtls_platform_memcpy( string, MBEDTLS_VERSION_STRING,
             sizeof( MBEDTLS_VERSION_STRING ) );
 }
 
 void mbedtls_version_get_string_full( char *string )
 {
-    memcpy( string, MBEDTLS_VERSION_STRING_FULL,
+    mbedtls_platform_memcpy( string, MBEDTLS_VERSION_STRING_FULL,
             sizeof( MBEDTLS_VERSION_STRING_FULL ) );
 }
 

--- a/library/x509_create.c
+++ b/library/x509_create.c
@@ -223,7 +223,7 @@ static int mbedtls_x509_set_extension( mbedtls_asn1_named_data **head, const cha
     }
 
     cur->val.p[0] = critical;
-    memcpy( cur->val.p + 1, val, val_len );
+    mbedtls_platform_memcpy( cur->val.p + 1, val, val_len );
 
     return( 0 );
 }
@@ -304,7 +304,7 @@ static int mbedtls_x509_write_sig( unsigned char **p, unsigned char *start,
 
     len = size;
     (*p) -= len;
-    memcpy( *p, sig, len );
+    mbedtls_platform_memcpy( *p, sig, len );
 
     if( *p - start < 1 )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -347,7 +347,7 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
     if( p == NULL )
         return( MBEDTLS_ERR_X509_ALLOC_FAILED );
 
-    memcpy( p, buf, buflen );
+    mbedtls_platform_memcpy( p, buf, buflen );
 
     crl->raw.p = p;
     crl->raw.len = buflen;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1559,7 +1559,7 @@ static int x509_crt_parse_der_core( mbedtls_x509_crt *crt,
         if( crt->raw.p == NULL )
             return( MBEDTLS_ERR_X509_ALLOC_FAILED );
         crt->raw.len = buflen;
-        memcpy( crt->raw.p, buf, buflen );
+        mbedtls_platform_memcpy( crt->raw.p, buf, buflen );
 
         crt->own_buffer = 1;
     }
@@ -1942,7 +1942,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
 
     mbedtls_platform_memset( szDir, 0, sizeof(szDir) );
     mbedtls_platform_memset( filename, 0, MAX_PATH );
-    memcpy( filename, path, len );
+    mbedtls_platform_memcpy( filename, path, len );
     filename[len++] = '\\';
     p = filename + len;
     filename[len++] = '*';

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -114,7 +114,7 @@ int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
     if( p == NULL )
         return( MBEDTLS_ERR_X509_ALLOC_FAILED );
 
-    memcpy( p, buf, buflen );
+    mbedtls_platform_memcpy( p, buf, buflen );
 
     csr->raw.p = p;
     csr->raw.len = len;

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -481,7 +481,7 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx, unsigned char *buf, 
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
     c2 -= len;
-    memcpy( c2, c, len );
+    mbedtls_platform_memcpy( c2, c, len );
 
     len += sig_and_oid_len;
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c2, buf, len ) );

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -259,7 +259,7 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
     c2 -= len;
-    memcpy( c2, c, len );
+    mbedtls_platform_memcpy( c2, c, len );
 
     len += sig_and_oid_len;
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c2, buf, len ) );

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -154,13 +154,13 @@ int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx, int mode, size_t length,
     {
         while( length > 0 )
         {
-            memcpy( temp, input, 8 );
+            mbedtls_platform_memcpy( temp, input, 8 );
             mbedtls_xtea_crypt_ecb( ctx, mode, input, output );
 
             for( i = 0; i < 8; i++ )
                 output[i] = (unsigned char)( output[i] ^ iv[i] );
 
-            memcpy( iv, temp, 8 );
+            mbedtls_platform_memcpy( iv, temp, 8 );
 
             input  += 8;
             output += 8;
@@ -175,7 +175,7 @@ int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx, int mode, size_t length,
                 output[i] = (unsigned char)( input[i] ^ iv[i] );
 
             mbedtls_xtea_crypt_ecb( ctx, mode, output, output );
-            memcpy( iv, output, 8 );
+            mbedtls_platform_memcpy( iv, output, 8 );
 
             input  += 8;
             output += 8;
@@ -245,7 +245,7 @@ int mbedtls_xtea_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  XTEA test #%d: ", i + 1 );
 
-        memcpy( buf, xtea_test_pt[i], 8 );
+        mbedtls_platform_memcpy( buf, xtea_test_pt[i], 8 );
 
         mbedtls_xtea_setup( &ctx, xtea_test_key[i] );
         mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_ENCRYPT, buf, buf );

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -245,7 +245,7 @@ int mbedtls_xtea_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  XTEA test #%d: ", i + 1 );
 
-        mbedtls_platform_memcpy( buf, xtea_test_pt[i], 8 );
+        memcpy( buf, xtea_test_pt[i], 8 );
 
         mbedtls_xtea_setup( &ctx, xtea_test_key[i] );
         mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_ENCRYPT, buf, buf );

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -88,7 +88,7 @@ int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 	/* This function is designed for test purposes-only (such as validating NIST
 	 * test vectors) as it uses a provided value for d instead of generating
 	 * it uniformly at random. */
-	memcpy (_private, d, NUM_ECC_BYTES);
+	mbedtls_platform_memcpy (_private, d, NUM_ECC_BYTES);
 
 	/* Computing public-key from private: */
 	if (EccPoint_compute_public_key(_public, _private, curve)) {


### PR DESCRIPTION
## Description

Changed memcpy to more safer version mbedtls_platform_memcpy to every occurance of memcpy. Then changed back those that are included in baremetal and are not so critical for side channel attacks to safe performance. Please review where the changes back to memcpy done to safe places are done and suggest if there are more places that could be changed back to memcpy within baremetal.

This pr depends on two pr's: 

[x] https://github.com/ARMmbed/mbedtls/pull/2870 (merged)
[x] https://github.com/ARMmbed/mbedtls/pull/2877 (merged)

__Impact on code-size:__

| | GCC | ARMC5 | ARMC6 |
| --- | --- | --- | --- |
| `libmbedtls.a` before | 15341| 16519| 17162|
| `libmbedtls.a` after | 15245| 16539| 17091|
| `libmbedcrypto.a` before | 21585| 21535| 23595|
| `libmbedcrypto.a` after | 21589| 21535| 23557|
| `libmbedx509.a` before | 5361| 5522| 5960|
| `libmbedx509.a` after | 5361| 5522 | 5960|
| gain in bytes TLS | 96| -20 | 71 |
| gain in bytes Crypto | -4 | ==| 38 |
| gain in bytes X.509 | == | == | == |
| gain Total | 92 | -20 | 109 |

## Status
**READY**
