### PR TITLE
Backport 2.7: Fix some possibly-undefined variable warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS 2.7.x branch released xxxx-xx-xx
 
+Bugfix
+   * Fix some false-positive uninitialized variable warnings. Fix
+     contributed by apple-ihack-geek in #2663.
+
 Changes
    * Add unit tests for AES-GCM when called through mbedtls_cipher_auth_xxx()
      from the cipher abstraction layer. Fixes #2198.

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -262,7 +262,7 @@ int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
  */
 static int entropy_gather_internal( mbedtls_entropy_context *ctx )
 {
-    int ret, i, have_one_strong = 0;
+    int ret = 0, i, have_one_strong = 0;
     unsigned char buf[MBEDTLS_ENTROPY_MAX_GATHER];
     size_t olen;
 

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -78,7 +78,7 @@ int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
     unsigned char rounds = ( additional != NULL && add_len != 0 ) ? 2 : 1;
     unsigned char sep[1];
     unsigned char K[MBEDTLS_MD_MAX_SIZE];
-    int ret;
+    int ret = 0;
 
     for( sep[0] = 0; sep[0] < rounds; sep[0]++ )
     {

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -544,7 +544,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
 {
 #if defined(MBEDTLS_PEM_PARSE_C)
     int ret;
-    size_t use_len;
+    size_t use_len = 0;
     mbedtls_pem_context pem;
     int is_pem = 0;
 


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2663 contributed by @apple-ihack-geek. The runtime behavior was always correct, but some compilers warned that they weren't sure about it.

2.7 has 3 of the 4 problematic code snippets: the one in `x509_crt_find_parent_in` is in code that was added after 2.7.

Development PR: https://github.com/ARMmbed/mbedtls/pull/2873, https://github.com/ARMmbed/mbed-crypto/pull/284