### PR TITLE
[baremetal] TinyCrypt: addtional SCA counter-measures

### DIFF
--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -484,7 +484,7 @@ bitcount_t uECC_vli_numBits(const uECC_word_t *vli,
  * @param vli IN -- very long integer
  * @param num_words IN -- number of words
  */
-void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words);
+void uECC_vli_clear(uECC_word_t *vli);
 
 /*
  * @brief check if it is a valid point in the curve

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -476,8 +476,7 @@ void uECC_vli_modAdd(uECC_word_t *result,  const uECC_word_t *left,
  * @param max_words IN -- number of words
  * @return number of bits in given vli
  */
-bitcount_t uECC_vli_numBits(const uECC_word_t *vli, 
-			    const wordcount_t max_words);
+bitcount_t uECC_vli_numBits(const uECC_word_t *vli);
 
 /*
  * @brief Erases (set to 0) vli

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -320,8 +320,7 @@ uECC_word_t EccPoint_isZero(const uECC_word_t *point, uECC_Curve curve);
  * @param num_words IN -- number of words
  * @return the sign of left - right
  */
-cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
-			 wordcount_t num_words);
+cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right);
 
 /*
  * @brief computes sign of left - right, not in constant time.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -283,33 +283,6 @@ uECC_word_t EccPoint_compute_public_key(uECC_word_t *result,
 					uECC_word_t *private_key, uECC_Curve curve);
 
 /*
- * @brief Regularize the bitcount for the private key so that attackers cannot
- * use a side channel attack to learn the number of leading zeros.
- * @return Regularized k
- * @param k IN -- private-key
- * @param k0 IN/OUT -- regularized k
- * @param k1 IN/OUT -- regularized k
- * @param curve IN -- elliptic curve
- */
-uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
-			 uECC_word_t *k1, uECC_Curve curve);
-
-/*
- * @brief Point multiplication algorithm using Montgomery's ladder with co-Z
- * coordinates. See http://eprint.iacr.org/2011/338.pdf.
- * @note Result may overlap point.
- * @param result OUT -- returns scalar*point
- * @param point IN -- elliptic curve point
- * @param scalar IN -- scalar
- * @param initial_Z IN -- initial value for z
- * @param num_bits IN -- number of bits in scalar
- * @param curve IN -- elliptic curve
- */
-void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
-		   const uECC_word_t * scalar, const uECC_word_t * initial_Z,
-		   bitcount_t num_bits, uECC_Curve curve);
-
-/*
  * @brief Point multiplication algorithm using Montgomery's ladder with co-Z
  * coordinates. See http://eprint.iacr.org/2011/338.pdf.
  * Uses scalar regularization and coordinate randomization (if a global RNG

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -367,8 +367,7 @@ void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1, uECC_word_t * X2,
  * @param Z IN -- z value
  * @param curve IN -- elliptic curve
  */
-void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z,
-	     uECC_Curve curve);
+void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z);
 
 /*
  * @brief Check if bit is set.
@@ -399,7 +398,7 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
  * @param curve IN -- elliptic curve
  */
 void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
-			   const uECC_word_t *right, uECC_Curve curve);
+			   const uECC_word_t *right);
 
 /*
  * @brief Computes result = left - right.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -111,6 +111,7 @@ typedef uint64_t uECC_dword_t;
 #define NUM_ECC_WORDS 8
 /* Number of bytes to represent an element of the the curve p-256: */
 #define NUM_ECC_BYTES (uECC_WORD_SIZE*NUM_ECC_WORDS)
+#define NUM_ECC_BITS 256
 
 /* structure that represents an elliptic curve (e.g. p256):*/
 struct uECC_Curve_t;

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -386,7 +386,7 @@ uECC_word_t uECC_vli_testBit(const uECC_word_t *vli, bitcount_t bit);
  * @warning Currently only designed to work for curve_p or curve_n.
  */
 void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
-		   const uECC_word_t *mod, wordcount_t num_words);
+		   const uECC_word_t *mod);
 
 /*
  * @brief Computes modular product (using curve->mmod_fast)

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -410,7 +410,7 @@ void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
  * @return borrow
  */
 uECC_word_t uECC_vli_sub(uECC_word_t *result, const uECC_word_t *left,
-			 const uECC_word_t *right, wordcount_t num_words);
+			 const uECC_word_t *right);
 
 /*
  * @brief Constant-time comparison function(secure way to compare long ints)

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -310,6 +310,20 @@ void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 		   bitcount_t num_bits, uECC_Curve curve);
 
 /*
+ * @brief Point multiplication algorithm using Montgomery's ladder with co-Z
+ * coordinates. See http://eprint.iacr.org/2011/338.pdf.
+ * Uses scalar regularization and coordinate randomization (if a global RNG
+ * function is set) in order to protect against some side channel attacks.
+ * @note Result may overlap point.
+ * @param result OUT -- returns scalar*point
+ * @param point IN -- elliptic curve point
+ * @param scalar IN -- scalar
+ * @param curve IN -- elliptic curve
+ */
+int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
+			const uECC_word_t * scalar, uECC_Curve curve);
+
+/*
  * @brief Constant-time comparison to zero - secure way to compare long integers
  * @param vli IN -- very long integer
  * @param num_words IN -- number of words in the vli

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -428,8 +428,7 @@ uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right);
  * @param num_words IN -- number of words
  */
 void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
-		      const uECC_word_t *right, const uECC_word_t *mod,
-	              wordcount_t num_words);
+		      const uECC_word_t *right, const uECC_word_t *mod);
 
 /*
  * @brief Computes (1 / input) % mod

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -453,8 +453,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
  * @param src IN --  origin buffer
  * @param num_words IN -- number of words
  */
-void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src,
-		  wordcount_t num_words);
+void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src);
 
 /*
  * @brief Computes (left + right) % mod.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -343,8 +343,7 @@ cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left, const uECC_word_t *righ
  * @param num_words IN -- number of words
  */
 void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
-		     const uECC_word_t *right, const uECC_word_t *mod,
-		     wordcount_t num_words);
+		     const uECC_word_t *right, const uECC_word_t *mod);
 
 /*
  * @brief Computes P' = (x1', y1', Z3), P + Q = (x3, y3, Z3) or

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -419,8 +419,7 @@ uECC_word_t uECC_vli_sub(uECC_word_t *result, const uECC_word_t *left,
  * @param num_words IN -- number of words
  * @return Returns 0 if left == right, 1 otherwise.
  */
-uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right,
-			   wordcount_t num_words);
+uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right);
 
 /*
  * @brief Computes (left * right) % mod

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -440,7 +440,7 @@ void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
  * @param num_words -- number of words
  */
 void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
-		     const uECC_word_t *mod, wordcount_t num_words);
+		     const uECC_word_t *mod);
 
 /*
  * @brief Sets dest = src.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -331,8 +331,7 @@ cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
  * @param num_words IN -- number of words
  * @return the sign of left - right
  */
-cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left, const uECC_word_t *right,
-				wordcount_t num_words);
+cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left, const uECC_word_t *right);
 
 /*
  * @brief Computes result = (left - right) % mod.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -463,8 +463,7 @@ void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src);
  * @param num_words IN -- number of words
  */
 void uECC_vli_modAdd(uECC_word_t *result,  const uECC_word_t *left,
-    		     const uECC_word_t *right, const uECC_word_t *mod,
-   		     wordcount_t num_words);
+    		     const uECC_word_t *right, const uECC_word_t *mod);
 
 /*
  * @brief Counts the number of bits required to represent vli.

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -303,7 +303,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
  * @param num_words IN -- number of words in the vli
  * @return 1 if vli == 0, 0 otherwise.
  */
-uECC_word_t uECC_vli_isZero(const uECC_word_t *vli, wordcount_t num_words);
+uECC_word_t uECC_vli_isZero(const uECC_word_t *vli);
 
 /*
  * @brief Check if 'point' is the point at infinity

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -121,27 +121,25 @@ uECC_word_t uECC_vli_testBit(const uECC_word_t *vli, bitcount_t bit)
 }
 
 /* Counts the number of words in vli. */
-static wordcount_t vli_numDigits(const uECC_word_t *vli,
-				 const wordcount_t max_words)
+static wordcount_t vli_numDigits(const uECC_word_t *vli)
 {
 
 	wordcount_t i;
 	/* Search from the end until we find a non-zero digit. We do it in reverse
 	 * because we expect that most digits will be nonzero. */
-	for (i = max_words - 1; i >= 0 && vli[i] == 0; --i) {
+	for (i = NUM_ECC_WORDS - 1; i >= 0 && vli[i] == 0; --i) {
 	}
 
 	return (i + 1);
 }
 
-bitcount_t uECC_vli_numBits(const uECC_word_t *vli,
-			    const wordcount_t max_words)
+bitcount_t uECC_vli_numBits(const uECC_word_t *vli)
 {
 
 	uECC_word_t i;
 	uECC_word_t digit;
 
-	wordcount_t num_digits = vli_numDigits(vli, max_words);
+	wordcount_t num_digits = vli_numDigits(vli);
 	if (num_digits == 0) {
 		return 0;
 	}
@@ -461,7 +459,7 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 
 	/* Shift mod so its highest set bit is at the maximum position. */
 	bitcount_t shift = (num_words * 2 * uECC_WORD_BITS) -
-			   uECC_vli_numBits(mod, num_words);
+			   uECC_vli_numBits(mod);
 	wordcount_t word_shift = shift / uECC_WORD_BITS;
 	wordcount_t bit_shift = shift % uECC_WORD_BITS;
 	uECC_word_t carry = 0;
@@ -1029,7 +1027,7 @@ int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
 {
 	uECC_word_t mask = (uECC_word_t)-1;
 	uECC_word_t tries;
-	bitcount_t num_bits = uECC_vli_numBits(top, num_words);
+	bitcount_t num_bits = uECC_vli_numBits(top);
 
 	if (!g_rng_function) {
 		return 0;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -431,11 +431,9 @@ void uECC_vli_modAdd(uECC_word_t *result, const uECC_word_t *left,
 }
 
 void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
-		     const uECC_word_t *right, const uECC_word_t *mod,
-		     wordcount_t num_words)
+		     const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t l_borrow = uECC_vli_sub(result, left, right);
-	(void) num_words;
 	if (l_borrow) {
 		/* In this case, result == -diff == (max int) - diff. Since -x % d == d - x,
 		 * we can get the correct result from result + mod (with overflow). */
@@ -598,7 +596,7 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 
 	uECC_vli_modAdd(X1, X1, Z1, curve->p); /* t1 = x1 + z1^2 */
 	uECC_vli_modAdd(Z1, Z1, Z1, curve->p); /* t3 = 2*z1^2 */
-	uECC_vli_modSub(Z1, X1, Z1, curve->p, num_words); /* t3 = x1 - z1^2 */
+	uECC_vli_modSub(Z1, X1, Z1, curve->p); /* t3 = x1 - z1^2 */
 	uECC_vli_modMult_fast(X1, X1, Z1); /* t1 = x1^2 - z1^4 */
 
 	uECC_vli_modAdd(Z1, X1, X1, curve->p); /* t3 = 2*(x1^2 - z1^4) */
@@ -613,12 +611,12 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 
 	/* t1 = 3/2*(x1^2 - z1^4) = B */
 	uECC_vli_modMult_fast(Z1, X1, X1); /* t3 = B^2 */
-	uECC_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - A */
-	uECC_vli_modSub(Z1, Z1, t5, curve->p, num_words); /* t3 = B^2 - 2A = x3 */
-	uECC_vli_modSub(t5, t5, Z1, curve->p, num_words); /* t5 = A - x3 */
+	uECC_vli_modSub(Z1, Z1, t5, curve->p); /* t3 = B^2 - A */
+	uECC_vli_modSub(Z1, Z1, t5, curve->p); /* t3 = B^2 - 2A = x3 */
+	uECC_vli_modSub(t5, t5, Z1, curve->p); /* t5 = A - x3 */
 	uECC_vli_modMult_fast(X1, X1, t5); /* t1 = B * (A - x3) */
 	/* t4 = B * (A - x3) - y1^4 = y3: */
-	uECC_vli_modSub(t4, X1, t4, curve->p, num_words);
+	uECC_vli_modSub(t4, X1, t4, curve->p);
 
 	uECC_vli_set(X1, Z1);
 	uECC_vli_set(Z1, Y1);
@@ -630,10 +628,9 @@ void x_side_default(uECC_word_t *result,
 		    uECC_Curve curve)
 {
 	uECC_word_t _3[NUM_ECC_WORDS] = {3}; /* -a = 3 */
-	wordcount_t num_words = curve->num_words;
 
 	uECC_vli_modMult_fast(result, x, x); /* r = x^2 */
-	uECC_vli_modSub(result, result, _3, curve->p, num_words); /* r = x^2 - 3 */
+	uECC_vli_modSub(result, result, _3, curve->p); /* r = x^2 - 3 */
 	uECC_vli_modMult_fast(result, result, x); /* r = x^3 - 3x */
 	/* r = x^3 - 3x + b: */
 	uECC_vli_modAdd(result, result, curve->b, curve->p);
@@ -790,22 +787,21 @@ static void XYcZ_add_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
 	uECC_word_t t5[NUM_ECC_WORDS];
 	const uECC_Curve curve = &curve_secp256r1;
-	const wordcount_t num_words = NUM_ECC_WORDS;
 
-	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+	uECC_vli_modSub(t5, X2, X1, curve->p); /* t5 = x2 - x1 */
 	uECC_vli_modMult_rnd(t5, t5, t5, s); /* t5 = (x2 - x1)^2 = A */
 	uECC_vli_modMult_rnd(X1, X1, t5, s); /* t1 = x1*A = B */
 	uECC_vli_modMult_rnd(X2, X2, t5, s); /* t3 = x2*A = C */
-	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p); /* t4 = y2 - y1 */
 	uECC_vli_modMult_rnd(t5, Y2, Y2, s); /* t5 = (y2 - y1)^2 = D */
 
-	uECC_vli_modSub(t5, t5, X1, curve->p, num_words); /* t5 = D - B */
-	uECC_vli_modSub(t5, t5, X2, curve->p, num_words); /* t5 = D - B - C = x3 */
-	uECC_vli_modSub(X2, X2, X1, curve->p, num_words); /* t3 = C - B */
+	uECC_vli_modSub(t5, t5, X1, curve->p); /* t5 = D - B */
+	uECC_vli_modSub(t5, t5, X2, curve->p); /* t5 = D - B - C = x3 */
+	uECC_vli_modSub(X2, X2, X1, curve->p); /* t3 = C - B */
 	uECC_vli_modMult_rnd(Y1, Y1, X2, s); /* t2 = y1*(C - B) */
-	uECC_vli_modSub(X2, X1, t5, curve->p, num_words); /* t3 = B - x3 */
+	uECC_vli_modSub(X2, X1, t5, curve->p); /* t3 = B - x3 */
 	uECC_vli_modMult_rnd(Y2, Y2, X2, s); /* t4 = (y2 - y1)*(B - x3) */
-	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y3 */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p); /* t4 = y3 */
 
 	uECC_vli_set(X2, t5);
 }
@@ -831,32 +827,31 @@ static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_word_t t6[NUM_ECC_WORDS];
 	uECC_word_t t7[NUM_ECC_WORDS];
 	const uECC_Curve curve = &curve_secp256r1;
-	const wordcount_t num_words = NUM_ECC_WORDS;
 
-	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
+	uECC_vli_modSub(t5, X2, X1, curve->p); /* t5 = x2 - x1 */
 	uECC_vli_modMult_rnd(t5, t5, t5, s); /* t5 = (x2 - x1)^2 = A */
 	uECC_vli_modMult_rnd(X1, X1, t5, s); /* t1 = x1*A = B */
 	uECC_vli_modMult_rnd(X2, X2, t5, s); /* t3 = x2*A = C */
 	uECC_vli_modAdd(t5, Y2, Y1, curve->p); /* t5 = y2 + y1 */
-	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p); /* t4 = y2 - y1 */
 
-	uECC_vli_modSub(t6, X2, X1, curve->p, num_words); /* t6 = C - B */
+	uECC_vli_modSub(t6, X2, X1, curve->p); /* t6 = C - B */
 	uECC_vli_modMult_rnd(Y1, Y1, t6, s); /* t2 = y1 * (C - B) = E */
 	uECC_vli_modAdd(t6, X1, X2, curve->p); /* t6 = B + C */
 	uECC_vli_modMult_rnd(X2, Y2, Y2, s); /* t3 = (y2 - y1)^2 = D */
-	uECC_vli_modSub(X2, X2, t6, curve->p, num_words); /* t3 = D - (B + C) = x3 */
+	uECC_vli_modSub(X2, X2, t6, curve->p); /* t3 = D - (B + C) = x3 */
 
-	uECC_vli_modSub(t7, X1, X2, curve->p, num_words); /* t7 = B - x3 */
+	uECC_vli_modSub(t7, X1, X2, curve->p); /* t7 = B - x3 */
 	uECC_vli_modMult_rnd(Y2, Y2, t7, s); /* t4 = (y2 - y1)*(B - x3) */
 	/* t4 = (y2 - y1)*(B - x3) - E = y3: */
-	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words);
+	uECC_vli_modSub(Y2, Y2, Y1, curve->p);
 
 	uECC_vli_modMult_rnd(t7, t5, t5, s); /* t7 = (y2 + y1)^2 = F */
-	uECC_vli_modSub(t7, t7, t6, curve->p, num_words); /* t7 = F - (B + C) = x3' */
-	uECC_vli_modSub(t6, t7, X1, curve->p, num_words); /* t6 = x3' - B */
+	uECC_vli_modSub(t7, t7, t6, curve->p); /* t7 = F - (B + C) = x3' */
+	uECC_vli_modSub(t6, t7, X1, curve->p); /* t6 = x3' - B */
 	uECC_vli_modMult_rnd(t6, t6, t5, s); /* t6 = (y2+y1)*(x3' - B) */
 	/* t2 = (y2+y1)*(x3' - B) - E = y3': */
-	uECC_vli_modSub(Y1, t6, Y1, curve->p, num_words);
+	uECC_vli_modSub(Y1, t6, Y1, curve->p);
 
 	uECC_vli_set(X1, t7);
 }
@@ -894,7 +889,7 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	XYcZ_addC_rnd(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], ws);
 
 	/* Find final 1/Z value. */
-	uECC_vli_modSub(z, Rx[1], Rx[0], curve->p, num_words); /* X1 - X0 */
+	uECC_vli_modSub(z, Rx[1], Rx[0], curve->p); /* X1 - X0 */
 	uECC_vli_modMult_fast(z, z, Ry[1 - nb]); /* Yb * (X1 - X0) */
 	uECC_vli_modMult_fast(z, z, point); /* xP * Yb * (X1 - X0) */
 	uECC_vli_modInv(z, z, curve->p, num_words); /* 1 / (xP * Yb * (X1 - X0))*/

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -253,7 +253,11 @@ static void uECC_vli_rshift1(uECC_word_t *vli, wordcount_t num_words)
 	}
 }
 
-/* Compute (r2, r1, r0) = a * b + (r1, r0):
+/* Compute a * b + r, where r is a double-word with high-order word r1 and
+ * low-order word r0, and store the result in the same double-word (r1, r0),
+ * with the carry bit stored in r2.
+ *
+ * (r2, r1, r0) = a * b + (r1, r0):
  * [in] a, b: operands to be multiplied
  * [in] r0, r1: low and high-order words of operand to add
  * [out] r0, r1: low and high-order words of the result

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -489,13 +489,11 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 }
 
 void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
-		      const uECC_word_t *right, const uECC_word_t *mod,
-		      wordcount_t num_words)
+		      const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t product[2 * NUM_ECC_WORDS];
 	uECC_vli_mult_rnd(product, left, right, NULL);
 	uECC_vli_mmod(result, product, mod);
-	(void) num_words;
 }
 
 static void uECC_vli_modMult_rnd(uECC_word_t *result, const uECC_word_t *left,

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -96,10 +96,10 @@ int uECC_curve_public_key_size(uECC_Curve curve)
 	return 2 * curve->num_bytes;
 }
 
-void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words)
+void uECC_vli_clear(uECC_word_t *vli)
 {
 	wordcount_t i;
-	for (i = 0; i < num_words; ++i) {
+	for (i = 0; i < NUM_ECC_WORDS; ++i) {
 		 vli[i] = 0;
 	}
 }
@@ -465,7 +465,7 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 	wordcount_t word_shift = shift / uECC_WORD_BITS;
 	wordcount_t bit_shift = shift % uECC_WORD_BITS;
 	uECC_word_t carry = 0;
-	uECC_vli_clear(mod_multiple, word_shift);
+	uECC_vli_clear(mod_multiple);
 	if (bit_shift > 0) {
 		for(index = 0; index < (uECC_word_t)num_words; ++index) {
 			mod_multiple[word_shift + index] = (mod[index] << bit_shift) | carry;
@@ -545,15 +545,15 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 	cmpresult_t cmpResult;
 
 	if (uECC_vli_isZero(input)) {
-		uECC_vli_clear(result, num_words);
+		uECC_vli_clear(result);
 		return;
 	}
 
 	uECC_vli_set(a, input, num_words);
 	uECC_vli_set(b, mod, num_words);
-	uECC_vli_clear(u, num_words);
+	uECC_vli_clear(u);
 	u[0] = 1;
-	uECC_vli_clear(v, num_words);
+	uECC_vli_clear(v);
 	while ((cmpResult = uECC_vli_cmp_unsafe(a, b, num_words)) != 0) {
 		if (EVEN(a)) {
 			uECC_vli_rshift1(a, num_words);
@@ -778,7 +778,7 @@ static void XYcZ_initial_double(uECC_word_t * X1, uECC_word_t * Y1,
 	if (initial_Z) {
 		uECC_vli_set(z, initial_Z, num_words);
 	} else {
-		uECC_vli_clear(z, num_words);
+		uECC_vli_clear(z);
 		z[0] = 1;
 	}
 
@@ -1016,7 +1016,7 @@ void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
 			    int num_bytes)
 {
 	wordcount_t i;
-	uECC_vli_clear(native, (num_bytes + (uECC_WORD_SIZE - 1)) / uECC_WORD_SIZE);
+	uECC_vli_clear(native);
 	for (i = 0; i < num_bytes; ++i) {
 		unsigned b = num_bytes - 1 - i;
 		native[b / uECC_WORD_SIZE] |=

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -291,12 +291,12 @@ static void muladd(uECC_word_t a, uECC_word_t b, uECC_word_t *r0,
 typedef struct {
 	uint8_t i;
 	uint8_t delays[14];
-} wait_state_t;
+} ecc_wait_state_t;
 
 /*
  * Reset wait_state so that it's ready to be used.
  */
-void wait_state_reset(wait_state_t *ws)
+void ecc_wait_state_reset(ecc_wait_state_t *ws)
 {
 	if (ws == NULL)
 		return;
@@ -324,7 +324,7 @@ void wait_state_reset(wait_state_t *ws)
  * know it's always 8. This saves a bit of code size and execution speed.
  */
 static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
-			      const uECC_word_t *right, wait_state_t *s)
+			      const uECC_word_t *right, ecc_wait_state_t *s)
 {
 
 	uECC_word_t r0 = 0;
@@ -508,7 +508,7 @@ void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
 }
 
 static void uECC_vli_modMult_rnd(uECC_word_t *result, const uECC_word_t *left,
-				 const uECC_word_t *right, wait_state_t *s)
+				 const uECC_word_t *right, ecc_wait_state_t *s)
 {
 	uECC_word_t product[2 * NUM_ECC_WORDS];
 	uECC_vli_mult_rnd(product, left, right, s);
@@ -527,7 +527,7 @@ void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
 
 static void uECC_vli_modSquare_rnd(uECC_word_t *result,
 				   const uECC_word_t *left,
-				   wait_state_t *s)
+				   ecc_wait_state_t *s)
 {
 	uECC_vli_modMult_rnd(result, left, left, s);
 }
@@ -813,7 +813,7 @@ static void XYcZ_initial_double(uECC_word_t * X1, uECC_word_t * Y1,
 
 static void XYcZ_add_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 			 uECC_word_t * X2, uECC_word_t * Y2,
-			 wait_state_t *s)
+			 ecc_wait_state_t *s)
 {
 	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
 	uECC_word_t t5[NUM_ECC_WORDS];
@@ -852,7 +852,7 @@ void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1,
  */
 static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 			  uECC_word_t * X2, uECC_word_t * Y2,
-			  wait_state_t *s)
+			  ecc_wait_state_t *s)
 {
 	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
 	uECC_word_t t5[NUM_ECC_WORDS];
@@ -901,8 +901,8 @@ void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	bitcount_t i;
 	uECC_word_t nb;
 	wordcount_t num_words = curve->num_words;
-	wait_state_t wait_state;
-	wait_state_t * const ws = g_rng_function ? &wait_state : NULL;
+	ecc_wait_state_t wait_state;
+	ecc_wait_state_t * const ws = g_rng_function ? &wait_state : NULL;
 
 	uECC_vli_set(Rx[1], point, num_words);
   	uECC_vli_set(Ry[1], point + num_words, num_words);
@@ -910,13 +910,13 @@ void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	XYcZ_initial_double(Rx[1], Ry[1], Rx[0], Ry[0], initial_Z, curve);
 
 	for (i = num_bits - 2; i > 0; --i) {
-		wait_state_reset(ws);
+		ecc_wait_state_reset(ws);
 		nb = !uECC_vli_testBit(scalar, i);
 		XYcZ_addC_rnd(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], ws);
 		XYcZ_add_rnd(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], ws);
 	}
 
-	wait_state_reset(ws);
+	ecc_wait_state_reset(ws);
 	nb = !uECC_vli_testBit(scalar, 0);
 	XYcZ_addC_rnd(Rx[1 - nb], Ry[1 - nb], Rx[nb], Ry[nb], ws);
 

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -104,11 +104,11 @@ void uECC_vli_clear(uECC_word_t *vli, wordcount_t num_words)
 	}
 }
 
-uECC_word_t uECC_vli_isZero(const uECC_word_t *vli, wordcount_t num_words)
+uECC_word_t uECC_vli_isZero(const uECC_word_t *vli)
 {
 	uECC_word_t bits = 0;
 	wordcount_t i;
-	for (i = 0; i < num_words; ++i) {
+	for (i = 0; i < NUM_ECC_WORDS; ++i) {
 		bits |= vli[i];
 	}
 	return (bits == 0);
@@ -236,7 +236,7 @@ cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
 {
 	uECC_word_t tmp[NUM_ECC_WORDS];
 	uECC_word_t neg = !!uECC_vli_sub(tmp, left, right, num_words);
-	uECC_word_t equal = uECC_vli_isZero(tmp, num_words);
+	uECC_word_t equal = uECC_vli_isZero(tmp);
 	return (!equal - 2 * neg);
 }
 
@@ -544,7 +544,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 	uECC_word_t u[NUM_ECC_WORDS], v[NUM_ECC_WORDS];
 	cmpresult_t cmpResult;
 
-	if (uECC_vli_isZero(input, num_words)) {
+	if (uECC_vli_isZero(input)) {
 		uECC_vli_clear(result, num_words);
 		return;
 	}
@@ -592,7 +592,7 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_word_t t5[NUM_ECC_WORDS];
 	wordcount_t num_words = curve->num_words;
 
-	if (uECC_vli_isZero(Z1, num_words)) {
+	if (uECC_vli_isZero(Z1)) {
 		return;
 	}
 
@@ -753,7 +753,8 @@ void vli_mmod_fast_secp256r1(unsigned int *result, unsigned int*product)
 
 uECC_word_t EccPoint_isZero(const uECC_word_t *point, uECC_Curve curve)
 {
-	return uECC_vli_isZero(point, curve->num_words * 2);
+	(void) curve;
+	return uECC_vli_isZero(point);
 }
 
 void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z)
@@ -1040,7 +1041,7 @@ int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
     		}
 		random[num_words - 1] &=
         		mask >> ((bitcount_t)(num_words * uECC_WORD_SIZE * 8 - num_bits));
-		if (!uECC_vli_isZero(random, num_words) &&
+		if (!uECC_vli_isZero(random) &&
 			uECC_vli_cmp(top, random, num_words) == 1) {
 			return 1;
 		}
@@ -1107,7 +1108,7 @@ int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
 	BITS_TO_BYTES(curve->num_n_bits));
 
 	/* Make sure the private key is in the range [1, n-1]. */
-	if (uECC_vli_isZero(_private, BITS_TO_WORDS(curve->num_n_bits))) {
+	if (uECC_vli_isZero(_private)) {
 		return 0;
 	}
 

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -342,7 +342,7 @@ static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
 	delays >>= 2;
 	/* k = 0 -> i in [1, 0] -> 0 extra muladd;
 	 * k = 3 -> i in [1, 3] -> 3 extra muladd */
-	for (i = 0; i <= k; ++i) {
+	for (i = 1; i <= k; ++i) {
 		muladd(left[i], right[k - i], &rr0, &rr1, &r2);
 	}
 	r = rr0;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -235,12 +235,12 @@ cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right)
 }
 
 /* Computes vli = vli >> 1. */
-static void uECC_vli_rshift1(uECC_word_t *vli, wordcount_t num_words)
+static void uECC_vli_rshift1(uECC_word_t *vli)
 {
 	uECC_word_t *end = vli;
 	uECC_word_t carry = 0;
 
-	vli += num_words;
+	vli += NUM_ECC_WORDS;
 	while (vli-- > end) {
 		uECC_word_t temp = *vli;
 		*vli = (temp >> 1) | carry;
@@ -483,10 +483,10 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 		}
 		/* Swap the index if there was no borrow */
 		index = !(index ^ borrow);
-		uECC_vli_rshift1(mod_multiple, num_words);
+		uECC_vli_rshift1(mod_multiple);
 		mod_multiple[num_words - 1] |= mod_multiple[num_words] <<
 					       (uECC_WORD_BITS - 1);
-		uECC_vli_rshift1(mod_multiple + num_words, num_words);
+		uECC_vli_rshift1(mod_multiple + num_words);
 	}
 	uECC_vli_set(result, v[index]);
 }
@@ -527,7 +527,7 @@ static void vli_modInv_update(uECC_word_t *uv,
 	if (!EVEN(uv)) {
 		carry = uECC_vli_add(uv, uv, mod);
 	}
-	uECC_vli_rshift1(uv, num_words);
+	uECC_vli_rshift1(uv);
 	if (carry) {
 		uv[num_words - 1] |= HIGH_BIT_SET;
 	}
@@ -552,14 +552,14 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 	uECC_vli_clear(v);
 	while ((cmpResult = uECC_vli_cmp_unsafe(a, b)) != 0) {
 		if (EVEN(a)) {
-			uECC_vli_rshift1(a, num_words);
+			uECC_vli_rshift1(a);
       			vli_modInv_update(u, mod, num_words);
     		} else if (EVEN(b)) {
-			uECC_vli_rshift1(b, num_words);
+			uECC_vli_rshift1(b);
 			vli_modInv_update(v, mod, num_words);
 		} else if (cmpResult > 0) {
 			uECC_vli_sub(a, a, b);
-			uECC_vli_rshift1(a, num_words);
+			uECC_vli_rshift1(a);
 			if (uECC_vli_cmp_unsafe(u, v) < 0) {
         			uECC_vli_add(u, u, mod);
       			}
@@ -567,7 +567,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
       			vli_modInv_update(u, mod, num_words);
     		} else {
       			uECC_vli_sub(b, b, a);
-      			uECC_vli_rshift1(b, num_words);
+      			uECC_vli_rshift1(b);
       			if (uECC_vli_cmp_unsafe(v, u) < 0) {
         			uECC_vli_add(v, v, mod);
       			}
@@ -607,10 +607,10 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = 3*(x1^2 - z1^4) */
 	if (uECC_vli_testBit(X1, 0)) {
 		uECC_word_t l_carry = uECC_vli_add(X1, X1, curve->p);
-		uECC_vli_rshift1(X1, num_words);
+		uECC_vli_rshift1(X1);
 		X1[num_words - 1] |= l_carry << (uECC_WORD_BITS - 1);
 	} else {
-		uECC_vli_rshift1(X1, num_words);
+		uECC_vli_rshift1(X1);
 	}
 
 	/* t1 = 3/2*(x1^2 - z1^4) = B */

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -420,11 +420,9 @@ static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
 }
 
 void uECC_vli_modAdd(uECC_word_t *result, const uECC_word_t *left,
-		     const uECC_word_t *right, const uECC_word_t *mod,
-		     wordcount_t num_words)
+		     const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t carry = uECC_vli_add(result, left, right);
-	(void) num_words;
 	if (carry || uECC_vli_cmp_unsafe(mod, result) != 1) {
 	/* result > mod (result = mod + remainder), so subtract mod to get
 	 * remainder. */
@@ -598,13 +596,13 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_vli_modMult_fast(Y1, Y1, Z1); /* t2 = y1*z1 = z3 */
 	uECC_vli_modMult_fast(Z1, Z1, Z1);   /* t3 = z1^2 */
 
-	uECC_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = x1 + z1^2 */
-	uECC_vli_modAdd(Z1, Z1, Z1, curve->p, num_words); /* t3 = 2*z1^2 */
+	uECC_vli_modAdd(X1, X1, Z1, curve->p); /* t1 = x1 + z1^2 */
+	uECC_vli_modAdd(Z1, Z1, Z1, curve->p); /* t3 = 2*z1^2 */
 	uECC_vli_modSub(Z1, X1, Z1, curve->p, num_words); /* t3 = x1 - z1^2 */
 	uECC_vli_modMult_fast(X1, X1, Z1); /* t1 = x1^2 - z1^4 */
 
-	uECC_vli_modAdd(Z1, X1, X1, curve->p, num_words); /* t3 = 2*(x1^2 - z1^4) */
-	uECC_vli_modAdd(X1, X1, Z1, curve->p, num_words); /* t1 = 3*(x1^2 - z1^4) */
+	uECC_vli_modAdd(Z1, X1, X1, curve->p); /* t3 = 2*(x1^2 - z1^4) */
+	uECC_vli_modAdd(X1, X1, Z1, curve->p); /* t1 = 3*(x1^2 - z1^4) */
 	if (uECC_vli_testBit(X1, 0)) {
 		uECC_word_t l_carry = uECC_vli_add(X1, X1, curve->p);
 		uECC_vli_rshift1(X1);
@@ -638,7 +636,7 @@ void x_side_default(uECC_word_t *result,
 	uECC_vli_modSub(result, result, _3, curve->p, num_words); /* r = x^2 - 3 */
 	uECC_vli_modMult_fast(result, result, x); /* r = x^3 - 3x */
 	/* r = x^3 - 3x + b: */
-	uECC_vli_modAdd(result, result, curve->b, curve->p, num_words);
+	uECC_vli_modAdd(result, result, curve->b, curve->p);
 }
 
 uECC_Curve uECC_secp256r1(void)
@@ -839,12 +837,12 @@ static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_vli_modMult_rnd(t5, t5, t5, s); /* t5 = (x2 - x1)^2 = A */
 	uECC_vli_modMult_rnd(X1, X1, t5, s); /* t1 = x1*A = B */
 	uECC_vli_modMult_rnd(X2, X2, t5, s); /* t3 = x2*A = C */
-	uECC_vli_modAdd(t5, Y2, Y1, curve->p, num_words); /* t5 = y2 + y1 */
+	uECC_vli_modAdd(t5, Y2, Y1, curve->p); /* t5 = y2 + y1 */
 	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y2 - y1 */
 
 	uECC_vli_modSub(t6, X2, X1, curve->p, num_words); /* t6 = C - B */
 	uECC_vli_modMult_rnd(Y1, Y1, t6, s); /* t2 = y1 * (C - B) = E */
-	uECC_vli_modAdd(t6, X1, X2, curve->p, num_words); /* t6 = B + C */
+	uECC_vli_modAdd(t6, X1, X2, curve->p); /* t6 = B + C */
 	uECC_vli_modMult_rnd(X2, Y2, Y2, s); /* t3 = (y2 - y1)^2 = D */
 	uECC_vli_modSub(X2, X2, t6, curve->p, num_words); /* t3 = D - (B + C) = x3 */
 

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -176,14 +176,13 @@ cmpresult_t uECC_vli_cmp_unsafe(const uECC_word_t *left,
 	return 0;
 }
 
-uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right,
-			   wordcount_t num_words)
+uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right)
 {
 
 	uECC_word_t diff = 0;
 	wordcount_t i;
 
-	for (i = num_words - 1; i >= 0; --i) {
+	for (i = NUM_ECC_WORDS - 1; i >= 0; --i) {
 		diff |= (left[i] ^ right[i]);
 	}
 	return !(diff == 0);
@@ -1066,7 +1065,7 @@ int uECC_valid_point(const uECC_word_t *point, uECC_Curve curve)
 	curve->x_side(tmp2, point, curve); /* tmp2 = x^3 + ax + b */
 
 	/* Make sure that y^2 == x^3 + ax + b */
-	if (uECC_vli_equal(tmp1, tmp2, num_words) != 0)
+	if (uECC_vli_equal(tmp1, tmp2) != 0)
 		return -3;
 
 	return 0;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -444,12 +444,13 @@ void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
 /* Computes result = product % mod, where product is 2N words long. */
 /* Currently only designed to work for curve_p or curve_n. */
 void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
-    		   const uECC_word_t *mod, wordcount_t num_words)
+    		   const uECC_word_t *mod)
 {
 	uECC_word_t mod_multiple[2 * NUM_ECC_WORDS];
 	uECC_word_t tmp[2 * NUM_ECC_WORDS];
 	uECC_word_t *v[2] = {tmp, product};
 	uECC_word_t index;
+	const wordcount_t num_words = NUM_ECC_WORDS;
 
 	/* Shift mod so its highest set bit is at the maximum position. */
 	bitcount_t shift = (num_words * 2 * uECC_WORD_BITS) -
@@ -493,7 +494,8 @@ void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
 {
 	uECC_word_t product[2 * NUM_ECC_WORDS];
 	uECC_vli_mult_rnd(product, left, right, NULL);
-	uECC_vli_mmod(result, product, mod, num_words);
+	uECC_vli_mmod(result, product, mod);
+	(void) num_words;
 }
 
 static void uECC_vli_modMult_rnd(uECC_word_t *result, const uECC_word_t *left,

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -336,7 +336,7 @@ static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
 	uECC_word_t r1 = 0;
 	uECC_word_t r2 = 0;
 	wordcount_t i, k;
-	const uint8_t num_words = 8;
+	const uint8_t num_words = NUM_ECC_WORDS;
 
 	/* Fetch 8 bit worth of delay from the state; 0 if we have no state */
 	uint8_t delays = s ? s->delays[s->i++] : 0;
@@ -796,7 +796,7 @@ static void XYcZ_add_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	/* t1 = X1, t2 = Y1, t3 = X2, t4 = Y2 */
 	uECC_word_t t5[NUM_ECC_WORDS];
 	const uECC_Curve curve = &curve_secp256r1;
-	const wordcount_t num_words = 8;
+	const wordcount_t num_words = NUM_ECC_WORDS;
 
 	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
 	uECC_vli_modMult_rnd(t5, t5, t5, s); /* t5 = (x2 - x1)^2 = A */
@@ -837,7 +837,7 @@ static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_word_t t6[NUM_ECC_WORDS];
 	uECC_word_t t7[NUM_ECC_WORDS];
 	const uECC_Curve curve = &curve_secp256r1;
-	const wordcount_t num_words = 8;
+	const wordcount_t num_words = NUM_ECC_WORDS;
 
 	uECC_vli_modSub(t5, X2, X1, curve->p, num_words); /* t5 = x2 - x1 */
 	uECC_vli_modMult_rnd(t5, t5, t5, s); /* t5 = (x2 - x1)^2 = A */
@@ -877,8 +877,8 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	uECC_word_t z[NUM_ECC_WORDS];
 	bitcount_t i;
 	uECC_word_t nb;
-	const wordcount_t num_words = 8;
-	const bitcount_t num_bits = 256 + 1; /* from regularize_k */
+	const wordcount_t num_words = NUM_ECC_WORDS;
+	const bitcount_t num_bits = NUM_ECC_BITS + 1; /* from regularize_k */
 	const uECC_Curve curve = uECC_secp256r1();
 	ecc_wait_state_t wait_state;
 	ecc_wait_state_t * const ws = g_rng_function ? &wait_state : NULL;
@@ -921,8 +921,8 @@ static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 			 uECC_word_t *k1)
 {
 
-	wordcount_t num_n_words = 8;
-	bitcount_t num_n_bits = 256;
+	wordcount_t num_n_words = NUM_ECC_WORDS;
+	bitcount_t num_n_bits = NUM_ECC_BITS;
 	const uECC_Curve curve = uECC_secp256r1();
 
 	uECC_word_t carry = uECC_vli_add(k0, k, curve->n, num_n_words) ||
@@ -940,7 +940,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 	uECC_word_t tmp[NUM_ECC_WORDS];
 	uECC_word_t s[NUM_ECC_WORDS];
 	uECC_word_t *k2[2] = {tmp, s};
-	wordcount_t num_words = 8;
+	wordcount_t num_words = NUM_ECC_WORDS;
 	uECC_word_t carry;
 	uECC_word_t *initial_Z = 0;
 	int r;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -514,8 +514,7 @@ void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
 #define EVEN(vli) (!(vli[0] & 1))
 
 static void vli_modInv_update(uECC_word_t *uv,
-			      const uECC_word_t *mod,
-			      wordcount_t num_words)
+			      const uECC_word_t *mod)
 {
 
 	uECC_word_t carry = 0;
@@ -525,12 +524,12 @@ static void vli_modInv_update(uECC_word_t *uv,
 	}
 	uECC_vli_rshift1(uv);
 	if (carry) {
-		uv[num_words - 1] |= HIGH_BIT_SET;
+		uv[NUM_ECC_WORDS - 1] |= HIGH_BIT_SET;
 	}
 }
 
 void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
-		     const uECC_word_t *mod, wordcount_t num_words)
+		     const uECC_word_t *mod)
 {
 	uECC_word_t a[NUM_ECC_WORDS], b[NUM_ECC_WORDS];
 	uECC_word_t u[NUM_ECC_WORDS], v[NUM_ECC_WORDS];
@@ -549,10 +548,10 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 	while ((cmpResult = uECC_vli_cmp_unsafe(a, b)) != 0) {
 		if (EVEN(a)) {
 			uECC_vli_rshift1(a);
-      			vli_modInv_update(u, mod, num_words);
+      			vli_modInv_update(u, mod);
     		} else if (EVEN(b)) {
 			uECC_vli_rshift1(b);
-			vli_modInv_update(v, mod, num_words);
+			vli_modInv_update(v, mod);
 		} else if (cmpResult > 0) {
 			uECC_vli_sub(a, a, b);
 			uECC_vli_rshift1(a);
@@ -560,7 +559,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
         			uECC_vli_add(u, u, mod);
       			}
       			uECC_vli_sub(u, u, v);
-      			vli_modInv_update(u, mod, num_words);
+      			vli_modInv_update(u, mod);
     		} else {
       			uECC_vli_sub(b, b, a);
       			uECC_vli_rshift1(b);
@@ -568,7 +567,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
         			uECC_vli_add(v, v, mod);
       			}
       			uECC_vli_sub(v, v, u);
-      			vli_modInv_update(v, mod, num_words);
+      			vli_modInv_update(v, mod);
     		}
   	}
   	uECC_vli_set(result, u);
@@ -892,7 +891,7 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	uECC_vli_modSub(z, Rx[1], Rx[0], curve->p); /* X1 - X0 */
 	uECC_vli_modMult_fast(z, z, Ry[1 - nb]); /* Yb * (X1 - X0) */
 	uECC_vli_modMult_fast(z, z, point); /* xP * Yb * (X1 - X0) */
-	uECC_vli_modInv(z, z, curve->p, num_words); /* 1 / (xP * Yb * (X1 - X0))*/
+	uECC_vli_modInv(z, z, curve->p); /* 1 / (xP * Yb * (X1 - X0))*/
 	/* yP / (xP * Yb * (X1 - X0)) */
 	uECC_vli_modMult_fast(z, z, point + num_words);
 	/* Xb * yP / (xP * Yb * (X1 - X0)) */

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -226,13 +226,11 @@ static uECC_word_t uECC_vli_add(uECC_word_t *result, const uECC_word_t *left,
 	return carry;
 }
 
-cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right,
-			 wordcount_t num_words)
+cmpresult_t uECC_vli_cmp(const uECC_word_t *left, const uECC_word_t *right)
 {
 	uECC_word_t tmp[NUM_ECC_WORDS];
 	uECC_word_t neg = !!uECC_vli_sub(tmp, left, right);
 	uECC_word_t equal = uECC_vli_isZero(tmp);
-	(void) num_words;
 	return (!equal - 2 * neg);
 }
 
@@ -1039,7 +1037,7 @@ int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
 		random[num_words - 1] &=
         		mask >> ((bitcount_t)(num_words * uECC_WORD_SIZE * 8 - num_bits));
 		if (!uECC_vli_isZero(random) &&
-			uECC_vli_cmp(top, random, num_words) == 1) {
+			uECC_vli_cmp(top, random) == 1) {
 			return 1;
 		}
 	}
@@ -1109,7 +1107,7 @@ int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
 		return 0;
 	}
 
-	if (uECC_vli_cmp(curve->n, _private, BITS_TO_WORDS(curve->num_n_bits)) != 1) {
+	if (uECC_vli_cmp(curve->n, _private) != 1) {
 		return 0;
 	}
 

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -152,12 +152,11 @@ bitcount_t uECC_vli_numBits(const uECC_word_t *vli)
 	return (((bitcount_t)(num_digits - 1) << uECC_WORD_BITS_SHIFT) + i);
 }
 
-void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src,
-		  wordcount_t num_words)
+void uECC_vli_set(uECC_word_t *dest, const uECC_word_t *src)
 {
 	wordcount_t i;
 
-	for (i = 0; i < num_words; ++i) {
+	for (i = 0; i < NUM_ECC_WORDS; ++i) {
 		dest[i] = src[i];
   	}
 }
@@ -470,7 +469,7 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 			carry = mod[index] >> (uECC_WORD_BITS - bit_shift);
 		}
 	} else {
-		uECC_vli_set(mod_multiple + word_shift, mod, num_words);
+		uECC_vli_set(mod_multiple + word_shift, mod);
 	}
 
 	for (index = 1; shift >= 0; --shift) {
@@ -490,7 +489,7 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 					       (uECC_WORD_BITS - 1);
 		uECC_vli_rshift1(mod_multiple + num_words, num_words);
 	}
-	uECC_vli_set(result, v[index], num_words);
+	uECC_vli_set(result, v[index]);
 }
 
 void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
@@ -547,8 +546,8 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 		return;
 	}
 
-	uECC_vli_set(a, input, num_words);
-	uECC_vli_set(b, mod, num_words);
+	uECC_vli_set(a, input);
+	uECC_vli_set(b, mod);
 	uECC_vli_clear(u);
 	u[0] = 1;
 	uECC_vli_clear(v);
@@ -577,7 +576,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
       			vli_modInv_update(v, mod, num_words);
     		}
   	}
-  	uECC_vli_set(result, u, num_words);
+  	uECC_vli_set(result, u);
 }
 
 /* ------ Point operations ------ */
@@ -624,9 +623,9 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
 	/* t4 = B * (A - x3) - y1^4 = y3: */
 	uECC_vli_modSub(t4, X1, t4, curve->p, num_words);
 
-	uECC_vli_set(X1, Z1, num_words);
-	uECC_vli_set(Z1, Y1, num_words);
-	uECC_vli_set(Y1, t4, num_words);
+	uECC_vli_set(X1, Z1);
+	uECC_vli_set(Z1, Y1);
+	uECC_vli_set(Y1, t4);
 }
 
 void x_side_default(uECC_word_t *result,
@@ -654,7 +653,7 @@ void vli_mmod_fast_secp256r1(unsigned int *result, unsigned int*product)
 	int carry;
 
 	/* t */
-	uECC_vli_set(result, product, NUM_ECC_WORDS);
+	uECC_vli_set(result, product);
 
 	/* s1 */
 	tmp[0] = tmp[1] = tmp[2] = 0;
@@ -772,16 +771,15 @@ static void XYcZ_initial_double(uECC_word_t * X1, uECC_word_t * Y1,
 				uECC_Curve curve)
 {
 	uECC_word_t z[NUM_ECC_WORDS];
-	wordcount_t num_words = curve->num_words;
 	if (initial_Z) {
-		uECC_vli_set(z, initial_Z, num_words);
+		uECC_vli_set(z, initial_Z);
 	} else {
 		uECC_vli_clear(z);
 		z[0] = 1;
 	}
 
-	uECC_vli_set(X2, X1, num_words);
-	uECC_vli_set(Y2, Y1, num_words);
+	uECC_vli_set(X2, X1);
+	uECC_vli_set(Y2, Y1);
 
 	apply_z(X1, Y1, z);
 	curve->double_jacobian(X1, Y1, z, curve);
@@ -812,7 +810,7 @@ static void XYcZ_add_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_vli_modMult_rnd(Y2, Y2, X2, s); /* t4 = (y2 - y1)*(B - x3) */
 	uECC_vli_modSub(Y2, Y2, Y1, curve->p, num_words); /* t4 = y3 */
 
-	uECC_vli_set(X2, t5, num_words);
+	uECC_vli_set(X2, t5);
 }
 
 void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1,
@@ -863,7 +861,7 @@ static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	/* t2 = (y2+y1)*(x3' - B) - E = y3': */
 	uECC_vli_modSub(Y1, t6, Y1, curve->p, num_words);
 
-	uECC_vli_set(X1, t7, num_words);
+	uECC_vli_set(X1, t7);
 }
 
 static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
@@ -882,8 +880,8 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	ecc_wait_state_t wait_state;
 	ecc_wait_state_t * const ws = g_rng_function ? &wait_state : NULL;
 
-	uECC_vli_set(Rx[1], point, num_words);
-  	uECC_vli_set(Ry[1], point + num_words, num_words);
+	uECC_vli_set(Rx[1], point);
+  	uECC_vli_set(Ry[1], point + num_words);
 
 	XYcZ_initial_double(Rx[1], Ry[1], Rx[0], Ry[0], initial_Z, curve);
 
@@ -912,8 +910,8 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	XYcZ_add_rnd(Rx[nb], Ry[nb], Rx[1 - nb], Ry[1 - nb], ws);
 	apply_z(Rx[0], Ry[0], z);
 
-	uECC_vli_set(result, Rx[0], num_words);
-	uECC_vli_set(result + num_words, Ry[0], num_words);
+	uECC_vli_set(result, Rx[0]);
+	uECC_vli_set(result + num_words, Ry[0]);
 }
 
 static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -871,7 +871,7 @@ static void XYcZ_addC_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 	uECC_vli_set(X1, t7, num_words);
 }
 
-void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
+static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 		   const uECC_word_t * scalar,
 		   const uECC_word_t * initial_Z,
 		   bitcount_t num_bits, uECC_Curve curve)
@@ -920,7 +920,7 @@ void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 	uECC_vli_set(result + num_words, Ry[0], num_words);
 }
 
-uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
+static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 			 uECC_word_t *k1, uECC_Curve curve)
 {
 

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -72,12 +72,6 @@
 #include <string.h>
 #include "mbedtls/platform_util.h"
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
-
 int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 			 unsigned int *d, uECC_Curve curve)
 {
@@ -160,11 +154,6 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 
 	uECC_word_t _public[NUM_ECC_WORDS * 2];
 	uECC_word_t _private[NUM_ECC_WORDS];
-
-	uECC_word_t tmp[NUM_ECC_WORDS];
-	uECC_word_t *p2[2] = {_private, tmp};
-	uECC_word_t *initial_Z = 0;
-	uECC_word_t carry;
 	wordcount_t num_words = curve->num_words;
 	wordcount_t num_bytes = curve->num_bytes;
 	int r;
@@ -186,30 +175,15 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 			       public_key + num_bytes,
 			       num_bytes);
 
-	/* Regularize the bitcount for the private key so that attackers cannot use a
-	 * side channel attack to learn the number of leading zeros. */
-	carry = regularize_k(_private, _private, tmp, curve);
-
-	/* If an RNG function was specified, try to get a random initial Z value to
-	 * improve protection against side-channel attacks. */
-	if (g_rng_function) {
-		if (!uECC_generate_random_int(p2[carry], curve->p, num_words)) {
-			r = 0;
-			goto clear_and_out;
-    		}
-    		initial_Z = p2[carry];
-  	}
-
-	EccPoint_mult(_public, _public, p2[!carry], initial_Z, curve->num_n_bits + 1,
-		      curve);
+	r = EccPoint_mult_safer(_public, _public, _private, curve);
+        if (r == 0)
+            goto clear_and_out;
 
 	uECC_vli_nativeToBytes(secret, num_bytes, _public);
 	r = !EccPoint_isZero(_public, curve);
 
 clear_and_out:
 	/* erasing temporary buffer used to store secret: */
-	mbedtls_platform_zeroize(p2, sizeof(p2));
-	mbedtls_platform_zeroize(tmp, sizeof(tmp));
 	mbedtls_platform_zeroize(_private, sizeof(_private));
 
 	return r;

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -169,6 +169,12 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 	wordcount_t num_bytes = curve->num_bytes;
 	int r;
 
+        /* Protect against invalid curve attacks */
+        if (uECC_valid_public_key(public_key, curve) != 0) {
+            r = 0;
+            goto clear_and_out;
+        }
+
 	/* Converting buffers to correct bit order: */
 	uECC_vli_bytesToNative(_private,
       			       private_key,

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -123,7 +123,7 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key, uECC_Curve curve)
 		}
 
 		/* computing modular reduction of _random (see FIPS 186.4 B.4.1): */
-		uECC_vli_mmod(_private, _random, curve->n, BITS_TO_WORDS(curve->num_n_bits));
+		uECC_vli_mmod(_private, _random, curve->n);
 
 		/* Computing public-key from private: */
 		if (EccPoint_compute_public_key(_public, _private, curve)) {

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -115,7 +115,6 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_word_t tmp[NUM_ECC_WORDS];
 	uECC_word_t s[NUM_ECC_WORDS];
 	uECC_word_t p[NUM_ECC_WORDS * 2];
-	wordcount_t num_words = curve->num_words;
 	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
 	int r;
 
@@ -153,7 +152,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_vli_bytesToNative(tmp, private_key, BITS_TO_BYTES(curve->num_n_bits));
 
 	s[num_n_words - 1] = 0;
-	uECC_vli_set(s, p, num_words);
+	uECC_vli_set(s, p);
 	uECC_vli_modMult(s, tmp, s, curve->n, num_n_words); /* s = r*d */
 
 	bits2int(tmp, message_hash, hash_size, curve);
@@ -250,10 +249,10 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_modMult(u2, r, z, curve->n, num_n_words); /* u2 = r/s */
 
 	/* Calculate sum = G + Q. */
-	uECC_vli_set(sum, _public, num_words);
-	uECC_vli_set(sum + num_words, _public + num_words, num_words);
-	uECC_vli_set(tx, curve->G, num_words);
-	uECC_vli_set(ty, curve->G + num_words, num_words);
+	uECC_vli_set(sum, _public);
+	uECC_vli_set(sum + num_words, _public + num_words);
+	uECC_vli_set(tx, curve->G);
+	uECC_vli_set(ty, curve->G + num_words);
 	uECC_vli_modSub(z, sum, tx, curve->p, num_words); /* z = x2 - x1 */
 	XYcZ_add(tx, ty, sum, sum + num_words, curve);
 	uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
@@ -269,8 +268,8 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 
 	point = points[(!!uECC_vli_testBit(u1, num_bits - 1)) |
                        ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
-	uECC_vli_set(rx, point, num_words);
-	uECC_vli_set(ry, point + num_words, num_words);
+	uECC_vli_set(rx, point);
+	uECC_vli_set(ry, point + num_words);
 	uECC_vli_clear(z);
 	z[0] = 1;
 
@@ -281,8 +280,8 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 		index = (!!uECC_vli_testBit(u1, i)) | ((!!uECC_vli_testBit(u2, i)) << 1);
 		point = points[index];
 		if (point) {
-			uECC_vli_set(tx, point, num_words);
-			uECC_vli_set(ty, point + num_words, num_words);
+			uECC_vli_set(tx, point);
+			uECC_vli_set(ty, point + num_words);
 			apply_z(tx, ty, z);
 			uECC_vli_modSub(tz, rx, tx, curve->p, num_words); /* Z = x2 - x1 */
 			XYcZ_add(tx, ty, rx, ry, curve);

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -87,7 +87,7 @@ static void bits2int(uECC_word_t *native, const uint8_t *bits,
 		bits_size = num_n_bytes;
 	}
 
-	uECC_vli_clear(native, num_n_words);
+	uECC_vli_clear(native);
 	uECC_vli_bytesToNative(native, bits, bits_size);
 	if (bits_size * 8 <= (unsigned)curve->num_n_bits) {
 		return;
@@ -134,7 +134,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	/* If an RNG function was specified, get a random number
 	to prevent side channel analysis of k. */
 	if (!g_rng_function) {
-		uECC_vli_clear(tmp, num_n_words);
+		uECC_vli_clear(tmp);
 		tmp[0] = 1;
 	}
 	else if (!uECC_generate_random_int(tmp, curve->n, num_n_words)) {
@@ -271,7 +271,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
                        ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
 	uECC_vli_set(rx, point, num_words);
 	uECC_vli_set(ry, point + num_words, num_words);
-	uECC_vli_clear(z, num_words);
+	uECC_vli_clear(z);
 	z[0] = 1;
 
 	for (i = num_bits - 2; i >= 0; --i) {

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -142,9 +142,9 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* Prevent side channel analysis of uECC_vli_modInv() to determine
 	bits of k / the private key by premultiplying by a random number */
-	uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k' = rand * k */
+	uECC_vli_modMult(k, k, tmp, curve->n); /* k' = rand * k */
 	uECC_vli_modInv(k, k, curve->n, num_n_words);       /* k = 1 / k' */
-	uECC_vli_modMult(k, k, tmp, curve->n, num_n_words); /* k = 1 / k */
+	uECC_vli_modMult(k, k, tmp, curve->n); /* k = 1 / k */
 
 	uECC_vli_nativeToBytes(signature, curve->num_bytes, p); /* store r */
 
@@ -153,11 +153,11 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	s[num_n_words - 1] = 0;
 	uECC_vli_set(s, p);
-	uECC_vli_modMult(s, tmp, s, curve->n, num_n_words); /* s = r*d */
+	uECC_vli_modMult(s, tmp, s, curve->n); /* s = r*d */
 
 	bits2int(tmp, message_hash, hash_size, curve);
 	uECC_vli_modAdd(s, tmp, s, curve->n); /* s = e + r*d */
-	uECC_vli_modMult(s, s, k, curve->n, num_n_words);  /* s = (e + r*d) / k */
+	uECC_vli_modMult(s, s, k, curve->n);  /* s = (e + r*d) / k */
 	if (uECC_vli_numBits(s) > (bitcount_t)curve->num_bytes * 8) {
 		return 0;
 	}
@@ -245,8 +245,8 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_modInv(z, s, curve->n, num_n_words); /* z = 1/s */
 	u1[num_n_words - 1] = 0;
 	bits2int(u1, message_hash, hash_size, curve);
-	uECC_vli_modMult(u1, u1, z, curve->n, num_n_words); /* u1 = e/s */
-	uECC_vli_modMult(u2, r, z, curve->n, num_n_words); /* u2 = r/s */
+	uECC_vli_modMult(u1, u1, z, curve->n); /* u1 = e/s */
+	uECC_vli_modMult(u2, r, z, curve->n); /* u2 = r/s */
 
 	/* Calculate sum = G + Q. */
 	uECC_vli_set(sum, _public);

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -121,7 +121,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* Make sure 0 < k < curve_n */
   	if (uECC_vli_isZero(k) ||
-	    uECC_vli_cmp(curve->n, k, num_n_words) != 1) {
+	    uECC_vli_cmp(curve->n, k) != 1) {
 		return 0;
 	}
 

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -182,7 +182,7 @@ int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
 		}
 
 		// computing k as modular reduction of _random (see FIPS 186.4 B.5.1):
-		uECC_vli_mmod(k, _random, curve->n, BITS_TO_WORDS(curve->num_n_bits));
+		uECC_vli_mmod(k, _random, curve->n);
 
 		if (uECC_sign_with_k(private_key, message_hash, hash_size, k, signature, 
 		    curve)) {

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -159,7 +159,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	bits2int(tmp, message_hash, hash_size, curve);
 	uECC_vli_modAdd(s, tmp, s, curve->n, num_n_words); /* s = e + r*d */
 	uECC_vli_modMult(s, s, k, curve->n, num_n_words);  /* s = (e + r*d) / k */
-	if (uECC_vli_numBits(s, num_n_words) > (bitcount_t)curve->num_bytes * 8) {
+	if (uECC_vli_numBits(s) > (bitcount_t)curve->num_bytes * 8) {
 		return 0;
 	}
 
@@ -264,8 +264,8 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	points[1] = curve->G;
 	points[2] = _public;
 	points[3] = sum;
-	num_bits = smax(uECC_vli_numBits(u1, num_n_words),
-	uECC_vli_numBits(u2, num_n_words));
+	num_bits = smax(uECC_vli_numBits(u1),
+	uECC_vli_numBits(u2));
 
 	point = points[(!!uECC_vli_testBit(u1, num_bits - 1)) |
                        ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -257,7 +257,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_modSub(z, sum, tx, curve->p, num_words); /* z = x2 - x1 */
 	XYcZ_add(tx, ty, sum, sum + num_words, curve);
 	uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
-	apply_z(sum, sum + num_words, z, curve);
+	apply_z(sum, sum + num_words, z);
 
 	/* Use Shamir's trick to calculate u1*G + u2*Q */
 	points[0] = 0;
@@ -283,15 +283,15 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 		if (point) {
 			uECC_vli_set(tx, point, num_words);
 			uECC_vli_set(ty, point + num_words, num_words);
-			apply_z(tx, ty, z, curve);
+			apply_z(tx, ty, z);
 			uECC_vli_modSub(tz, rx, tx, curve->p, num_words); /* Z = x2 - x1 */
 			XYcZ_add(tx, ty, rx, ry, curve);
-			uECC_vli_modMult_fast(z, z, tz, curve);
+			uECC_vli_modMult_fast(z, z, tz);
 		}
   	}
 
 	uECC_vli_modInv(z, z, curve->p, num_words); /* Z = 1/Z */
-	apply_z(rx, ry, z, curve);
+	apply_z(rx, ry, z);
 
 	/* v = x1 (mod n) */
 	if (uECC_vli_cmp_unsafe(curve->n, rx, num_n_words) != 1) {

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -121,13 +121,13 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 
 	/* Make sure 0 < k < curve_n */
-  	if (uECC_vli_isZero(k, num_words) ||
+  	if (uECC_vli_isZero(k) ||
 	    uECC_vli_cmp(curve->n, k, num_n_words) != 1) {
 		return 0;
 	}
 
 	r = EccPoint_mult_safer(p, curve->G, k, curve);
-	if (r == 0 || uECC_vli_isZero(p, num_words)) {
+	if (r == 0 || uECC_vli_isZero(p)) {
 		return 0;
 	}
 
@@ -232,7 +232,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_bytesToNative(s, signature + curve->num_bytes, curve->num_bytes);
 
 	/* r, s must not be 0. */
-	if (uECC_vli_isZero(r, num_words) || uECC_vli_isZero(s, num_words)) {
+	if (uECC_vli_isZero(r) || uECC_vli_isZero(s)) {
 		return 0;
 	}
 

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -220,6 +220,9 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	wordcount_t num_words = curve->num_words;
 	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
 
+	if (curve != uECC_secp256r1())
+		return 0;
+
 	rx[num_n_words - 1] = 0;
 	r[num_n_words - 1] = 0;
 	s[num_n_words - 1] = 0;

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -102,7 +102,7 @@ static void bits2int(uECC_word_t *native, const uint8_t *bits,
 	}
 
 	/* Reduce mod curve_n */
-	if (uECC_vli_cmp_unsafe(curve->n, native, num_n_words) != 1) {
+	if (uECC_vli_cmp_unsafe(curve->n, native) != 1) {
 		uECC_vli_sub(native, native, curve->n, num_n_words);
 	}
 }
@@ -236,8 +236,8 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	}
 
 	/* r, s must be < n. */
-	if (uECC_vli_cmp_unsafe(curve->n, r, num_n_words) != 1 ||
-	    uECC_vli_cmp_unsafe(curve->n, s, num_n_words) != 1) {
+	if (uECC_vli_cmp_unsafe(curve->n, r) != 1 ||
+	    uECC_vli_cmp_unsafe(curve->n, s) != 1) {
 		return 0;
 	}
 
@@ -293,7 +293,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	apply_z(rx, ry, z);
 
 	/* v = x1 (mod n) */
-	if (uECC_vli_cmp_unsafe(curve->n, rx, num_n_words) != 1) {
+	if (uECC_vli_cmp_unsafe(curve->n, rx) != 1) {
 		uECC_vli_sub(rx, rx, curve->n, num_n_words);
 	}
 

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -103,7 +103,7 @@ static void bits2int(uECC_word_t *native, const uint8_t *bits,
 
 	/* Reduce mod curve_n */
 	if (uECC_vli_cmp_unsafe(curve->n, native) != 1) {
-		uECC_vli_sub(native, native, curve->n, num_n_words);
+		uECC_vli_sub(native, native, curve->n);
 	}
 }
 
@@ -294,7 +294,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 
 	/* v = x1 (mod n) */
 	if (uECC_vli_cmp_unsafe(curve->n, rx) != 1) {
-		uECC_vli_sub(rx, rx, curve->n, num_n_words);
+		uECC_vli_sub(rx, rx, curve->n);
 	}
 
 	/* Accept only if v == r. */

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -253,7 +253,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_set(sum + num_words, _public + num_words);
 	uECC_vli_set(tx, curve->G);
 	uECC_vli_set(ty, curve->G + num_words);
-	uECC_vli_modSub(z, sum, tx, curve->p, num_words); /* z = x2 - x1 */
+	uECC_vli_modSub(z, sum, tx, curve->p); /* z = x2 - x1 */
 	XYcZ_add(tx, ty, sum, sum + num_words, curve);
 	uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
 	apply_z(sum, sum + num_words, z);
@@ -283,7 +283,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 			uECC_vli_set(tx, point);
 			uECC_vli_set(ty, point + num_words);
 			apply_z(tx, ty, z);
-			uECC_vli_modSub(tz, rx, tx, curve->p, num_words); /* Z = x2 - x1 */
+			uECC_vli_modSub(tz, rx, tx, curve->p); /* Z = x2 - x1 */
 			XYcZ_add(tx, ty, rx, ry, curve);
 			uECC_vli_modMult_fast(z, z, tz);
 		}

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -143,7 +143,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	/* Prevent side channel analysis of uECC_vli_modInv() to determine
 	bits of k / the private key by premultiplying by a random number */
 	uECC_vli_modMult(k, k, tmp, curve->n); /* k' = rand * k */
-	uECC_vli_modInv(k, k, curve->n, num_n_words);       /* k = 1 / k' */
+	uECC_vli_modInv(k, k, curve->n);       /* k = 1 / k' */
 	uECC_vli_modMult(k, k, tmp, curve->n); /* k = 1 / k */
 
 	uECC_vli_nativeToBytes(signature, curve->num_bytes, p); /* store r */
@@ -242,7 +242,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	}
 
 	/* Calculate u1 and u2. */
-	uECC_vli_modInv(z, s, curve->n, num_n_words); /* z = 1/s */
+	uECC_vli_modInv(z, s, curve->n); /* z = 1/s */
 	u1[num_n_words - 1] = 0;
 	bits2int(u1, message_hash, hash_size, curve);
 	uECC_vli_modMult(u1, u1, z, curve->n); /* u1 = e/s */
@@ -255,7 +255,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_set(ty, curve->G + num_words);
 	uECC_vli_modSub(z, sum, tx, curve->p); /* z = x2 - x1 */
 	XYcZ_add(tx, ty, sum, sum + num_words, curve);
-	uECC_vli_modInv(z, z, curve->p, num_words); /* z = 1/z */
+	uECC_vli_modInv(z, z, curve->p); /* z = 1/z */
 	apply_z(sum, sum + num_words, z);
 
 	/* Use Shamir's trick to calculate u1*G + u2*Q */
@@ -289,7 +289,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 		}
   	}
 
-	uECC_vli_modInv(z, z, curve->p, num_words); /* Z = 1/Z */
+	uECC_vli_modInv(z, z, curve->p); /* Z = 1/Z */
 	apply_z(rx, ry, z);
 
 	/* v = x1 (mod n) */

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -116,6 +116,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_word_t s[NUM_ECC_WORDS];
 	uECC_word_t *k2[2] = {tmp, s};
 	uECC_word_t p[NUM_ECC_WORDS * 2];
+	uECC_word_t *initial_Z = 0;
 	uECC_word_t carry;
 	wordcount_t num_words = curve->num_words;
 	wordcount_t num_n_words = BITS_TO_WORDS(curve->num_n_bits);
@@ -127,8 +128,20 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 		return 0;
 	}
 
+	/* Regularize the bitcount for the private key so that attackers cannot use a
+	 * side channel attack to learn the number of leading zeros. */
 	carry = regularize_k(k, tmp, s, curve);
-	EccPoint_mult(p, curve->G, k2[!carry], 0, num_n_bits + 1, curve);
+
+	/* If an RNG function was specified, get a random initial Z value to
+         * protect against side-channel attacks such as Template SPA */
+	if (g_rng_function) {
+		if (!uECC_generate_random_int(k2[carry], curve->p, num_words)) {
+			return 0;
+		}
+		initial_Z = k2[carry];
+	}
+
+	EccPoint_mult(p, curve->G, k2[!carry], initial_Z, num_n_bits + 1, curve);
 	if (uECC_vli_isZero(p, num_words)) {
 		return 0;
 	}

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -298,7 +298,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	}
 
 	/* Accept only if v == r. */
-	return (int)(uECC_vli_equal(rx, r, num_words) == 0);
+	return (int)(uECC_vli_equal(rx, r) == 0);
 }
 #else
 typedef int mbedtls_dummy_tinycrypt_def;

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -156,7 +156,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_vli_modMult(s, tmp, s, curve->n, num_n_words); /* s = r*d */
 
 	bits2int(tmp, message_hash, hash_size, curve);
-	uECC_vli_modAdd(s, tmp, s, curve->n, num_n_words); /* s = e + r*d */
+	uECC_vli_modAdd(s, tmp, s, curve->n); /* s = e + r*d */
 	uECC_vli_modMult(s, s, k, curve->n, num_n_words);  /* s = (e + r*d) / k */
 	if (uECC_vli_numBits(s) > (bitcount_t)curve->num_bytes * 8) {
 		return 0;


### PR DESCRIPTION
## Description

The TinyCrypt code already includes counter-measures against a number of side-channels. However, internal analysis has identified a number of additional counter-measures that could help protect against more attacks. This PR implements them.

Since the counter-measures add a non-trivial amount of code, the PR then looks at easy ways to save code size. One of them is implemented (hardcoding numwords internally), the other (hardcoding curve internally) might be deferred to a later PR.

### Impact on size

Size of `libmbedcrypto.a` in bytes, measured with `scripts/baremetal.sh --rom --armc5`.

| | size (bytes) | diff (prev. line) | diff (first line) |
| --- | --- | --- | --- |
| before | 18699 | | |
| after counter-measures | 19099 | +400 | |
| after hardcoding numwords | 18427 | -672 | -272 |

### Impact on speed

Time in ms for a **key generation** (representative of operations except signature verification, see below), measured on `NUCLEO_L073RZ` using Jarno's [test program](https://github.com/ARMmbed/mbedtls-test/tree/master/benchmark/rng_test).

| | time in ms | diff (prev. line) | diff (first line) |
| --- | --- | --- | --- |
| before | 1560 | | |
| after counter-measures | 1908 | +22% | |
| after hardcoding numwords | 1748 | -8% | +12% |

Note: **signature verification** sees an impact of +7% execution time. It doesn't run the countermeasure against horizontal attacks (which has the most impact on performance), and the performance degradation seems to be due to the logic of using or skipping the randomization in multi-precision multiplication. This could only be avoided by having near-duplicate implementations of several functions in the stack, which seems undesirable due to the negative impact on code size.

## To do

- [x] include code size figures in description above
- [x] measure impact on performance on target and include results in description above
- [x] optional: save code size by hardcoding numwords in internal functions
- [ ] optional: save code size by hardcoding `curve` (and its fields) in internal functions
- [x] investigate and fix performance impact on verification

## Status
**READY**

