### PR TITLE
[baremetal] Disable use of HRNG in SCA-hardened mem-functions

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -142,7 +142,10 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
 uint32_t mbedtls_platform_random_in_range( size_t num )
 {
-#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+    /* Temporary force the dummy version - drawing directly from the HRNG
+     * seems to be causing issues, avoid doing that until we understood the
+     * issue, and perhaps we'll need to draw from a DRBG instead. */
+#if 1 || !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     (void) num;
     return 0;
 #else


### PR DESCRIPTION
## Description
This is a temporary work-around for an integration issue.

A future task will re-integrate randomness into these functions are their
entire point is to be randomized; this is really just temporary.

## Status
**READY**

