### PR TITLE
[baremetal] Remove TinyCrypt config condition in source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,10 @@ endif(ENABLE_ZLIB_SUPPORT)
 
 add_subdirectory(library)
 add_subdirectory(include)
-add_subdirectory(tinycrypt)
+
+if(USE_TINYCRYPT)
+    add_subdirectory(tinycrypt)
+endif()
 
 if(ENABLE_PROGRAMS)
     add_subdirectory(programs)

--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -73,7 +73,6 @@
  *
  */
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #ifndef __TC_UECC_H__
 #define __TC_UECC_H__
 
@@ -528,4 +527,3 @@ void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
 #endif
 
 #endif /* __TC_UECC_H__ */
-#endif /* MBEDTLS_USE_TINYCRYPT */

--- a/include/tinycrypt/ecc_dh.h
+++ b/include/tinycrypt/ecc_dh.h
@@ -71,7 +71,6 @@
  *  Security: The curve NIST p-256 provides approximately 128 bits of security.
  */
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #ifndef __TC_ECC_DH_H__
 #define __TC_ECC_DH_H__
 
@@ -135,4 +134,3 @@ int uECC_shared_secret(const uint8_t *p_public_key, const uint8_t *p_private_key
 #endif
 
 #endif /* __TC_ECC_DH_H__ */
-#endif /* MBEDTLS_USE_TINYCRYPT */

--- a/include/tinycrypt/ecc_dsa.h
+++ b/include/tinycrypt/ecc_dsa.h
@@ -80,7 +80,6 @@
  *          the signer's public key and the signature values (r and s).
  */
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #ifndef __TC_ECC_DSA_H__
 #define __TC_ECC_DSA_H__
 
@@ -143,4 +142,3 @@ int uECC_verify(const uint8_t *p_public_key, const uint8_t *p_message_hash,
 #endif
 
 #endif /* __TC_ECC_DSA_H__ */
-#endif /* MBEDTLS_USE_TINYCRYPT */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
+option(USE_TINYCRYPT "Include TinyCrypt." ON)
 option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
 option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)
 
@@ -123,7 +124,9 @@ if(LINK_WITH_PTHREAD)
     set(libs ${libs} pthread)
 endif()
 
-set(libs ${libs} tinycrypt)
+if(USE_TINYCRYPT)
+    set(libs ${libs} tinycrypt)
+endif()
 
 if (NOT USE_STATIC_MBEDTLS_LIBRARY AND NOT USE_SHARED_MBEDTLS_LIBRARY)
     message(FATAL_ERROR "Need to choose static or shared mbedtls build!")

--- a/library/Makefile
+++ b/library/Makefile
@@ -99,8 +99,7 @@ OBJS_CRYPTO=	aes.o		aesni.o		arc4.o		\
 		ripemd160.o	rsa_internal.o	rsa.o  		\
 		sha1.o		sha256.o	sha512.o	\
 		threading.o	timing.o	version.o	\
-		version_features.o		xtea.o		\
-		ecc.o		ecc_dh.o	ecc_dsa.o
+		version_features.o		xtea.o
 
 OBJS_X509=	certs.o		pkcs11.o	x509.o
 
@@ -109,6 +108,17 @@ OBJS_TLS=	debug.o		net_sockets.o		\
 		ssl_cli.o	ssl_cookie.o		\
 		ssl_srv.o	ssl_ticket.o		\
 		ssl_tls.o
+
+# Default to always build TinyCrypt
+ifndef TINYCRYPT_BUILD
+TINYCRYPT_BUILD=1
+endif
+
+ifeq ($(TINYCRYPT_BUILD),1)
+# Add TinyCrypt to the targets and Makefile path
+VPATH = ../tinycrypt
+OBJS_CRYPTO += ecc.o           ecc_dh.o        ecc_dsa.o
+endif
 
 .SILENT:
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1491,7 +1491,7 @@ component_build_arm_none_eabi_gcc_no_64bit_multiplication () {
     msg "build: arm-none-eabi-gcc MBEDTLS_NO_64BIT_MULTIPLICATION, make" # ~ 10s
     scripts/config.pl baremetal
     scripts/config.pl set MBEDTLS_NO_64BIT_MULTIPLICATION
-    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1 -march=armv6-m -mthumb' lib
+    make TINYCRYPT_BUILD=0 CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -O1 -march=armv6-m -mthumb' lib
     echo "Checking that software 64-bit multiplication is not required"
     if_build_succeeded not grep __aeabi_lmul library/*.o
 }

--- a/tests/scripts/list-symbols.sh
+++ b/tests/scripts/list-symbols.sh
@@ -16,7 +16,7 @@ cp include/mbedtls/config.h include/mbedtls/config.h.bak
 scripts/config.pl full
 make clean
 make_ret=
-CFLAGS=-fno-asynchronous-unwind-tables make lib \
+CFLAGS=-fno-asynchronous-unwind-tables TINYCRYPT_BUILD=0 make lib \
       >list-symbols.make.log 2>&1 ||
   {
     make_ret=$?

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -63,7 +63,6 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #include <tinycrypt/ecc.h>
 #include "mbedtls/platform_util.h"
 #include <string.h>
@@ -1114,7 +1113,4 @@ int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key,
 	curve->num_bytes, curve->num_bytes, _public + curve->num_words);
 	return 1;
 }
-#else
-typedef int mbedtls_dummy_tinycrypt_def;
-#endif /* MBEDTLS_USE_TINYCRYPT */
 

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -66,7 +66,6 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dh.h>
 #include <string.h>
@@ -188,6 +187,3 @@ clear_and_out:
 
 	return r;
 }
-#else
-typedef int mbedtls_dummy_tinycrypt_def;
-#endif /* MBEDTLS_USE_TINYCRYPT */

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -64,7 +64,6 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if defined(MBEDTLS_USE_TINYCRYPT)
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dsa.h>
 
@@ -303,6 +302,3 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	/* Accept only if v == r. */
 	return (int)(uECC_vli_equal(rx, r) == 0);
 }
-#else
-typedef int mbedtls_dummy_tinycrypt_def;
-#endif /* MBEDTLS_USE_TINYCRYPT */


### PR DESCRIPTION
## Description
This PR removes from the TinyCrypt header and source code files, the configuration condition on `MBEDTLS_USE_TINYCRYPT` to include the file contents.

This is to allow use of the library by the Factory Tool without enabling `MBEDTLS_USE_TINYCRYPT`, and also removes a modification we've made to make the code closer to the upstream TinyCrypt making it easier to maintain.

This change has already been made in the solution repo in PR #160 downstream, and needs to be reflected here.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO