### PR TITLE
[Baremetal] Use mbedtls_platform_memcmp instead of memcmp for critical data in baremetal

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -130,11 +130,11 @@
  */
 #define MBEDTLS_OID_CMP(oid_str, oid_buf)                                   \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf)->len ) ||                \
-          memcmp( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
+          mbedtls_platform_memcmp( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
 
 #define MBEDTLS_OID_CMP_RAW(oid_str, oid_buf, oid_buf_len)                  \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf_len) ) ||                 \
-          memcmp( (oid_str), (oid_buf), (oid_buf_len) ) != 0 )
+          mbedtls_platform_memcmp( (oid_str), (oid_buf), (oid_buf_len) ) != 0 )
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/compat-1.3.h
+++ b/include/mbedtls/compat-1.3.h
@@ -2231,7 +2231,7 @@
 #define rsa_rsassa_pss_verify_ext mbedtls_rsa_rsassa_pss_verify_ext
 #define rsa_self_test mbedtls_rsa_self_test
 #define rsa_set_padding mbedtls_rsa_set_padding
-#define safer_memcmp mbedtls_ssl_safer_memcmp
+#define safer_memcmp mbedtls_platform_memcmp
 #define set_alarm mbedtls_set_alarm
 #define sha1 mbedtls_sha1
 #define sha1_context mbedtls_sha1_context

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3683,6 +3683,14 @@
  */
 //#define MBEDTLS_PLATFORM_GMTIME_R_ALT
 
+/**
+ * Uncomment the macro to let Mbed TLS use a platform implementation of
+ * global RNG.
+ *
+ * By default the global RNG function will be a no-op.
+ */
+//#define MBEDTLS_PLATFORM_GLOBAL_RNG
+
 /* \} name SECTION: Customisation configuration options */
 
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -170,7 +170,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
-size_t mbedtls_random_in_range( size_t num );
+size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,6 +164,14 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+void mbedtls_platform_memset( void *ptr, int value, size_t num );
+
+void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+
+int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
+
+size_t mbedtls_random_in_range( size_t num );
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -228,7 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  * \param num   Max-value for the generated random number.
  *
  */ 
-size_t mbedtls_platform_random_in_range( size_t num );
+uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -225,8 +225,9 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              cryptographically secure RNG, but provide an RNG for utility
  *              functions.
  *
- * \param num   Max-value for the generated random number.
- *
+ * \param num   Max-value for the generated random number, exclusive.
+ *              The generated number will be on range [0, num).
+ * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -178,8 +178,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
  *
+ * \return      The value of \p ptr.
  */
-void mbedtls_platform_memset( void *ptr, int value, size_t num );
+void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 
 /**
  * \brief       Secure memcpy
@@ -195,8 +196,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num );
  * \param src   Source buffer where the data is being copied from.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      The value of \p dst.
  */
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
 /**
  * \brief       Secure memcmp

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -164,12 +164,70 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  */
 void mbedtls_platform_zeroize( void *buf, size_t len );
 
+/**
+ * \brief       Secure memset
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memset. It starts by initialising the given memory area
+ *              from random tail location with random data. After tail is
+ *              initialised, the remaining head of the buffer is initialised
+ *              with random data. After initialisation, the original memset
+ *              is performed
+ *
+ * \param ptr   Buffer to be set.
+ * \param value Value to be used when setting the buffer.
+ * \param num   The length of the buffer in bytes.
+ * 
+ */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 
+/**
+ * \brief       Secure memcpy
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcpy. It starts by initialising the given memory area
+ *              with random data. After initialisation, the original memcpy
+ *              is performed by starting first copying from random tail
+ *              location of the buffer. After tail has been copied, the
+ *              remaining head is copied as well.
+ *
+ * \param dst   Destination buffer where the data is being copied to.
+ * \param src   Source buffer where the data is being copied from.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 
+/**
+ * \brief       Secure memcmp
+ *
+ *              This function is meant to provide a more secure way to do
+ *              memcmp. It starts comparing from a random offset and goes
+ *              through the tail part of buffers first byte by byte. After
+ *              that it starts going through the head part of buffer. In the
+ *              end, the number of equal bytes is compared to the length of the
+ *              buffers, thus making the function a fixed time memcmp.
+ *
+ * \param buf1  First buffer to compare.
+ * \param buf2  Second buffer to compare against.
+ * \param num   The length of the buffers in bytes.
+ *
+ */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
+/**
+ * \brief       A global RNG-function
+ *
+ *              This function is meant to provide a global RNG to be used
+ *              throughout Mbed TLS for hardening the library. It is used
+ *              for generating a random delay, random data or random offset
+ *              for utility functions. It is not meant to be a
+ *              cryptographically secure RNG, but provide an RNG for utility
+ *              functions.
+ *
+ * \param num   Max-value for the generated random number.
+ *
+ */ 
 size_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -212,6 +212,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
  * \param buf2  Second buffer to compare against.
  * \param num   The length of the buffers in bytes.
  *
+ * \return      0 if the buffers were equal.
  */
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 
@@ -227,6 +228,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *
  * \param num   Max-value for the generated random number, exclusive.
  *              The generated number will be on range [0, num).
+ *
  * \return      The generated random number.
  */ 
 uint32_t mbedtls_platform_random_in_range( size_t num );

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -177,7 +177,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param ptr   Buffer to be set.
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
- * 
+ *
  */
 void mbedtls_platform_memset( void *ptr, int value, size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -230,7 +230,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
  *              The generated number will be on range [0, num).
  *
  * \return      The generated random number.
- */ 
+ */
 uint32_t mbedtls_platform_random_in_range( size_t num );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -1159,26 +1159,6 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
                               const mbedtls_ssl_session *src );
 
-/* constant-time buffer comparison */
-static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )
-{
-    size_t i;
-    volatile const unsigned char *A = (volatile const unsigned char *) a;
-    volatile const unsigned char *B = (volatile const unsigned char *) b;
-    volatile unsigned char diff = 0;
-
-    for( i = 0; i < n; i++ )
-    {
-        /* Read volatile data in order before computing diff.
-         * This avoids IAR compiler warning:
-         * 'the order of volatile accesses is undefined ..' */
-        unsigned char x = A[i], y = B[i];
-        diff |= x ^ y;
-    }
-
-    return( diff );
-}
-
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
 int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -431,7 +431,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *
     while( list != NULL )
     {
         if( list->oid.len == len &&
-            memcmp( list->oid.p, oid, len ) == 0 )
+            mbedtls_platform_memcmp( list->oid.p, oid, len ) == 0 )
         {
             break;
         }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -28,12 +28,12 @@
 #if defined(MBEDTLS_ASN1_WRITE_C)
 
 #include "mbedtls/asn1write.h"
+#include "mbedtls/platform_util.h"
 
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#include "mbedtls/platform_util.h"
 #else
 #include <stdlib.h>
 #define mbedtls_calloc    calloc

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -347,7 +347,7 @@ static mbedtls_asn1_named_data *asn1_find_named_data(
     while( list != NULL )
     {
         if( list->oid.len == len &&
-            memcmp( list->oid.p, oid, len ) == 0 )
+            mbedtls_platform_memcmp( list->oid.p, oid, len ) == 0 )
         {
             break;
         }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -33,6 +33,7 @@
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
 #else
 #include <stdlib.h>
 #define mbedtls_calloc    calloc

--- a/library/base64.c
+++ b/library/base64.c
@@ -260,7 +260,7 @@ int mbedtls_base64_self_test( int verbose )
     src = base64_test_dec;
 
     if( mbedtls_base64_encode( buffer, sizeof( buffer ), &len, src, 64 ) != 0 ||
-         memcmp( base64_test_enc, buffer, 88 ) != 0 )
+            memcmp( base64_test_enc, buffer, 88 ) != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );
@@ -274,7 +274,7 @@ int mbedtls_base64_self_test( int verbose )
     src = base64_test_enc;
 
     if( mbedtls_base64_decode( buffer, sizeof( buffer ), &len, src, 88 ) != 0 ||
-         memcmp( base64_test_dec, buffer, 64 ) != 0 )
+            memcmp( base64_test_dec, buffer, 64 ) != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -505,7 +505,7 @@ int mbedtls_ccm_self_test( int verbose )
                                            ciphertext + msg_len[i], tag_len[i] );
 
         if( ret != 0 ||
-            memcmp( ciphertext, res[i], msg_len[i] + tag_len[i] ) != 0 )
+                memcmp( ciphertext, res[i], msg_len[i] + tag_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
@@ -520,7 +520,7 @@ int mbedtls_ccm_self_test( int verbose )
                                         ciphertext + msg_len[i], tag_len[i] );
 
         if( ret != 0 ||
-            memcmp( plaintext, msg, msg_len[i] ) != 0 )
+                memcmp( plaintext, msg, msg_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -902,7 +902,7 @@ static int test_aes128_cmac_prf( int verbose )
         mbedtls_printf( "  AES CMAC 128 PRF #%u: ", i );
         ret = mbedtls_aes_cmac_prf_128( PRFK, PRFKlen[i], PRFM, 20, output );
         if( ret != 0 ||
-            memcmp( output, PRFT[i], MBEDTLS_AES_BLOCK_SIZE ) != 0 )
+                memcmp( output, PRFT[i], MBEDTLS_AES_BLOCK_SIZE ) != 0 )
         {
 
             if( verbose != 0 )

--- a/library/des.c
+++ b/library/des.c
@@ -417,7 +417,7 @@ int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
     int i;
 
     for( i = 0; i < WEAK_KEY_COUNT; i++ )
-        if( memcmp( weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0 )
+        if( mbedtls_platform_memcmp( weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0 )
             return( 1 );
 
     return( 0 );
@@ -939,7 +939,7 @@ int mbedtls_des_self_test( int verbose )
         if( ( v == MBEDTLS_DES_DECRYPT &&
                 memcmp( buf, des3_test_ecb_dec[u], 8 ) != 0 ) ||
             ( v != MBEDTLS_DES_DECRYPT &&
-                memcmp( buf, des3_test_ecb_enc[u], 8 ) != 0 ) )
+                    memcmp( buf, des3_test_ecb_enc[u], 8 ) != 0 ) )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
@@ -1035,7 +1035,7 @@ int mbedtls_des_self_test( int verbose )
         if( ( v == MBEDTLS_DES_DECRYPT &&
                 memcmp( buf, des3_test_cbc_dec[u], 8 ) != 0 ) ||
             ( v != MBEDTLS_DES_DECRYPT &&
-                memcmp( buf, des3_test_cbc_enc[u], 8 ) != 0 ) )
+                    memcmp( buf, des3_test_cbc_enc[u], 8 ) != 0 ) )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -823,7 +823,7 @@ int mbedtls_gcm_self_test( int verbose )
                 goto exit;
 
             if ( memcmp( buf, ct[j * 6 + i], pt_len[i] ) != 0 ||
-                 memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+                    memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
             {
                 ret = 1;
                 goto exit;
@@ -855,7 +855,7 @@ int mbedtls_gcm_self_test( int verbose )
                 goto exit;
 
             if( memcmp( buf, pt[pt_index[i]], pt_len[i] ) != 0 ||
-                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+                    memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
             {
                 ret = 1;
                 goto exit;
@@ -907,7 +907,7 @@ int mbedtls_gcm_self_test( int verbose )
                 goto exit;
 
             if( memcmp( buf, ct[j * 6 + i], pt_len[i] ) != 0 ||
-                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+                    memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
             {
                 ret = 1;
                 goto exit;
@@ -960,7 +960,7 @@ int mbedtls_gcm_self_test( int verbose )
                 goto exit;
 
             if( memcmp( buf, pt[pt_index[i]], pt_len[i] ) != 0 ||
-                memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
+                    memcmp( tag_buf, tag[j * 6 + i], 16 ) != 0 )
             {
                 ret = 1;
                 goto exit;

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -651,7 +651,7 @@ int mbedtls_nist_kw_self_test( int verbose )
         ret = mbedtls_nist_kw_wrap( &ctx, MBEDTLS_KW_MODE_KW, kw_msg[i],
                                     kw_msg_len[i], out, &olen, sizeof( out ) );
         if( ret != 0 || kw_out_len[i] != olen ||
-            memcmp( out, kw_res[i], kw_out_len[i] ) != 0 )
+                memcmp( out, kw_res[i], kw_out_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed. ");
@@ -674,7 +674,7 @@ int mbedtls_nist_kw_self_test( int verbose )
                                       out, olen, out, &olen, sizeof( out ) );
 
         if( ret != 0 || olen != kw_msg_len[i] ||
-            memcmp( out, kw_msg[i], kw_msg_len[i] ) != 0 )
+                memcmp( out, kw_msg[i], kw_msg_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
@@ -706,7 +706,7 @@ int mbedtls_nist_kw_self_test( int verbose )
                                     kwp_msg_len[i], out, &olen, sizeof( out ) );
 
         if( ret != 0 || kwp_out_len[i] != olen ||
-            memcmp( out, kwp_res[i], kwp_out_len[i] ) != 0 )
+                memcmp( out, kwp_res[i], kwp_out_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed. ");
@@ -729,7 +729,7 @@ int mbedtls_nist_kw_self_test( int verbose )
                                        olen, out, &olen, sizeof( out ) );
 
         if( ret != 0 || olen != kwp_msg_len[i] ||
-            memcmp( out, kwp_msg[i], kwp_msg_len[i] ) != 0 )
+                memcmp( out, kwp_msg[i], kwp_msg_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed. ");

--- a/library/oid.c
+++ b/library/oid.c
@@ -75,7 +75,7 @@
         if( p == NULL || oid == NULL ) return( NULL );                  \
         while( cur->asn1 != NULL ) {                                    \
             if( cur->asn1_len == oid->len &&                            \
-                memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {          \
+                mbedtls_platform_memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {          \
                 return( p );                                            \
             }                                                           \
             p++;                                                        \

--- a/library/pem.c
+++ b/library/pem.c
@@ -273,7 +273,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
     enc = 0;
 
-    if( s2 - s1 >= 22 && memcmp( s1, "Proc-Type: 4,ENCRYPTED", 22 ) == 0 )
+    if( s2 - s1 >= 22 && mbedtls_platform_memcmp( s1, "Proc-Type: 4,ENCRYPTED", 22 ) == 0 )
     {
 #if defined(MBEDTLS_MD5_C) && defined(MBEDTLS_CIPHER_MODE_CBC) &&         \
     ( defined(MBEDTLS_DES_C) || defined(MBEDTLS_AES_C) )
@@ -286,7 +286,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
 
 #if defined(MBEDTLS_DES_C)
-        if( s2 - s1 >= 23 && memcmp( s1, "DEK-Info: DES-EDE3-CBC,", 23 ) == 0 )
+        if( s2 - s1 >= 23 && mbedtls_platform_memcmp( s1, "DEK-Info: DES-EDE3-CBC,", 23 ) == 0 )
         {
             enc_alg = MBEDTLS_CIPHER_DES_EDE3_CBC;
 
@@ -296,7 +296,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
             s1 += 16;
         }
-        else if( s2 - s1 >= 18 && memcmp( s1, "DEK-Info: DES-CBC,", 18 ) == 0 )
+        else if( s2 - s1 >= 18 && mbedtls_platform_memcmp( s1, "DEK-Info: DES-CBC,", 18 ) == 0 )
         {
             enc_alg = MBEDTLS_CIPHER_DES_CBC;
 
@@ -309,15 +309,15 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 #endif /* MBEDTLS_DES_C */
 
 #if defined(MBEDTLS_AES_C)
-        if( s2 - s1 >= 14 && memcmp( s1, "DEK-Info: AES-", 14 ) == 0 )
+        if( s2 - s1 >= 14 && mbedtls_platform_memcmp( s1, "DEK-Info: AES-", 14 ) == 0 )
         {
             if( s2 - s1 < 22 )
                 return( MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG );
-            else if( memcmp( s1, "DEK-Info: AES-128-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-128-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_128_CBC;
-            else if( memcmp( s1, "DEK-Info: AES-192-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-192-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_192_CBC;
-            else if( memcmp( s1, "DEK-Info: AES-256-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-256-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_256_CBC;
             else
                 return( MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG );

--- a/library/pk.c
+++ b/library/pk.c
@@ -556,7 +556,7 @@ static int uecc_eckey_check_pair( const void *pub, const void *prv )
     const mbedtls_uecc_keypair *uecc_prv =
         (const mbedtls_uecc_keypair *) prv;
 
-    if( memcmp( uecc_pub->public_key,
+    if( mbedtls_platform_memcmp( uecc_pub->public_key,
                 uecc_prv->public_key,
                 2 * NUM_ECC_BYTES ) == 0 )
     {

--- a/library/pkcs5.c
+++ b/library/pkcs5.c
@@ -383,7 +383,7 @@ int mbedtls_pkcs5_self_test( int verbose )
         ret = mbedtls_pkcs5_pbkdf2_hmac( &sha1_ctx, password[i], plen[i], salt[i],
                                   slen[i], it_cnt[i], key_len[i], key );
         if( ret != 0 ||
-            memcmp( result_key[i], key, key_len[i] ) != 0 )
+                memcmp( result_key[i], key, key_len[i] ) != 0 )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -309,7 +309,7 @@ static int pk_group_from_specified( const mbedtls_asn1_buf *params, mbedtls_ecp_
         return( ret );
 
     if( len != MBEDTLS_OID_SIZE( MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD ) ||
-        memcmp( p, MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD, len ) != 0 )
+        mbedtls_platform_memcmp( p, MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD, len ) != 0 )
     {
         return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
     }

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -40,7 +40,6 @@
 #if defined(MBEDTLS_ECP_C)
 #include "mbedtls/bignum.h"
 #include "mbedtls/ecp.h"
-#include "mbedtls/platform_util.h"
 #endif
 #if defined(MBEDTLS_ECDSA_C)
 #include "mbedtls/ecdsa.h"

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -79,7 +79,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
-void mbedtls_platform_memset( void *ptr, int value, size_t num )
+void *mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -93,10 +93,10 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
-    memset( ptr, value, num );
+    return( memset( ptr, value, num ) );
 }
 
-void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
+void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
@@ -107,7 +107,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),
             (void *) ( (unsigned char *) src + start_offset ),
             ( num - start_offset ) );
-    memcpy( (void *) dst, (void *) src, start_offset );
+    return( memcpy( (void *) dst, (void *) src, start_offset ) );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -84,7 +84,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -101,7 +101,7 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
     /* Randomize start offset. */
     size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = (size_t) mbedtls_platform_random_in_range( 256 );
+    uint32_t data = mbedtls_platform_random_in_range( 256 );
 
     memset( (void *) dst, data, num );
     memcpy( (void *) ( (unsigned char *) dst + start_offset ),

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_platform_random_in_range( 0xff );
+    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_platform_random_in_range( num );
+    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_platform_random_in_range( size_t num )
+uint32_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -112,7 +112,9 @@ void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 {
-    volatile unsigned int equal = 0;
+    volatile const unsigned char *A = (volatile const unsigned char *) buf1;
+    volatile const unsigned char *B = (volatile const unsigned char *) buf2;
+    volatile unsigned char diff = 0;
 
     size_t i = num;
 
@@ -120,22 +122,17 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
     for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( (unsigned char *) buf1 )[i] ==
-                   ( (unsigned char *) buf2 )[i] );
+        unsigned char x = A[i], y = B[i];
+        diff |= x ^ y;
     }
 
-    if ( equal == num )
-    {
-        return 0;
-    }
-
-    return 1;
+    return( diff );
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,15 +82,15 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
-            ( num - startOffset ) );
-    memset( ( void * ) ptr, data, startOffset );
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+            ( num - start_offset ) );
+    memset( (void *) ptr, data, start_offset );
 
     /* Perform the original memset */
     memset( ptr, value, num );
@@ -99,15 +99,15 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = ( size_t ) mbedtls_platform_random_in_range( 0xff );
+    size_t data = (size_t) mbedtls_platform_random_in_range( 0xff );
 
-    memset( ( void * ) dst, data, num );
-    memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
-            ( void * ) ( ( unsigned char * ) src + startOffset ),
-            ( num - startOffset ) );
-    memcpy( ( void * ) dst, ( void * ) src, startOffset );
+    memset( (void *) dst, data, num );
+    memcpy( (void *) ( (unsigned char *) dst + start_offset ),
+            (void *) ( (unsigned char *) src + start_offset ),
+            ( num - start_offset ) );
+    memcpy( (void *) dst, (void *) src, start_offset );
 }
 
 int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
@@ -116,18 +116,18 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = ( size_t ) mbedtls_platform_random_in_range( num );
+    size_t start_offset = (size_t) mbedtls_platform_random_in_range( num );
 
-    for( i = startOffset; i < num; i++ )
+    for( i = start_offset; i < num; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
-    for( i = 0; i < startOffset; i++ )
+    for( i = 0; i < start_offset; i++ )
     {
-        equal += ( ( ( unsigned char * ) buf1 )[i] ==
-                   ( ( unsigned char * ) buf2 )[i] );
+        equal += ( ( (unsigned char *) buf1 )[i] ==
+                   ( (unsigned char *) buf2 )[i] );
     }
 
     if ( equal == num )

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,8 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( ( void * ) ( ptr + startOffset ), value, ( num - startOffset ) );
+    memset( ( void * ) ( ( unsigned char * ) ptr + startOffset ), value,
+            ( num - startOffset ) );
     memset( ( void * ) ptr, data, startOffset );
 
     /* Perform the original memset */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -137,12 +137,13 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
     return 1;
 }
 
-//TODO: This is a stub implementation of the global RNG function.
+#if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
 size_t mbedtls_random_in_range( size_t num )
 {
     (void) num;
     return 0;
 }
+#endif /* !MBEDTLS_PLATFORM_GLOBAL_RNG */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -82,9 +82,9 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 void mbedtls_platform_memset( void *ptr, int value, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize data */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     /* Perform a pair of memset operations from random locations with
      * random data */
@@ -99,9 +99,9 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 void mbedtls_platform_memcpy( void *dst, const void *src, size_t num )
 {
     /* Randomize start offset. */
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
     /* Randomize initial data to prevent leakage while copying */
-    size_t data = mbedtls_random_in_range( 0xff );
+    size_t data = mbedtls_platform_random_in_range( 0xff );
 
     memset( ( void * ) dst, data, num );
     memcpy( ( void * ) ( ( unsigned char * ) dst + startOffset ),
@@ -116,7 +116,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
     size_t i = num;
 
-    size_t startOffset = mbedtls_random_in_range( num );
+    size_t startOffset = mbedtls_platform_random_in_range( num );
 
     for( i = startOffset; i < num; i++ )
     {
@@ -139,7 +139,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 }
 
 #if !defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
-size_t mbedtls_random_in_range( size_t num )
+size_t mbedtls_platform_random_in_range( size_t num )
 {
     (void) num;
     return 0;

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -88,7 +88,7 @@ void mbedtls_platform_memset( void *ptr, int value, size_t num )
 
     /* Perform a pair of memset operations from random locations with
      * random data */
-    memset( (void *) ( (unsigned char *) ptr + start_offset ), value,
+    memset( (void *) ( (unsigned char *) ptr + start_offset ), data,
             ( num - start_offset ) );
     memset( (void *) ptr, data, start_offset );
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2266,7 +2266,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     if ( ret != 0 )
         goto exit;
 
-    if( memcmp( hash_start, result, hlen ) != 0 )
+    if( mbedtls_platform_memcmp( hash_start, result, hlen ) != 0 )
     {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto exit;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -93,7 +93,7 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
             continue;
         }
 
-        if( memcmp( session->id, entry->session.id,
+        if( mbedtls_platform_memcmp( session->id, entry->session.id,
                     entry->session.id_len ) != 0 )
             continue;
 
@@ -179,7 +179,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
         }
 #endif
 
-        if( memcmp( session->id, cur->session.id, cur->session.id_len ) == 0 )
+        if( mbedtls_platform_memcmp( session->id, cur->session.id, cur->session.id_len ) == 0 )
             break; /* client reconnected, keep timestamp for session id */
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1482,7 +1482,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
     for( p = ssl->conf->alpn_list; *p != NULL; p++ )
     {
         if( name_len == strlen( *p ) &&
-            memcmp( buf + 3, *p, name_len ) == 0 )
+            mbedtls_platform_memcmp( buf + 3, *p, name_len ) == 0 )
         {
             ssl->alpn_chosen = *p;
             return( 0 );
@@ -1815,7 +1815,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         mbedtls_ssl_session_get_ciphersuite( ssl->session_negotiate ) != i ||
         mbedtls_ssl_session_get_compression( ssl->session_negotiate ) != comp ||
         ssl->session_negotiate->id_len != n ||
-        memcmp( ssl->session_negotiate->id, buf + 35, n ) != 0 )
+        mbedtls_platform_memcmp( ssl->session_negotiate->id, buf + 35, n ) != 0 )
     {
         ssl->handshake->resume = 0;
     }
@@ -2811,7 +2811,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
         }
 
-        if( memcmp( p, ecdh_group, sizeof( ecdh_group ) ) != 0 )
+        if( mbedtls_platform_memcmp( p, ecdh_group, sizeof( ecdh_group ) ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad server key exchange (unexpected header)" ) );
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1152,9 +1152,9 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len * 2 ||
             buf[0] !=     ssl->verify_data_len * 2 ||
-            mbedtls_ssl_safer_memcmp( buf + 1,
+            mbedtls_platform_memcmp( buf + 1,
                           ssl->own_verify_data, ssl->verify_data_len ) != 0 ||
-            mbedtls_ssl_safer_memcmp( buf + 1 + ssl->verify_data_len,
+            mbedtls_platform_memcmp( buf + 1 + ssl->verify_data_len,
                           ssl->peer_verify_data, ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -229,7 +229,7 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     if( ret != 0 )
         return( ret );
 
-    if( mbedtls_ssl_safer_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
+    if( mbedtls_platform_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
         return( -1 );
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -160,7 +160,7 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len ||
             buf[0] !=     ssl->verify_data_len ||
-            mbedtls_ssl_safer_memcmp( buf + 1, ssl->peer_verify_data,
+            mbedtls_platform_memcmp( buf + 1, ssl->peer_verify_data,
                           ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );
@@ -4089,7 +4089,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
         /* Identity is not a big secret since clients send it in the clear,
          * but treat it carefully anyway, just in case */
         if( n != ssl->conf->psk_identity_len ||
-            mbedtls_ssl_safer_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
+            mbedtls_platform_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
         {
             ret = MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY;
         }

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -708,7 +708,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
             cur_len = *theirs++;
 
             if( cur_len == ours_len &&
-                memcmp( theirs, *ours, cur_len ) == 0 )
+                mbedtls_platform_memcmp( theirs, *ours, cur_len ) == 0 )
             {
                 ssl->alpn_chosen = *ours;
                 return( 0 );
@@ -1618,7 +1618,7 @@ read_record_header:
          * fragment_offset == 0 and fragment_length == length
          */
         if( ssl->in_msg[6] != 0 || ssl->in_msg[7] != 0 || ssl->in_msg[8] != 0 ||
-            memcmp( ssl->in_msg + 1, ssl->in_msg + 9, 3 ) != 0 )
+            mbedtls_platform_memcmp( ssl->in_msg + 1, ssl->in_msg + 9, 3 ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello fragmentation not supported" ) );
             return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -259,7 +259,7 @@ static mbedtls_ssl_ticket_key *ssl_ticket_select_key(
     unsigned char i;
 
     for( i = 0; i < sizeof( ctx->keys ) / sizeof( *ctx->keys ); i++ )
-        if( memcmp( name, ctx->keys[i].name, 4 ) == 0 )
+        if( mbedtls_platform_memcmp( name, ctx->keys[i].name, 4 ) == 0 )
             return( &ctx->keys[i] );
 
     return( NULL );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3083,7 +3083,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
              *
              * Afterwards, we know that data + data_len is followed by at
              * least maclen Bytes, which justifies the call to
-             * mbedtls_ssl_safer_memcmp() below.
+             * mbedtls_platform_memcmp() below.
              *
              * Further, we still know that data_len > minlen */
             rec->data_len -= transform->maclen;
@@ -3105,7 +3105,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                                    transform->maclen );
 
             /* Compare expected MAC with MAC at the end of the record. */
-            if( mbedtls_ssl_safer_memcmp( data + rec->data_len, mac_expect,
+            if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
                                           transform->maclen ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "message mac does not match" ) );
@@ -3444,7 +3444,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         MBEDTLS_SSL_DEBUG_BUF( 4, "message  mac", data + rec->data_len, transform->maclen );
 #endif
 
-        if( mbedtls_ssl_safer_memcmp( data + rec->data_len, mac_expect,
+        if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
                                       transform->maclen ) != 0 )
         {
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
@@ -7913,7 +7913,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_HS_FINISHED );
     }
 
-    if( mbedtls_ssl_safer_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
+    if( mbedtls_platform_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
                       buf, hash_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2883,7 +2883,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
      * Match record's CID with incoming CID.
      */
     if( rec->cid_len != transform->in_cid_len ||
-        memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 )
+        mbedtls_platform_memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 )
     {
         return( MBEDTLS_ERR_SSL_UNEXPECTED_CID );
     }
@@ -4634,8 +4634,8 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
 static int ssl_hs_is_proper_fragment( mbedtls_ssl_context *ssl )
 {
     if( ssl->in_msglen < ssl->in_hslen ||
-        memcmp( ssl->in_msg + 6, "\0\0\0",        3 ) != 0 ||
-        memcmp( ssl->in_msg + 9, ssl->in_msg + 1, 3 ) != 0 )
+        mbedtls_platform_memcmp( ssl->in_msg + 6, "\0\0\0",        3 ) != 0 ||
+        mbedtls_platform_memcmp( ssl->in_msg + 9, ssl->in_msg + 1, 3 ) != 0 )
     {
         return( 1 );
     }
@@ -6013,7 +6013,7 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
             else
             {
                 /* Make sure msg_type and length are consistent */
-                if( memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 )
+                if( mbedtls_platform_memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 )
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Fragment header mismatch - ignore" ) );
                     /* Ignore */
@@ -6872,7 +6872,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( peer_crt->raw.len != crt_buf_len )
         return( -1 );
 
-    return( memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
+    return( mbedtls_platform_memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
 }
 #elif defined(MBEDTLS_SSL_RENEGOTIATION)
 static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
@@ -6903,7 +6903,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( ret != 0 )
         return( -1 );
 
-    return( memcmp( tmp_digest, peer_cert_digest, digest_len ) );
+    return( mbedtls_platform_memcmp( tmp_digest, peer_cert_digest, digest_len ) );
 }
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE && MBEDTLS_SSL_RENEGOTIATION */
 #endif /* MBEDTLS_SSL_RENEGOTIATION && MBEDTLS_SSL_CLI_C */
@@ -7086,7 +7086,7 @@ static int ssl_srv_check_client_no_crt_notification( mbedtls_ssl_context *ssl )
     if( ssl->in_hslen   == 3 + mbedtls_ssl_hs_hdr_len( ssl ) &&
         ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE    &&
         ssl->in_msg[0]  == MBEDTLS_SSL_HS_CERTIFICATE   &&
-        memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 )
+        mbedtls_platform_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "TLSv1 client has no certificate" ) );
         return( 0 );
@@ -9961,7 +9961,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( (size_t)( end - p ) < sizeof( ssl_serialized_session_header ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        if( memcmp( p, ssl_serialized_session_header,
+        if( mbedtls_platform_memcmp( p, ssl_serialized_session_header,
                     sizeof( ssl_serialized_session_header ) ) != 0 )
         {
             return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );
@@ -10403,9 +10403,9 @@ static int ssl_check_ctr_renegotiate( mbedtls_ssl_context *ssl )
         return( 0 );
     }
 
-    in_ctr_cmp = memcmp( ssl->in_ctr + ep_len,
+    in_ctr_cmp = mbedtls_platform_memcmp( ssl->in_ctr + ep_len,
                         ssl->conf->renego_period + ep_len, 8 - ep_len );
-    out_ctr_cmp = memcmp( ssl->cur_out_ctr + ep_len,
+    out_ctr_cmp = mbedtls_platform_memcmp( ssl->cur_out_ctr + ep_len,
                           ssl->conf->renego_period + ep_len, 8 - ep_len );
 
     if( in_ctr_cmp <= 0 && out_ctr_cmp <= 0 )
@@ -11448,7 +11448,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < sizeof( ssl_serialized_context_header ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    if( memcmp( p, ssl_serialized_context_header,
+    if( mbedtls_platform_memcmp( p, ssl_serialized_context_header,
                 sizeof( ssl_serialized_context_header ) ) != 0 )
     {
         return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );
@@ -11615,7 +11615,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
             for( cur = ssl->conf->alpn_list; *cur != NULL; cur++ )
             {
                 if( strlen( *cur ) == alpn_len &&
-                    memcmp( p, cur, alpn_len ) == 0 )
+                    mbedtls_platform_memcmp( p, cur, alpn_len ) == 0 )
                 {
                     ssl->alpn_chosen = *cur;
                     break;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2883,7 +2883,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
      * Match record's CID with incoming CID.
      */
     if( rec->cid_len != transform->in_cid_len ||
-        memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 ) // use regular memcmp as CID is not that critical
+        memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 ) // use regular memcmp as CID is public
     {
         return( MBEDTLS_ERR_SSL_UNEXPECTED_CID );
     }
@@ -6013,7 +6013,7 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
             else
             {
                 /* Make sure msg_type and length are consistent */
-                if( memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 ) // use regular memcmp as msg type is not that critical
+                if( memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 ) // use regular memcmp as msg type is public
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Fragment header mismatch - ignore" ) );
                     /* Ignore */
@@ -7086,7 +7086,7 @@ static int ssl_srv_check_client_no_crt_notification( mbedtls_ssl_context *ssl )
     if( ssl->in_hslen   == 3 + mbedtls_ssl_hs_hdr_len( ssl ) &&
         ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE    &&
         ssl->in_msg[0]  == MBEDTLS_SSL_HS_CERTIFICATE   &&
-        memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 ) // use regular memcmp as this compare is not that critical
+        memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 ) // use regular memcmp as comparing public data
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "TLSv1 client has no certificate" ) );
         return( 0 );
@@ -9961,7 +9961,7 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( (size_t)( end - p ) < sizeof( ssl_serialized_session_header ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        // use regular memcmp as session header is not that critical
+        // use regular memcmp as session header is public data
         if( memcmp( p, ssl_serialized_session_header,
                     sizeof( ssl_serialized_session_header ) ) != 0 )
         {
@@ -10404,7 +10404,7 @@ static int ssl_check_ctr_renegotiate( mbedtls_ssl_context *ssl )
         return( 0 );
     }
 
-    // use regular memcmp as counters are not that critical
+    // use regular memcmp as counters are public data
     in_ctr_cmp = memcmp( ssl->in_ctr + ep_len,
                         ssl->conf->renego_period + ep_len, 8 - ep_len );
     out_ctr_cmp = memcmp( ssl->cur_out_ctr + ep_len,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2883,7 +2883,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
      * Match record's CID with incoming CID.
      */
     if( rec->cid_len != transform->in_cid_len ||
-        mbedtls_platform_memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 )
+        memcmp( rec->cid, transform->in_cid, rec->cid_len ) != 0 ) // use regular memcmp as CID is not that critical
     {
         return( MBEDTLS_ERR_SSL_UNEXPECTED_CID );
     }
@@ -6013,7 +6013,7 @@ static int ssl_buffer_message( mbedtls_ssl_context *ssl )
             else
             {
                 /* Make sure msg_type and length are consistent */
-                if( mbedtls_platform_memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 )
+                if( memcmp( hs_buf->data, ssl->in_msg, 4 ) != 0 ) // use regular memcmp as msg type is not that critical
                 {
                     MBEDTLS_SSL_DEBUG_MSG( 1, ( "Fragment header mismatch - ignore" ) );
                     /* Ignore */
@@ -7086,7 +7086,7 @@ static int ssl_srv_check_client_no_crt_notification( mbedtls_ssl_context *ssl )
     if( ssl->in_hslen   == 3 + mbedtls_ssl_hs_hdr_len( ssl ) &&
         ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE    &&
         ssl->in_msg[0]  == MBEDTLS_SSL_HS_CERTIFICATE   &&
-        mbedtls_platform_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 )
+        memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ), "\0\0\0", 3 ) == 0 ) // use regular memcmp as this compare is not that critical
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "TLSv1 client has no certificate" ) );
         return( 0 );
@@ -9961,7 +9961,8 @@ static int ssl_session_load( mbedtls_ssl_session *session,
         if( (size_t)( end - p ) < sizeof( ssl_serialized_session_header ) )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        if( mbedtls_platform_memcmp( p, ssl_serialized_session_header,
+        // use regular memcmp as session header is not that critical
+        if( memcmp( p, ssl_serialized_session_header,
                     sizeof( ssl_serialized_session_header ) ) != 0 )
         {
             return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );
@@ -10403,9 +10404,10 @@ static int ssl_check_ctr_renegotiate( mbedtls_ssl_context *ssl )
         return( 0 );
     }
 
-    in_ctr_cmp = mbedtls_platform_memcmp( ssl->in_ctr + ep_len,
+    // use regular memcmp as counters are not that critical
+    in_ctr_cmp = memcmp( ssl->in_ctr + ep_len,
                         ssl->conf->renego_period + ep_len, 8 - ep_len );
-    out_ctr_cmp = mbedtls_platform_memcmp( ssl->cur_out_ctr + ep_len,
+    out_ctr_cmp = memcmp( ssl->cur_out_ctr + ep_len,
                           ssl->conf->renego_period + ep_len, 8 - ep_len );
 
     if( in_ctr_cmp <= 0 && out_ctr_cmp <= 0 )
@@ -11448,7 +11450,8 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
     if( (size_t)( end - p ) < sizeof( ssl_serialized_context_header ) )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    if( mbedtls_platform_memcmp( p, ssl_serialized_context_header,
+    // use regular memcmp as header is not that critical
+    if( memcmp( p, ssl_serialized_context_header,
                 sizeof( ssl_serialized_context_header ) ) != 0 )
     {
         return( MBEDTLS_ERR_SSL_VERSION_MISMATCH );

--- a/library/x509.c
+++ b/library/x509.c
@@ -588,9 +588,8 @@ int mbedtls_x509_name_cmp_raw( mbedtls_x509_buf_raw const *a,
         if( ret != 0 )
             goto exit;
 
-        // use regular memcmp as oid is not that critical
         if( oid[0].len != oid[1].len ||
-            memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
+            mbedtls_platform_memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
         {
             return( 1 );
         }

--- a/library/x509.c
+++ b/library/x509.c
@@ -588,8 +588,9 @@ int mbedtls_x509_name_cmp_raw( mbedtls_x509_buf_raw const *a,
         if( ret != 0 )
             goto exit;
 
+        // use regular memcmp as oid is not that critical
         if( oid[0].len != oid[1].len ||
-            mbedtls_platform_memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
+            memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
         {
             return( 1 );
         }

--- a/library/x509.c
+++ b/library/x509.c
@@ -500,7 +500,7 @@ static int x509_string_cmp( const mbedtls_x509_buf *a,
 {
     if( a->tag == b->tag &&
         a->len == b->len &&
-        memcmp( a->p, b->p, b->len ) == 0 )
+        mbedtls_platform_memcmp( a->p, b->p, b->len ) == 0 )
     {
         return( 0 );
     }
@@ -589,7 +589,7 @@ int mbedtls_x509_name_cmp_raw( mbedtls_x509_buf_raw const *a,
             goto exit;
 
         if( oid[0].len != oid[1].len ||
-            memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
+            mbedtls_platform_memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
         {
             return( 1 );
         }

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -511,10 +511,10 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
     }
 
     if( crl->sig_oid.len != sig_oid2.len ||
-        memcmp( crl->sig_oid.p, sig_oid2.p, crl->sig_oid.len ) != 0 ||
+        mbedtls_platform_memcmp( crl->sig_oid.p, sig_oid2.p, crl->sig_oid.len ) != 0 ||
         sig_params1.len != sig_params2.len ||
         ( sig_params1.len != 0 &&
-          memcmp( sig_params1.p, sig_params2.p, sig_params1.len ) != 0 ) )
+          mbedtls_platform_memcmp( sig_params1.p, sig_params2.p, sig_params1.len ) != 0 ) )
     {
         mbedtls_x509_crl_free( crl );
         return( MBEDTLS_ERR_X509_SIG_MISMATCH );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1316,7 +1316,7 @@ static int x509_crt_parse_frame( unsigned char *start,
      *    signature field in the sequence tbsCertificate (Section 4.1.2.3).
      */
     if( outer_sig_alg.len != inner_sig_alg_len ||
-        memcmp( outer_sig_alg.p, inner_sig_alg_start, inner_sig_alg_len ) != 0 )
+        mbedtls_platform_memcmp( outer_sig_alg.p, inner_sig_alg_start, inner_sig_alg_len ) != 0 )
     {
         return( MBEDTLS_ERR_X509_SIG_MISMATCH );
     }
@@ -2588,7 +2588,7 @@ static int x509_crt_check_ext_key_usage_cb( void *ctx,
         return( 1 );
     }
 
-    if( data_len == cb_ctx->oid_len && memcmp( data, cb_ctx->oid,
+    if( data_len == cb_ctx->oid_len && mbedtls_platform_memcmp( data, cb_ctx->oid,
                                                data_len ) == 0 )
     {
         return( 1 );
@@ -2646,7 +2646,7 @@ static int x509_serial_is_revoked( unsigned char const *serial,
     while( cur != NULL && cur->serial.len != 0 )
     {
         if( serial_len == cur->serial.len &&
-            memcmp( serial, cur->serial.p, serial_len ) == 0 )
+            mbedtls_platform_memcmp( serial, cur->serial.p, serial_len ) == 0 )
         {
             if( mbedtls_x509_time_is_past( &cur->revocation_date ) )
                 return( 1 );
@@ -3173,7 +3173,7 @@ static int x509_crt_check_ee_locally_trusted(
     for( cur = trust_ca; cur != NULL; cur = cur->next )
     {
         if( crt->raw.len == cur->raw.len &&
-            memcmp( crt->raw.p, cur->raw.p, crt->raw.len ) == 0 )
+            mbedtls_platform_memcmp( crt->raw.p, cur->raw.p, crt->raw.len ) == 0 )
         {
             return( 0 );
         }

--- a/programs/ssl/query_config.c
+++ b/programs/ssl/query_config.c
@@ -2666,6 +2666,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
+#if defined(MBEDTLS_PLATFORM_GLOBAL_RNG)
+    if( strcmp( "MBEDTLS_PLATFORM_GLOBAL_RNG", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PLATFORM_GLOBAL_RNG );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PLATFORM_GLOBAL_RNG */
+
 #if defined(MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION)
     if( strcmp( "MBEDTLS_SSL_CONF_ALLOW_LEGACY_RENEGOTIATION", config ) == 0 )
     {


### PR DESCRIPTION
## Description

Changed memcmp to more safer version mbedtls_platform_memcmp to every occurance of memcmp excluding selftests. Then changed back those that are included in baremetal and are not so critical for side channel attacks to safe performance. Please review where the changes back to memcmp are done to safe places and suggest if there are more places that could be changed back to memcmp within baremetal.

NOTE!
Implementation is done on top of this pr: https://github.com/ARMmbed/mbedtls/pull/2870
so all the changes are not from this pr. Review can be done to my commits only.

This pr depends on https://github.com/ARMmbed/mbedtls/pull/2870 which must be merged first.

[ ] https://github.com/ARMmbed/mbedtls/pull/2870

__Impact on code-size:__

| | GCC | ARMC5 | ARMC6 |
| --- | --- | --- | --- |
| `libmbedtls.a` before | 15341| 16519| 17162|
| `libmbedtls.a` after | 15245| 16539| 17091|
| `libmbedcrypto.a` before | 21585| 21535| 23595|
| `libmbedcrypto.a` after | 21553| 21535| 23595|
| `libmbedx509.a` before | 5361| 5522| 5960|
| `libmbedx509.a` after | 5333| 5522 | 5951|
| gain in bytes TLS | 96| -20 | 71 |
| gain in bytes Crypto | 32 | ==| == |
| gain in bytes X.509 | 28 | == | 9 |
| gain Total | 156| -20 | 80 |

## Status
**DEVELOPMENT**
