### PR TITLE
Mock TCP sockets and callbacks for SSL unit tests

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -242,7 +242,7 @@ typedef enum
  * You must set \p pointer to \c NULL before calling this macro and
  * put `mbedtls_free( pointer )` in the test's cleanup code.
  *
- * If \p size is zero, the resulting \p pointer will be \c NULL.
+ * If \p length is zero, the resulting \p pointer will be \c NULL.
  * This is usually what we want in tests since API functions are
  * supposed to accept null pointers when a buffer size is zero.
  *
@@ -252,20 +252,21 @@ typedef enum
  * \param pointer   An lvalue where the address of the allocated buffer
  *                  will be stored.
  *                  This expression may be evaluated multiple times.
- * \param size      Buffer size to allocate in bytes.
+ * \param length    Number of elements to allocate.
  *                  This expression may be evaluated multiple times.
  *
  */
-#define ASSERT_ALLOC( pointer, size )                           \
-    do                                                          \
-    {                                                           \
-        TEST_ASSERT( ( pointer ) == NULL );                     \
-        if( ( size ) != 0 )                                     \
-        {                                                       \
-            ( pointer ) = mbedtls_calloc( 1, ( size ) );        \
-            TEST_ASSERT( ( pointer ) != NULL );                 \
-        }                                                       \
-    }                                                           \
+#define ASSERT_ALLOC( pointer, length )                           \
+    do                                                            \
+    {                                                             \
+        TEST_ASSERT( ( pointer ) == NULL );                       \
+        if( ( length ) != 0 )                                     \
+        {                                                         \
+            ( pointer ) = mbedtls_calloc( sizeof( *( pointer ) ), \
+                                          ( length ) );           \
+            TEST_ASSERT( ( pointer ) != NULL );                   \
+        }                                                         \
+    }                                                             \
     while( 0 )
 
 /*

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -230,12 +230,43 @@ typedef enum
 #define TEST_VALID_PARAM( TEST )                                    \
     TEST_ASSERT( ( TEST, 1 ) );
 
-#define TEST_HELPER_ASSERT(a) if( !( a ) )                                      \
+#define TEST_HELPER_ASSERT(a) if( !( a ) )                          \
 {                                                                   \
-    mbedtls_fprintf( stderr, "Assertion Failed at %s:%d - %s\n",   \
+    mbedtls_fprintf( stderr, "Assertion Failed at %s:%d - %s\n",    \
                              __FILE__, __LINE__, #a );              \
-    mbedtls_exit( 1 );                                             \
+    mbedtls_exit( 1 );                                              \
 }
+
+/** Allocate memory dynamically and fail the test case if this fails.
+ *
+ * You must set \p pointer to \c NULL before calling this macro and
+ * put `mbedtls_free( pointer )` in the test's cleanup code.
+ *
+ * If \p size is zero, the resulting \p pointer will be \c NULL.
+ * This is usually what we want in tests since API functions are
+ * supposed to accept null pointers when a buffer size is zero.
+ *
+ * This macro expands to an instruction, not an expression.
+ * It may jump to the \c exit label.
+ *
+ * \param pointer   An lvalue where the address of the allocated buffer
+ *                  will be stored.
+ *                  This expression may be evaluated multiple times.
+ * \param size      Buffer size to allocate in bytes.
+ *                  This expression may be evaluated multiple times.
+ *
+ */
+#define ASSERT_ALLOC( pointer, size )                           \
+    do                                                          \
+    {                                                           \
+        TEST_ASSERT( ( pointer ) == NULL );                     \
+        if( ( size ) != 0 )                                     \
+        {                                                       \
+            ( pointer ) = mbedtls_calloc( 1, ( size ) );        \
+            TEST_ASSERT( ( pointer ) != NULL );                 \
+        }                                                       \
+    }                                                           \
+    while( 0 )
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -75,7 +75,7 @@ uint8_t receive_byte()
     c[1] = greentea_getc();
     c[2] = '\0';
 
-    assert( unhexify( &byte, c ) != 2 );
+    TEST_HELPER_ASSERT( unhexify( &byte, c ) != 2 );
     return( byte );
 }
 
@@ -100,7 +100,7 @@ uint32_t receive_uint32()
                            greentea_getc(),
                            '\0'
                          };
-    assert( unhexify( &value, c ) != 8 );
+    TEST_HELPER_ASSERT( unhexify( &value, c ) != 8 );
     return( (uint32_t)value );
 }
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -31,6 +31,9 @@ test_callback_buffer:50:50:50:0:0:10:0:60:50
 Callback buffer test: Reading from empty buffer
 test_callback_buffer:50:0:0:10:0:0:0:0:0
 
+Test mock TCP connection
+ssl_mock_tcp:
+
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -31,6 +31,9 @@ test_callback_buffer:50:50:50:0:0:10:0:60:50
 Callback buffer test: Reading from empty buffer
 test_callback_buffer:50:0:0:10:0:0:0:0:0
 
+Test mock socket sanity
+ssl_mock_sanity:
+
 Test mock blocking TCP connection
 ssl_mock_tcp:1:0:0
 
@@ -45,6 +48,21 @@ ssl_mock_tcp:0:0x0FB1:0
 
 Test mock non-blocking TCP connection: both peers would block
 ssl_mock_tcp:0:0x1111:0xEEEE
+
+Test mock blocking TCP connection (interleaving)
+ssl_mock_tcp_interleaving:1:0:0
+
+Test mock non-blocking TCP connection: would not block (interleaving)
+ssl_mock_tcp_interleaving:0:0:0
+
+Test mock non-blocking TCP connection: client would block (interleaving)
+ssl_mock_tcp_interleaving:0:0xB509:0
+
+Test mock non-blocking TCP connection: server would block (interleaving)
+ssl_mock_tcp_interleaving:0:0x0FB1:0
+
+Test mock non-blocking TCP connection: both peers would block (interleaving)
+ssl_mock_tcp_interleaving:0:0x1111:0xEEEE
 
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -31,8 +31,20 @@ test_callback_buffer:50:50:50:0:0:10:0:60:50
 Callback buffer test: Reading from empty buffer
 test_callback_buffer:50:0:0:10:0:0:0:0:0
 
-Test mock TCP connection
-ssl_mock_tcp:
+Test mock blocking TCP connection
+ssl_mock_tcp:1:0:0
+
+Test mock non-blocking TCP connection: would not block
+ssl_mock_tcp:0:0:0
+
+Test mock non-blocking TCP connection: client would block
+ssl_mock_tcp:0:0xB509:0
+
+Test mock non-blocking TCP connection: server would block
+ssl_mock_tcp:0:0x0FB1:0
+
+Test mock non-blocking TCP connection: both peers would block
+ssl_mock_tcp:0:0x1111:0xEEEE
 
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -1,3 +1,36 @@
+Test calback buffer sanity
+test_callback_buffer_sanity:
+
+Callback buffer test: Exercise simple write/read
+test_callback_buffer:50:25:25:25:25:0:0:0:0
+
+Callback buffer test: Filling up the buffer
+test_callback_buffer:50:50:50:50:50:0:0:0:0
+
+Callback buffer test: Filling up the buffer in two steps
+test_callback_buffer:50:20:20:0:0:30:30:50:50
+
+Callback buffer test: Reading out the buffer in two steps
+test_callback_buffer:50:50:50:30:30:0:0:20:20
+
+Callback buffer test: Data wraps in buffer
+test_callback_buffer:50:45:45:10:10:10:10:45:45
+
+Callback buffer test: Data starts at the end
+test_callback_buffer:50:50:50:49:49:10:10:11:11
+
+Callback buffer test: Can write less than requested
+test_callback_buffer:50:75:50:30:30:25:25:45:45
+
+Callback buffer test: Can read less than requested
+test_callback_buffer:50:25:25:30:25:5:5:5:5
+
+Callback buffer test: Writing to full buffer
+test_callback_buffer:50:50:50:0:0:10:0:60:50
+
+Callback buffer test: Reading from empty buffer
+test_callback_buffer:50:0:0:10:0:0:0:0:0
+
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -138,6 +138,147 @@ int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
 }
 
 /*
+ * Context for the I/O callbacks simulating network connection.
+ */
+
+#define MBEDTLS_MOCK_SOCKET_CONNECTED 1
+
+typedef struct mbedtls_mock_socket
+{
+    int status;
+    mbedtls_test_buffer *input;
+    mbedtls_test_buffer *output;
+    struct mbedtls_mock_socket *peer;
+} mbedtls_mock_socket;
+
+/*
+ * Setup and teardown functions for mock sockets.
+ */
+void mbedtls_mock_socket_init( mbedtls_mock_socket *socket )
+{
+    memset( socket, 0, sizeof( *socket ) );
+}
+
+/*
+ * Closes the socket \p socket.
+ *
+ * \p socket must have been previously initialized by calling
+ * mbedtls_mock_socket_init().
+ *
+ * This function frees all allocated resources and both sockets are aware of the
+ * new connection state.
+ *
+ * That is, this function does not simulate half-open TCP connections and the
+ * phenomenon that when closing a UDP connection the peer is not aware of the
+ * connection having been closed.
+ */
+void mbedtls_mock_socket_close( mbedtls_mock_socket* socket )
+{
+    if( socket == NULL )
+        return;
+
+    if( socket->input != NULL )
+    {
+        mbedtls_test_buffer_free( socket->input );
+        mbedtls_free( socket->input );
+    }
+
+    if( socket->output != NULL )
+    {
+        mbedtls_test_buffer_free( socket->output );
+        mbedtls_free( socket->output );
+    }
+
+    if( socket->peer != NULL )
+        memset( socket->peer, 0, sizeof( *socket->peer ) );
+
+    memset( socket, 0, sizeof( *socket ) );
+}
+
+/*
+ * Establishes a connection between \p peer1 and \p peer2.
+ *
+ * \p peer1 and \p peer2 must have been previously initialized by calling
+ * mbedtls_mock_socket_init().
+ *
+ * The capacites of the internal buffers are set to \p bufsize. Setting this to
+ * the correct value allows for simulation of MTU, sanity testing the mock
+ * implementation and mocking TCP connections with lower memory cost.
+ */
+int mbedtls_mock_socket_connect( mbedtls_mock_socket* peer1,
+                                 mbedtls_mock_socket* peer2,
+                                 size_t bufsize )
+{
+    int ret = -1;
+
+    peer1->input = peer2->output =
+        (mbedtls_test_buffer*) mbedtls_calloc( 1, sizeof(mbedtls_test_buffer) );
+    if( peer1->input == NULL )
+    {
+        ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+        goto exit;
+    }
+    mbedtls_test_buffer_init( peer1->input );
+    if( 0 != ( ret = mbedtls_test_buffer_setup( peer1->input, bufsize ) ) )
+    {
+        goto exit;
+    }
+
+    peer1->output = peer2->input =
+        (mbedtls_test_buffer*) mbedtls_calloc( 1, sizeof(mbedtls_test_buffer) );
+    if( peer1->output == NULL )
+    {
+        ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
+        goto exit;
+    }
+    mbedtls_test_buffer_init( peer1->output );
+    if( 0 != ( ret = mbedtls_test_buffer_setup( peer1->output, bufsize ) ) )
+    {
+        goto exit;
+    }
+
+    peer1->peer = peer2;
+    peer2->peer = peer1;
+
+    peer1->status = peer2->status = MBEDTLS_MOCK_SOCKET_CONNECTED;
+    ret = 0;
+
+exit:
+
+    if( ret != 0 )
+    {
+        mbedtls_mock_socket_close( peer1 );
+        mbedtls_mock_socket_close( peer2 );
+    }
+
+    return ret;
+}
+
+/*
+ * Callbacks for simulating blocking I/O over connection-oriented transport.
+ */
+
+int mbedtls_mock_tcp_send_b( void *ctx, const unsigned char *buf, size_t len )
+{
+    mbedtls_mock_socket *socket = (mbedtls_mock_socket*) ctx;
+
+    if( socket == NULL || socket->status != MBEDTLS_MOCK_SOCKET_CONNECTED )
+        return -1;
+
+    return mbedtls_test_buffer_put( socket->output, buf, len );
+}
+
+int mbedtls_mock_tcp_recv_b( void *ctx, unsigned char *buf, size_t len )
+{
+    mbedtls_mock_socket *socket = (mbedtls_mock_socket*) ctx;
+
+    if( socket == NULL || socket->status != MBEDTLS_MOCK_SOCKET_CONNECTED )
+        return -1;
+
+    return mbedtls_test_buffer_get( socket->input, buf, len );
+}
+
+/*
  * Helper function setting up inverse record transformations
  * using given cipher, hash, EtM mode, authentication tag length,
  * and version.
@@ -575,8 +716,7 @@ void test_callback_buffer( int size, int put1, int put1_ret,
     size_t input_len;
     unsigned char* output = NULL;
     size_t output_len;
-    size_t i, written, read;
-    int j;
+    size_t i, j, written, read;
 
     mbedtls_test_buffer_init( &buf );
     TEST_ASSERT( mbedtls_test_buffer_setup( &buf, size ) == 0 );
@@ -662,6 +802,131 @@ exit:
     mbedtls_free( input );
     mbedtls_free( output );
     mbedtls_test_buffer_free( &buf );
+}
+/* END_CASE */
+
+/*
+ * Test if the implementation of `mbedtls_mock_socket` related functions is
+ * correct and works as expected.
+ */
+
+/* BEGIN_CASE */
+void ssl_mock_tcp()
+{
+    enum { ROUNDS = 2 };
+    enum { MSGLEN = 105 };
+    unsigned char message[ROUNDS][MSGLEN];
+    unsigned char received[ROUNDS][MSGLEN];
+    mbedtls_mock_socket client;
+    mbedtls_mock_socket server;
+    size_t written[ROUNDS];
+    size_t read[ROUNDS];
+    int send_ret[ROUNDS];
+    int recv_ret[ROUNDS];
+    unsigned i, j, progress;
+
+    mbedtls_mock_socket_init( &client );
+    mbedtls_mock_socket_init( &server );
+
+    /* Fill up the buffers with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < ROUNDS; i++ )
+    {
+        for( j = 0; j < MSGLEN; j++ )
+        {
+            message[i][j] = ( i * MSGLEN + j ) & 0xFF;
+        }
+    }
+
+    /* Try sending or receiving on an unconnected socket */
+    TEST_ASSERT( mbedtls_mock_tcp_send_b( &client, message[0], MSGLEN ) < 0 );
+    TEST_ASSERT( mbedtls_mock_tcp_recv_b( &client, received[0], MSGLEN ) < 0 );
+
+    /* Make sure that sending a message takes a few  iterations. */
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN / 5 ) );
+
+    /* Send the message to the server */
+    send_ret[0] = recv_ret[0] = 1;
+    written[0] = read[0] = 0;
+    while( send_ret[0] != 0 || recv_ret[0] != 0 )
+    {
+        send_ret[0] = mbedtls_mock_tcp_send_b( &client,
+                                               message[0] + written[0],
+                                               MSGLEN - written[0] );
+        TEST_ASSERT( send_ret[0] >= 0 );
+        written[0] += send_ret[0];
+
+        recv_ret[0] = mbedtls_mock_tcp_recv_b( &server,
+                                               received[0] + read[0],
+                                               MSGLEN - read[0] );
+        TEST_ASSERT( recv_ret[0] >= 0 );
+        read[0] += recv_ret[0];
+    }
+    TEST_ASSERT( memcmp( message[0], received[0], MSGLEN ) == 0 );
+
+    /* Reset connection for the next test */
+    mbedtls_mock_socket_close( &client );
+    mbedtls_mock_socket_close( &server );
+    mbedtls_mock_socket_init( &client );
+    mbedtls_mock_socket_init( &server );
+    /* Make sure that sending a message takes a few  iterations. */
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN / 5 ) );
+
+    /* Send the message from both sides, interleaving. */
+    progress = 1;
+    for( i = 0; i < ROUNDS; i++ )
+    {
+        written[i] = 0;
+        read[i] = 0;
+    }
+    /* This loop does not stop as long as there was a successful write or read
+     * of at least one byte on either side. */
+    while( progress != 0 )
+    {
+        send_ret[0] = mbedtls_mock_tcp_send_b( &client,
+                                               message[0] + written[0],
+                                               MSGLEN - written[0] );
+        TEST_ASSERT( send_ret[0] >= 0 );
+        written[0] += send_ret[0];
+
+        send_ret[1] = mbedtls_mock_tcp_send_b( &server,
+                                               message[1] + written[1],
+                                               MSGLEN - written[1] );
+        TEST_ASSERT( send_ret[1] >= 0 );
+        written[1] += send_ret[1];
+
+        recv_ret[0] = mbedtls_mock_tcp_recv_b( &server,
+                                               received[0] + read[0],
+                                               MSGLEN - read[0] );
+        TEST_ASSERT( recv_ret[0] >= 0 );
+        read[0] += recv_ret[0];
+
+        recv_ret[1] = mbedtls_mock_tcp_recv_b( &client,
+                                               received[1] + read[1],
+                                               MSGLEN - read[1] );
+        TEST_ASSERT( recv_ret[1] >= 0 );
+        read[1] += recv_ret[1];
+
+        progress = 0;
+        for( i = 0; i < ROUNDS; i++ )
+        {
+            if( send_ret[i] > 0 )
+                progress++;
+
+            if( recv_ret[i] > 0 )
+                progress++;
+        }
+    }
+
+    for( i = 0; i < ROUNDS; i++ )
+        TEST_ASSERT( memcmp( message[i], received[i], MSGLEN ) == 0 );
+
+exit:
+
+    mbedtls_mock_socket_close( &client );
+    mbedtls_mock_socket_close( &server );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -867,12 +867,134 @@ exit:
 /* END_CASE */
 
 /*
- * Test if the implementation of `mbedtls_mock_socket` related functions is
- * correct and works as expected.
+ * Test if the implementation of `mbedtls_mock_socket` related I/O functions is
+ * correct and works as expected on unconnected sockets.
+ */
+
+/* BEGIN_CASE */
+void ssl_mock_sanity( )
+{
+    enum { MSGLEN = 105 };
+    unsigned char message[MSGLEN];
+    unsigned char received[MSGLEN];
+    mbedtls_mock_socket socket;
+
+    mbedtls_mock_socket_init( &socket );
+    TEST_ASSERT( mbedtls_mock_tcp_send_b( &socket, message, MSGLEN ) < 0 );
+    mbedtls_mock_socket_close( &socket );
+    mbedtls_mock_socket_init( &socket );
+    TEST_ASSERT( mbedtls_mock_tcp_recv_b( &socket, received, MSGLEN ) < 0 );
+    mbedtls_mock_socket_close( &socket );
+
+    mbedtls_mock_socket_init( &socket );
+    TEST_ASSERT( mbedtls_mock_tcp_send_nb( &socket, message, MSGLEN ) < 0 );
+    mbedtls_mock_socket_close( &socket );
+    mbedtls_mock_socket_init( &socket );
+    TEST_ASSERT( mbedtls_mock_tcp_recv_nb( &socket, received, MSGLEN ) < 0 );
+    mbedtls_mock_socket_close( &socket );
+
+exit:
+
+    mbedtls_mock_socket_close( &socket );
+}
+/* END_CASE */
+
+/*
+ * Test if the implementation of `mbedtls_mock_socket` related functions can
+ * send a single message from the client to the server.
  */
 
 /* BEGIN_CASE */
 void ssl_mock_tcp( int blocking, int client_pattern, int server_pattern )
+{
+    enum { MSGLEN = 105 };
+    unsigned char message[MSGLEN];
+    unsigned char received[MSGLEN];
+    mbedtls_mock_socket client;
+    mbedtls_mock_socket server;
+    size_t written, read;
+    int send_ret, recv_ret;
+    mbedtls_ssl_send_t *send;
+    mbedtls_ssl_recv_t *recv;
+    uint32_t client_block = client_pattern;
+    uint32_t server_block = server_pattern;
+    unsigned i;
+
+    if( blocking == 0 )
+    {
+        send = mbedtls_mock_tcp_send_nb;
+        recv = mbedtls_mock_tcp_recv_nb;
+    }
+    else
+    {
+        send = mbedtls_mock_tcp_send_b;
+        recv = mbedtls_mock_tcp_recv_b;
+    }
+
+    mbedtls_mock_socket_init( &client );
+    mbedtls_mock_socket_init( &server );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+
+    /* Make sure that sending a message takes a few  iterations. */
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN / 5 ) );
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &client, client_block ) );
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &server, server_block ) );
+
+    /* Send the message to the server */
+    send_ret = recv_ret = 1;
+    written = read = 0;
+    while( send_ret != 0 || recv_ret != 0 )
+    {
+        send_ret = send( &client, message + written, MSGLEN - written );
+
+        if( ( blocking == 0 ) && ( client_block & 1 ) )
+        {
+            TEST_ASSERT( send_ret == MBEDTLS_ERR_SSL_WANT_WRITE );
+        }
+        else
+        {
+            TEST_ASSERT( send_ret >= 0 );
+            written += send_ret;
+        }
+        client_block >>= 1;
+
+        recv_ret = recv( &server, received + read, MSGLEN - read );
+        if( ( blocking == 0 ) && ( server_block & 1 ) )
+        {
+            TEST_ASSERT( recv_ret == MBEDTLS_ERR_SSL_WANT_READ );
+        }
+        else
+        {
+            TEST_ASSERT( recv_ret >= 0 );
+            read += recv_ret;
+        }
+        server_block >>= 1;
+    }
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+exit:
+
+    mbedtls_mock_socket_close( &client );
+    mbedtls_mock_socket_close( &server );
+}
+/* END_CASE */
+
+/*
+ * Test if the implementation of `mbedtls_mock_socket` related functions can
+ * send messages in both direction at the same time (with the I/O calls
+ * interleaving).
+ */
+
+/* BEGIN_CASE */
+void ssl_mock_tcp_interleaving( int blocking,
+                                int client_pattern, int server_pattern )
 {
     enum { ROUNDS = 2 };
     enum { MSGLEN = 105 };
@@ -914,60 +1036,9 @@ void ssl_mock_tcp( int blocking, int client_pattern, int server_pattern )
         }
     }
 
-    /* Try sending or receiving on an unconnected socket */
-    TEST_ASSERT( send( &client, message[0], MSGLEN ) < 0 );
-    TEST_ASSERT( recv( &client, received[0], MSGLEN ) < 0 );
-
     /* Make sure that sending a message takes a few  iterations. */
     TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
                                                    MSGLEN / 5 ) );
-    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &client, client_block ) );
-    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &server, server_block ) );
-
-    /* Send the message to the server */
-    send_ret[0] = recv_ret[0] = 1;
-    written[0] = read[0] = 0;
-    while( send_ret[0] != 0 || recv_ret[0] != 0 )
-    {
-        send_ret[0] = send( &client, message[0] + written[0],
-                                               MSGLEN - written[0] );
-
-        if( ( blocking == 0 ) && ( client_block & 1 ) )
-        {
-            TEST_ASSERT( send_ret[0] == MBEDTLS_ERR_SSL_WANT_WRITE );
-        }
-        else
-        {
-            TEST_ASSERT( send_ret[0] >= 0 );
-            written[0] += send_ret[0];
-        }
-        client_block >>= 1;
-
-        recv_ret[0] = recv( &server, received[0] + read[0],
-                                               MSGLEN - read[0] );
-        if( ( blocking == 0 ) && ( server_block & 1 ) )
-        {
-            TEST_ASSERT( recv_ret[0] == MBEDTLS_ERR_SSL_WANT_READ );
-        }
-        else
-        {
-            TEST_ASSERT( recv_ret[0] >= 0 );
-            read[0] += recv_ret[0];
-        }
-        server_block >>= 1;
-    }
-    TEST_ASSERT( memcmp( message[0], received[0], MSGLEN ) == 0 );
-
-    /* Reset connection for the next test */
-    mbedtls_mock_socket_close( &client );
-    mbedtls_mock_socket_close( &server );
-    mbedtls_mock_socket_init( &client );
-    mbedtls_mock_socket_init( &server );
-    /* Make sure that sending a message takes a few  iterations. */
-    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
-                                                   MSGLEN / 5 ) );
-    client_block = client_pattern;
-    server_block = server_pattern;
     TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &client, client_block ) );
     TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &server, server_block ) );
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -146,6 +146,7 @@ int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
 typedef struct mbedtls_mock_socket
 {
     int status;
+    uint32_t blocking_pattern;
     mbedtls_test_buffer *input;
     mbedtls_test_buffer *output;
     struct mbedtls_mock_socket *peer;
@@ -255,6 +256,26 @@ exit:
 }
 
 /*
+ * Set the blocking pattern for the socket.
+ *
+ * For every bit of \p blocking_pattern set to one the socket will simulate a
+ * "would block" event. The bits are processed starting with the least
+ * significant bit and every call to a non-blocking I/O function consumes one.
+ *
+ * The behaviour of blocking I/O functions remains unchanged.
+ */
+int mbedtls_mock_socket_set_block( mbedtls_mock_socket* socket,
+                                   uint32_t blocking_pattern )
+{
+    if( socket == NULL )
+        return -1;
+
+    socket->blocking_pattern = blocking_pattern;
+
+    return 0;
+}
+
+/*
  * Callbacks for simulating blocking I/O over connection-oriented transport.
  */
 
@@ -274,6 +295,46 @@ int mbedtls_mock_tcp_recv_b( void *ctx, unsigned char *buf, size_t len )
 
     if( socket == NULL || socket->status != MBEDTLS_MOCK_SOCKET_CONNECTED )
         return -1;
+
+    return mbedtls_test_buffer_get( socket->input, buf, len );
+}
+
+/*
+ * Callbacks for simulating non-blocking I/O over connection-oriented transport.
+ */
+
+int mbedtls_mock_tcp_send_nb( void *ctx, const unsigned char *buf, size_t len )
+{
+    mbedtls_mock_socket *socket = (mbedtls_mock_socket*) ctx;
+
+    if( socket == NULL || socket->status != MBEDTLS_MOCK_SOCKET_CONNECTED )
+        return -1;
+
+    if( socket->blocking_pattern & 1 )
+    {
+        socket->blocking_pattern >>= 1;
+        return MBEDTLS_ERR_SSL_WANT_WRITE;
+    }
+
+    socket->blocking_pattern >>= 1;
+
+    return mbedtls_test_buffer_put( socket->output, buf, len );
+}
+
+int mbedtls_mock_tcp_recv_nb( void *ctx, unsigned char *buf, size_t len )
+{
+    mbedtls_mock_socket *socket = (mbedtls_mock_socket*) ctx;
+
+    if( socket == NULL || socket->status != MBEDTLS_MOCK_SOCKET_CONNECTED )
+        return -1;
+
+    if( socket->blocking_pattern & 1 )
+    {
+        socket->blocking_pattern >>= 1;
+        return MBEDTLS_ERR_SSL_WANT_READ;
+    }
+
+    socket->blocking_pattern >>= 1;
 
     return mbedtls_test_buffer_get( socket->input, buf, len );
 }
@@ -811,7 +872,7 @@ exit:
  */
 
 /* BEGIN_CASE */
-void ssl_mock_tcp()
+void ssl_mock_tcp( int blocking, int client_pattern, int server_pattern )
 {
     enum { ROUNDS = 2 };
     enum { MSGLEN = 105 };
@@ -824,6 +885,21 @@ void ssl_mock_tcp()
     int send_ret[ROUNDS];
     int recv_ret[ROUNDS];
     unsigned i, j, progress;
+    mbedtls_ssl_send_t *send;
+    mbedtls_ssl_recv_t *recv;
+    uint32_t client_block = client_pattern;
+    uint32_t server_block = server_pattern;
+
+    if( blocking == 0 )
+    {
+        send = mbedtls_mock_tcp_send_nb;
+        recv = mbedtls_mock_tcp_recv_nb;
+    }
+    else
+    {
+        send = mbedtls_mock_tcp_send_b;
+        recv = mbedtls_mock_tcp_recv_b;
+    }
 
     mbedtls_mock_socket_init( &client );
     mbedtls_mock_socket_init( &server );
@@ -839,29 +915,46 @@ void ssl_mock_tcp()
     }
 
     /* Try sending or receiving on an unconnected socket */
-    TEST_ASSERT( mbedtls_mock_tcp_send_b( &client, message[0], MSGLEN ) < 0 );
-    TEST_ASSERT( mbedtls_mock_tcp_recv_b( &client, received[0], MSGLEN ) < 0 );
+    TEST_ASSERT( send( &client, message[0], MSGLEN ) < 0 );
+    TEST_ASSERT( recv( &client, received[0], MSGLEN ) < 0 );
 
     /* Make sure that sending a message takes a few  iterations. */
     TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
                                                    MSGLEN / 5 ) );
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &client, client_block ) );
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &server, server_block ) );
 
     /* Send the message to the server */
     send_ret[0] = recv_ret[0] = 1;
     written[0] = read[0] = 0;
     while( send_ret[0] != 0 || recv_ret[0] != 0 )
     {
-        send_ret[0] = mbedtls_mock_tcp_send_b( &client,
-                                               message[0] + written[0],
+        send_ret[0] = send( &client, message[0] + written[0],
                                                MSGLEN - written[0] );
-        TEST_ASSERT( send_ret[0] >= 0 );
-        written[0] += send_ret[0];
 
-        recv_ret[0] = mbedtls_mock_tcp_recv_b( &server,
-                                               received[0] + read[0],
+        if( ( blocking == 0 ) && ( client_block & 1 ) )
+        {
+            TEST_ASSERT( send_ret[0] == MBEDTLS_ERR_SSL_WANT_WRITE );
+        }
+        else
+        {
+            TEST_ASSERT( send_ret[0] >= 0 );
+            written[0] += send_ret[0];
+        }
+        client_block >>= 1;
+
+        recv_ret[0] = recv( &server, received[0] + read[0],
                                                MSGLEN - read[0] );
-        TEST_ASSERT( recv_ret[0] >= 0 );
-        read[0] += recv_ret[0];
+        if( ( blocking == 0 ) && ( server_block & 1 ) )
+        {
+            TEST_ASSERT( recv_ret[0] == MBEDTLS_ERR_SSL_WANT_READ );
+        }
+        else
+        {
+            TEST_ASSERT( recv_ret[0] >= 0 );
+            read[0] += recv_ret[0];
+        }
+        server_block >>= 1;
     }
     TEST_ASSERT( memcmp( message[0], received[0], MSGLEN ) == 0 );
 
@@ -873,6 +966,10 @@ void ssl_mock_tcp()
     /* Make sure that sending a message takes a few  iterations. */
     TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
                                                    MSGLEN / 5 ) );
+    client_block = client_pattern;
+    server_block = server_pattern;
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &client, client_block ) );
+    TEST_ASSERT( 0 == mbedtls_mock_socket_set_block( &server, server_block ) );
 
     /* Send the message from both sides, interleaving. */
     progress = 1;
@@ -885,38 +982,72 @@ void ssl_mock_tcp()
      * of at least one byte on either side. */
     while( progress != 0 )
     {
-        send_ret[0] = mbedtls_mock_tcp_send_b( &client,
-                                               message[0] + written[0],
+        send_ret[0] = send( &client, message[0] + written[0],
                                                MSGLEN - written[0] );
-        TEST_ASSERT( send_ret[0] >= 0 );
-        written[0] += send_ret[0];
+        if( ( blocking == 0 ) && ( client_block & 1 ) )
+        {
+            TEST_ASSERT( send_ret[0] == MBEDTLS_ERR_SSL_WANT_WRITE );
+        }
+        else
+        {
+            TEST_ASSERT( send_ret[0] >= 0 );
+            written[0] += send_ret[0];
+        }
+        client_block >>= 1;
 
-        send_ret[1] = mbedtls_mock_tcp_send_b( &server,
-                                               message[1] + written[1],
+        send_ret[1] = send( &server, message[1] + written[1],
                                                MSGLEN - written[1] );
-        TEST_ASSERT( send_ret[1] >= 0 );
-        written[1] += send_ret[1];
+        if( ( blocking == 0 ) && ( server_block & 1 ) )
+        {
+            TEST_ASSERT( send_ret[1] == MBEDTLS_ERR_SSL_WANT_WRITE );
+        }
+        else
+        {
+            TEST_ASSERT( send_ret[1] >= 0 );
+            written[1] += send_ret[1];
+        }
+        server_block >>= 1;
 
-        recv_ret[0] = mbedtls_mock_tcp_recv_b( &server,
-                                               received[0] + read[0],
+        recv_ret[0] = recv( &server, received[0] + read[0],
                                                MSGLEN - read[0] );
-        TEST_ASSERT( recv_ret[0] >= 0 );
-        read[0] += recv_ret[0];
+        if( ( blocking == 0 ) && ( server_block & 1 ) )
+        {
+            TEST_ASSERT( recv_ret[0] == MBEDTLS_ERR_SSL_WANT_READ );
+        }
+        else
+        {
+            TEST_ASSERT( recv_ret[0] >= 0 );
+            read[0] += recv_ret[0];
+        }
+        server_block >>= 1;
 
-        recv_ret[1] = mbedtls_mock_tcp_recv_b( &client,
-                                               received[1] + read[1],
+        recv_ret[1] = recv( &client, received[1] + read[1],
                                                MSGLEN - read[1] );
-        TEST_ASSERT( recv_ret[1] >= 0 );
-        read[1] += recv_ret[1];
+        if( ( blocking == 0 ) && ( client_block & 1 ) )
+        {
+            TEST_ASSERT( recv_ret[1] == MBEDTLS_ERR_SSL_WANT_READ );
+        }
+        else
+        {
+            TEST_ASSERT( recv_ret[1] >= 0 );
+            read[1] += recv_ret[1];
+        }
+        client_block >>= 1;
 
         progress = 0;
         for( i = 0; i < ROUNDS; i++ )
         {
-            if( send_ret[i] > 0 )
+            if( ( send_ret[i] > 0 ) ||
+                    ( send_ret[i] == MBEDTLS_ERR_SSL_WANT_WRITE ) )
+            {
                 progress++;
+            }
 
-            if( recv_ret[i] > 0 )
+            if( ( recv_ret[i] > 0 ) ||
+                    ( recv_ret[i] == MBEDTLS_ERR_SSL_WANT_READ ) )
+            {
                 progress++;
+            }
         }
     }
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2,6 +2,141 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/ssl_internal.h>
 
+
+/*
+ * Buffer structure for custom I/O callbacks.
+ */
+
+typedef struct mbedtls_test_buffer
+{
+    size_t start;
+    size_t content_length;
+    size_t capacity;
+    unsigned char *buffer;
+} mbedtls_test_buffer;
+
+/*
+ * Initialises \p buf. After calling this function it is safe to call
+ * `mbedtls_test_buffer_free()` on \p buf.
+ */
+void mbedtls_test_buffer_init( mbedtls_test_buffer *buf )
+{
+    memset( buf, 0, sizeof( *buf ) );
+}
+
+/*
+ * Sets up \p buf. After calling this function it is safe to call
+ * `mbedtls_test_buffer_put()` and `mbedtls_test_buffer_get()` on \p buf.
+ */
+int mbedtls_test_buffer_setup( mbedtls_test_buffer *buf, size_t capacity )
+{
+    buf->buffer = (unsigned char*) mbedtls_calloc( capacity,
+                                                   sizeof(unsigned char) );
+    if( NULL == buf->buffer )
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    buf->capacity = capacity;
+
+    return 0;
+}
+
+void mbedtls_test_buffer_free( mbedtls_test_buffer *buf )
+{
+    if( buf->buffer != NULL )
+        mbedtls_free( buf->buffer );
+
+    memset( buf, 0, sizeof( *buf ) );
+}
+
+/*
+ * Puts \p input_len bytes from the \p input buffer into the ring buffer \p buf.
+ *
+ * \p buf must have been initialized and set up by calling
+ * `mbedtls_test_buffer_init()` and `mbedtls_test_buffer_setup()`.
+ *
+ * \retval  \p input_len, if the data fits.
+ * \retval  0 <= value < \p input_len, if the data does not fit.
+ * \retval  -1, if \p buf is NULL, it hasn't been set up or \p input_len is not
+ *          zero and \p input is NULL.
+ */
+int mbedtls_test_buffer_put( mbedtls_test_buffer *buf,
+                             const unsigned char* input, size_t input_len )
+{
+    size_t overflow = 0;
+
+    if( ( buf == NULL ) || ( buf->buffer == NULL ) )
+        return -1;
+
+    /* Reduce input_len to a number that fits in the buffer. */
+    if ( ( buf->content_length + input_len ) > buf->capacity )
+    {
+        input_len = buf->capacity - buf->content_length;
+    }
+
+    if( input == NULL )
+    {
+        return ( input_len == 0 ) ? 0 : -1;
+    }
+
+    /* Calculate the number of bytes that need to be placed at lower memory
+     * address */
+    if( buf->start + buf->content_length + input_len
+        > buf->capacity )
+    {
+        overflow = ( buf->start + buf->content_length + input_len )
+                    % buf->capacity;
+    }
+
+    memcpy( buf->buffer + buf->start + buf->content_length, input,
+            input_len - overflow );
+    memcpy( buf->buffer, input + input_len - overflow, overflow );
+    buf->content_length += input_len;
+
+    return input_len;
+}
+
+/*
+ * Gets \p output_len bytes from the \p output buffer into the ring buffer
+ * \p buf.
+ *
+ * \p buf must have been initialized and set up by calling
+ * `mbedtls_test_buffer_init()` and `mbedtls_test_buffer_setup()`.
+ *
+ * \retval  \p output_len, if the data is available.
+ * \retval  0 <= value < \p output_len, if the data is not available.
+ * \retval  -1, if \buf is NULL, it hasn't been set up or \p output_len is not
+ *          zero and \p output is NULL
+ */
+int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
+                             unsigned char* output, size_t output_len )
+{
+    size_t overflow = 0;
+
+    if( ( buf == NULL ) || ( buf->buffer == NULL ) )
+        return -1;
+
+    if( output == NULL )
+    {
+        return ( output_len == 0 ) ? 0 : -1;
+    }
+
+    if( buf->content_length < output_len )
+        output_len = buf->content_length;
+
+    /* Calculate the number of bytes that need to be drawn from lower memory
+     * address */
+    if( buf->start + output_len > buf->capacity )
+    {
+        overflow = ( buf->start + output_len ) % buf->capacity;
+    }
+
+    memcpy( output, buf->buffer + buf->start, output_len - overflow );
+    memcpy( output + output_len - overflow, buf->buffer, overflow );
+    buf->content_length -= output_len;
+    buf->start = ( buf->start + output_len ) % buf->capacity;
+
+    return output_len;
+}
+
 /*
  * Helper function setting up inverse record transformations
  * using given cipher, hash, EtM mode, authentication tag length,
@@ -360,6 +495,175 @@ static int ssl_populate_session( mbedtls_ssl_session *session,
  * depends_on:MBEDTLS_SSL_TLS_C
  * END_DEPENDENCIES
  */
+
+/* BEGIN_CASE */
+void test_callback_buffer_sanity()
+{
+    enum { MSGLEN = 10 };
+    mbedtls_test_buffer buf;
+    unsigned char input[MSGLEN];
+    unsigned char output[MSGLEN];
+
+    memset( input, 0, sizeof(input) );
+
+    /* Make sure calling put and get on NULL buffer results in error. */
+    TEST_ASSERT( mbedtls_test_buffer_put( NULL, input, sizeof( input ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( NULL, output, sizeof( output ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_put( NULL, NULL, sizeof( input ) ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( NULL, NULL, sizeof( output ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_put( NULL, NULL, 0 ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( NULL, NULL, 0 ) == -1 );
+
+    /* Make sure calling put and get on a buffer that hasn't been set up results
+     * in eror. */
+    mbedtls_test_buffer_init( &buf );
+
+    TEST_ASSERT( mbedtls_test_buffer_put( &buf, input, sizeof( input ) ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( &buf, output, sizeof( output ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, sizeof( input ) ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, sizeof( output ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, 0 ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, 0 ) == -1 );
+
+    /* Make sure calling put end get on NULL input and output only results in
+     * error if the length is not zero. */
+
+    TEST_ASSERT( mbedtls_test_buffer_setup( &buf, sizeof( input ) ) == 0 );
+
+    TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, sizeof( input ) ) == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, sizeof( output ) )
+                    == -1 );
+    TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, 0 ) == 0 );
+
+exit:
+
+    mbedtls_test_buffer_free( &buf );
+}
+/* END_CASE */
+
+/*
+ * Test if the implementation of `mbedtls_test_buffer` related functions is
+ * correct and works as expected.
+ *
+ * That is
+ *  - If we try to put in \p put1 bytes then we can put in \p put1_ret bytes.
+ *  - Afterwards if we try to get \p get1 bytes then we can get \get1_ret bytes.
+ *  - Next, if we try to put in \p put1 bytes then we can put in \p put1_ret
+ *    bytes.
+ *  - Afterwards if we try to get \p get1 bytes then we can get \get1_ret bytes.
+ *  - All of the bytes we got match the bytes we put in in a FIFO manner.
+ */
+
+/* BEGIN_CASE */
+void test_callback_buffer( int size, int put1, int put1_ret,
+                           int get1, int get1_ret, int put2, int put2_ret,
+                           int get2, int get2_ret )
+{
+    enum { ROUNDS = 2 };
+    size_t put[ROUNDS];
+    int put_ret[ROUNDS];
+    size_t get[ROUNDS];
+    int get_ret[ROUNDS];
+    mbedtls_test_buffer buf;
+    unsigned char* input = NULL;
+    size_t input_len;
+    unsigned char* output = NULL;
+    size_t output_len;
+    size_t i, written, read;
+    int j;
+
+    mbedtls_test_buffer_init( &buf );
+    TEST_ASSERT( mbedtls_test_buffer_setup( &buf, size ) == 0 );
+
+    /* Check the sanity of input parameters and initialise local variables. That
+     * is, ensure that the amount of data is not negative and that we are not
+     * expecting more to put or get than we actually asked for. */
+    TEST_ASSERT( put1 >= 0 );
+    put[0] = put1;
+    put_ret[0] = put1_ret;
+    TEST_ASSERT( put1_ret <= put1 );
+    TEST_ASSERT( put2 >= 0 );
+    put[1] = put2;
+    put_ret[1] = put2_ret;
+    TEST_ASSERT( put2_ret <= put2 );
+
+    TEST_ASSERT( get1 >= 0 );
+    get[0] = get1;
+    get_ret[0] = get1_ret;
+    TEST_ASSERT( get1_ret <= get1 );
+    TEST_ASSERT( get2 >= 0 );
+    get[1] = get2;
+    get_ret[1] = get2_ret;
+    TEST_ASSERT( get2_ret <= get2 );
+
+    input_len = 0;
+    /* Calculate actual input and output lengths */
+    for( j = 0; j < ROUNDS; j++ )
+    {
+        if( put_ret[j] > 0 )
+        {
+            input_len += put_ret[j];
+        }
+    }
+    /* In order to always have a valid pointer we always allocate at least 1
+     * byte. */
+    if( input_len == 0 )
+        input_len = 1;
+    ASSERT_ALLOC( input, input_len );
+
+    output_len = 0;
+    for( j = 0; j < ROUNDS; j++ )
+    {
+        if( get_ret[j] > 0 )
+        {
+            output_len += get_ret[j];
+        }
+    }
+    TEST_ASSERT( output_len <= input_len );
+    /* In order to always have a valid pointer we always allocate at least 1
+     * byte. */
+    if( output_len == 0 )
+        output_len = 1;
+    ASSERT_ALLOC( output, output_len );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < input_len; i++ )
+    {
+        input[i] = i & 0xFF;
+    }
+
+    written = read = 0;
+    for( j = 0; j < ROUNDS; j++ )
+    {
+        TEST_ASSERT( put_ret[j] == mbedtls_test_buffer_put( &buf,
+                                        input + written, put[j] ) );
+        written += put_ret[j];
+        TEST_ASSERT( get_ret[j] == mbedtls_test_buffer_get( &buf,
+                                        output + read, get[j] ) );
+        read += get_ret[j];
+        TEST_ASSERT( read <= written );
+        if( get_ret[j] > 0 )
+        {
+            TEST_ASSERT( memcmp( output + read - get_ret[j],
+                                 input + read - get_ret[j], get_ret[j] )
+                         == 0 );
+        }
+    }
+
+exit:
+
+    mbedtls_free( input );
+    mbedtls_free( output );
+    mbedtls_test_buffer_free( &buf );
+}
+/* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 void ssl_dtls_replay( data_t * prevs, data_t * new, int ret )


### PR DESCRIPTION
## Description

In a unit test we want to avoid accessing the network. To test the handshake in the unit test suite we need to implement a connection between the server and the client.

This PR implements a ring buffer and uses them to provide mock TCP sockets and corresponding blocking and non-blocking callbacks.

Sanity tests for the mocks are also provided.

## Remark

The first two commits are cherry-picked from Mbed Crypto and only introduce a test helper macro.

## Status
**READY**

## Requires Backporting
NO  

