### PR TITLE
[baremetal] Use mbedtls_platform_memset()

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,14 +3683,6 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
-/**
- * Uncomment the macro to let Mbed TLS use a platform implementation of
- * global RNG.
- *
- * By default the global RNG function will be a no-op.
- */
-//#define MBEDTLS_PLATFORM_GLOBAL_RNG
-
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,6 +3683,14 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
+/**
+ * Uncomment the macro to let Mbed TLS use a platform implementation of
+ * global RNG.
+ *
+ * By default the global RNG function will be a no-op.
+ */
+//#define MBEDTLS_PLATFORM_GLOBAL_RNG
+
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -170,7 +170,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
-size_t mbedtls_random_in_range( size_t num );
+size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,6 +164,14 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+void mbedtls_platform_memset( void *ptr, int value, size_t num );
+
+void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+
+int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
+
+size_t mbedtls_random_in_range( size_t num );
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -228,7 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  * \param num   Max-value for the generated random number.
  *
  */ 
-size_t mbedtls_platform_random_in_range( size_t num );
+uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -225,8 +225,9 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
  *
- * \param num   Max-value for the generated random number.
- *
+ * \param num   Max-value for the generated random number, exclusive.
+ *              The generated number will be on range [0, num).
+ * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -178,8 +178,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
  *
+ * \return      The value of \p ptr.
  */
-void mbedtls_platform_memset( void *ptr, int value, size_t num );
+void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 
 /**
  * \brief       Secure memcpy
@@ -195,8 +196,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num );
  * \param src   Source buffer where the data is being copied from.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      The value of \p dst.
  */
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 /**
  * \brief       Secure memcmp

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,12 +164,70 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+/**
+ * \brief       Secure memset
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memset. It starts by initialising the given memory area
+ *              from random tail location with random data. After tail is
+ *              initialised, the remaining head of the buffer is initialised
+ *              with random data. After initialisation, the original memset
+ *              is performed
+ *
+ * \param ptr   Buffer to be set.
+ * \param value Value to be used when setting the buffer.
+ * \param num   The length of the buffer in bytes.
+ * 
+ */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 
+/**
+ * \brief       Secure memcpy
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcpy. It starts by initialising the given memory area
+ *              with random data. After initialisation, the original memcpy
+ *              is performed by starting first copying from random tail
+ *              location of the buffer. After tail has been copied, the
+ *              remaining head is copied as well.
+ *
+ * \param dst   Destination buffer where the data is being copied to.
+ * \param src   Source buffer where the data is being copied from.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
+/**
+ * \brief       Secure memcmp
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcmp. It starts comparing from a random offset and goes
+ *              through the tail part of buffers first byte by byte. After
+ *              that it starts going through the head part of buffer. In the
+ *              end, the number of equal bytes is compared to the length of the
+ *              buffers, thus making the function a fixed time memcmp.
+ *
+ * \param buf1  First buffer to compare.
+ * \param buf2  Second buffer to compare against.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
+/**
+ * \brief       A global RNG-function
+ *
+ *              This function is meant to provide a global RNG to be used
+ *              throughout Mbed TLS for hardening the library. It is used
+ *              for generating a random delay, random data or random offset
+ *              for utility functions. It is not meant to be a
+ *              cryptographically secure RNG, but provide an RNG for utility
+ *              functions.
+ *
+ * \param num   Max-value for the generated random number.
+ *
+ */ 
 size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -212,6 +212,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      0 if the buffers were equal.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
@@ -227,6 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).
+ *
  * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -177,7 +177,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
- * 
+ *
  */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -219,7 +219,7 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
 /**
- * \brief       A global RNG-function
+ * \brief       RNG-function for getting a random in given range.
  *
  *              This function is meant to provide a global RNG to be used
  *              throughout Mbed TLS for hardening the library. It is used
@@ -227,6 +227,12 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              for utility functions. It is not meant to be a
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
+ *
+ * \note        Currently the function is dependent of hardware providing an
+ *              rng with MBEDTLS_ENTROPY_HARDWARE_ALT. By default, 0 is
+ *              returned.
+ *
+ * \note        If the given range is [0, 0), 0 is returned.
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -230,7 +230,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              The generated number will be on range [0, num).
  *
  * \return      The generated random number.
- */ 
+ */
 uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -167,12 +167,11 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
 /**
  * \brief       Secure memset
  *
- *              This function is meant to provide a more secure way to do
- *              memset. It starts by initialising the given memory area
- *              from random tail location with random data. After tail is
- *              initialised, the remaining head of the buffer is initialised
- *              with random data. After initialisation, the original memset
- *              is performed
+ *              This is a constant-time version of memset(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the buffer is
+ *              initialised with random data and the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
@@ -185,12 +184,11 @@ void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 /**
  * \brief       Secure memcpy
  *
- *              This function is meant to provide a more secure way to do
- *              memcpy. It starts by initialising the given memory area
- *              with random data. After initialisation, the original memcpy
- *              is performed by starting first copying from random tail
- *              location of the buffer. After tail has been copied, the
- *              remaining head is copied as well.
+ *              This is a constant-time version of memcpy(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the buffer is
+ *              initialised with random data and the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param dst   Destination buffer where the data is being copied to.
  * \param src   Source buffer where the data is being copied from.
@@ -203,18 +201,17 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 /**
  * \brief       Secure memcmp
  *
- *              This function is meant to provide a more secure way to do
- *              memcmp. It starts comparing from a random offset and goes
- *              through the tail part of buffers first byte by byte. After
- *              that it starts going through the head part of buffer. In the
- *              end, the number of equal bytes is compared to the length of the
- *              buffers, thus making the function a fixed time memcmp.
+ *              This is a constant-time version of memcmp(). If
+ *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the order is also
+ *              randomised using the hardware RNG in order to further harden
+ *              against side-channel attacks.
  *
  * \param buf1  First buffer to compare.
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
- * \return      0 if the buffers were equal.
+ * \return      0 if the buffers were equal or an unspecified non-zero value
+ *              otherwise.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -519,7 +519,7 @@ void mbedtls_aes_init( mbedtls_aes_context *ctx )
 {
     AES_VALIDATE( ctx != NULL );
 
-    memset( ctx, 0, sizeof( mbedtls_aes_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_aes_context ) );
 }
 
 void mbedtls_aes_free( mbedtls_aes_context *ctx )
@@ -1809,7 +1809,7 @@ int mbedtls_aes_self_test( int verbose )
 #endif
     mbedtls_aes_context ctx;
 
-    memset( key, 0, 32 );
+    mbedtls_platform_memset( key, 0, 32 );
     mbedtls_aes_init( &ctx );
 
     /*
@@ -1825,7 +1825,7 @@ int mbedtls_aes_self_test( int verbose )
             mbedtls_printf( "  AES-ECB-%3d (%s): ", keybits,
                             ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
 
-        memset( buf, 0, 16 );
+        mbedtls_platform_memset( buf, 0, 16 );
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
@@ -1887,9 +1887,9 @@ int mbedtls_aes_self_test( int verbose )
             mbedtls_printf( "  AES-CBC-%3d (%s): ", keybits,
                             ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
 
-        memset( iv , 0, 16 );
-        memset( prv, 0, 16 );
-        memset( buf, 0, 16 );
+        mbedtls_platform_memset( iv , 0, 16 );
+        mbedtls_platform_memset( prv, 0, 16 );
+        mbedtls_platform_memset( buf, 0, 16 );
 
         if( mode == MBEDTLS_AES_DECRYPT )
         {
@@ -2147,7 +2147,7 @@ int mbedtls_aes_self_test( int verbose )
             mbedtls_printf( "  AES-XTS-128 (%s): ",
                             ( mode == MBEDTLS_AES_DECRYPT ) ? "dec" : "enc" );
 
-        memset( key, 0, sizeof( key ) );
+        mbedtls_platform_memset( key, 0, sizeof( key ) );
         memcpy( key, aes_test_xts_key[u], 32 );
         data_unit = aes_test_xts_data_unit[u];
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -519,7 +519,7 @@ void mbedtls_aes_init( mbedtls_aes_context *ctx )
 {
     AES_VALIDATE( ctx != NULL );
 
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_aes_context ) );
+    memset( ctx, 0, sizeof( mbedtls_aes_context ) );
 }
 
 void mbedtls_aes_free( mbedtls_aes_context *ctx )

--- a/library/arc4.c
+++ b/library/arc4.c
@@ -50,7 +50,7 @@
 
 void mbedtls_arc4_init( mbedtls_arc4_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_arc4_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_arc4_context ) );
 }
 
 void mbedtls_arc4_free( mbedtls_arc4_context *ctx )

--- a/library/aria.c
+++ b/library/aria.c
@@ -467,7 +467,7 @@ int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
     GET_UINT32_LE( w[0][2], key,  8 );
     GET_UINT32_LE( w[0][3], key, 12 );
 
-    memset( w[1], 0, 16 );
+    mbedtls_platform_memset( w[1], 0, 16 );
     if( keybits >= 192 )
     {
         GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
@@ -600,7 +600,7 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
 void mbedtls_aria_init( mbedtls_aria_context *ctx )
 {
     ARIA_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_aria_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_aria_context ) );
 }
 
 /* Clear context */
@@ -987,7 +987,7 @@ int mbedtls_aria_self_test( int verbose )
             mbedtls_printf( "  ARIA-CBC-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
         memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        memset( buf, 0x55, sizeof( buf ) );
+        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, iv,
             aria_test2_pt, buf );
         if( memcmp( buf, aria_test2_cbc_ct[i], 48 ) != 0 )
@@ -998,7 +998,7 @@ int mbedtls_aria_self_test( int verbose )
             mbedtls_printf( "  ARIA-CBC-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_dec( &ctx, aria_test2_key, 128 + 64 * i );
         memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        memset( buf, 0xAA, sizeof( buf ) );
+        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
         mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, 48, iv,
             aria_test2_cbc_ct[i], buf );
         if( memcmp( buf, aria_test2_pt, 48 ) != 0 )
@@ -1017,7 +1017,7 @@ int mbedtls_aria_self_test( int verbose )
             mbedtls_printf( "  ARIA-CFB-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
         memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        memset( buf, 0x55, sizeof( buf ) );
+        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT, 48, &j, iv,
             aria_test2_pt, buf );
@@ -1029,7 +1029,7 @@ int mbedtls_aria_self_test( int verbose )
             mbedtls_printf( "  ARIA-CFB-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
         memcpy( iv, aria_test2_iv, MBEDTLS_ARIA_BLOCKSIZE );
-        memset( buf, 0xAA, sizeof( buf ) );
+        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT, 48, &j,
             iv, aria_test2_cfb_ct[i], buf );
@@ -1047,8 +1047,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CTR-%d (enc): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
-        memset( buf, 0x55, sizeof( buf ) );
+        mbedtls_platform_memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
+        mbedtls_platform_memset( buf, 0x55, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_ctr( &ctx, 48, &j, iv, blk,
             aria_test2_pt, buf );
@@ -1059,8 +1059,8 @@ int mbedtls_aria_self_test( int verbose )
         if( verbose )
             mbedtls_printf( "  ARIA-CTR-%d (dec): ", 128 + 64 * i );
         mbedtls_aria_setkey_enc( &ctx, aria_test2_key, 128 + 64 * i );
-        memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
-        memset( buf, 0xAA, sizeof( buf ) );
+        mbedtls_platform_memset( iv, 0, MBEDTLS_ARIA_BLOCKSIZE );                    // IV = 0
+        mbedtls_platform_memset( buf, 0xAA, sizeof( buf ) );
         j = 0;
         mbedtls_aria_crypt_ctr( &ctx, 48, &j, iv, blk,
             aria_test2_ctr_ct[i], buf );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -391,7 +391,7 @@ int mbedtls_asn1_get_alg_null( unsigned char **p,
     int ret;
     mbedtls_asn1_buf params;
 
-    mbedtls_platform_memset( &params, 0, sizeof(mbedtls_asn1_buf) );
+    memset( &params, 0, sizeof(mbedtls_asn1_buf) );
 
     if( ( ret = mbedtls_asn1_get_alg( p, end, alg, &params ) ) != 0 )
         return( ret );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -337,7 +337,7 @@ int mbedtls_asn1_get_sequence_of( unsigned char **p,
                           int tag)
 {
     asn1_get_sequence_of_cb_ctx_t cb_ctx = { tag, cur };
-    memset( cur, 0, sizeof( mbedtls_asn1_sequence ) );
+    mbedtls_platform_memset( cur, 0, sizeof( mbedtls_asn1_sequence ) );
     return( mbedtls_asn1_traverse_sequence_of(
                 p, end, 0xFF, tag, 0, 0,
                 asn1_get_sequence_of_cb, &cb_ctx ) );
@@ -391,7 +391,7 @@ int mbedtls_asn1_get_alg_null( unsigned char **p,
     int ret;
     mbedtls_asn1_buf params;
 
-    memset( &params, 0, sizeof(mbedtls_asn1_buf) );
+    mbedtls_platform_memset( &params, 0, sizeof(mbedtls_asn1_buf) );
 
     if( ( ret = mbedtls_asn1_get_alg( p, end, alg, &params ) ) != 0 )
         return( ret );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -217,7 +217,7 @@ int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y )
     }
     else
     {
-        memset( X->p + i, 0, ( X->n - i ) * ciL );
+        mbedtls_platform_memset( X->p + i, 0, ( X->n - i ) * ciL );
     }
 
     memcpy( X->p, Y->p, i * ciL );
@@ -318,7 +318,7 @@ int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z )
     MPI_VALIDATE_RET( X != NULL );
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, 1 ) );
-    memset( X->p, 0, X->n * ciL );
+    mbedtls_platform_memset( X->p, 0, X->n * ciL );
 
     X->p[0] = ( z < 0 ) ? -z : z;
     X->s    = ( z < 0 ) ? -1 : 1;
@@ -673,7 +673,7 @@ int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin )
     if( radix < 2 || radix > 16 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
-    memset( s, 0, sizeof( s ) );
+    mbedtls_platform_memset( s, 0, sizeof( s ) );
     if( fgets( s, sizeof( s ) - 1, fin ) == NULL )
         return( MBEDTLS_ERR_MPI_FILE_IO_ERROR );
 
@@ -709,7 +709,7 @@ int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X, int radix, FILE
     if( radix < 2 || radix > 16 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
-    memset( s, 0, sizeof( s ) );
+    mbedtls_platform_memset( s, 0, sizeof( s ) );
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_string( X, radix, s, sizeof( s ) - 2, &n ) );
 
@@ -888,7 +888,7 @@ int mbedtls_mpi_write_binary( const mbedtls_mpi *X,
          * number. */
         bytes_to_copy = stored_bytes;
         p = buf + buflen - stored_bytes;
-        memset( buf, 0, buflen - stored_bytes );
+        mbedtls_platform_memset( buf, 0, buflen - stored_bytes );
     }
     else
     {
@@ -1797,7 +1797,7 @@ static int mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi 
     if( T->n < N->n + 1 || T->p == NULL )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
-    memset( T->p, 0, T->n * ciL );
+    mbedtls_platform_memset( T->p, 0, T->n * ciL );
 
     d = T->p;
     n = N->n;
@@ -1875,7 +1875,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     mpi_montg_init( &mm, N );
     mbedtls_mpi_init( &RR ); mbedtls_mpi_init( &T );
     mbedtls_mpi_init( &Apos );
-    memset( W, 0, sizeof( W ) );
+    mbedtls_platform_memset( W, 0, sizeof( W ) );
 
     i = mbedtls_mpi_bitlen( E );
 

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -160,7 +160,7 @@ static void blowfish_dec( mbedtls_blowfish_context *ctx, uint32_t *xl, uint32_t 
 void mbedtls_blowfish_init( mbedtls_blowfish_context *ctx )
 {
     BLOWFISH_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_blowfish_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_blowfish_context ) );
 }
 
 void mbedtls_blowfish_free( mbedtls_blowfish_context *ctx )

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -328,7 +328,7 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
 void mbedtls_camellia_init( mbedtls_camellia_context *ctx )
 {
     CAMELLIA_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_camellia_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_camellia_context ) );
 }
 
 void mbedtls_camellia_free( mbedtls_camellia_context *ctx )
@@ -359,8 +359,8 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
 
     RK = ctx->rk;
 
-    memset( t, 0, 64 );
-    memset( RK, 0, sizeof(ctx->rk) );
+    mbedtls_platform_memset( t, 0, 64 );
+    mbedtls_platform_memset( RK, 0, sizeof(ctx->rk) );
 
     switch( keybits )
     {
@@ -390,7 +390,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
      * Key storage in KC
      * Order: KL, KR, KA, KB
      */
-    memset( KC, 0, sizeof(KC) );
+    mbedtls_platform_memset( KC, 0, sizeof(KC) );
 
     /* Store KL, KR */
     for( i = 0; i < 8; i++ )
@@ -951,7 +951,7 @@ int mbedtls_camellia_self_test( int verbose )
 
     mbedtls_camellia_context ctx;
 
-    memset( key, 0, 32 );
+    mbedtls_platform_memset( key, 0, 32 );
 
     for( j = 0; j < 6; j++ ) {
         u = j >> 1;

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -66,7 +66,7 @@
 void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
 {
     CCM_VALIDATE( ctx != NULL );
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
+    memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
 }
 
 int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -211,7 +211,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
 
 
     /* Start CBC-MAC with first block */
-    mbedtls_platform_memset( y, 0, 16 );
+    memset( y, 0, 16 );
     UPDATE_CBC_MAC;
 
     /*

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -66,7 +66,7 @@
 void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
 {
     CCM_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
 }
 
 int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
@@ -211,7 +211,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
 
 
     /* Start CBC-MAC with first block */
-    memset( y, 0, 16 );
+    mbedtls_platform_memset( y, 0, 16 );
     UPDATE_CBC_MAC;
 
     /*
@@ -224,7 +224,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         len_left = add_len;
         src = add;
 
-        memset( b, 0, 16 );
+        mbedtls_platform_memset( b, 0, 16 );
         b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
         b[1] = (unsigned char)( ( add_len      ) & 0xFF );
 
@@ -239,7 +239,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         {
             use_len = len_left > 16 ? 16 : len_left;
 
-            memset( b, 0, 16 );
+            mbedtls_platform_memset( b, 0, 16 );
             memcpy( b, src, use_len );
             UPDATE_CBC_MAC;
 
@@ -260,7 +260,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
      */
     ctr[0] = q - 1;
     memcpy( ctr + 1, iv, iv_len );
-    memset( ctr + 1 + iv_len, 0, q );
+    mbedtls_platform_memset( ctr + 1 + iv_len, 0, q );
     ctr[15] = 1;
 
     /*
@@ -279,7 +279,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
 
         if( mode == CCM_ENCRYPT )
         {
-            memset( b, 0, 16 );
+            mbedtls_platform_memset( b, 0, 16 );
             memcpy( b, src, use_len );
             UPDATE_CBC_MAC;
         }
@@ -288,7 +288,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
 
         if( mode == CCM_DECRYPT )
         {
-            memset( b, 0, 16 );
+            mbedtls_platform_memset( b, 0, 16 );
             memcpy( b, dst, use_len );
             UPDATE_CBC_MAC;
         }
@@ -495,8 +495,8 @@ int mbedtls_ccm_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  CCM-AES #%u: ", (unsigned int) i + 1 );
 
-        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
-        memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
+        mbedtls_platform_memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+        mbedtls_platform_memset( ciphertext, 0, CCM_SELFTEST_CT_MAX_LEN );
         memcpy( plaintext, msg, msg_len[i] );
 
         ret = mbedtls_ccm_encrypt_and_tag( &ctx, msg_len[i],
@@ -512,7 +512,7 @@ int mbedtls_ccm_self_test( int verbose )
 
             return( 1 );
         }
-        memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
+        mbedtls_platform_memset( plaintext, 0, CCM_SELFTEST_PT_MAX_LEN );
 
         ret = mbedtls_ccm_auth_decrypt( &ctx, msg_len[i],
                                         iv, iv_len[i], ad, add_len[i],

--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -68,7 +68,7 @@ static int chachapoly_pad_aad( mbedtls_chachapoly_context *ctx )
     if( partial_block_len == 0U )
         return( 0 );
 
-    memset( zeroes, 0, sizeof( zeroes ) );
+    mbedtls_platform_memset( zeroes, 0, sizeof( zeroes ) );
 
     return( mbedtls_poly1305_update( &ctx->poly1305_ctx,
                                      zeroes,
@@ -88,7 +88,7 @@ static int chachapoly_pad_ciphertext( mbedtls_chachapoly_context *ctx )
     if( partial_block_len == 0U )
         return( 0 );
 
-    memset( zeroes, 0, sizeof( zeroes ) );
+    mbedtls_platform_memset( zeroes, 0, sizeof( zeroes ) );
     return( mbedtls_poly1305_update( &ctx->poly1305_ctx,
                                      zeroes,
                                      16U - partial_block_len ) );
@@ -150,7 +150,7 @@ int mbedtls_chachapoly_starts( mbedtls_chachapoly_context *ctx,
      * Only the first 256-bits (32 bytes) of the key is used for Poly1305.
      * The other 256 bits are discarded.
      */
-    memset( poly1305_key, 0, sizeof( poly1305_key ) );
+    mbedtls_platform_memset( poly1305_key, 0, sizeof( poly1305_key ) );
     ret = mbedtls_chacha20_update( &ctx->chacha20_ctx, sizeof( poly1305_key ),
                                       poly1305_key, poly1305_key );
     if( ret != 0 )

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -156,7 +156,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_ciph
 void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx )
 {
     CIPHER_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
 }
 
 void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )
@@ -185,7 +185,7 @@ int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_in
     if( cipher_info == NULL )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
-    memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
 
     if( NULL == ( ctx->cipher_ctx = cipher_info->base->ctx_alloc_func() ) )
         return( MBEDTLS_ERR_CIPHER_ALLOC_FAILED );

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -156,7 +156,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_ciph
 void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx )
 {
     CIPHER_VALIDATE( ctx != NULL );
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
+    memset( ctx, 0, sizeof( mbedtls_cipher_context_t ) );
 }
 
 void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -450,7 +450,7 @@ int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_length,
     }
     else
     {
-        memset( zero_key, 0, MBEDTLS_AES_BLOCK_SIZE );
+        mbedtls_platform_memset( zero_key, 0, MBEDTLS_AES_BLOCK_SIZE );
 
         ret = mbedtls_cipher_cmac( cipher_info, zero_key, 128, key,
                                    key_length, int_key );

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -55,7 +55,7 @@
  */
 void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_ctr_drbg_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ctr_drbg_context ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );
@@ -89,7 +89,7 @@ int mbedtls_ctr_drbg_seed_entropy_len(
     int ret;
     unsigned char key[MBEDTLS_CTR_DRBG_KEYSIZE];
 
-    memset( key, 0, MBEDTLS_CTR_DRBG_KEYSIZE );
+    mbedtls_platform_memset( key, 0, MBEDTLS_CTR_DRBG_KEYSIZE );
 
     mbedtls_aes_init( &ctx->aes_ctx );
 
@@ -168,7 +168,7 @@ static int block_cipher_df( unsigned char *output,
     if( data_len > MBEDTLS_CTR_DRBG_MAX_SEED_INPUT )
         return( MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG );
 
-    memset( buf, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT + MBEDTLS_CTR_DRBG_BLOCKSIZE + 16 );
+    mbedtls_platform_memset( buf, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT + MBEDTLS_CTR_DRBG_BLOCKSIZE + 16 );
     mbedtls_aes_init( &aes_ctx );
 
     /*
@@ -204,7 +204,7 @@ static int block_cipher_df( unsigned char *output,
     for( j = 0; j < MBEDTLS_CTR_DRBG_SEEDLEN; j += MBEDTLS_CTR_DRBG_BLOCKSIZE )
     {
         p = buf;
-        memset( chain, 0, MBEDTLS_CTR_DRBG_BLOCKSIZE );
+        mbedtls_platform_memset( chain, 0, MBEDTLS_CTR_DRBG_BLOCKSIZE );
         use_len = buf_len;
 
         while( use_len > 0 )
@@ -284,7 +284,7 @@ static int ctr_drbg_update_internal( mbedtls_ctr_drbg_context *ctx,
     int i, j;
     int ret = 0;
 
-    memset( tmp, 0, MBEDTLS_CTR_DRBG_SEEDLEN );
+    mbedtls_platform_memset( tmp, 0, MBEDTLS_CTR_DRBG_SEEDLEN );
 
     for( j = 0; j < MBEDTLS_CTR_DRBG_SEEDLEN; j += MBEDTLS_CTR_DRBG_BLOCKSIZE )
     {
@@ -387,7 +387,7 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
         len > MBEDTLS_CTR_DRBG_MAX_SEED_INPUT - ctx->entropy_len )
         return( MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG );
 
-    memset( seed, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
+    mbedtls_platform_memset( seed, 0, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT );
 
     /*
      * Gather entropy_len bytes of entropy to seed state
@@ -464,7 +464,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
     if( add_len > MBEDTLS_CTR_DRBG_MAX_INPUT )
         return( MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG );
 
-    memset( add_input, 0, MBEDTLS_CTR_DRBG_SEEDLEN );
+    mbedtls_platform_memset( add_input, 0, MBEDTLS_CTR_DRBG_SEEDLEN );
 
     if( ctx->reseed_counter > ctx->reseed_interval ||
         ctx->prediction_resistance )

--- a/library/debug.c
+++ b/library/debug.c
@@ -42,6 +42,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)

--- a/library/debug.c
+++ b/library/debug.c
@@ -170,7 +170,7 @@ void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
     debug_send_line( ssl, level, file, line, str );
 
     idx = 0;
-    memset( txt, 0, sizeof( txt ) );
+    mbedtls_platform_memset( txt, 0, sizeof( txt ) );
     for( i = 0; i < len; i++ )
     {
         if( i >= 4096 )
@@ -184,7 +184,7 @@ void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
                 debug_send_line( ssl, level, file, line, str );
 
                 idx = 0;
-                memset( txt, 0, sizeof( txt ) );
+                mbedtls_platform_memset( txt, 0, sizeof( txt ) );
             }
 
             idx += mbedtls_snprintf( str + idx, sizeof( str ) - idx, "%04x: ",
@@ -309,7 +309,7 @@ static void debug_print_pk( const mbedtls_ssl_context *ssl, int level,
     mbedtls_pk_debug_item items[MBEDTLS_PK_DEBUG_MAX_ITEMS];
     char name[16];
 
-    memset( items, 0, sizeof( items ) );
+    mbedtls_platform_memset( items, 0, sizeof( items ) );
 
     if( mbedtls_pk_debug( pk, items ) != 0 )
     {

--- a/library/des.c
+++ b/library/des.c
@@ -311,7 +311,7 @@ static const uint32_t RHs[16] =
 
 void mbedtls_des_init( mbedtls_des_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_des_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_des_context ) );
 }
 
 void mbedtls_des_free( mbedtls_des_context *ctx )
@@ -324,7 +324,7 @@ void mbedtls_des_free( mbedtls_des_context *ctx )
 
 void mbedtls_des3_init( mbedtls_des3_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_des3_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_des3_context ) );
 }
 
 void mbedtls_des3_free( mbedtls_des3_context *ctx )

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -127,7 +127,7 @@ cleanup:
 void mbedtls_dhm_init( mbedtls_dhm_context *ctx )
 {
     DHM_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_dhm_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_dhm_context ) );
 }
 
 /*

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -179,7 +179,7 @@ void mbedtls_ecdh_init( mbedtls_ecdh_context *ctx )
     mbedtls_ecp_point_init( &ctx->Vf  );
     mbedtls_mpi_init( &ctx->_d );
 #else
-    memset( ctx, 0, sizeof( mbedtls_ecdh_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ecdh_context ) );
 
     ctx->var = MBEDTLS_ECDH_VARIANT_NONE;
 #endif

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -1104,7 +1104,7 @@ int mbedtls_ecjpake_self_test( int verbose )
     TEST_ASSERT( len == sizeof( ecjpake_test_pms ) );
     TEST_ASSERT( memcmp( buf, ecjpake_test_pms, len ) == 0 );
 
-    memset( buf, 0, len ); /* Avoid interferences with next step */
+    mbedtls_platform_memset( buf, 0, len ); /* Avoid interferences with next step */
 
     /* Client derives PMS */
     TEST_ASSERT( mbedtls_ecjpake_derive_secret( &cli,

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1553,7 +1553,7 @@ static void ecp_comb_recode_core( unsigned char x[], size_t d,
     size_t i, j;
     unsigned char c, cc, adjust;
 
-    memset( x, 0, d+1 );
+    mbedtls_platform_memset( x, 0, d+1 );
 
     /* First get the classical comb values (except for x_d = 0) */
     for( i = 0; i < d; i++ )

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -1001,7 +1001,7 @@ static inline void sub32( uint32_t *dst, uint32_t src, signed char *carry )
     C.s = 1;                                                            \
     C.n = (b) / 8 / sizeof( mbedtls_mpi_uint) + 1;                      \
     C.p = Cp;                                                           \
-    memset( Cp, 0, C.n * sizeof( mbedtls_mpi_uint ) );                  \
+    mbedtls_platform_memset( Cp, 0, C.n * sizeof( mbedtls_mpi_uint ) );                  \
                                                                         \
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( N, (b) * 2 / 8 /                 \
                                        sizeof( mbedtls_mpi_uint ) ) );  \
@@ -1248,7 +1248,7 @@ static int ecp_mod_p255( mbedtls_mpi *N )
     if( M.n > P255_WIDTH + 1 )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
     M.p = Mp;
-    memset( Mp, 0, sizeof Mp );
+    mbedtls_platform_memset( Mp, 0, sizeof Mp );
     memcpy( Mp, N->p + P255_WIDTH - 1, M.n * sizeof( mbedtls_mpi_uint ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, 255 % ( 8 * sizeof( mbedtls_mpi_uint ) ) ) );
     M.n++; /* Make room for multiplication by 19 */
@@ -1306,7 +1306,7 @@ static int ecp_mod_p448( mbedtls_mpi *N )
         /* Shouldn't be called with N larger than 2^896! */
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
     M.p = Mp;
-    memset( Mp, 0, sizeof( Mp ) );
+    mbedtls_platform_memset( Mp, 0, sizeof( Mp ) );
     memcpy( Mp, N->p + P448_WIDTH, M.n * sizeof( mbedtls_mpi_uint ) );
 
     /* N = A0 */
@@ -1374,7 +1374,7 @@ static inline int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t 
     M.n = N->n - ( p_limbs - adjust );
     if( M.n > p_limbs + adjust )
         M.n = p_limbs + adjust;
-    memset( Mp, 0, sizeof Mp );
+    mbedtls_platform_memset( Mp, 0, sizeof Mp );
     memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
     if( shift != 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, shift ) );
@@ -1396,7 +1396,7 @@ static inline int ecp_mod_koblitz( mbedtls_mpi *N, mbedtls_mpi_uint *Rp, size_t 
     M.n = N->n - ( p_limbs - adjust );
     if( M.n > p_limbs + adjust )
         M.n = p_limbs + adjust;
-    memset( Mp, 0, sizeof Mp );
+    mbedtls_platform_memset( Mp, 0, sizeof Mp );
     memcpy( Mp, N->p + p_limbs - adjust, M.n * sizeof( mbedtls_mpi_uint ) );
     if( shift != 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &M, shift ) );

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -65,7 +65,7 @@
 void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
 {
     ctx->source_count = 0;
-    mbedtls_platform_memset( ctx->source, 0, sizeof( ctx->source ) );
+    memset( ctx->source, 0, sizeof( ctx->source ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -65,7 +65,7 @@
 void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
 {
     ctx->source_count = 0;
-    memset( ctx->source, 0, sizeof( ctx->source ) );
+    mbedtls_platform_memset( ctx->source, 0, sizeof( ctx->source ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );
@@ -370,7 +370,7 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     }
     while( ! done );
 
-    memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    mbedtls_platform_memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     /*
@@ -453,7 +453,7 @@ int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx )
         return( MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR );
 
     /* Manually update the remaining stream with a separator value to diverge */
-    memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    mbedtls_platform_memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
     ret = mbedtls_entropy_update_manual( ctx, buf, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
     return( ret );
@@ -531,7 +531,7 @@ static int entropy_dummy_source( void *data, unsigned char *output,
 {
     ((void) data);
 
-    memset( output, 0x2a, len );
+    mbedtls_platform_memset( output, 0x2a, len );
     *olen = len;
 
     return( 0 );
@@ -602,8 +602,8 @@ int mbedtls_entropy_source_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "  ENTROPY_BIAS test: " );
 
-    memset( buf0, 0x00, sizeof( buf0 ) );
-    memset( buf1, 0x00, sizeof( buf1 ) );
+    mbedtls_platform_memset( buf0, 0x00, sizeof( buf0 ) );
+    mbedtls_platform_memset( buf1, 0x00, sizeof( buf1 ) );
 
     if( ( ret = mbedtls_entropy_source_self_test_gather( buf0, sizeof( buf0 ) ) ) != 0 )
         goto cleanup;

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -370,7 +370,7 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     }
     while( ! done );
 
-    mbedtls_platform_memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     /*

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 #if defined(MBEDTLS_ENTROPY_C)
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -106,7 +106,7 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
     /* MemSan cannot understand that the syscall writes to the buffer */
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
-    memset( buf, 0, buflen );
+    mbedtls_platform_memset( buf, 0, buflen );
 #endif
 #endif
     return( syscall( SYS_getrandom, buf, buflen, flags ) );
@@ -218,7 +218,7 @@ int mbedtls_nv_seed_poll( void *data,
     size_t use_len = MBEDTLS_ENTROPY_BLOCK_SIZE;
     ((void) data);
 
-    memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
+    mbedtls_platform_memset( buf, 0, MBEDTLS_ENTROPY_BLOCK_SIZE );
 
     if( mbedtls_nv_seed_read( buf, MBEDTLS_ENTROPY_BLOCK_SIZE ) < 0 )
       return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );

--- a/library/error.c
+++ b/library/error.c
@@ -28,6 +28,7 @@
 #if defined(MBEDTLS_ERROR_C) || defined(MBEDTLS_ERROR_STRERROR_DUMMY)
 #include "mbedtls/error.h"
 #include <string.h>
+#include "mbedtls/platform_util.h"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_C)

--- a/library/error.c
+++ b/library/error.c
@@ -218,7 +218,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     if( buflen == 0 )
         return;
 
-    memset( buf, 0x00, buflen );
+    mbedtls_platform_memset( buf, 0x00, buflen );
 
     if( ret < 0 )
         ret = -ret;

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -92,7 +92,7 @@
 void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
 {
     GCM_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
 }
 
 /*
@@ -111,7 +111,7 @@ static int gcm_gen_table( mbedtls_gcm_context *ctx )
     unsigned char h[16];
     size_t olen = 0;
 
-    memset( h, 0, 16 );
+    mbedtls_platform_memset( h, 0, 16 );
     if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, h, 16, h, &olen ) ) != 0 )
         return( ret );
 
@@ -298,8 +298,8 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
         return( MBEDTLS_ERR_GCM_BAD_INPUT );
     }
 
-    memset( ctx->y, 0x00, sizeof(ctx->y) );
-    memset( ctx->buf, 0x00, sizeof(ctx->buf) );
+    mbedtls_platform_memset( ctx->y, 0x00, sizeof(ctx->y) );
+    mbedtls_platform_memset( ctx->buf, 0x00, sizeof(ctx->buf) );
 
     ctx->mode = mode;
     ctx->len = 0;
@@ -312,7 +312,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     }
     else
     {
-        memset( work_buf, 0x00, 16 );
+        mbedtls_platform_memset( work_buf, 0x00, 16 );
         PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
 
         p = iv;
@@ -444,7 +444,7 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
 
     if( orig_len || orig_add_len )
     {
-        memset( work_buf, 0x00, 16 );
+        mbedtls_platform_memset( work_buf, 0x00, 16 );
 
         PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
         PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );

--- a/library/havege.c
+++ b/library/havege.c
@@ -184,7 +184,7 @@ static void havege_fill( mbedtls_havege_state *hs )
 
     (void)PTX;
 
-    memset( RES, 0, sizeof( RES ) );
+    mbedtls_platform_memset( RES, 0, sizeof( RES ) );
 
     while( n < MBEDTLS_HAVEGE_COLLECT_SIZE * 4 )
     {
@@ -206,7 +206,7 @@ static void havege_fill( mbedtls_havege_state *hs )
  */
 void mbedtls_havege_init( mbedtls_havege_state *hs )
 {
-    memset( hs, 0, sizeof( mbedtls_havege_state ) );
+    mbedtls_platform_memset( hs, 0, sizeof( mbedtls_havege_state ) );
 
     havege_fill( hs );
 }

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -178,7 +178,7 @@ static int hmac_drbg_reseed_core( mbedtls_hmac_drbg_context *ctx,
         }
     }
 
-    mbedtls_platform_memset( seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT );
+    memset( seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT );
 
     /* IV. Gather entropy_len bytes of entropy for the seed */
     if( ( ret = ctx->f_entropy( ctx->p_entropy,

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -56,7 +56,7 @@
  */
 void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx )
 {
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_hmac_drbg_context ) );
+    memset( ctx, 0, sizeof( mbedtls_hmac_drbg_context ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -56,7 +56,7 @@
  */
 void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_hmac_drbg_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_hmac_drbg_context ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );
@@ -141,7 +141,7 @@ int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
     if( ( ret = mbedtls_md_hmac_starts( &ctx->md_ctx, ctx->V,
                                         mbedtls_md_get_size( md_info ) ) ) != 0 )
         return( ret );
-    memset( ctx->V, 0x01, mbedtls_md_get_size( md_info ) );
+    mbedtls_platform_memset( ctx->V, 0x01, mbedtls_md_get_size( md_info ) );
 
     if( ( ret = mbedtls_hmac_drbg_update_ret( ctx, data, data_len ) ) != 0 )
         return( ret );
@@ -178,7 +178,7 @@ static int hmac_drbg_reseed_core( mbedtls_hmac_drbg_context *ctx,
         }
     }
 
-    memset( seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT );
+    mbedtls_platform_memset( seed, 0, MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT );
 
     /* IV. Gather entropy_len bytes of entropy for the seed */
     if( ( ret = ctx->f_entropy( ctx->p_entropy,
@@ -268,7 +268,7 @@ int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
      */
     if( ( ret = mbedtls_md_hmac_starts( &ctx->md_ctx, ctx->V, md_size ) ) != 0 )
         return( ret );
-    memset( ctx->V, 0x01, md_size );
+    mbedtls_platform_memset( ctx->V, 0x01, md_size );
 
     ctx->f_entropy = f_entropy;
     ctx->p_entropy = p_entropy;

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -141,7 +141,7 @@ int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
     if( ( ret = mbedtls_md_hmac_starts( &ctx->md_ctx, ctx->V,
                                         mbedtls_md_get_size( md_info ) ) ) != 0 )
         return( ret );
-    mbedtls_platform_memset( ctx->V, 0x01, mbedtls_md_get_size( md_info ) );
+    memset( ctx->V, 0x01, mbedtls_md_get_size( md_info ) );
 
     if( ( ret = mbedtls_hmac_drbg_update_ret( ctx, data, data_len ) ) != 0 )
         return( ret );
@@ -268,7 +268,7 @@ int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
      */
     if( ( ret = mbedtls_md_hmac_starts( &ctx->md_ctx, ctx->V, md_size ) ) != 0 )
         return( ret );
-    mbedtls_platform_memset( ctx->V, 0x01, md_size );
+    memset( ctx->V, 0x01, md_size );
 
     ctx->f_entropy = f_entropy;
     ctx->p_entropy = p_entropy;

--- a/library/md.c
+++ b/library/md.c
@@ -387,7 +387,7 @@ mbedtls_md_handle_t mbedtls_md_info_from_type( mbedtls_md_type_t md_type )
 
 void mbedtls_md_init( mbedtls_md_context_t *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_md_context_t ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_md_context_t ) );
 
 #if defined(MBEDTLS_MD_SINGLE_HASH)
     mbedtls_md_info_init( mbedtls_md_get_handle( ctx ),
@@ -563,8 +563,8 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
     opad = (unsigned char *) ctx->hmac_ctx +
         mbedtls_md_info_block_size( md_info );
 
-    memset( ipad, 0x36, mbedtls_md_info_block_size( md_info ) );
-    memset( opad, 0x5C, mbedtls_md_info_block_size( md_info ) );
+    mbedtls_platform_memset( ipad, 0x36, mbedtls_md_info_block_size( md_info ) );
+    mbedtls_platform_memset( opad, 0x5C, mbedtls_md_info_block_size( md_info ) );
 
     for( i = 0; i < keylen; i++ )
     {

--- a/library/md.c
+++ b/library/md.c
@@ -387,7 +387,7 @@ mbedtls_md_handle_t mbedtls_md_info_from_type( mbedtls_md_type_t md_type )
 
 void mbedtls_md_init( mbedtls_md_context_t *ctx )
 {
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_md_context_t ) );
+    memset( ctx, 0, sizeof( mbedtls_md_context_t ) );
 
 #if defined(MBEDTLS_MD_SINGLE_HASH)
     mbedtls_md_info_init( mbedtls_md_get_handle( ctx ),

--- a/library/md2.c
+++ b/library/md2.c
@@ -81,7 +81,7 @@ static const unsigned char PI_SUBST[256] =
 
 void mbedtls_md2_init( mbedtls_md2_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_md2_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_md2_context ) );
 }
 
 void mbedtls_md2_free( mbedtls_md2_context *ctx )
@@ -103,9 +103,9 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  */
 int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx )
 {
-    memset( ctx->cksum, 0, 16 );
-    memset( ctx->state, 0, 46 );
-    memset( ctx->buffer, 0, 16 );
+    mbedtls_platform_memset( ctx->cksum, 0, 16 );
+    mbedtls_platform_memset( ctx->state, 0, 46 );
+    mbedtls_platform_memset( ctx->buffer, 0, 16 );
     ctx->left = 0;
 
     return( 0 );

--- a/library/md4.c
+++ b/library/md4.c
@@ -74,7 +74,7 @@
 
 void mbedtls_md4_init( mbedtls_md4_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_md4_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_md4_context ) );
 }
 
 void mbedtls_md4_free( mbedtls_md4_context *ctx )

--- a/library/md5.c
+++ b/library/md5.c
@@ -73,7 +73,7 @@
 
 void mbedtls_md5_init( mbedtls_md5_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_md5_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_md5_context ) );
 }
 
 void mbedtls_md5_free( mbedtls_md5_context *ctx )
@@ -332,17 +332,17 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
     if( used <= 56 )
     {
         /* Enough room for padding + length in current block */
-        memset( ctx->buffer + used, 0, 56 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 56 - used );
     }
     else
     {
         /* We'll need an extra block */
-        memset( ctx->buffer + used, 0, 64 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 64 - used );
 
         if( ( ret = mbedtls_internal_md5_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
-        memset( ctx->buffer, 0, 56 );
+        mbedtls_platform_memset( ctx->buffer, 0, 56 );
     }
 
     /*

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -315,7 +315,7 @@ static void *buffer_alloc_calloc( size_t n, size_t size )
             mbedtls_exit( 1 );
 
         ret = (unsigned char *) cur + sizeof( memory_header );
-        memset( ret, 0, original_len );
+        mbedtls_platform_memset( ret, 0, original_len );
 
         return( ret );
     }
@@ -373,7 +373,7 @@ static void *buffer_alloc_calloc( size_t n, size_t size )
         mbedtls_exit( 1 );
 
     ret = (unsigned char *) cur + sizeof( memory_header );
-    memset( ret, 0, original_len );
+    mbedtls_platform_memset( ret, 0, original_len );
 
     return( ret );
 }
@@ -438,7 +438,7 @@ static void buffer_alloc_free( void *ptr )
         if( hdr->next != NULL )
             hdr->next->prev = hdr;
 
-        memset( old, 0, sizeof(memory_header) );
+        mbedtls_platform_memset( old, 0, sizeof(memory_header) );
     }
 
     // Regroup with block after
@@ -477,7 +477,7 @@ static void buffer_alloc_free( void *ptr )
         if( hdr->next != NULL )
             hdr->next->prev = hdr;
 
-        memset( old, 0, sizeof(memory_header) );
+        mbedtls_platform_memset( old, 0, sizeof(memory_header) );
     }
 
     // Prepend to free_list if we have not merged
@@ -572,7 +572,7 @@ static void buffer_alloc_free_mutexed( void *ptr )
 
 void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len )
 {
-    memset( &heap, 0, sizeof( buffer_alloc_ctx ) );
+    mbedtls_platform_memset( &heap, 0, sizeof( buffer_alloc_ctx ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &heap.mutex );
@@ -593,7 +593,7 @@ void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len )
              - (size_t)buf % MBEDTLS_MEMORY_ALIGN_MULTIPLE;
     }
 
-    memset( buf, 0, len );
+    mbedtls_platform_memset( buf, 0, len );
 
     heap.buf = buf;
     heap.len = len;

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -47,6 +47,7 @@
 #include "mbedtls/net_sockets.h"
 
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 #if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
     !defined(EFI32)

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -154,7 +154,7 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,
         return( ret );
 
     /* Do name resolution with both IPv6 and IPv4 */
-    memset( &hints, 0, sizeof( hints ) );
+    mbedtls_platform_memset( &hints, 0, sizeof( hints ) );
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
     hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
@@ -201,7 +201,7 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
         return( ret );
 
     /* Bind to IPv6 and/or IPv4, but only in the desired protocol */
-    memset( &hints, 0, sizeof( hints ) );
+    mbedtls_platform_memset( &hints, 0, sizeof( hints ) );
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
     hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
@@ -471,8 +471,8 @@ int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout )
     /* Ensure that memory sanitizers consider read_fds and write_fds as
      * initialized even on platforms such as Glibc/x86_64 where FD_ZERO
      * is implemented in assembly. */
-    memset( &read_fds, 0, sizeof( read_fds ) );
-    memset( &write_fds, 0, sizeof( write_fds ) );
+    mbedtls_platform_memset( &read_fds, 0, sizeof( read_fds ) );
+    mbedtls_platform_memset( &write_fds, 0, sizeof( write_fds ) );
 #endif
 #endif
 

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -107,7 +107,7 @@ do {                                                    \
  */
 void mbedtls_nist_kw_init( mbedtls_nist_kw_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_nist_kw_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_nist_kw_context ) );
 }
 
 int mbedtls_nist_kw_setkey( mbedtls_nist_kw_context *ctx,
@@ -254,7 +254,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
                        KW_SEMIBLOCK_LENGTH / 2 );
 
         memcpy( output + KW_SEMIBLOCK_LENGTH, input, in_len );
-        memset( output + KW_SEMIBLOCK_LENGTH + in_len, 0, padlen );
+        mbedtls_platform_memset( output + KW_SEMIBLOCK_LENGTH + in_len, 0, padlen );
     }
     semiblocks = ( ( in_len + padlen ) / KW_SEMIBLOCK_LENGTH ) + 1;
 
@@ -307,7 +307,7 @@ cleanup:
 
     if( ret != 0)
     {
-        memset( output, 0, semiblocks * KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memset( output, 0, semiblocks * KW_SEMIBLOCK_LENGTH );
     }
     mbedtls_platform_zeroize( inbuff, KW_SEMIBLOCK_LENGTH * 2 );
     mbedtls_platform_zeroize( outbuff, KW_SEMIBLOCK_LENGTH * 2 );
@@ -373,7 +373,7 @@ static int unwrap( mbedtls_nist_kw_context *ctx,
 
 cleanup:
     if( ret != 0)
-        memset( output, 0, ( semiblocks - 1 ) * KW_SEMIBLOCK_LENGTH );
+        mbedtls_platform_memset( output, 0, ( semiblocks - 1 ) * KW_SEMIBLOCK_LENGTH );
     mbedtls_platform_zeroize( inbuff, sizeof( inbuff )  );
     mbedtls_platform_zeroize( outbuff, sizeof( outbuff ) );
 
@@ -509,7 +509,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
         {
             goto cleanup;
         }
-        memset( output + Plen, 0, padlen );
+        mbedtls_platform_memset( output + Plen, 0, padlen );
         *out_len = Plen;
     }
     else
@@ -521,7 +521,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
 cleanup:
     if( ret != 0 )
     {
-        memset( output, 0, *out_len );
+        mbedtls_platform_memset( output, 0, *out_len );
         *out_len = 0;
     }
 

--- a/library/pem.c
+++ b/library/pem.c
@@ -48,7 +48,7 @@
 #if defined(MBEDTLS_PEM_PARSE_C)
 void mbedtls_pem_init( mbedtls_pem_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_pem_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_pem_context ) );
 }
 
 #if defined(MBEDTLS_MD5_C) && defined(MBEDTLS_CIPHER_MODE_CBC) &&         \
@@ -61,7 +61,7 @@ static int pem_get_iv( const unsigned char *s, unsigned char *iv,
 {
     size_t i, j, k;
 
-    memset( iv, 0, iv_len );
+    mbedtls_platform_memset( iv, 0, iv_len );
 
     for( i = 0; i < iv_len * 2; i++, s++ )
     {

--- a/library/pk.c
+++ b/library/pk.c
@@ -1291,7 +1291,7 @@ void mbedtls_pk_init( mbedtls_pk_context *ctx )
     ctx->pk_info = MBEDTLS_PK_INVALID_HANDLE;
     ctx->pk_ctx = NULL;
 #else
-    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_pk_context ) );
+    memset( ctx, 0, sizeof( mbedtls_pk_context ) );
 #endif
 }
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -511,7 +511,7 @@ static int extract_ecdsa_sig_int( unsigned char **from, const unsigned char *end
         return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
 
     padding_len = to_len - unpadded_len;
-    mbedtls_platform_memset( to, 0x00, padding_len );
+    memset( to, 0x00, padding_len );
     memcpy( to + padding_len, *from, unpadded_len );
     ( *from ) += unpadded_len;
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -511,7 +511,7 @@ static int extract_ecdsa_sig_int( unsigned char **from, const unsigned char *end
         return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
 
     padding_len = to_len - unpadded_len;
-    memset( to, 0x00, padding_len );
+    mbedtls_platform_memset( to, 0x00, padding_len );
     memcpy( to + padding_len, *from, unpadded_len );
     ( *from ) += unpadded_len;
 
@@ -941,7 +941,7 @@ static int rsa_alt_check_pair( const void *pub, const void *prv )
     if( rsa_alt_get_bitlen( prv ) != rsa_get_bitlen( pub ) )
         return( MBEDTLS_ERR_RSA_KEY_CHECK_FAILED );
 
-    memset( hash, 0x2a, sizeof( hash ) );
+    mbedtls_platform_memset( hash, 0x2a, sizeof( hash ) );
 
     if( ( ret = rsa_alt_sign_wrap( (void *) prv, MBEDTLS_MD_NONE,
                                    hash, sizeof( hash ),
@@ -965,7 +965,7 @@ static void *rsa_alt_alloc_wrap( void )
     void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_rsa_alt_context ) );
 
     if( ctx != NULL )
-        memset( ctx, 0, sizeof( mbedtls_rsa_alt_context ) );
+        mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_rsa_alt_context ) );
 
     return( ctx );
 }

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -40,6 +40,7 @@
 #endif
 
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx )
 {

--- a/library/pkcs11.c
+++ b/library/pkcs11.c
@@ -43,7 +43,7 @@
 
 void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_pkcs11_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_pkcs11_context ) );
 }
 
 int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert, pkcs11h_certificate_t pkcs11_cert )

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -99,8 +99,8 @@ static int pkcs12_pbe_derive_key_iv( mbedtls_asn1_buf *pbe_params, mbedtls_md_ty
     if( pwdlen > PKCS12_MAX_PWDLEN )
         return( MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA );
 
-    memset( &salt, 0, sizeof(mbedtls_asn1_buf) );
-    memset( &unipwd, 0, sizeof(unipwd) );
+    mbedtls_platform_memset( &salt, 0, sizeof(mbedtls_asn1_buf) );
+    mbedtls_platform_memset( &unipwd, 0, sizeof(unipwd) );
 
     if( ( ret = pkcs12_parse_pbe_params( pbe_params, &salt,
                                          &iterations ) ) != 0 )
@@ -283,7 +283,7 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
     else
         v = 128;
 
-    memset( diversifier, (unsigned char) id, v );
+    mbedtls_platform_memset( diversifier, (unsigned char) id, v );
 
     pkcs12_fill_buffer( salt_block, v, salt, saltlen );
     pkcs12_fill_buffer( pwd_block,  v, pwd,  pwdlen  );

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -231,7 +231,7 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
     unsigned char *out_p = output;
     unsigned char counter[4];
 
-    memset( counter, 0, 4 );
+    mbedtls_platform_memset( counter, 0, 4 );
     counter[3] = 1;
 
 #if UINT_MAX > 0xFFFFFFFF

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -46,6 +46,7 @@
 #endif /* MBEDTLS_ASN1_PARSE_C */
 
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -654,7 +654,7 @@ static int pk_get_pk_alg( unsigned char **p,
     int ret;
     mbedtls_asn1_buf alg_oid;
 
-    memset( params, 0, sizeof(mbedtls_asn1_buf) );
+    mbedtls_platform_memset( params, 0, sizeof(mbedtls_asn1_buf) );
 
     if( ( ret = mbedtls_asn1_get_alg( p, end, &alg_oid, params ) ) != 0 )
         return( MBEDTLS_ERR_PK_INVALID_ALG + ret );

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -72,7 +72,8 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
-static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
+void *mbedtls_platform_memset( void *, int, size_t );
+static void * (* const volatile memset_func)( void *, int, size_t ) = mbedtls_platform_memset;
 
 void mbedtls_platform_zeroize( void *buf, size_t len )
 {

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -79,7 +79,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
-void mbedtls_platform_memset( void *ptr, int value, size_t num )
+void *mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -93,10 +93,10 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
-    memset( ptr, value, num );
+    return( memset( ptr, value, num ) );
 }
 
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -107,7 +107,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),
             (void *) ( (unsigned char *) src + start_offset ),
             ( num - start_offset ) );
-    memcpy( (void *) dst, (void *) src, start_offset );
+    return( memcpy( (void *) dst, (void *) src, start_offset ) );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -38,6 +38,10 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/threading.h"
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+#include "mbedtls/entropy_poll.h"
+#endif
+
 #include <stddef.h>
 #include <string.h>
 
@@ -135,13 +139,20 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return( diff );
 }
 
-#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 uint32_t mbedtls_platform_random_in_range( size_t num )
 {
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     (void) num;
     return 0;
+#else
+    uint32_t result = 0;
+    size_t olen = 0;
+
+    mbedtls_hardware_poll( NULL, (unsigned char *) &result, sizeof( result ),
+                           &olen );
+    return( result % num );
+#endif
 }
-#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_platform_random_in_range( size_t num )
+uint32_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -112,7 +112,9 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 {
-    volatile unsigned int equal = 0;
+    volatile const unsigned char *A = (volatile const unsigned char *) buf1;
+    volatile const unsigned char *B = (volatile const unsigned char *) buf2;
+    volatile unsigned char diff = 0;
 
     size_t i = num;
 
@@ -120,22 +122,17 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
     for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
-    if ( equal == num )
-    {
-        return 0;
-    }
-
-    return 1;
+    return( diff );
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,15 +82,15 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
-            ( num - startOffset ) );
-    memset( ( void * ) ptr, data, startOffset );
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+            ( num - start_offset ) );
+    memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
     memset( ptr, value, num );
@@ -99,15 +99,15 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
-    memset( ( void * ) dst, data, num );
-    memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
-            ( void * ) ( ( unsigned char * ) src + startOffset ),
-            ( num - startOffset ) );
-    memcpy( ( void * ) dst, ( void * ) src, startOffset );
+    memset( (void *) dst, data, num );
+    memcpy( (void *) ( (unsigned char *) dst + start_offset ),
+            (void *) ( (unsigned char *) src + start_offset ),
+            ( num - start_offset ) );
+    memcpy( (void *) dst, (void *) src, start_offset );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
@@ -116,18 +116,18 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
 
-    for( i = startOffset; i < num; i++ )
+    for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
-    for( i = 0; i < startOffset; i++ )
+    for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
     if ( equal == num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,8 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ptr + startOffset ), value, ( num - startOffset ) );
+    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
+            ( num - startOffset ) );
     memset( ( void * ) ptr, data, startOffset );
 
     /* Perform the original memset */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -137,12 +137,13 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return 1;
 }
 
-//TODO: This is a stub implementation of the global RNG function.
+#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 size_t mbedtls_random_in_range( size_t num )
 {
     (void) num;
     return 0;
 }
+#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_random_in_range( size_t num )
+size_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), data,
             ( num - start_offset ) );
     memset( (void *) ptr, data, start_offset );
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -150,7 +150,17 @@ uint32_t mbedtls_platform_random_in_range( size_t num )
 
     mbedtls_hardware_poll( NULL, (unsigned char *) &result, sizeof( result ),
                            &olen );
-    return( result % num );
+
+    if( num == 0 )
+    {
+        result = 0;
+    }
+    else
+    {
+        result %= num;
+    }
+
+    return( result );
 #endif
 }
 

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -404,7 +404,7 @@ int mbedtls_poly1305_finish( mbedtls_poly1305_context *ctx,
         ctx->queue_len++;
 
         /* Pad with zeroes */
-        memset( &ctx->queue[ctx->queue_len],
+        mbedtls_platform_memset( &ctx->queue[ctx->queue_len],
                 0,
                 POLY1305_BLOCK_SIZE_BYTES - ctx->queue_len );
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -74,7 +74,7 @@
 
 void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_ripemd160_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ripemd160_context ) );
 }
 
 void mbedtls_ripemd160_free( mbedtls_ripemd160_context *ctx )
@@ -520,7 +520,7 @@ int mbedtls_ripemd160_self_test( int verbose )
     int i, ret = 0;
     unsigned char output[20];
 
-    memset( output, 0, sizeof output );
+    mbedtls_platform_memset( output, 0, sizeof output );
 
     for( i = 0; i < TESTS; i++ )
     {

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -481,7 +481,7 @@ void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
     RSA_VALIDATE( padding == MBEDTLS_RSA_PKCS_V15 ||
                   padding == MBEDTLS_RSA_PKCS_V21 );
 
-    memset( ctx, 0, sizeof( mbedtls_rsa_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_rsa_context ) );
 
     mbedtls_rsa_set_padding( ctx, padding, hash_id );
 
@@ -1073,8 +1073,8 @@ static int mgf_mask( unsigned char *dst, size_t dlen, unsigned char *src,
     size_t i, use_len;
     int ret = 0;
 
-    memset( mask, 0, MBEDTLS_MD_MAX_SIZE );
-    memset( counter, 0, 4 );
+    mbedtls_platform_memset( mask, 0, MBEDTLS_MD_MAX_SIZE );
+    mbedtls_platform_memset( counter, 0, 4 );
 
     hlen = mbedtls_md_get_size( mbedtls_md_get_handle( md_ctx ) );
 
@@ -1155,7 +1155,7 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
     if( ilen + 2 * hlen + 2 < ilen || olen < ilen + 2 * hlen + 2 )
         return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
 
-    memset( output, 0, olen );
+    mbedtls_platform_memset( output, 0, olen );
 
     *p++ = 0;
 
@@ -1510,7 +1510,7 @@ static unsigned if_int( unsigned cond, unsigned if1, unsigned if0 )
  * `mem_move_to_left(start, total, offset)` is functionally equivalent to
  * ```
  * memmove(start, start + offset, total - offset);
- * memset(start + offset, 0, total - offset);
+ * mbedtls_platform_memset(start + offset, 0, total - offset);
  * ```
  * but it strives to use a memory access pattern (and thus total timing)
  * that does not depend on \p offset. This timing independence comes at
@@ -1815,7 +1815,7 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
     else
         slen = olen - hlen - 2;
 
-    memset( sig, 0, olen );
+    mbedtls_platform_memset( sig, 0, olen );
 
     /* Generate salt of length slen */
     if( ( ret = f_rng( p_rng, salt, slen ) ) != 0 )
@@ -1958,7 +1958,7 @@ static int rsa_rsassa_pkcs1_v15_encode( mbedtls_md_type_t md_alg,
     /* Write signature header and padding */
     *p++ = 0;
     *p++ = MBEDTLS_RSA_SIGN;
-    memset( p, 0xFF, nb_pad );
+    mbedtls_platform_memset( p, 0xFF, nb_pad );
     p += nb_pad;
     *p++ = 0;
 
@@ -2198,7 +2198,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
 
     hlen = mbedtls_md_get_size( md_info );
 
-    memset( zeros, 0, 8 );
+    mbedtls_platform_memset( zeros, 0, 8 );
 
     /*
      * Note: EMSA-PSS verification is over the length of N - 1 bits

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -80,7 +80,7 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
 {
     SHA1_VALIDATE( ctx != NULL );
 
-    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
 }
 
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
@@ -385,17 +385,17 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
     if( used <= 56 )
     {
         /* Enough room for padding + length in current block */
-        memset( ctx->buffer + used, 0, 56 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 56 - used );
     }
     else
     {
         /* We'll need an extra block */
-        memset( ctx->buffer + used, 0, 64 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 64 - used );
 
         if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
-        memset( ctx->buffer, 0, 56 );
+        mbedtls_platform_memset( ctx->buffer, 0, 56 );
     }
 
     /*
@@ -523,7 +523,7 @@ int mbedtls_sha1_self_test( int verbose )
 
         if( i == 2 )
         {
-            memset( buf, 'a', buflen = 1000 );
+            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -59,7 +59,7 @@ void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
     SHA256_VALIDATE( ctx != NULL );
 
-    memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
 }
 
 void mbedtls_sha256_free( mbedtls_sha256_context *ctx )
@@ -337,17 +337,17 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
     if( used <= 56 )
     {
         /* Enough room for padding + length in current block */
-        memset( ctx->buffer + used, 0, 56 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 56 - used );
     }
     else
     {
         /* We'll need an extra block */
-        memset( ctx->buffer + used, 0, 64 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 64 - used );
 
         if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
-        memset( ctx->buffer, 0, 56 );
+        mbedtls_platform_memset( ctx->buffer, 0, 56 );
     }
 
     /*
@@ -527,7 +527,7 @@ int mbedtls_sha256_self_test( int verbose )
 
         if( j == 2 )
         {
-            memset( buf, 'a', buflen = 1000 );
+            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -59,7 +59,7 @@ void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
     SHA256_VALIDATE( ctx != NULL );
 
-    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
+    memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
 }
 
 void mbedtls_sha256_free( mbedtls_sha256_context *ctx )

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -96,7 +96,7 @@ void mbedtls_sha512_init( mbedtls_sha512_context *ctx )
 {
     SHA512_VALIDATE( ctx != NULL );
 
-    memset( ctx, 0, sizeof( mbedtls_sha512_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_sha512_context ) );
 }
 
 void mbedtls_sha512_free( mbedtls_sha512_context *ctx )
@@ -383,17 +383,17 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
     if( used <= 112 )
     {
         /* Enough room for padding + length in current block */
-        memset( ctx->buffer + used, 0, 112 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 112 - used );
     }
     else
     {
         /* We'll need an extra block */
-        memset( ctx->buffer + used, 0, 128 - used );
+        mbedtls_platform_memset( ctx->buffer + used, 0, 128 - used );
 
         if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
             return( ret );
 
-        memset( ctx->buffer, 0, 112 );
+        mbedtls_platform_memset( ctx->buffer, 0, 112 );
     }
 
     /*
@@ -585,7 +585,7 @@ int mbedtls_sha512_self_test( int verbose )
 
         if( j == 2 )
         {
-            memset( buf, 'a', buflen = 1000 );
+            mbedtls_platform_memset( buf, 'a', buflen = 1000 );
 
             for( j = 0; j < 1000; j++ )
             {

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -43,6 +43,7 @@
 #include "mbedtls/ssl_internal.h"
 
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -46,7 +46,7 @@
 
 void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 {
-    memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
+    mbedtls_platform_memset( cache, 0, sizeof( mbedtls_ssl_cache_context ) );
 
     cache->timeout = MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT;
     cache->max_entries = MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES;
@@ -260,7 +260,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
     if( cur->peer_cert.p != NULL )
     {
         mbedtls_free( cur->peer_cert.p );
-        memset( &cur->peer_cert, 0, sizeof(mbedtls_x509_buf) );
+        mbedtls_platform_memset( &cur->peer_cert, 0, sizeof(mbedtls_x509_buf) );
     }
 #endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1215,12 +1215,12 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 
     p = buf + 6 + ciph_len;
     ssl->session_negotiate->id_len = sess_len;
-    memset( ssl->session_negotiate->id, 0,
+    mbedtls_platform_memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
     memcpy( ssl->session_negotiate->id, p, ssl->session_negotiate->id_len );
 
     p += sess_len;
-    memset( ssl->handshake->randbytes, 0, 64 );
+    mbedtls_platform_memset( ssl->handshake->randbytes, 0, 64 );
     memcpy( ssl->handshake->randbytes + 32 - chal_len, p, chal_len );
 
     /*
@@ -1735,7 +1735,7 @@ read_record_header:
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, session id", buf + 35, sess_len );
 
     ssl->session_negotiate->id_len = sess_len;
-    memset( ssl->session_negotiate->id, 0,
+    mbedtls_platform_memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
     memcpy( ssl->session_negotiate->id, buf + 35,
             ssl->session_negotiate->id_len );
@@ -2863,7 +2863,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
         if( ssl->handshake->new_session_ticket != 0 )
         {
             ssl->session_negotiate->id_len = n = 0;
-            memset( ssl->session_negotiate->id, 0, 32 );
+            mbedtls_platform_memset( ssl->session_negotiate->id, 0, 32 );
         }
         else
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1215,12 +1215,12 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 
     p = buf + 6 + ciph_len;
     ssl->session_negotiate->id_len = sess_len;
-    mbedtls_platform_memset( ssl->session_negotiate->id, 0,
+    memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
     memcpy( ssl->session_negotiate->id, p, ssl->session_negotiate->id_len );
 
     p += sess_len;
-    mbedtls_platform_memset( ssl->handshake->randbytes, 0, 64 );
+    memset( ssl->handshake->randbytes, 0, 64 );
     memcpy( ssl->handshake->randbytes + 32 - chal_len, p, chal_len );
 
     /*
@@ -1735,7 +1735,7 @@ read_record_header:
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, session id", buf + 35, sess_len );
 
     ssl->session_negotiate->id_len = sess_len;
-    mbedtls_platform_memset( ssl->session_negotiate->id, 0,
+    memset( ssl->session_negotiate->id, 0,
             sizeof( ssl->session_negotiate->id ) );
     memcpy( ssl->session_negotiate->id, buf + 35,
             ssl->session_negotiate->id_len );
@@ -2863,7 +2863,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
         if( ssl->handshake->new_session_ticket != 0 )
         {
             ssl->session_negotiate->id_len = n = 0;
-            mbedtls_platform_memset( ssl->session_negotiate->id, 0, 32 );
+            memset( ssl->session_negotiate->id, 0, 32 );
         }
         else
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -45,7 +45,7 @@
  */
 void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_ssl_ticket_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_ssl_ticket_context ) );
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &ctx->mutex );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -615,7 +615,7 @@ MBEDTLS_NO_INLINE static int ssl3_prf( const unsigned char *secret, size_t slen,
      */
     for( i = 0; i < dlen / 16; i++ )
     {
-        memset( padding, (unsigned char) ('A' + i), 1 + i );
+        mbedtls_platform_memset( padding, (unsigned char) ('A' + i), 1 + i );
 
         if( ( ret = mbedtls_sha1_starts_ret( &sha1 ) ) != 0 )
             goto exit;
@@ -942,7 +942,7 @@ MBEDTLS_NO_INLINE static void ssl_calc_finished_ssl(
     sender = ( from == MBEDTLS_SSL_IS_CLIENT ) ? "CLNT"
                                        : "SRVR";
 
-    memset( padbuf, 0x36, 48 );
+    mbedtls_platform_memset( padbuf, 0x36, 48 );
 
     mbedtls_md5_update_ret( &md5, (const unsigned char *) sender, 4 );
     mbedtls_md5_update_ret( &md5, session->master, 48 );
@@ -954,7 +954,7 @@ MBEDTLS_NO_INLINE static void ssl_calc_finished_ssl(
     mbedtls_sha1_update_ret( &sha1, padbuf, 40 );
     mbedtls_sha1_finish_ret( &sha1, sha1sum );
 
-    memset( padbuf, 0x5C, 48 );
+    mbedtls_platform_memset( padbuf, 0x5C, 48 );
 
     mbedtls_md5_starts_ret( &md5 );
     mbedtls_md5_update_ret( &md5, session->master, 48 );
@@ -1600,8 +1600,8 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Initializing zlib states" ) );
 
-        memset( &transform->ctx_deflate, 0, sizeof( transform->ctx_deflate ) );
-        memset( &transform->ctx_inflate, 0, sizeof( transform->ctx_inflate ) );
+        mbedtls_platform_memset( &transform->ctx_deflate, 0, sizeof( transform->ctx_deflate ) );
+        mbedtls_platform_memset( &transform->ctx_inflate, 0, sizeof( transform->ctx_inflate ) );
 
         if( deflateInit( &transform->ctx_deflate,
                          Z_DEFAULT_COMPRESSION )   != Z_OK ||
@@ -1634,8 +1634,8 @@ static inline void ssl_calc_verify_ssl( const mbedtls_ssl_context *ssl,
     mbedtls_md5_clone( &md5, &ssl->handshake->fin_md5 );
     mbedtls_sha1_clone( &sha1, &ssl->handshake->fin_sha1 );
 
-    memset( pad_1, 0x36, 48 );
-    memset( pad_2, 0x5C, 48 );
+    mbedtls_platform_memset( pad_1, 0x36, 48 );
+    mbedtls_platform_memset( pad_2, 0x5C, 48 );
 
     mbedtls_md5_update_ret( &md5, ssl->session_negotiate->master, 48 );
     mbedtls_md5_update_ret( &md5, pad_1, 48 );
@@ -2116,7 +2116,7 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
         if( end < p || (size_t)( end - p ) < psk_len )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        memset( p, 0, psk_len );
+        mbedtls_platform_memset( p, 0, psk_len );
         p += psk_len;
     }
     else
@@ -2247,7 +2247,7 @@ static void ssl_mac( mbedtls_md_context_t *md_ctx,
     header[8] = (unsigned char) type;
     (void)mbedtls_platform_put_uint16_be( &header[9], len );
 
-    memset( padding, 0x36, padlen );
+    mbedtls_platform_memset( padding, 0x36, padlen );
     mbedtls_md_starts( md_ctx );
     mbedtls_md_update( md_ctx, secret,  md_size );
     mbedtls_md_update( md_ctx, padding, padlen  );
@@ -2255,7 +2255,7 @@ static void ssl_mac( mbedtls_md_context_t *md_ctx,
     mbedtls_md_update( md_ctx, buf,     len     );
     mbedtls_md_finish( md_ctx, out              );
 
-    memset( padding, 0x5C, padlen );
+    mbedtls_platform_memset( padding, 0x5C, padlen );
     mbedtls_md_starts( md_ctx );
     mbedtls_md_update( md_ctx, secret,    md_size );
     mbedtls_md_update( md_ctx, padding,   padlen  );
@@ -2335,7 +2335,7 @@ static int ssl_cid_build_inner_plaintext( unsigned char *content,
 
     if( remaining < pad )
         return( -1 );
-    memset( content + len, 0, pad );
+    mbedtls_platform_memset( content + len, 0, pad );
     len += pad;
     remaining -= pad;
 
@@ -3376,7 +3376,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             const size_t max_len = rec->data_len + padlen;
             const size_t min_len = ( max_len > 256 ) ? max_len - 256 : 0;
 
-            memset( tmp, 0, sizeof( tmp ) );
+            mbedtls_platform_memset( tmp, 0, sizeof( tmp ) );
 
             switch( mbedtls_md_get_type(
                         mbedtls_md_get_handle( &transform->md_ctx_dec ) ) )
@@ -4400,7 +4400,7 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
 
             /* Handshake hashes are computed without fragmentation,
              * so set frag_offset = 0 and frag_len = hs_len for now */
-            memset( ssl->out_msg + 6, 0x00, 3 );
+            mbedtls_platform_memset( ssl->out_msg + 6, 0x00, 3 );
             memcpy( ssl->out_msg + 9, ssl->out_msg + 1, 3 );
         }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
@@ -4712,7 +4712,7 @@ static void ssl_bitmask_set( unsigned char *mask, size_t offset, size_t len )
             mask[last_byte_idx] |= 1 << ( 8 - end_bits );
     }
 
-    memset( mask + offset / 8, 0xFF, len / 8 );
+    mbedtls_platform_memset( mask + offset / 8, 0xFF, len / 8 );
 }
 
 /*
@@ -4886,7 +4886,7 @@ void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl )
         }
 
         /* Create a fresh last entry */
-        memset( hs_buf, 0, sizeof( mbedtls_ssl_hs_buffer ) );
+        mbedtls_platform_memset( hs_buf, 0, sizeof( mbedtls_ssl_hs_buffer ) );
     }
 #endif
 }
@@ -6003,7 +6003,7 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
                 /* Prepare final header: copy msg_type, length and message_seq,
                  * then add standardised fragment_offset and fragment_length */
                 memcpy( hs_buf->data, ssl->in_msg, 6 );
-                memset( hs_buf->data + 6, 0, 3 );
+                mbedtls_platform_memset( hs_buf->data + 6, 0, 3 );
                 memcpy( hs_buf->data + 9, hs_buf->data + 1, 3 );
 
                 hs_buf->is_valid = 1;
@@ -7594,7 +7594,7 @@ int mbedtls_ssl_parse_change_cipher_spec( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 #if defined(MBEDTLS_SSL_PROTO_TLS)
     {
-        memset( ssl->in_ctr, 0, 8 );
+        mbedtls_platform_memset( ssl->in_ctr, 0, 8 );
     }
 #endif
 
@@ -7799,7 +7799,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
         memcpy( ssl->handshake->alt_out_ctr, ssl->cur_out_ctr, 8 );
 
         /* Set sequence_number to zero */
-        memset( ssl->cur_out_ctr + 2, 0, 6 );
+        mbedtls_platform_memset( ssl->cur_out_ctr + 2, 0, 6 );
 
         /* Increment epoch */
         for( i = 2; i > 0; i-- )
@@ -7817,7 +7817,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 #if defined(MBEDTLS_SSL_PROTO_TLS)
     {
-        memset( ssl->cur_out_ctr, 0, 8 );
+        mbedtls_platform_memset( ssl->cur_out_ctr, 0, 8 );
     }
 #endif
 
@@ -7955,7 +7955,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 
 static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 {
-    memset( handshake, 0, sizeof( mbedtls_ssl_handshake_params ) );
+    mbedtls_platform_memset( handshake, 0, sizeof( mbedtls_ssl_handshake_params ) );
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
@@ -8010,7 +8010,7 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 
 void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform )
 {
-    memset( transform, 0, sizeof(mbedtls_ssl_transform) );
+    mbedtls_platform_memset( transform, 0, sizeof(mbedtls_ssl_transform) );
 
     mbedtls_cipher_init( &transform->cipher_ctx_enc );
     mbedtls_cipher_init( &transform->cipher_ctx_dec );
@@ -8023,7 +8023,7 @@ void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform )
 
 void mbedtls_ssl_session_init( mbedtls_ssl_session *session )
 {
-    memset( session, 0, sizeof(mbedtls_ssl_session) );
+    mbedtls_platform_memset( session, 0, sizeof(mbedtls_ssl_session) );
 }
 
 static int ssl_handshake_init( mbedtls_ssl_context *ssl )
@@ -8226,7 +8226,7 @@ static void ssl_update_in_pointers( mbedtls_ssl_context *ssl )
  */
 void mbedtls_ssl_init( mbedtls_ssl_context *ssl )
 {
-    memset( ssl, 0, sizeof( mbedtls_ssl_context ) );
+    mbedtls_platform_memset( ssl, 0, sizeof( mbedtls_ssl_context ) );
 }
 
 /*
@@ -8348,8 +8348,8 @@ static int ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl->renego_records_seen = 0;
 
     ssl->verify_data_len = 0;
-    memset( ssl->own_verify_data, 0, MBEDTLS_SSL_VERIFY_DATA_MAX_LEN );
-    memset( ssl->peer_verify_data, 0, MBEDTLS_SSL_VERIFY_DATA_MAX_LEN );
+    mbedtls_platform_memset( ssl->own_verify_data, 0, MBEDTLS_SSL_VERIFY_DATA_MAX_LEN );
+    mbedtls_platform_memset( ssl->peer_verify_data, 0, MBEDTLS_SSL_VERIFY_DATA_MAX_LEN );
 #endif
     ssl->secure_renegotiation = MBEDTLS_SSL_LEGACY_RENEGOTIATION;
 
@@ -8379,7 +8379,7 @@ static int ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
         ssl->split_done = 0;
 #endif
 
-    memset( ssl->cur_out_ctr, 0, sizeof( ssl->cur_out_ctr ) );
+    mbedtls_platform_memset( ssl->cur_out_ctr, 0, sizeof( ssl->cur_out_ctr ) );
 
     ssl->transform_in = NULL;
     ssl->transform_out = NULL;
@@ -8387,14 +8387,14 @@ static int ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
     ssl->session_in = NULL;
     ssl->session_out = NULL;
 
-    memset( ssl->out_buf, 0, MBEDTLS_SSL_OUT_BUFFER_LEN );
+    mbedtls_platform_memset( ssl->out_buf, 0, MBEDTLS_SSL_OUT_BUFFER_LEN );
 
 #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && defined(MBEDTLS_SSL_SRV_C)
     if( partial == 0 )
 #endif /* MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE && MBEDTLS_SSL_SRV_C */
     {
         ssl->in_left = 0;
-        memset( ssl->in_buf, 0, MBEDTLS_SSL_IN_BUFFER_LEN );
+        mbedtls_platform_memset( ssl->in_buf, 0, MBEDTLS_SSL_IN_BUFFER_LEN );
     }
 
 #if defined(MBEDTLS_SSL_HW_RECORD_ACCEL)
@@ -10992,7 +10992,7 @@ static void ssl_buffering_free_slot( mbedtls_ssl_context *ssl,
         hs->buffering.total_bytes_buffered -= hs_buf->data_len;
         mbedtls_platform_zeroize( hs_buf->data, hs_buf->data_len );
         mbedtls_free( hs_buf->data );
-        memset( hs_buf, 0, sizeof( mbedtls_ssl_hs_buffer ) );
+        mbedtls_platform_memset( hs_buf, 0, sizeof( mbedtls_ssl_hs_buffer ) );
     }
 }
 
@@ -11773,7 +11773,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
  */
 void mbedtls_ssl_config_init( mbedtls_ssl_config *conf )
 {
-    memset( conf, 0, sizeof( mbedtls_ssl_config ) );
+    mbedtls_platform_memset( conf, 0, sizeof( mbedtls_ssl_config ) );
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS)
     conf->transport = MBEDTLS_SSL_TRANSPORT_DATAGRAM;
@@ -11908,8 +11908,8 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     conf->renego_max_records = MBEDTLS_SSL_RENEGO_MAX_RECORDS_DEFAULT;
-    memset( conf->renego_period,     0x00, 2 );
-    memset( conf->renego_period + 2, 0xFF, 6 );
+    mbedtls_platform_memset( conf->renego_period,     0x00, 2 );
+    mbedtls_platform_memset( conf->renego_period + 2, 0xFF, 6 );
 #endif
 
 #if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_SRV_C)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4712,7 +4712,7 @@ static void ssl_bitmask_set( unsigned char *mask, size_t offset, size_t len )
             mask[last_byte_idx] |= 1 << ( 8 - end_bits );
     }
 
-    mbedtls_platform_memset( mask + offset / 8, 0xFF, len / 8 );
+    memset( mask + offset / 8, 0xFF, len / 8 );
 }
 
 /*
@@ -7799,7 +7799,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
         memcpy( ssl->handshake->alt_out_ctr, ssl->cur_out_ctr, 8 );
 
         /* Set sequence_number to zero */
-        mbedtls_platform_memset( ssl->cur_out_ctr + 2, 0, 6 );
+        memset( ssl->cur_out_ctr + 2, 0, 6 );
 
         /* Increment epoch */
         for( i = 2; i > 0; i-- )
@@ -8379,7 +8379,7 @@ static int ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial )
         ssl->split_done = 0;
 #endif
 
-    mbedtls_platform_memset( ssl->cur_out_ctr, 0, sizeof( ssl->cur_out_ctr ) );
+    memset( ssl->cur_out_ctr, 0, sizeof( ssl->cur_out_ctr ) );
 
     ssl->transform_in = NULL;
     ssl->transform_out = NULL;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7955,7 +7955,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 
 static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 {
-    mbedtls_platform_memset( handshake, 0, sizeof( mbedtls_ssl_handshake_params ) );
+    memset( handshake, 0, sizeof( mbedtls_ssl_handshake_params ) );
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
@@ -8010,7 +8010,7 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
 
 void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform )
 {
-    mbedtls_platform_memset( transform, 0, sizeof(mbedtls_ssl_transform) );
+    memset( transform, 0, sizeof(mbedtls_ssl_transform) );
 
     mbedtls_cipher_init( &transform->cipher_ctx_enc );
     mbedtls_cipher_init( &transform->cipher_ctx_dec );
@@ -8023,7 +8023,7 @@ void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform )
 
 void mbedtls_ssl_session_init( mbedtls_ssl_session *session )
 {
-    mbedtls_platform_memset( session, 0, sizeof(mbedtls_ssl_session) );
+    memset( session, 0, sizeof(mbedtls_ssl_session) );
 }
 
 static int ssl_handshake_init( mbedtls_ssl_context *ssl )
@@ -8226,7 +8226,7 @@ static void ssl_update_in_pointers( mbedtls_ssl_context *ssl )
  */
 void mbedtls_ssl_init( mbedtls_ssl_context *ssl )
 {
-    mbedtls_platform_memset( ssl, 0, sizeof( mbedtls_ssl_context ) );
+    memset( ssl, 0, sizeof( mbedtls_ssl_context ) );
 }
 
 /*
@@ -11773,7 +11773,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
  */
 void mbedtls_ssl_config_init( mbedtls_ssl_config *conf )
 {
-    mbedtls_platform_memset( conf, 0, sizeof( mbedtls_ssl_config ) );
+    memset( conf, 0, sizeof( mbedtls_ssl_config ) );
 
 #if !defined(MBEDTLS_SSL_PROTO_TLS)
     conf->transport = MBEDTLS_SSL_TRANSPORT_DATAGRAM;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3376,7 +3376,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             const size_t max_len = rec->data_len + padlen;
             const size_t min_len = ( max_len > 256 ) ? max_len - 256 : 0;
 
-            mbedtls_platform_memset( tmp, 0, sizeof( tmp ) );
+            memset( tmp, 0, sizeof( tmp ) );
 
             switch( mbedtls_md_get_type(
                         mbedtls_md_get_handle( &transform->md_ctx_dec ) ) )

--- a/library/x509.c
+++ b/library/x509.c
@@ -943,7 +943,7 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn )
     const char *short_name = NULL;
     char s[MBEDTLS_X509_MAX_DN_NAME_SIZE], *p;
 
-    mbedtls_platform_memset( s, 0, sizeof( s ) );
+    memset( s, 0, sizeof( s ) );
 
     name = dn;
     p = buf;

--- a/library/x509.c
+++ b/library/x509.c
@@ -650,7 +650,7 @@ int mbedtls_x509_get_name( unsigned char *p,
                            mbedtls_x509_name *cur )
 {
     mbedtls_x509_buf_raw name_buf = { p, len };
-    memset( cur, 0, sizeof( mbedtls_x509_name ) );
+    mbedtls_platform_memset( cur, 0, sizeof( mbedtls_x509_name ) );
     return( mbedtls_x509_name_cmp_raw( &name_buf, &name_buf,
                                        x509_get_name_cb,
                                        &cur ) );
@@ -943,7 +943,7 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn )
     const char *short_name = NULL;
     char s[MBEDTLS_X509_MAX_DN_NAME_SIZE], *p;
 
-    memset( s, 0, sizeof( s ) );
+    mbedtls_platform_memset( s, 0, sizeof( s ) );
 
     name = dn;
     p = buf;

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -313,9 +313,9 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
     if( crl == NULL || buf == NULL )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
 
-    memset( &sig_params1, 0, sizeof( mbedtls_x509_buf ) );
-    memset( &sig_params2, 0, sizeof( mbedtls_x509_buf ) );
-    memset( &sig_oid2, 0, sizeof( mbedtls_x509_buf ) );
+    mbedtls_platform_memset( &sig_params1, 0, sizeof( mbedtls_x509_buf ) );
+    mbedtls_platform_memset( &sig_params2, 0, sizeof( mbedtls_x509_buf ) );
+    mbedtls_platform_memset( &sig_oid2, 0, sizeof( mbedtls_x509_buf ) );
 
     /*
      * Add new CRL on the end of the chain if needed.
@@ -709,7 +709,7 @@ int mbedtls_x509_crl_info( char *buf, size_t size, const char *prefix,
  */
 void mbedtls_x509_crl_init( mbedtls_x509_crl *crl )
 {
-    memset( crl, 0, sizeof(mbedtls_x509_crl) );
+    mbedtls_platform_memset( crl, 0, sizeof(mbedtls_x509_crl) );
 }
 
 /*

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -292,7 +292,7 @@ int mbedtls_x509_crt_cache_provide_pk( mbedtls_x509_crt const *crt )
 
 static void x509_crt_cache_init( mbedtls_x509_crt_cache *cache )
 {
-    memset( cache, 0, sizeof( *cache ) );
+    mbedtls_platform_memset( cache, 0, sizeof( *cache ) );
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &cache->frame_mutex );
     mbedtls_mutex_init( &cache->pk_mutex );
@@ -332,7 +332,7 @@ static void x509_crt_cache_free( mbedtls_x509_crt_cache *cache )
     x509_crt_cache_clear_frame( cache );
     x509_crt_cache_clear_pk( cache );
 
-    memset( cache, 0, sizeof( *cache ) );
+    mbedtls_platform_memset( cache, 0, sizeof( *cache ) );
 }
 
 #if !defined(MBEDTLS_X509_REMOVE_HOSTNAME_VERIFICATION)
@@ -1182,7 +1182,7 @@ static int x509_crt_parse_frame( unsigned char *start,
     size_t inner_sig_alg_len;
     unsigned char *inner_sig_alg_start;
 
-    memset( frame, 0, sizeof( *frame ) );
+    mbedtls_platform_memset( frame, 0, sizeof( *frame ) );
 
     /*
      * Certificate  ::=  SEQUENCE {
@@ -1484,7 +1484,7 @@ static int x509_crt_subject_alt_from_frame( mbedtls_x509_crt_frame const *frame,
     unsigned char *p   = frame->subject_alt_raw.p;
     unsigned char *end = p + frame->subject_alt_raw.len;
 
-    memset( subject_alt, 0, sizeof( *subject_alt ) );
+    mbedtls_platform_memset( subject_alt, 0, sizeof( *subject_alt ) );
 
     if( ( frame->ext_types & MBEDTLS_X509_EXT_SUBJECT_ALT_NAME ) == 0 )
         return( 0 );
@@ -1503,7 +1503,7 @@ static int x509_crt_ext_key_usage_from_frame( mbedtls_x509_crt_frame const *fram
     unsigned char *p   = frame->ext_key_usage_raw.p;
     unsigned char *end = p + frame->ext_key_usage_raw.len;
 
-    memset( ext_key_usage, 0, sizeof( *ext_key_usage ) );
+    mbedtls_platform_memset( ext_key_usage, 0, sizeof( *ext_key_usage ) );
 
     if( ( frame->ext_types & MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE ) == 0 )
         return( 0 );
@@ -1940,8 +1940,8 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     if( len > MAX_PATH - 3 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
 
-    memset( szDir, 0, sizeof(szDir) );
-    memset( filename, 0, MAX_PATH );
+    mbedtls_platform_memset( szDir, 0, sizeof(szDir) );
+    mbedtls_platform_memset( filename, 0, MAX_PATH );
     memcpy( filename, path, len );
     filename[len++] = '\\';
     p = filename + len;
@@ -1959,7 +1959,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path )
     len = MAX_PATH - len;
     do
     {
-        memset( p, 0, len );
+        mbedtls_platform_memset( p, 0, len );
 
         if( file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY )
             continue;
@@ -2271,7 +2271,7 @@ int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
     p = buf;
     n = size;
 
-    memset( &sig_info, 0, sizeof( mbedtls_x509_crt_sig_info ) );
+    mbedtls_platform_memset( &sig_info, 0, sizeof( mbedtls_x509_crt_sig_info ) );
     mbedtls_pk_init( &pk );
 
     if( NULL == crt )
@@ -3834,7 +3834,7 @@ exit:
  */
 void mbedtls_x509_crt_init( mbedtls_x509_crt *crt )
 {
-    memset( crt, 0, sizeof(mbedtls_x509_crt) );
+    mbedtls_platform_memset( crt, 0, sizeof(mbedtls_x509_crt) );
 }
 
 /*

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2271,7 +2271,7 @@ int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
     p = buf;
     n = size;
 
-    mbedtls_platform_memset( &sig_info, 0, sizeof( mbedtls_x509_crt_sig_info ) );
+    memset( &sig_info, 0, sizeof( mbedtls_x509_crt_sig_info ) );
     mbedtls_pk_init( &pk );
 
     if( NULL == crt )

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -292,7 +292,7 @@ int mbedtls_x509_crt_cache_provide_pk( mbedtls_x509_crt const *crt )
 
 static void x509_crt_cache_init( mbedtls_x509_crt_cache *cache )
 {
-    mbedtls_platform_memset( cache, 0, sizeof( *cache ) );
+    memset( cache, 0, sizeof( *cache ) );
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_init( &cache->frame_mutex );
     mbedtls_mutex_init( &cache->pk_mutex );
@@ -3834,7 +3834,7 @@ exit:
  */
 void mbedtls_x509_crt_init( mbedtls_x509_crt *crt )
 {
-    mbedtls_platform_memset( crt, 0, sizeof(mbedtls_x509_crt) );
+    memset( crt, 0, sizeof(mbedtls_x509_crt) );
 }
 
 /*

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -96,7 +96,7 @@ int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
     unsigned char *p, *end;
     mbedtls_x509_buf sig_params;
 
-    memset( &sig_params, 0, sizeof( mbedtls_x509_buf ) );
+    mbedtls_platform_memset( &sig_params, 0, sizeof( mbedtls_x509_buf ) );
 
     /*
      * Check for valid input
@@ -383,7 +383,7 @@ int mbedtls_x509_csr_info( char *buf, size_t size, const char *prefix,
  */
 void mbedtls_x509_csr_init( mbedtls_x509_csr *csr )
 {
-    memset( csr, 0, sizeof(mbedtls_x509_csr) );
+    mbedtls_platform_memset( csr, 0, sizeof(mbedtls_x509_csr) );
 }
 
 /*

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -58,7 +58,7 @@
 
 void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_x509write_cert ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_x509write_cert ) );
 
     mbedtls_mpi_init( &ctx->serial );
     ctx->version = MBEDTLS_X509_CRT_VERSION_3;
@@ -150,7 +150,7 @@ int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
     unsigned char *c = buf + sizeof(buf);
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    mbedtls_platform_memset( buf, 0, sizeof(buf) );
 
     if( is_ca && max_pathlen > 127 )
         return( MBEDTLS_ERR_X509_BAD_INPUT_DATA );
@@ -181,7 +181,7 @@ int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ct
     unsigned char *c = buf + sizeof(buf);
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    mbedtls_platform_memset( buf, 0, sizeof(buf) );
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_pk_write_pubkey( &c, buf, ctx->subject_key ) );
 
     ret = mbedtls_sha1_ret( buf + sizeof( buf ) - len, len,
@@ -206,7 +206,7 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
     unsigned char *c = buf + sizeof( buf );
     size_t len = 0;
 
-    memset( buf, 0, sizeof(buf) );
+    mbedtls_platform_memset( buf, 0, sizeof(buf) );
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_pk_write_pubkey( &c, buf, ctx->issuer_key ) );
 
     ret = mbedtls_sha1_ret( buf + sizeof( buf ) - len, len,

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -57,7 +57,7 @@
 
 void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_x509write_csr ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_x509write_csr ) );
 }
 
 void mbedtls_x509write_csr_free( mbedtls_x509write_csr *ctx )

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -68,7 +68,7 @@
 
 void mbedtls_xtea_init( mbedtls_xtea_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_xtea_context ) );
+    mbedtls_platform_memset( ctx, 0, sizeof( mbedtls_xtea_context ) );
 }
 
 void mbedtls_xtea_free( mbedtls_xtea_context *ctx )
@@ -86,7 +86,7 @@ void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] 
 {
     int i;
 
-    memset( ctx, 0, sizeof(mbedtls_xtea_context) );
+    mbedtls_platform_memset( ctx, 0, sizeof(mbedtls_xtea_context) );
 
     for( i = 0; i < 4; i++ )
     {

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -80,6 +80,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -82,6 +82,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -52,6 +52,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 static int generic_wrapper( mbedtls_md_handle_t md_info, char *filename, unsigned char *sum )
 {

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -48,6 +48,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -72,6 +72,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -69,6 +69,18 @@ int main( void )
  */
 #define GENERATOR "4"
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char **argv )
 {

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -72,6 +72,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -100,6 +100,18 @@ static void dump_pubkey( const char *title, mbedtls_ecdsa_context *key )
 #define dump_pubkey( a, b )
 #endif
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -137,6 +137,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -74,6 +74,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -99,6 +99,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * global options

--- a/programs/pkey/mpi_demo.c
+++ b/programs/pkey/mpi_demo.c
@@ -50,6 +50,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -60,6 +60,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -61,6 +61,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -61,6 +61,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 /*
  * For the currently used signature algorithms the buffer to store any signature

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -57,6 +57,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -59,6 +59,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -59,6 +59,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -64,6 +64,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( void )
 {

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -56,6 +56,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -60,6 +60,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -55,6 +55,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -60,6 +60,18 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -51,6 +51,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -54,6 +54,18 @@ int main( void )
 }
 #else
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -109,6 +109,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret, len;

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -118,6 +118,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret, len;

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -180,6 +180,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = exit_ok;

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,6 +2666,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
+#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
+    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
+
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,14 +2666,6 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
-#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
-    {
-        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
-        return( 0 );
-    }
-#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
-
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -99,6 +99,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = 1, len;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -925,6 +925,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 0, len, tail_len, i, written, frags, retry_left;

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -116,6 +116,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret = 1, len, cnt = 0, pid;

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -375,6 +375,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1, len;

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -111,6 +111,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( void )
 {
     int ret, len;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1536,6 +1536,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 0, len, written, frags, exchanges_left;

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -258,6 +258,18 @@ typedef struct {
          rsa, dhm, ecdsa, ecdh;
 } todo_list;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
 
 int main( int argc, char *argv[] )
 {

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -279,6 +279,19 @@ const selftest_t selftests[] =
 };
 #endif /* MBEDTLS_SELF_TEST */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
 #if defined(MBEDTLS_SELF_TEST)

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -79,6 +79,19 @@ int main( void )
 #include <unistd.h>
 #endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 #define MAX_MSG_SIZE            16384 + 2048 /* max record/datagram size */
 
 #define DFL_SERVER_ADDR         "localhost"

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -59,19 +59,6 @@ void usage( void )
     mbedtls_printf( "       zeroize <FILE>\n" );
 }
 
-#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
-int mbedtls_hardware_poll( void *data, unsigned char *output,
-                           size_t len, size_t *olen )
-{
-    size_t i;
-    (void) data;
-    for( i = 0; i < len; ++i )
-        output[i] = rand();
-    *olen = len;
-    return( 0 );
-}
-#endif
-
 int main( int argc, char** argv )
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;
@@ -112,3 +99,16 @@ int main( int argc, char** argv )
 
     return( exit_code );
 }
+
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -59,6 +59,19 @@ void usage( void )
     mbedtls_printf( "       zeroize <FILE>\n" );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char** argv )
 {
     int exit_code = MBEDTLS_EXIT_FAILURE;

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -165,6 +165,19 @@ int rng_wrap( void *ctx, unsigned char *dst, size_t len )
 }
 #endif /* MBEDTLS_SSL_CONF_RNG */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -154,6 +154,19 @@ int write_certificate_request( mbedtls_x509write_csr *req, const char *output_fi
     return( 0 );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -214,6 +214,19 @@ int write_certificate( mbedtls_x509write_cert *crt, const char *output_file,
     return( 0 );
 }
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -72,6 +72,19 @@ struct options
     const char *filename;       /* filename of the certificate file     */
 } opt;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -72,6 +72,19 @@ struct options
     const char *filename;       /* filename of the certificate request  */
 } opt;
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    size_t i;
+    (void) data;
+    for( i = 0; i < len; ++i )
+        output[i] = rand();
+    *olen = len;
+    return( 0 );
+}
+#endif
+
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -51,7 +51,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     if( buflen == 0 )
         return;
 
-    memset( buf, 0x00, buflen );
+    mbedtls_platform_memset( buf, 0x00, buflen );
 
     if( ret < 0 )
         ret = -ret;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -28,6 +28,7 @@
 #if defined(MBEDTLS_ERROR_C) || defined(MBEDTLS_ERROR_STRERROR_DUMMY)
 #include "mbedtls/error.h"
 #include <string.h>
+#include "mbedtls/platform_util.h"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_C)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1561,6 +1561,16 @@ component_test_baremetal () {
     if_build_succeeded tests/ssl-opt.sh --filter "^Default, DTLS$"
 }
 
+component_test_hardware_entropy () {
+    msg "build: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
+    scripts/config.pl set MBEDTLS_ENTROPY_HARDWARE_ALT
+    make CFLAGS='-Werror -O1'
+
+    msg "test: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
+    if_build_succeeded make test
+    if_build_succeeded tests/ssl-opt.sh --filter "^Default, DTLS$"
+}
+
 component_test_allow_sha1 () {
     msg "build: allow SHA1 in certificates by default"
     scripts/config.pl set MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -426,7 +426,9 @@ $text"
                 ;;
             *)
                 record_status command make "$@"
-                build_status=$last_status
+                if [ $build_status -eq 0 ]; then
+                    build_status=$last_status
+                fi
                 ;;
         esac
     }
@@ -1564,7 +1566,8 @@ component_test_baremetal () {
 component_test_hardware_entropy () {
     msg "build: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
     scripts/config.pl set MBEDTLS_ENTROPY_HARDWARE_ALT
-    make CFLAGS='-Werror -O1'
+    make CFLAGS='-Werror -O1' lib tests
+    make CFLAGS='-Werror -O1' -C programs ssl/ssl_server2 ssl/ssl_client2 test/udp_proxy
 
     msg "test: default config + MBEDTLS_ENTROPY_HARDWARE_ALT"
     if_build_succeeded make test

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -561,6 +561,16 @@ static int uecc_rng_wrapper( uint8_t *dest, unsigned int size )
 }
 #endif /* MBEDTLS_USE_TINYCRYPT */
 
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+int mbedtls_hardware_poll( void *data, unsigned char *output,
+                           size_t len, size_t *olen )
+{
+    (void) data;
+    *olen = len;
+    return( rnd_std_rand( NULL, output, len ) );
+}
+#endif
+
 /**
  * This function only returns zeros
  *

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -105,7 +105,7 @@ int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 				       _public + curve->num_words);
 
 		/* erasing temporary buffer used to store secret: */
-		memset(_private, 0, NUM_ECC_BYTES);
+		mbedtls_platform_memset(_private, 0, NUM_ECC_BYTES);
 
 		return 1;
 	}
@@ -146,7 +146,7 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key, uECC_Curve curve)
 					       _public + curve->num_words);
 
 			/* erasing temporary buffer that stored secret: */
-			memset(_private, 0, NUM_ECC_BYTES);
+			mbedtls_platform_memset(_private, 0, NUM_ECC_BYTES);
 
       			return 1;
     		}


### PR DESCRIPTION
## Description

This PR makes sure that the function `mbedtls_platform_memset()` introduced by #2870 is used in all relevant places in the library, while trying to minimise the impact on code size. It does that in two steps:

1. Replace `memset()` with `mbedtls_platform_memset()` everywhere.
2. Revert to `memset()` in places that are identified as safe and relevant with `config/baremetal.h`.

Impact on code size (sum of the three libraries in bytes, with armcc 5):

| | total | diff from previous line | diff from first line |
| --- | --- | --- | --- |
| before this PR | 43572 | | |
| after step 1 | 43672 | +100 | +100 |
| after step 2 | 43724 | -48 | +52 |

__Note to gatekeeper:__ This PR is based on #2870 which needs to be merged first.

__Note to reviewers:__ The first commit in this PR (not in #2870) is "Replace memset() with mbedtls_platform_memset()". Earlier commits need not be reviewed here.

_See also:_ Siblings PRs #2876 and #2880 do the same for `memcpy()` and `memcmp()` respectively.

## Status
**READY**
