### PR TITLE
WIP: Remove AES forward tables to save codespace

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -539,7 +539,7 @@
  * This option is independent of \c MBEDTLS_AES_FEWER_TABLES.
  *
  */
-//#define MBEDTLS_AES_ROM_TABLES
+#define MBEDTLS_AES_ROM_TABLES
 
 /**
  * \def MBEDTLS_AES_FEWER_TABLES
@@ -562,6 +562,28 @@
  *
  */
 //#define MBEDTLS_AES_FEWER_TABLES
+
+/**
+ * \def MBEDTLS_AES_SBOX_TABLE_ONLY
+ *
+ * Use less ROM/RAM for AES tables.
+ *
+ * Uncommenting this macro omits 75% of the AES tables from
+ * ROM / RAM (depending on the value of \c MBEDTLS_AES_ROM_TABLES)
+ * by computing their values on the fly during operations
+ * (the tables are entry-wise rotations of one another).
+ *
+ * Tradeoff: Uncommenting this reduces the RAM / ROM footprint
+ * by ~6kb but at the cost of more arithmetic operations during
+ * runtime. Specifically, one has to compare 4 accesses within
+ * different tables to 4 accesses with additional arithmetic
+ * operations within the same table. The performance gain/loss
+ * depends on the system and memory details.
+ *
+ * This option is independent of \c MBEDTLS_AES_ROM_TABLES.
+ *
+ */
+#define MBEDTLS_AES_SBOX_TABLE_ONLY
 
 /**
  * \def MBEDTLS_CAMELLIA_SMALL_MEMORY
@@ -1877,7 +1899,7 @@
  *
  * This modules adds support for the AES-NI instructions on x86-64
  */
-#define MBEDTLS_AESNI_C
+//#define MBEDTLS_AESNI_C
 
 /**
  * \def MBEDTLS_AES_C


### PR DESCRIPTION
## Description
This PR removes the AES forward tables, leaving only the S-box tables, as a code size optimisation.

The PR is a work in progress.

## Status
**READY**

## Requires Backporting
NO  

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
