### PR TITLE
Update crypto 2019-10-04

### DIFF
--- a/library/error.c
+++ b/library/error.c
@@ -642,7 +642,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     if( use_ret == -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH) )
         mbedtls_snprintf( buf, buflen, "ASN1 - Actual length differs from expected length" );
     if( use_ret == -(MBEDTLS_ERR_ASN1_INVALID_DATA) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Data is invalid. (not used)" );
+        mbedtls_snprintf( buf, buflen, "ASN1 - Data is invalid" );
     if( use_ret == -(MBEDTLS_ERR_ASN1_ALLOC_FAILED) )
         mbedtls_snprintf( buf, buflen, "ASN1 - Memory allocation failed" );
     if( use_ret == -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL) )

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -1832,15 +1832,10 @@ depends_on:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
 # signature = bit string with invalid encoding (number of unused bits too large)
 x509parse_crt:"3081bc3081a7a0030201028204deadbeef300d06092a864886f70d01010b0500300c310a30080600130454657374301c170c303930313031303030303030170c303931323331323335393539300c310a30080600130454657374302a300d06092A864886F70D010101050003190030160210ffffffffffffffffffffffffffffffff0202ffffa100a200a321301f301d0603551d11041630148208666f6f2e7465737482086261722e74657374300d06092a864886f70d01010b0500030108":"":MBEDTLS_ERR_X509_INVALID_SIGNATURE + MBEDTLS_ERR_ASN1_INVALID_DATA
 
-## This edge case currently fails to parse due to an ASN.1 bug.
-## It doesn't matter as far as X.509 is concerned since the signature would
-## not be valid anyway.
-## https://github.com/ARMmbed/mbed-crypto/pull/75 will fix this bug and make
-## this test case pass.
-# X509 CRT ASN1 (empty Signature)
-# depends_on:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
-# # signature = empty bit string in DER encoding
-# x509parse_crt:"3081bc3081a7a0030201028204deadbeef300d06092a864886f70d01010b0500300c310a30080600130454657374301c170c303930313031303030303030170c303931323331323335393539300c310a30080600130454657374302a300d06092A864886F70D010101050003190030160210ffffffffffffffffffffffffffffffff0202ffffa100a200a321301f301d0603551d11041630148208666f6f2e7465737482086261722e74657374300d06092a864886f70d01010b0500030100":"cert. version     \: 3\nserial number     \: DE\:AD\:BE\:EF\nissuer name       \: ??=Test\nsubject name      \: ??=Test\nissued  on        \: 2009-01-01 00\:00\:00\nexpires on        \: 2009-12-31 23\:59\:59\nsigned using      \: RSA with SHA-256\nRSA key size      \: 128 bits\nsubject alt name  \:\n    dNSName \: foo.test\n    dNSName \: bar.test\n":0
+X509 CRT ASN1 (empty Signature)
+depends_on:MBEDTLS_RSA_C:MBEDTLS_SHA256_C
+# signature = empty bit string in DER encoding
+x509parse_crt:"3081bc3081a7a0030201028204deadbeef300d06092a864886f70d01010b0500300c310a30080600130454657374301c170c303930313031303030303030170c303931323331323335393539300c310a30080600130454657374302a300d06092A864886F70D010101050003190030160210ffffffffffffffffffffffffffffffff0202ffffa100a200a321301f301d0603551d11041630148208666f6f2e7465737482086261722e74657374300d06092a864886f70d01010b0500030100":"cert. version     \: 3\nserial number     \: DE\:AD\:BE\:EF\nissuer name       \: ??=Test\nsubject name      \: ??=Test\nissued  on        \: 2009-01-01 00\:00\:00\nexpires on        \: 2009-12-31 23\:59\:59\nsigned using      \: RSA with SHA-256\nRSA key size      \: 128 bits\nsubject alt name  \:\n    dNSName \: foo.test\n    dNSName \: bar.test\n":0
 
 X509 CRT ASN1 (dummy 24-bit Signature)
 depends_on:MBEDTLS_RSA_C:MBEDTLS_SHA256_C


### PR DESCRIPTION
Update crypto submodule:

* ARMmbed/mbed-crypto#277: Improve speed of PBKDF2 by caching the digest state of the passphrase
* ARMmbed/mbed-crypto#269: Add PSA API versioning
* ARMmbed/mbed-crypto#278: Fix on target test issues
* ARMmbed/mbed-crypto#286: Fix defgroup syntax for API version section
* ARMmbed/mbed-crypto#75: ASN.1 tests without x509

Update `error.c`; this fixes `check-generated-files` breaking in the TLS testing on Mbed Crypto.

Uncomment a test case that was broken until ARMmbed/mbed-crypto#75 fixed it.
