### PR TITLE
Add support for building MSVC shared libraries

### DIFF
--- a/include/mbedtls/certs.h
+++ b/include/mbedtls/certs.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -39,211 +41,211 @@ extern "C" {
 /* List of all PEM-encoded CA certificates, terminated by NULL;
  * PEM encoded if MBEDTLS_PEM_PARSE_C is enabled, DER encoded
  * otherwise. */
-extern const char * mbedtls_test_cas[];
-extern const size_t mbedtls_test_cas_len[];
+MBEDX509_EXTERN const char * mbedtls_test_cas[];
+MBEDX509_EXTERN const size_t mbedtls_test_cas_len[];
 
 /* List of all DER-encoded CA certificates, terminated by NULL */
-extern const unsigned char * mbedtls_test_cas_der[];
-extern const size_t mbedtls_test_cas_der_len[];
+MBEDX509_EXTERN const unsigned char * mbedtls_test_cas_der[];
+MBEDX509_EXTERN const size_t mbedtls_test_cas_der_len[];
 
 #if defined(MBEDTLS_PEM_PARSE_C)
 /* Concatenation of all CA certificates in PEM format if available */
-extern const char   mbedtls_test_cas_pem[];
-extern const size_t mbedtls_test_cas_pem_len;
+MBEDX509_EXTERN const char   mbedtls_test_cas_pem[];
+MBEDX509_EXTERN const size_t mbedtls_test_cas_pem_len;
 #endif /* MBEDTLS_PEM_PARSE_C */
 
 /*
  * CA test certificates
  */
 
-extern const char mbedtls_test_ca_crt_ec_pem[];
-extern const char mbedtls_test_ca_key_ec_pem[];
-extern const char mbedtls_test_ca_pwd_ec_pem[];
-extern const char mbedtls_test_ca_key_rsa_pem[];
-extern const char mbedtls_test_ca_pwd_rsa_pem[];
-extern const char mbedtls_test_ca_crt_rsa_sha1_pem[];
-extern const char mbedtls_test_ca_crt_rsa_sha256_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_key_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_pwd_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_key_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_pwd_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_rsa_sha1_pem[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_rsa_sha256_pem[];
 
-extern const unsigned char mbedtls_test_ca_crt_ec_der[];
-extern const unsigned char mbedtls_test_ca_key_ec_der[];
-extern const unsigned char mbedtls_test_ca_key_rsa_der[];
-extern const unsigned char mbedtls_test_ca_crt_rsa_sha1_der[];
-extern const unsigned char mbedtls_test_ca_crt_rsa_sha256_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_ca_crt_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_ca_key_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_ca_key_rsa_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_ca_crt_rsa_sha1_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_ca_crt_rsa_sha256_der[];
 
-extern const size_t mbedtls_test_ca_crt_ec_pem_len;
-extern const size_t mbedtls_test_ca_key_ec_pem_len;
-extern const size_t mbedtls_test_ca_pwd_ec_pem_len;
-extern const size_t mbedtls_test_ca_key_rsa_pem_len;
-extern const size_t mbedtls_test_ca_pwd_rsa_pem_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha1_pem_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha256_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha1_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha256_pem_len;
 
-extern const size_t mbedtls_test_ca_crt_ec_der_len;
-extern const size_t mbedtls_test_ca_key_ec_der_len;
-extern const size_t mbedtls_test_ca_pwd_ec_der_len;
-extern const size_t mbedtls_test_ca_key_rsa_der_len;
-extern const size_t mbedtls_test_ca_pwd_rsa_der_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha1_der_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha256_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha1_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha256_der_len;
 
 /* Config-dependent dispatch between PEM and DER encoding
  * (PEM if enabled, otherwise DER) */
 
-extern const char mbedtls_test_ca_crt_ec[];
-extern const char mbedtls_test_ca_key_ec[];
-extern const char mbedtls_test_ca_pwd_ec[];
-extern const char mbedtls_test_ca_key_rsa[];
-extern const char mbedtls_test_ca_pwd_rsa[];
-extern const char mbedtls_test_ca_crt_rsa_sha1[];
-extern const char mbedtls_test_ca_crt_rsa_sha256[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_ec[];
+MBEDX509_EXTERN const char mbedtls_test_ca_key_ec[];
+MBEDX509_EXTERN const char mbedtls_test_ca_pwd_ec[];
+MBEDX509_EXTERN const char mbedtls_test_ca_key_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_ca_pwd_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_rsa_sha1[];
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_rsa_sha256[];
 
-extern const size_t mbedtls_test_ca_crt_ec_len;
-extern const size_t mbedtls_test_ca_key_ec_len;
-extern const size_t mbedtls_test_ca_pwd_ec_len;
-extern const size_t mbedtls_test_ca_key_rsa_len;
-extern const size_t mbedtls_test_ca_pwd_rsa_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha1_len;
-extern const size_t mbedtls_test_ca_crt_rsa_sha256_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha1_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_sha256_len;
 
 /* Config-dependent dispatch between SHA-1 and SHA-256
  * (SHA-256 if enabled, otherwise SHA-1) */
 
-extern const char mbedtls_test_ca_crt_rsa[];
-extern const size_t mbedtls_test_ca_crt_rsa_len;
+MBEDX509_EXTERN const char mbedtls_test_ca_crt_rsa[];
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_rsa_len;
 
 /* Config-dependent dispatch between EC and RSA
  * (RSA if enabled, otherwise EC) */
 
-extern const char * mbedtls_test_ca_crt;
-extern const char * mbedtls_test_ca_key;
-extern const char * mbedtls_test_ca_pwd;
-extern const size_t mbedtls_test_ca_crt_len;
-extern const size_t mbedtls_test_ca_key_len;
-extern const size_t mbedtls_test_ca_pwd_len;
+MBEDX509_EXTERN const char * mbedtls_test_ca_crt;
+MBEDX509_EXTERN const char * mbedtls_test_ca_key;
+MBEDX509_EXTERN const char * mbedtls_test_ca_pwd;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_crt_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_key_len;
+MBEDX509_EXTERN const size_t mbedtls_test_ca_pwd_len;
 
 /*
  * Server test certificates
  */
 
-extern const char mbedtls_test_srv_crt_ec_pem[];
-extern const char mbedtls_test_srv_key_ec_pem[];
-extern const char mbedtls_test_srv_pwd_ec_pem[];
-extern const char mbedtls_test_srv_key_rsa_pem[];
-extern const char mbedtls_test_srv_pwd_rsa_pem[];
-extern const char mbedtls_test_srv_crt_rsa_sha1_pem[];
-extern const char mbedtls_test_srv_crt_rsa_sha256_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_key_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_pwd_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_key_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_pwd_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_rsa_sha1_pem[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_rsa_sha256_pem[];
 
-extern const unsigned char mbedtls_test_srv_crt_ec_der[];
-extern const unsigned char mbedtls_test_srv_key_ec_der[];
-extern const unsigned char mbedtls_test_srv_key_rsa_der[];
-extern const unsigned char mbedtls_test_srv_crt_rsa_sha1_der[];
-extern const unsigned char mbedtls_test_srv_crt_rsa_sha256_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_srv_crt_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_srv_key_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_srv_key_rsa_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_srv_crt_rsa_sha1_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_srv_crt_rsa_sha256_der[];
 
-extern const size_t mbedtls_test_srv_crt_ec_pem_len;
-extern const size_t mbedtls_test_srv_key_ec_pem_len;
-extern const size_t mbedtls_test_srv_pwd_ec_pem_len;
-extern const size_t mbedtls_test_srv_key_rsa_pem_len;
-extern const size_t mbedtls_test_srv_pwd_rsa_pem_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha1_pem_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha256_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha1_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha256_pem_len;
 
-extern const size_t mbedtls_test_srv_crt_ec_der_len;
-extern const size_t mbedtls_test_srv_key_ec_der_len;
-extern const size_t mbedtls_test_srv_pwd_ec_der_len;
-extern const size_t mbedtls_test_srv_key_rsa_der_len;
-extern const size_t mbedtls_test_srv_pwd_rsa_der_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha1_der_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha256_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha1_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha256_der_len;
 
 /* Config-dependent dispatch between PEM and DER encoding
  * (PEM if enabled, otherwise DER) */
 
-extern const char mbedtls_test_srv_crt_ec[];
-extern const char mbedtls_test_srv_key_ec[];
-extern const char mbedtls_test_srv_pwd_ec[];
-extern const char mbedtls_test_srv_key_rsa[];
-extern const char mbedtls_test_srv_pwd_rsa[];
-extern const char mbedtls_test_srv_crt_rsa_sha1[];
-extern const char mbedtls_test_srv_crt_rsa_sha256[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_ec[];
+MBEDX509_EXTERN const char mbedtls_test_srv_key_ec[];
+MBEDX509_EXTERN const char mbedtls_test_srv_pwd_ec[];
+MBEDX509_EXTERN const char mbedtls_test_srv_key_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_srv_pwd_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_rsa_sha1[];
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_rsa_sha256[];
 
-extern const size_t mbedtls_test_srv_crt_ec_len;
-extern const size_t mbedtls_test_srv_key_ec_len;
-extern const size_t mbedtls_test_srv_pwd_ec_len;
-extern const size_t mbedtls_test_srv_key_rsa_len;
-extern const size_t mbedtls_test_srv_pwd_rsa_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha1_len;
-extern const size_t mbedtls_test_srv_crt_rsa_sha256_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha1_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_sha256_len;
 
 /* Config-dependent dispatch between SHA-1 and SHA-256
  * (SHA-256 if enabled, otherwise SHA-1) */
 
-extern const char mbedtls_test_srv_crt_rsa[];
-extern const size_t mbedtls_test_srv_crt_rsa_len;
+MBEDX509_EXTERN const char mbedtls_test_srv_crt_rsa[];
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_rsa_len;
 
 /* Config-dependent dispatch between EC and RSA
  * (RSA if enabled, otherwise EC) */
 
-extern const char * mbedtls_test_srv_crt;
-extern const char * mbedtls_test_srv_key;
-extern const char * mbedtls_test_srv_pwd;
-extern const size_t mbedtls_test_srv_crt_len;
-extern const size_t mbedtls_test_srv_key_len;
-extern const size_t mbedtls_test_srv_pwd_len;
+MBEDX509_EXTERN const char * mbedtls_test_srv_crt;
+MBEDX509_EXTERN const char * mbedtls_test_srv_key;
+MBEDX509_EXTERN const char * mbedtls_test_srv_pwd;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_crt_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_key_len;
+MBEDX509_EXTERN const size_t mbedtls_test_srv_pwd_len;
 
 /*
  * Client test certificates
  */
 
-extern const char mbedtls_test_cli_crt_ec_pem[];
-extern const char mbedtls_test_cli_key_ec_pem[];
-extern const char mbedtls_test_cli_pwd_ec_pem[];
-extern const char mbedtls_test_cli_key_rsa_pem[];
-extern const char mbedtls_test_cli_pwd_rsa_pem[];
-extern const char mbedtls_test_cli_crt_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_crt_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_key_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_pwd_ec_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_key_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_pwd_rsa_pem[];
+MBEDX509_EXTERN const char mbedtls_test_cli_crt_rsa_pem[];
 
-extern const unsigned char mbedtls_test_cli_crt_ec_der[];
-extern const unsigned char mbedtls_test_cli_key_ec_der[];
-extern const unsigned char mbedtls_test_cli_key_rsa_der[];
-extern const unsigned char mbedtls_test_cli_crt_rsa_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_cli_crt_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_cli_key_ec_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_cli_key_rsa_der[];
+MBEDX509_EXTERN const unsigned char mbedtls_test_cli_crt_rsa_der[];
 
-extern const size_t mbedtls_test_cli_crt_ec_pem_len;
-extern const size_t mbedtls_test_cli_key_ec_pem_len;
-extern const size_t mbedtls_test_cli_pwd_ec_pem_len;
-extern const size_t mbedtls_test_cli_key_rsa_pem_len;
-extern const size_t mbedtls_test_cli_pwd_rsa_pem_len;
-extern const size_t mbedtls_test_cli_crt_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_pwd_ec_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_pwd_rsa_pem_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_rsa_pem_len;
 
-extern const size_t mbedtls_test_cli_crt_ec_der_len;
-extern const size_t mbedtls_test_cli_key_ec_der_len;
-extern const size_t mbedtls_test_cli_key_rsa_der_len;
-extern const size_t mbedtls_test_cli_crt_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_ec_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_rsa_der_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_rsa_der_len;
 
 /* Config-dependent dispatch between PEM and DER encoding
  * (PEM if enabled, otherwise DER) */
 
-extern const char mbedtls_test_cli_crt_ec[];
-extern const char mbedtls_test_cli_key_ec[];
-extern const char mbedtls_test_cli_pwd_ec[];
-extern const char mbedtls_test_cli_key_rsa[];
-extern const char mbedtls_test_cli_pwd_rsa[];
-extern const char mbedtls_test_cli_crt_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_cli_crt_ec[];
+MBEDX509_EXTERN const char mbedtls_test_cli_key_ec[];
+MBEDX509_EXTERN const char mbedtls_test_cli_pwd_ec[];
+MBEDX509_EXTERN const char mbedtls_test_cli_key_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_cli_pwd_rsa[];
+MBEDX509_EXTERN const char mbedtls_test_cli_crt_rsa[];
 
-extern const size_t mbedtls_test_cli_crt_ec_len;
-extern const size_t mbedtls_test_cli_key_ec_len;
-extern const size_t mbedtls_test_cli_pwd_ec_len;
-extern const size_t mbedtls_test_cli_key_rsa_len;
-extern const size_t mbedtls_test_cli_pwd_rsa_len;
-extern const size_t mbedtls_test_cli_crt_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_pwd_ec_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_pwd_rsa_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_rsa_len;
 
 /* Config-dependent dispatch between EC and RSA
  * (RSA if enabled, otherwise EC) */
 
-extern const char * mbedtls_test_cli_crt;
-extern const char * mbedtls_test_cli_key;
-extern const char * mbedtls_test_cli_pwd;
-extern const size_t mbedtls_test_cli_crt_len;
-extern const size_t mbedtls_test_cli_key_len;
-extern const size_t mbedtls_test_cli_pwd_len;
+MBEDX509_EXTERN const char * mbedtls_test_cli_crt;
+MBEDX509_EXTERN const char * mbedtls_test_cli_key;
+MBEDX509_EXTERN const char * mbedtls_test_cli_pwd;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_crt_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_key_len;
+MBEDX509_EXTERN const size_t mbedtls_test_cli_pwd_len;
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ssl.h"
 
 #if defined(MBEDTLS_ECP_C)
@@ -101,7 +103,7 @@ extern "C" {
  *                              - 3 Informational
  *                              - 4 Verbose
  */
-void mbedtls_debug_set_threshold( int threshold );
+MBEDTLS_EXPORT void mbedtls_debug_set_threshold( int threshold );
 
 /**
  * \brief    Print a message to the debug output. This function is always used
@@ -118,7 +120,7 @@ void mbedtls_debug_set_threshold( int threshold );
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
                               const char *file, int line,
                               const char *format, ... );
 
@@ -137,7 +139,7 @@ void mbedtls_debug_print_msg( const mbedtls_ssl_context *ssl, int level,
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_ret( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_ret( const mbedtls_ssl_context *ssl, int level,
                       const char *file, int line,
                       const char *text, int ret );
 
@@ -158,7 +160,7 @@ void mbedtls_debug_print_ret( const mbedtls_ssl_context *ssl, int level,
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
                       const char *file, int line, const char *text,
                       const unsigned char *buf, size_t len );
 
@@ -179,7 +181,7 @@ void mbedtls_debug_print_buf( const mbedtls_ssl_context *ssl, int level,
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
                       const char *file, int line,
                       const char *text, const mbedtls_mpi *X );
 #endif
@@ -201,7 +203,7 @@ void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_ecp( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_ecp( const mbedtls_ssl_context *ssl, int level,
                       const char *file, int line,
                       const char *text, const mbedtls_ecp_point *X );
 #endif
@@ -222,7 +224,7 @@ void mbedtls_debug_print_ecp( const mbedtls_ssl_context *ssl, int level,
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_print_crt( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_print_crt( const mbedtls_ssl_context *ssl, int level,
                       const char *file, int line,
                       const char *text, const mbedtls_x509_crt *crt );
 #endif
@@ -251,7 +253,7 @@ typedef enum
  * \attention       This function is intended for INTERNAL usage within the
  *                  library only.
  */
-void mbedtls_debug_printf_ecdh( const mbedtls_ssl_context *ssl, int level,
+MBEDTLS_EXPORT void mbedtls_debug_printf_ecdh( const mbedtls_ssl_context *ssl, int level,
                                 const char *file, int line,
                                 const mbedtls_ecdh_context *ecdh,
                                 mbedtls_debug_ecdh_attr attr );

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /**
@@ -121,7 +123,7 @@ extern "C" {
  * \param buffer    buffer to place representation in
  * \param buflen    length of the buffer
  */
-void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
+MBEDCRYPTO_EXPORT void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/export.h
+++ b/include/mbedtls/export.h
@@ -1,0 +1,73 @@
+/**
+ * \file export.h
+ *
+ * \brief Handles export macros
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if _MSC_VER
+#define _DLL_EXPORT_FLAG __declspec(dllexport)
+#define _DLL_IMPORT_FLAG __declspec(dllimport)
+#elif __GNUC__ >= 4
+#define _DLL_EXPORT_FLAG __dllexport__ __attribute__((visibility("default")))
+#define _DLL_IMPORT_FLAG __dllimport__
+#else
+#define _DLL_EXPORT_FLAG
+#define _DLL_IMPORT_FLAG
+#endif
+
+#ifndef MBEDTLS_EXTERN
+#if defined(MAKING_SHARED_MBEDTLS) || defined(MAKING_MBEDTLS_SHARED)
+#define MBEDTLS_EXTERN _DLL_EXPORT_FLAG
+#define MBEDTLS_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDTLS_EXTERN _DLL_IMPORT_FLAG
+#define MBEDTLS_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDTLS_EXTERN extern
+#define MBEDTLS_EXPORT
+#endif
+#endif
+
+#ifndef MBEDX509_EXTERN
+#if defined(MAKING_SHARED_MBEDX509) || defined(MAKING_MBEDX509_SHARED)
+#define MBEDX509_EXTERN _DLL_EXPORT_FLAG
+#define MBEDX509_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDX509_EXTERN _DLL_IMPORT_FLAG
+#define MBEDX509_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDX509_EXTERN extern
+#define MBEDX509_EXPORT
+#endif
+#endif
+
+#ifndef MBEDCRYPTO_EXTERN
+#if defined(MAKING_SHARED_MBEDCRYPTO) || defined(MAKING_MBEDCRYPTO_SHARED)
+#define MBEDCRYPTO_EXTERN _DLL_EXPORT_FLAG
+#define MBEDCRYPTO_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDCRYPTO_EXTERN _DLL_IMPORT_FLAG
+#define MBEDCRYPTO_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDCRYPTO_EXTERN extern
+#define MBEDCRYPTO_EXPORT
+#endif
+#endif

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -46,6 +46,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ssl.h"
 
 #include <stddef.h>
@@ -96,7 +98,7 @@ mbedtls_net_context;
  *
  * \param ctx      Context to initialize
  */
-void mbedtls_net_init( mbedtls_net_context *ctx );
+MBEDTLS_EXPORT void mbedtls_net_init( mbedtls_net_context *ctx );
 
 /**
  * \brief          Initiate a connection with host:port in the given protocol
@@ -113,7 +115,7 @@ void mbedtls_net_init( mbedtls_net_context *ctx );
  *
  * \note           Sets the socket in connected mode even with UDP.
  */
-int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto );
+MBEDTLS_EXPORT int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto );
 
 /**
  * \brief          Create a receiving socket on bind_ip:port in the chosen
@@ -132,7 +134,7 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  * \note           Regardless of the protocol, opens the sockets and binds it.
  *                 In addition, make the socket listening if protocol is TCP.
  */
-int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto );
+MBEDTLS_EXPORT int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto );
 
 /**
  * \brief           Accept a connection from a remote client
@@ -150,7 +152,7 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *                  MBEDTLS_ERR_SSL_WANT_READ if bind_fd was set to
  *                  non-blocking and accept() would block.
  */
-int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
+MBEDTLS_EXPORT int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
                         mbedtls_net_context *client_ctx,
                         void *client_ip, size_t buf_size, size_t *ip_len );
 
@@ -175,7 +177,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
  * \return         Bitmask composed of MBEDTLS_NET_POLL_READ/WRITE
  *                 on success or timeout, or a negative return code otherwise.
  */
-int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout );
+MBEDTLS_EXPORT int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout );
 
 /**
  * \brief          Set the socket blocking
@@ -184,7 +186,7 @@ int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout );
  *
  * \return         0 if successful, or a non-zero error code
  */
-int mbedtls_net_set_block( mbedtls_net_context *ctx );
+MBEDTLS_EXPORT int mbedtls_net_set_block( mbedtls_net_context *ctx );
 
 /**
  * \brief          Set the socket non-blocking
@@ -193,7 +195,7 @@ int mbedtls_net_set_block( mbedtls_net_context *ctx );
  *
  * \return         0 if successful, or a non-zero error code
  */
-int mbedtls_net_set_nonblock( mbedtls_net_context *ctx );
+MBEDTLS_EXPORT int mbedtls_net_set_nonblock( mbedtls_net_context *ctx );
 
 /**
  * \brief          Portable usleep helper
@@ -203,7 +205,7 @@ int mbedtls_net_set_nonblock( mbedtls_net_context *ctx );
  * \note           Real amount of time slept will not be less than
  *                 select()'s timeout granularity (typically, 10ms).
  */
-void mbedtls_net_usleep( unsigned long usec );
+MBEDTLS_EXPORT void mbedtls_net_usleep( unsigned long usec );
 
 /**
  * \brief          Read at most 'len' characters. If no error occurs,
@@ -217,7 +219,7 @@ void mbedtls_net_usleep( unsigned long usec );
  *                 or a non-zero error code; with a non-blocking socket,
  *                 MBEDTLS_ERR_SSL_WANT_READ indicates read() would block.
  */
-int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len );
+MBEDTLS_EXPORT int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len );
 
 /**
  * \brief          Write at most 'len' characters. If no error occurs,
@@ -231,7 +233,7 @@ int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len );
  *                 or a non-zero error code; with a non-blocking socket,
  *                 MBEDTLS_ERR_SSL_WANT_WRITE indicates write() would block.
  */
-int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
+MBEDTLS_EXPORT int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
 
 /**
  * \brief          Read at most 'len' characters, blocking for at most
@@ -254,7 +256,7 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  *                 non-blocking. Handling timeouts with non-blocking reads
  *                 requires a different strategy.
  */
-int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
+MBEDTLS_EXPORT int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
                       uint32_t timeout );
 
 /**
@@ -262,14 +264,14 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
  *
  * \param ctx      The context to close
  */
-void mbedtls_net_close( mbedtls_net_context *ctx );
+MBEDTLS_EXPORT void mbedtls_net_close( mbedtls_net_context *ctx );
 
 /**
  * \brief          Gracefully shutdown the connection and free associated data
  *
  * \param ctx      The context to free
  */
-void mbedtls_net_free( mbedtls_net_context *ctx );
+MBEDTLS_EXPORT void mbedtls_net_free( mbedtls_net_context *ctx );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/pkcs11.h
+++ b/include/mbedtls/pkcs11.h
@@ -32,6 +32,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #if defined(MBEDTLS_PKCS11_C)
 
 #include "mbedtls/x509_crt.h"
@@ -60,7 +62,7 @@ typedef struct mbedtls_pkcs11_context
  * Initialize a mbedtls_pkcs11_context.
  * (Just making memory references valid.)
  */
-void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
+MBEDX509_EXPORT void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
 
 /**
  * Fill in a mbed TLS certificate, based on the given PKCS11 helper certificate.
@@ -70,7 +72,7 @@ void mbedtls_pkcs11_init( mbedtls_pkcs11_context *ctx );
  *
  * \return              0 on success.
  */
-int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert, pkcs11h_certificate_t pkcs11h_cert );
+MBEDX509_EXPORT int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert, pkcs11h_certificate_t pkcs11h_cert );
 
 /**
  * Set up a mbedtls_pkcs11_context storing the given certificate. Note that the
@@ -82,7 +84,7 @@ int mbedtls_pkcs11_x509_cert_bind( mbedtls_x509_crt *cert, pkcs11h_certificate_t
  *
  * \return              0 on success
  */
-int mbedtls_pkcs11_priv_key_bind( mbedtls_pkcs11_context *priv_key,
+MBEDX509_EXPORT int mbedtls_pkcs11_priv_key_bind( mbedtls_pkcs11_context *priv_key,
         pkcs11h_certificate_t pkcs11_cert );
 
 /**
@@ -91,7 +93,7 @@ int mbedtls_pkcs11_priv_key_bind( mbedtls_pkcs11_context *priv_key,
  *
  * \param priv_key      Private key structure to cleanup
  */
-void mbedtls_pkcs11_priv_key_free( mbedtls_pkcs11_context *priv_key );
+MBEDX509_EXPORT void mbedtls_pkcs11_priv_key_free( mbedtls_pkcs11_context *priv_key );
 
 /**
  * \brief          Do an RSA private key decrypt, then remove the message
@@ -110,7 +112,7 @@ void mbedtls_pkcs11_priv_key_free( mbedtls_pkcs11_context *priv_key );
  *                 of ctx->N (eg. 128 bytes if RSA-1024 is used) otherwise
  *                 an error is thrown.
  */
-int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
+MBEDX509_EXPORT int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
                        int mode, size_t *olen,
                        const unsigned char *input,
                        unsigned char *output,
@@ -132,7 +134,7 @@ int mbedtls_pkcs11_decrypt( mbedtls_pkcs11_context *ctx,
  * \note           The "sig" buffer must be as large as the size
  *                 of ctx->N (eg. 128 bytes if RSA-1024 is used).
  */
-int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
+MBEDX509_EXPORT int mbedtls_pkcs11_sign( mbedtls_pkcs11_context *ctx,
                     int mode,
                     mbedtls_md_type_t md_alg,
                     unsigned int hashlen,

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/bignum.h"
 #include "mbedtls/ecp.h"
 
@@ -1348,7 +1350,7 @@ extern int (*mbedtls_ssl_hw_record_finish)(mbedtls_ssl_context *ssl);
  *
  * \return              a string containing the ciphersuite name
  */
-const char *mbedtls_ssl_get_ciphersuite_name( const int ciphersuite_id );
+MBEDTLS_EXPORT const char *mbedtls_ssl_get_ciphersuite_name( const int ciphersuite_id );
 
 /**
  * \brief               Return the ID of the ciphersuite associated with the
@@ -1358,7 +1360,7 @@ const char *mbedtls_ssl_get_ciphersuite_name( const int ciphersuite_id );
  *
  * \return              the ID with the ciphersuite or 0 if not found
  */
-int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name );
+MBEDTLS_EXPORT int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name );
 
 /**
  * \brief          Initialize an SSL context
@@ -1367,7 +1369,7 @@ int mbedtls_ssl_get_ciphersuite_id( const char *ciphersuite_name );
  *
  * \param ssl      SSL context
  */
-void mbedtls_ssl_init( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_init( mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Set up an SSL context for use
@@ -1389,7 +1391,7 @@ void mbedtls_ssl_init( mbedtls_ssl_context *ssl );
  * \return         0 if successful, or MBEDTLS_ERR_SSL_ALLOC_FAILED if
  *                 memory allocation failed
  */
-int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
                        const mbedtls_ssl_config *conf );
 
 /**
@@ -1402,7 +1404,7 @@ int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
                    MBEDTLS_ERR_SSL_HW_ACCEL_FAILED or
  *                 MBEDTLS_ERR_SSL_COMPRESSION_FAILED
  */
-int mbedtls_ssl_session_reset( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_session_reset( mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Set the current endpoint type
@@ -1410,7 +1412,7 @@ int mbedtls_ssl_session_reset( mbedtls_ssl_context *ssl );
  * \param conf     SSL configuration
  * \param endpoint must be MBEDTLS_SSL_IS_CLIENT or MBEDTLS_SSL_IS_SERVER
  */
-void mbedtls_ssl_conf_endpoint( mbedtls_ssl_config *conf, int endpoint );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_endpoint( mbedtls_ssl_config *conf, int endpoint );
 
 /**
  * \brief           Set the transport type (TLS or DTLS).
@@ -1426,7 +1428,7 @@ void mbedtls_ssl_conf_endpoint( mbedtls_ssl_config *conf, int endpoint );
  *                  MBEDTLS_SSL_TRANSPORT_STREAM for TLS,
  *                  MBEDTLS_SSL_TRANSPORT_DATAGRAM for DTLS.
  */
-void mbedtls_ssl_conf_transport( mbedtls_ssl_config *conf, int transport );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_transport( mbedtls_ssl_config *conf, int transport );
 
 /**
  * \brief          Set the certificate verification mode
@@ -1454,7 +1456,7 @@ void mbedtls_ssl_conf_transport( mbedtls_ssl_config *conf, int transport );
  * the verification as soon as possible. For example, REQUIRED was protecting
  * against the "triple handshake" attack even before it was found.
  */
-void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**
@@ -1472,7 +1474,7 @@ void mbedtls_ssl_conf_authmode( mbedtls_ssl_config *conf, int authmode );
  * \param f_vrfy   The verification callback to use during CRT verification.
  * \param p_vrfy   The opaque context to be passed to the callback.
  */
-void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
                      int (*f_vrfy)(void *, mbedtls_x509_crt *, int, uint32_t *),
                      void *p_vrfy );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -1484,7 +1486,7 @@ void mbedtls_ssl_conf_verify( mbedtls_ssl_config *conf,
  * \param f_rng    RNG function
  * \param p_rng    RNG parameter
  */
-void mbedtls_ssl_conf_rng( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_rng( mbedtls_ssl_config *conf,
                   int (*f_rng)(void *, unsigned char *, size_t),
                   void *p_rng );
 
@@ -1502,7 +1504,7 @@ void mbedtls_ssl_conf_rng( mbedtls_ssl_config *conf,
  * \param f_dbg    debug function
  * \param p_dbg    debug parameter
  */
-void mbedtls_ssl_conf_dbg( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_dbg( mbedtls_ssl_config *conf,
                   void (*f_dbg)(void *, int, const char *, int, const char *),
                   void  *p_dbg );
 
@@ -1536,7 +1538,7 @@ void mbedtls_ssl_conf_dbg( mbedtls_ssl_config *conf,
  *                 \c mbedtls_net_recv_timeout() that are suitable to be used
  *                 here.
  */
-void mbedtls_ssl_set_bio( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_bio( mbedtls_ssl_context *ssl,
                           void *p_bio,
                           mbedtls_ssl_send_t *f_send,
                           mbedtls_ssl_recv_t *f_recv,
@@ -1630,7 +1632,7 @@ void mbedtls_ssl_set_bio( mbedtls_ssl_context *ssl,
  *                    applies to the next handshake.
  * \return            A negative error code on failure.
  */
-int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
                          int enable,
                          unsigned char const *own_cid,
                          size_t own_cid_len );
@@ -1672,7 +1674,7 @@ int mbedtls_ssl_set_cid( mbedtls_ssl_context *ssl,
  * \return            \c 0 on success.
  * \return            A negative error code on failure.
  */
-int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
                      int *enabled,
                      unsigned char peer_cid[ MBEDTLS_SSL_CID_OUT_LEN_MAX ],
                      size_t *peer_cid_len );
@@ -1721,7 +1723,7 @@ int mbedtls_ssl_get_peer_cid( mbedtls_ssl_context *ssl,
  * \param ssl      SSL context
  * \param mtu      Value of the path MTU in bytes
  */
-void mbedtls_ssl_set_mtu( mbedtls_ssl_context *ssl, uint16_t mtu );
+MBEDTLS_EXPORT void mbedtls_ssl_set_mtu( mbedtls_ssl_context *ssl, uint16_t mtu );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -1743,7 +1745,7 @@ void mbedtls_ssl_set_mtu( mbedtls_ssl_context *ssl, uint16_t mtu );
  * \param f_vrfy   The verification callback to use during CRT verification.
  * \param p_vrfy   The opaque context to be passed to the callback.
  */
-void mbedtls_ssl_set_verify( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_verify( mbedtls_ssl_context *ssl,
                      int (*f_vrfy)(void *, mbedtls_x509_crt *, int, uint32_t *),
                      void *p_vrfy );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -1764,7 +1766,7 @@ void mbedtls_ssl_set_verify( mbedtls_ssl_context *ssl,
  * \note           With non-blocking I/O, you may also skip this function
  *                 altogether and handle timeouts at the application layer.
  */
-void mbedtls_ssl_conf_read_timeout( mbedtls_ssl_config *conf, uint32_t timeout );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_read_timeout( mbedtls_ssl_config *conf, uint32_t timeout );
 
 #if defined(MBEDTLS_SSL_RECORD_CHECKING)
 /**
@@ -1811,7 +1813,7 @@ void mbedtls_ssl_conf_read_timeout( mbedtls_ssl_config *conf, uint32_t timeout )
  *                 In this case, the SSL context becomes unusable and needs
  *                 to be freed or reset before reuse.
  */
-int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
                               unsigned char *buf,
                               size_t buflen );
 #endif /* MBEDTLS_SSL_RECORD_CHECKING */
@@ -1836,7 +1838,7 @@ int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
  * \note           See also the "DTLS tutorial" article in our knowledge base.
  *                 https://tls.mbed.org/kb/how-to/dtls-tutorial
  */
-void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
                                void *p_timer,
                                mbedtls_ssl_set_timer_t *f_set_timer,
                                mbedtls_ssl_get_timer_t *f_get_timer );
@@ -1974,7 +1976,7 @@ typedef int mbedtls_ssl_ticket_parse_t( void *p_ticket,
  * \param f_ticket_parse    Callback for parsing a ticket
  * \param p_ticket          Context shared by the two callbacks
  */
-void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_ticket_write_t *f_ticket_write,
         mbedtls_ssl_ticket_parse_t *f_ticket_parse,
         void *p_ticket );
@@ -1991,7 +1993,7 @@ void mbedtls_ssl_conf_session_tickets_cb( mbedtls_ssl_config *conf,
  * \param f_export_keys     Callback for exporting keys
  * \param p_export_keys     Context for the callback
  */
-void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_export_keys_t *f_export_keys,
         void *p_export_keys );
 
@@ -2005,7 +2007,7 @@ void mbedtls_ssl_conf_export_keys_cb( mbedtls_ssl_config *conf,
  * \param f_export_keys_ext Callback for exporting keys
  * \param p_export_keys     Context for the callback
  */
-void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
         mbedtls_ssl_export_keys_ext_t *f_export_keys_ext,
         void *p_export_keys );
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
@@ -2041,7 +2043,7 @@ void mbedtls_ssl_conf_export_keys_ext_cb( mbedtls_ssl_config *conf,
  *                          mbedtls_ssl_conf_get_async_config_data(). The
  *                          library stores this value without dereferencing it.
  */
-void mbedtls_ssl_conf_async_private_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_async_private_cb( mbedtls_ssl_config *conf,
                                         mbedtls_ssl_async_sign_t *f_async_sign,
                                         mbedtls_ssl_async_decrypt_t *f_async_decrypt,
                                         mbedtls_ssl_async_resume_t *f_async_resume,
@@ -2056,7 +2058,7 @@ void mbedtls_ssl_conf_async_private_cb( mbedtls_ssl_config *conf,
  * \return          The configuration data set by
  *                  mbedtls_ssl_conf_async_private_cb().
  */
-void *mbedtls_ssl_conf_get_async_config_data( const mbedtls_ssl_config *conf );
+MBEDTLS_EXPORT void *mbedtls_ssl_conf_get_async_config_data( const mbedtls_ssl_config *conf );
 
 /**
  * \brief           Retrieve the asynchronous operation user context.
@@ -2072,7 +2074,7 @@ void *mbedtls_ssl_conf_get_async_config_data( const mbedtls_ssl_config *conf );
  *                  called during the current handshake, this function returns
  *                  \c NULL.
  */
-void *mbedtls_ssl_get_async_operation_data( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void *mbedtls_ssl_get_async_operation_data( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief           Retrieve the asynchronous operation user context.
@@ -2085,7 +2087,7 @@ void *mbedtls_ssl_get_async_operation_data( const mbedtls_ssl_context *ssl );
  *                  Call mbedtls_ssl_get_async_operation_data() later during the
  *                  same handshake to retrieve this value.
  */
-void mbedtls_ssl_set_async_operation_data( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_async_operation_data( mbedtls_ssl_context *ssl,
                                  void *ctx );
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */
 
@@ -2153,7 +2155,7 @@ typedef int mbedtls_ssl_cookie_check_t( void *ctx,
  * \param f_cookie_check    Cookie check callback
  * \param p_cookie          Context for both callbacks
  */
-void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
                            mbedtls_ssl_cookie_write_t *f_cookie_write,
                            mbedtls_ssl_cookie_check_t *f_cookie_check,
                            void *p_cookie );
@@ -2177,7 +2179,7 @@ void mbedtls_ssl_conf_dtls_cookies( mbedtls_ssl_config *conf,
  *                 MBEDTLS_ERR_SSL_BAD_INPUT_DATA if used on client,
  *                 MBEDTLS_ERR_SSL_ALLOC_FAILED if out of memory.
  */
-int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
                                  const unsigned char *info,
                                  size_t ilen );
 
@@ -2199,7 +2201,7 @@ int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
  *                 packets and needs information about them to adjust its
  *                 transmission strategy, then you'll want to disable this.
  */
-void mbedtls_ssl_conf_dtls_anti_replay( mbedtls_ssl_config *conf, char mode );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_dtls_anti_replay( mbedtls_ssl_config *conf, char mode );
 #endif /* MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 
 #if defined(MBEDTLS_SSL_DTLS_BADMAC_LIMIT)
@@ -2226,7 +2228,7 @@ void mbedtls_ssl_conf_dtls_anti_replay( mbedtls_ssl_config *conf, char mode );
  *                 might make us waste resources checking authentication on
  *                 many bogus packets.
  */
-void mbedtls_ssl_conf_dtls_badmac_limit( mbedtls_ssl_config *conf, unsigned limit );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_dtls_badmac_limit( mbedtls_ssl_config *conf, unsigned limit );
 #endif /* MBEDTLS_SSL_DTLS_BADMAC_LIMIT */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -2259,7 +2261,7 @@ void mbedtls_ssl_conf_dtls_badmac_limit( mbedtls_ssl_config *conf, unsigned limi
  *                 are currently always sent in separate datagrams.
  *
  */
-void mbedtls_ssl_set_datagram_packing( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_datagram_packing( mbedtls_ssl_context *ssl,
                                        unsigned allow_packing );
 
 /**
@@ -2293,7 +2295,7 @@ void mbedtls_ssl_set_datagram_packing( mbedtls_ssl_context *ssl,
  *                 goes: send ... 1s -> resend ... 2s -> resend ... 4s ->
  *                 resend ... 5s -> give up and return a timeout error.
  */
-void mbedtls_ssl_conf_handshake_timeout( mbedtls_ssl_config *conf, uint32_t min, uint32_t max );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_handshake_timeout( mbedtls_ssl_config *conf, uint32_t min, uint32_t max );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_SSL_SRV_C)
@@ -2334,7 +2336,7 @@ void mbedtls_ssl_conf_handshake_timeout( mbedtls_ssl_config *conf, uint32_t min,
  * \param f_get_cache    session get callback
  * \param f_set_cache    session set callback
  */
-void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
         void *p_cache,
         int (*f_get_cache)(void *, mbedtls_ssl_session *),
         int (*f_set_cache)(void *, const mbedtls_ssl_session *) );
@@ -2355,7 +2357,7 @@ void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
  *
  * \sa             mbedtls_ssl_get_session()
  */
-int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session *session );
+MBEDTLS_EXPORT int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session *session );
 #endif /* MBEDTLS_SSL_CLI_C */
 
 /**
@@ -2390,7 +2392,7 @@ int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session
  * \return         Another negative value for other kinds of errors (for
  *                 example, unsupported features in the embedded certificate).
  */
-int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
+MBEDTLS_EXPORT int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
                               const unsigned char *buf,
                               size_t len );
 
@@ -2420,7 +2422,7 @@ int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
  * \return         \c 0 if successful.
  * \return         #MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL if \p buf is too small.
  */
-int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
+MBEDTLS_EXPORT int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
                               unsigned char *buf,
                               size_t buf_len,
                               size_t *olen );
@@ -2440,7 +2442,7 @@ int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
  * \return         A pointer to the current session if successful.
  * \return         \c NULL if no session is active.
  */
-const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief               Set the list of allowed ciphersuites and the preference
@@ -2457,7 +2459,7 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
  * \param conf          SSL configuration
  * \param ciphersuites  0-terminated list of allowed ciphersuites
  */
-void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
                                    const int *ciphersuites );
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -2495,7 +2497,7 @@ void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
  * \return              #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if \p own_cid_len
  *                      is too large.
  */
-int mbedtls_ssl_conf_cid( mbedtls_ssl_config *conf, size_t len,
+MBEDTLS_EXPORT int mbedtls_ssl_conf_cid( mbedtls_ssl_config *conf, size_t len,
                           int ignore_other_cids );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
@@ -2518,7 +2520,7 @@ int mbedtls_ssl_conf_cid( mbedtls_ssl_config *conf, size_t len,
  * \note                With DTLS, use MBEDTLS_SSL_MINOR_VERSION_2 for DTLS 1.0
  *                      and MBEDTLS_SSL_MINOR_VERSION_3 for DTLS 1.2
  */
-void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
                                        const int *ciphersuites,
                                        int major, int minor );
 
@@ -2533,7 +2535,7 @@ void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
  * \param conf     SSL configuration
  * \param profile  Profile to use
  */
-void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
                                     const mbedtls_x509_crt_profile *profile );
 
 /**
@@ -2547,7 +2549,7 @@ void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
  * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
  * \param ca_crl   trusted CA CRLs
  */
-void mbedtls_ssl_conf_ca_chain( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_ca_chain( mbedtls_ssl_config *conf,
                                mbedtls_x509_crt *ca_chain,
                                mbedtls_x509_crl *ca_crl );
 
@@ -2603,7 +2605,7 @@ void mbedtls_ssl_conf_ca_chain( mbedtls_ssl_config *conf,
  *                 to guarantee this (for example through a mutex
  *                 contained in the callback context pointed to by \p p_ca_cb).
  */
-void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
                              mbedtls_x509_crt_ca_cb_t f_ca_cb,
                              void *p_ca_cb );
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
@@ -2644,7 +2646,7 @@ void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
  *
  * \return         0 on success or MBEDTLS_ERR_SSL_ALLOC_FAILED
  */
-int mbedtls_ssl_conf_own_cert( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT int mbedtls_ssl_conf_own_cert( mbedtls_ssl_config *conf,
                               mbedtls_x509_crt *own_cert,
                               mbedtls_pk_context *pk_key );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -2678,7 +2680,7 @@ int mbedtls_ssl_conf_own_cert( mbedtls_ssl_config *conf,
  * \return         \c 0 if successful.
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
-int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
                 const unsigned char *psk, size_t psk_len,
                 const unsigned char *psk_identity, size_t psk_identity_len );
 
@@ -2715,7 +2717,7 @@ int mbedtls_ssl_conf_psk( mbedtls_ssl_config *conf,
  * \return         \c 0 if successful.
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
-int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
                                  psa_key_handle_t psk,
                                  const unsigned char *psk_identity,
                                  size_t psk_identity_len );
@@ -2734,7 +2736,7 @@ int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
  * \return         \c 0 if successful.
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
-int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
                             const unsigned char *psk, size_t psk_len );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -2755,7 +2757,7 @@ int mbedtls_ssl_set_hs_psk( mbedtls_ssl_context *ssl,
  * \return         \c 0 if successful.
  * \return         An \c MBEDTLS_ERR_SSL_XXX error code on failure.
  */
-int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
                                    psa_key_handle_t psk );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -2792,7 +2794,7 @@ int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
  * \param p_psk    A pointer to an opaque structure to be passed to
  *                 the callback, for example a PSK store.
  */
-void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_psk_cb( mbedtls_ssl_config *conf,
                      int (*f_psk)(void *, mbedtls_ssl_context *, const unsigned char *,
                                   size_t),
                      void *p_psk );
@@ -2840,7 +2842,7 @@ MBEDTLS_DEPRECATED int mbedtls_ssl_conf_dh_param( mbedtls_ssl_config *conf,
  *
  * \return         0 if successful
  */
-int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
                                    const unsigned char *dhm_P, size_t P_len,
                                    const unsigned char *dhm_G,  size_t G_len );
 
@@ -2853,7 +2855,7 @@ int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
  *
  * \return         0 if successful
  */
-int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context *dhm_ctx );
+MBEDTLS_EXPORT int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context *dhm_ctx );
 #endif /* MBEDTLS_DHM_C && defined(MBEDTLS_SSL_SRV_C) */
 
 #if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_CLI_C)
@@ -2865,7 +2867,7 @@ int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context
  * \param conf     SSL configuration
  * \param bitlen   Minimum bit length of the DHM prime
  */
-void mbedtls_ssl_conf_dhm_min_bitlen( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_dhm_min_bitlen( mbedtls_ssl_config *conf,
                                       unsigned int bitlen );
 #endif /* MBEDTLS_DHM_C && MBEDTLS_SSL_CLI_C */
 
@@ -2897,7 +2899,7 @@ void mbedtls_ssl_conf_dhm_min_bitlen( mbedtls_ssl_config *conf,
  * \param curves   Ordered list of allowed curves,
  *                 terminated by MBEDTLS_ECP_DP_NONE.
  */
-void mbedtls_ssl_conf_curves( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_curves( mbedtls_ssl_config *conf,
                               const mbedtls_ecp_group_id *curves );
 #endif /* MBEDTLS_ECP_C */
 
@@ -2920,7 +2922,7 @@ void mbedtls_ssl_conf_curves( mbedtls_ssl_config *conf,
  * \param hashes   Ordered list of allowed signature hashes,
  *                 terminated by \c MBEDTLS_MD_NONE.
  */
-void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
                                   const int *hashes );
 #endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
@@ -2943,7 +2945,7 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
  *                 when NULL). On allocation failure hostname is cleared.
  *                 On too long input failure, old hostname is unchanged.
  */
-int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
+MBEDTLS_EXPORT int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -2959,7 +2961,7 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
  *
  * \return         0 on success or MBEDTLS_ERR_SSL_ALLOC_FAILED
  */
-int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
                                  mbedtls_x509_crt *own_cert,
                                  mbedtls_pk_context *pk_key );
 
@@ -2974,7 +2976,7 @@ int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
  * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
  * \param ca_crl   trusted CA CRLs
  */
-void mbedtls_ssl_set_hs_ca_chain( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_hs_ca_chain( mbedtls_ssl_context *ssl,
                                   mbedtls_x509_crt *ca_chain,
                                   mbedtls_x509_crl *ca_crl );
 
@@ -2988,7 +2990,7 @@ void mbedtls_ssl_set_hs_ca_chain( mbedtls_ssl_context *ssl,
  * \param authmode MBEDTLS_SSL_VERIFY_NONE, MBEDTLS_SSL_VERIFY_OPTIONAL or
  *                 MBEDTLS_SSL_VERIFY_REQUIRED
  */
-void mbedtls_ssl_set_hs_authmode( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_set_hs_authmode( mbedtls_ssl_context *ssl,
                                   int authmode );
 
 /**
@@ -3014,7 +3016,7 @@ void mbedtls_ssl_set_hs_authmode( mbedtls_ssl_context *ssl,
  * \param f_sni    verification function
  * \param p_sni    verification parameter
  */
-void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,
                   int (*f_sni)(void *, mbedtls_ssl_context *, const unsigned char *,
                                size_t),
                   void *p_sni );
@@ -3038,7 +3040,7 @@ void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,
  *
  * \return         0 on success, or a negative error code.
  */
-int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
                                          const unsigned char *pw,
                                          size_t pw_len );
 #endif /*MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
@@ -3056,7 +3058,7 @@ int mbedtls_ssl_set_hs_ecjpake_password( mbedtls_ssl_context *ssl,
  *
  * \return         0 on success, or MBEDTLS_ERR_SSL_BAD_INPUT_DATA.
  */
-int mbedtls_ssl_conf_alpn_protocols( mbedtls_ssl_config *conf, const char **protos );
+MBEDTLS_EXPORT int mbedtls_ssl_conf_alpn_protocols( mbedtls_ssl_config *conf, const char **protos );
 
 /**
  * \brief          Get the name of the negotiated Application Layer Protocol.
@@ -3067,7 +3069,7 @@ int mbedtls_ssl_conf_alpn_protocols( mbedtls_ssl_config *conf, const char **prot
  *
  * \return         Protcol name, or NULL if no protocol was negotiated.
  */
-const char *mbedtls_ssl_get_alpn_protocol( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT const char *mbedtls_ssl_get_alpn_protocol( const mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_ALPN */
 
 /**
@@ -3086,7 +3088,7 @@ const char *mbedtls_ssl_get_alpn_protocol( const mbedtls_ssl_context *ssl );
  *                 MBEDTLS_SSL_MINOR_VERSION_1 and MBEDTLS_SSL_MINOR_VERSION_2,
  *                 MBEDTLS_SSL_MINOR_VERSION_3 supported)
  */
-void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor );
 
 /**
  * \brief          Set the minimum accepted SSL/TLS protocol version
@@ -3106,7 +3108,7 @@ void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int mino
  *                 MBEDTLS_SSL_MINOR_VERSION_1 and MBEDTLS_SSL_MINOR_VERSION_2,
  *                 MBEDTLS_SSL_MINOR_VERSION_3 supported)
  */
-void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int minor );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int minor );
 
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV) && defined(MBEDTLS_SSL_CLI_C)
 /**
@@ -3128,7 +3130,7 @@ void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int mino
  * \param conf     SSL configuration
  * \param fallback MBEDTLS_SSL_IS_NOT_FALLBACK or MBEDTLS_SSL_IS_FALLBACK
  */
-void mbedtls_ssl_conf_fallback( mbedtls_ssl_config *conf, char fallback );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_fallback( mbedtls_ssl_config *conf, char fallback );
 #endif /* MBEDTLS_SSL_FALLBACK_SCSV && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
@@ -3143,7 +3145,7 @@ void mbedtls_ssl_conf_fallback( mbedtls_ssl_config *conf, char fallback );
  * \param conf      SSL configuration
  * \param etm       MBEDTLS_SSL_ETM_ENABLED or MBEDTLS_SSL_ETM_DISABLED
  */
-void mbedtls_ssl_conf_encrypt_then_mac( mbedtls_ssl_config *conf, char etm );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_encrypt_then_mac( mbedtls_ssl_config *conf, char etm );
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
 
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
@@ -3158,7 +3160,7 @@ void mbedtls_ssl_conf_encrypt_then_mac( mbedtls_ssl_config *conf, char etm );
  * \param conf      SSL configuration
  * \param ems       MBEDTLS_SSL_EXTENDED_MS_ENABLED or MBEDTLS_SSL_EXTENDED_MS_DISABLED
  */
-void mbedtls_ssl_conf_extended_master_secret( mbedtls_ssl_config *conf, char ems );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_extended_master_secret( mbedtls_ssl_config *conf, char ems );
 #endif /* MBEDTLS_SSL_EXTENDED_MASTER_SECRET */
 
 #if defined(MBEDTLS_ARC4_C)
@@ -3177,7 +3179,7 @@ void mbedtls_ssl_conf_extended_master_secret( mbedtls_ssl_config *conf, char ems
  * \param conf     SSL configuration
  * \param arc4     MBEDTLS_SSL_ARC4_ENABLED or MBEDTLS_SSL_ARC4_DISABLED
  */
-void mbedtls_ssl_conf_arc4_support( mbedtls_ssl_config *conf, char arc4 );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_arc4_support( mbedtls_ssl_config *conf, char arc4 );
 #endif /* MBEDTLS_ARC4_C */
 
 #if defined(MBEDTLS_SSL_SRV_C)
@@ -3190,7 +3192,7 @@ void mbedtls_ssl_conf_arc4_support( mbedtls_ssl_config *conf, char arc4 );
  * \param cert_req_ca_list   MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED or
  *                          MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED
  */
-void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
                                           char cert_req_ca_list );
 #endif /* MBEDTLS_SSL_SRV_C */
 
@@ -3229,7 +3231,7 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  *
  * \return         0 if successful or MBEDTLS_ERR_SSL_BAD_INPUT_DATA
  */
-int mbedtls_ssl_conf_max_frag_len( mbedtls_ssl_config *conf, unsigned char mfl_code );
+MBEDTLS_EXPORT int mbedtls_ssl_conf_max_frag_len( mbedtls_ssl_config *conf, unsigned char mfl_code );
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
@@ -3241,7 +3243,7 @@ int mbedtls_ssl_conf_max_frag_len( mbedtls_ssl_config *conf, unsigned char mfl_c
  * \param truncate Enable or disable (MBEDTLS_SSL_TRUNC_HMAC_ENABLED or
  *                                    MBEDTLS_SSL_TRUNC_HMAC_DISABLED)
  */
-void mbedtls_ssl_conf_truncated_hmac( mbedtls_ssl_config *conf, int truncate );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_truncated_hmac( mbedtls_ssl_config *conf, int truncate );
 #endif /* MBEDTLS_SSL_TRUNCATED_HMAC */
 
 #if defined(MBEDTLS_SSL_CBC_RECORD_SPLITTING)
@@ -3256,7 +3258,7 @@ void mbedtls_ssl_conf_truncated_hmac( mbedtls_ssl_config *conf, int truncate );
  * \param split    MBEDTLS_SSL_CBC_RECORD_SPLITTING_ENABLED or
  *                 MBEDTLS_SSL_CBC_RECORD_SPLITTING_DISABLED
  */
-void mbedtls_ssl_conf_cbc_record_splitting( mbedtls_ssl_config *conf, char split );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_cbc_record_splitting( mbedtls_ssl_config *conf, char split );
 #endif /* MBEDTLS_SSL_CBC_RECORD_SPLITTING */
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
@@ -3270,7 +3272,7 @@ void mbedtls_ssl_conf_cbc_record_splitting( mbedtls_ssl_config *conf, char split
  * \param use_tickets   Enable or disable (MBEDTLS_SSL_SESSION_TICKETS_ENABLED or
  *                                         MBEDTLS_SSL_SESSION_TICKETS_DISABLED)
  */
-void mbedtls_ssl_conf_session_tickets( mbedtls_ssl_config *conf, int use_tickets );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_session_tickets( mbedtls_ssl_config *conf, int use_tickets );
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
@@ -3291,7 +3293,7 @@ void mbedtls_ssl_conf_session_tickets( mbedtls_ssl_config *conf, int use_tickets
  * \param renegotiation     Enable or disable (MBEDTLS_SSL_RENEGOTIATION_ENABLED or
  *                                             MBEDTLS_SSL_RENEGOTIATION_DISABLED)
  */
-void mbedtls_ssl_conf_renegotiation( mbedtls_ssl_config *conf, int renegotiation );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_renegotiation( mbedtls_ssl_config *conf, int renegotiation );
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
 /**
@@ -3321,7 +3323,7 @@ void mbedtls_ssl_conf_renegotiation( mbedtls_ssl_config *conf, int renegotiation
  *                                        SSL_ALLOW_LEGACY_RENEGOTIATION or
  *                                        MBEDTLS_SSL_LEGACY_BREAK_HANDSHAKE)
  */
-void mbedtls_ssl_conf_legacy_renegotiation( mbedtls_ssl_config *conf, int allow_legacy );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_legacy_renegotiation( mbedtls_ssl_config *conf, int allow_legacy );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 /**
@@ -3361,7 +3363,7 @@ void mbedtls_ssl_conf_legacy_renegotiation( mbedtls_ssl_config *conf, int allow_
  *                 enforce renegotiation, or a non-negative value to enforce
  *                 it but allow for a grace period of max_records records.
  */
-void mbedtls_ssl_conf_renegotiation_enforced( mbedtls_ssl_config *conf, int max_records );
+MBEDTLS_EXPORT void mbedtls_ssl_conf_renegotiation_enforced( mbedtls_ssl_config *conf, int max_records );
 
 /**
  * \brief          Set record counter threshold for periodic renegotiation.
@@ -3388,7 +3390,7 @@ void mbedtls_ssl_conf_renegotiation_enforced( mbedtls_ssl_config *conf, int max_
  * \param conf     SSL configuration
  * \param period   The threshold value: a big-endian 64-bit number.
  */
-void mbedtls_ssl_conf_renegotiation_period( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT void mbedtls_ssl_conf_renegotiation_period( mbedtls_ssl_config *conf,
                                    const unsigned char period[8] );
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
@@ -3430,7 +3432,7 @@ void mbedtls_ssl_conf_renegotiation_period( mbedtls_ssl_config *conf,
  *                 that all internal data has been processed.
  *
  */
-int mbedtls_ssl_check_pending( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_check_pending( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Return the number of application data bytes
@@ -3447,7 +3449,7 @@ int mbedtls_ssl_check_pending( const mbedtls_ssl_context *ssl );
  *                 amount of data fitting into the input buffer.
  *
  */
-size_t mbedtls_ssl_get_bytes_avail( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT size_t mbedtls_ssl_get_bytes_avail( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Return the result of the certificate verification
@@ -3461,7 +3463,7 @@ size_t mbedtls_ssl_get_bytes_avail( const mbedtls_ssl_context *ssl );
  * \return         A bitwise combination of \c MBEDTLS_X509_BADCERT_XXX
  *                 and \c MBEDTLS_X509_BADCRL_XXX failure flags; see x509.h.
  */
-uint32_t mbedtls_ssl_get_verify_result( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT uint32_t mbedtls_ssl_get_verify_result( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Return the name of the current ciphersuite
@@ -3470,7 +3472,7 @@ uint32_t mbedtls_ssl_get_verify_result( const mbedtls_ssl_context *ssl );
  *
  * \return         a string containing the ciphersuite name
  */
-const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Return the current SSL version (SSLv3/TLSv1/etc)
@@ -3479,7 +3481,7 @@ const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl );
  *
  * \return         a string containing the SSL version
  */
-const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Return the (maximum) number of bytes added by the record
@@ -3494,7 +3496,7 @@ const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl );
  *                 MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE if compression is
  *                 enabled, which makes expansion much less predictable
  */
-int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
 /**
@@ -3509,7 +3511,7 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl );
  *
  * \return         Current maximum fragment length.
  */
-size_t mbedtls_ssl_get_max_frag_len( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT size_t mbedtls_ssl_get_max_frag_len( const mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 /**
@@ -3538,7 +3540,7 @@ size_t mbedtls_ssl_get_max_frag_len( const mbedtls_ssl_context *ssl );
  * \return         Current maximum payload for an outgoing record,
  *                 or a negative error code.
  */
-int mbedtls_ssl_get_max_out_record_payload( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_get_max_out_record_payload( const mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**
@@ -3571,7 +3573,7 @@ int mbedtls_ssl_get_max_out_record_payload( const mbedtls_ssl_context *ssl );
  *                 If you want to use the certificate across API calls,
  *                 you must make a copy.
  */
-const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_CLI_C)
@@ -3601,7 +3603,7 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *
  * \sa             mbedtls_ssl_set_session()
  */
-int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl, mbedtls_ssl_session *session );
+MBEDTLS_EXPORT int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl, mbedtls_ssl_session *session );
 #endif /* MBEDTLS_SSL_CLI_C */
 
 /**
@@ -3654,7 +3656,7 @@ int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl, mbedtls_ssl_session
  *                 currently being processed might or might not contain further
  *                 DTLS records.
  */
-int mbedtls_ssl_handshake( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_handshake( mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Perform a single step of the SSL handshake
@@ -3676,7 +3678,7 @@ int mbedtls_ssl_handshake( mbedtls_ssl_context *ssl );
  *                 re-using it for a new connection; the current connection
  *                 must be closed.
  */
-int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 /**
@@ -3702,7 +3704,7 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl );
  *                 must be closed.
  *
  */
-int mbedtls_ssl_renegotiate( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_renegotiate( mbedtls_ssl_context *ssl );
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
 /**
@@ -3775,7 +3777,7 @@ int mbedtls_ssl_renegotiate( mbedtls_ssl_context *ssl );
  *                   \c mbedtls_ssl_check_pending to check for remaining records.
  *
  */
-int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len );
+MBEDTLS_EXPORT int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len );
 
 /**
  * \brief          Try to write exactly 'len' application data bytes
@@ -3837,7 +3839,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
  * \note           Attempting to write 0 bytes will result in an empty TLS
  *                 application record being sent.
  */
-int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_t len );
+MBEDTLS_EXPORT int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_t len );
 
 /**
  * \brief           Send an alert message
@@ -3855,7 +3857,7 @@ int mbedtls_ssl_write( mbedtls_ssl_context *ssl, const unsigned char *buf, size_
  *                 call \c mbedtls_ssl_session_reset() on it before re-using it
  *                 for a new connection; the current connection must be closed.
  */
-int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
                             unsigned char level,
                             unsigned char message );
 /**
@@ -3871,14 +3873,14 @@ int mbedtls_ssl_send_alert_message( mbedtls_ssl_context *ssl,
  *                 call \c mbedtls_ssl_session_reset() on it before re-using it
  *                 for a new connection; the current connection must be closed.
  */
-int mbedtls_ssl_close_notify( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_close_notify( mbedtls_ssl_context *ssl );
 
 /**
  * \brief          Free referenced items in an SSL context and clear memory
  *
  * \param ssl      SSL context
  */
-void mbedtls_ssl_free( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_free( mbedtls_ssl_context *ssl );
 
 #if defined(MBEDTLS_SSL_CONTEXT_SERIALIZATION)
 /**
@@ -3929,7 +3931,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl );
  *                 or the connection does not use DTLS 1.2 with an AEAD
  *                 ciphersuite, or renegotiation is enabled.
  */
-int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
                               unsigned char *buf,
                               size_t buf_len,
                               size_t *olen );
@@ -3999,7 +4001,7 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
  *                 comes from a different Mbed TLS version or build.
  * \return         #MBEDTLS_ERR_SSL_BAD_INPUT_DATA if input data is invalid.
  */
-int mbedtls_ssl_context_load( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_context_load( mbedtls_ssl_context *ssl,
                               const unsigned char *buf,
                               size_t len );
 #endif /* MBEDTLS_SSL_CONTEXT_SERIALIZATION */
@@ -4014,7 +4016,7 @@ int mbedtls_ssl_context_load( mbedtls_ssl_context *ssl,
  *
  * \param conf     SSL configuration context
  */
-void mbedtls_ssl_config_init( mbedtls_ssl_config *conf );
+MBEDTLS_EXPORT void mbedtls_ssl_config_init( mbedtls_ssl_config *conf );
 
 /**
  * \brief          Load reasonnable default SSL configuration values.
@@ -4031,7 +4033,7 @@ void mbedtls_ssl_config_init( mbedtls_ssl_config *conf );
  * \return         0 if successful, or
  *                 MBEDTLS_ERR_XXX_ALLOC_FAILED on memory allocation error.
  */
-int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
+MBEDTLS_EXPORT int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
                                  int endpoint, int transport, int preset );
 
 /**
@@ -4039,14 +4041,14 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
  *
  * \param conf     SSL configuration context
  */
-void mbedtls_ssl_config_free( mbedtls_ssl_config *conf );
+MBEDTLS_EXPORT void mbedtls_ssl_config_free( mbedtls_ssl_config *conf );
 
 /**
  * \brief          Initialize SSL session structure
  *
  * \param session  SSL session
  */
-void mbedtls_ssl_session_init( mbedtls_ssl_session *session );
+MBEDTLS_EXPORT void mbedtls_ssl_session_init( mbedtls_ssl_session *session );
 
 /**
  * \brief          Free referenced items in an SSL session including the
@@ -4057,7 +4059,7 @@ void mbedtls_ssl_session_init( mbedtls_ssl_session *session );
  *
  * \param session  SSL session
  */
-void mbedtls_ssl_session_free( mbedtls_ssl_session *session );
+MBEDTLS_EXPORT void mbedtls_ssl_session_free( mbedtls_ssl_session *session );
 
 /**
  * \brief          TLS-PRF function for key derivation.
@@ -4074,7 +4076,7 @@ void mbedtls_ssl_session_free( mbedtls_ssl_session *session );
  *
  * \return         0 on sucess. An SSL specific error on failure.
  */
-int  mbedtls_ssl_tls_prf( const mbedtls_tls_prf_types prf,
+MBEDTLS_EXPORT int  mbedtls_ssl_tls_prf( const mbedtls_tls_prf_types prf,
                           const unsigned char *secret, size_t slen,
                           const char *label,
                           const unsigned char *random, size_t rlen,

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ssl.h"
 
 #if defined(MBEDTLS_THREADING_C)
@@ -95,7 +97,7 @@ struct mbedtls_ssl_cache_context
  *
  * \param cache    SSL cache context
  */
-void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache );
+MBEDTLS_EXPORT void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache );
 
 /**
  * \brief          Cache get callback implementation
@@ -104,7 +106,7 @@ void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache );
  * \param data     SSL cache context
  * \param session  session to retrieve entry for
  */
-int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session );
+MBEDTLS_EXPORT int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session );
 
 /**
  * \brief          Cache set callback implementation
@@ -113,7 +115,7 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session );
  * \param data     SSL cache context
  * \param session  session to store entry for
  */
-int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session );
+MBEDTLS_EXPORT int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session );
 
 #if defined(MBEDTLS_HAVE_TIME)
 /**
@@ -125,7 +127,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session );
  * \param cache    SSL cache context
  * \param timeout  cache entry timeout in seconds
  */
-void mbedtls_ssl_cache_set_timeout( mbedtls_ssl_cache_context *cache, int timeout );
+MBEDTLS_EXPORT void mbedtls_ssl_cache_set_timeout( mbedtls_ssl_cache_context *cache, int timeout );
 #endif /* MBEDTLS_HAVE_TIME */
 
 /**
@@ -135,14 +137,14 @@ void mbedtls_ssl_cache_set_timeout( mbedtls_ssl_cache_context *cache, int timeou
  * \param cache    SSL cache context
  * \param max      cache entry maximum
  */
-void mbedtls_ssl_cache_set_max_entries( mbedtls_ssl_cache_context *cache, int max );
+MBEDTLS_EXPORT void mbedtls_ssl_cache_set_max_entries( mbedtls_ssl_cache_context *cache, int max );
 
 /**
  * \brief          Free referenced items in a cache context and clear memory
  *
  * \param cache    SSL cache context
  */
-void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache );
+MBEDTLS_EXPORT void mbedtls_ssl_cache_free( mbedtls_ssl_cache_context *cache );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/pk.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/md.h"
@@ -404,18 +406,18 @@ struct mbedtls_ssl_ciphersuite_t
     unsigned char flags;
 };
 
-const int *mbedtls_ssl_list_ciphersuites( void );
+MBEDTLS_EXPORT const int *mbedtls_ssl_list_ciphersuites( void );
 
-const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_string( const char *ciphersuite_name );
-const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_id( int ciphersuite_id );
+MBEDTLS_EXPORT const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_string( const char *ciphersuite_name );
+MBEDTLS_EXPORT const mbedtls_ssl_ciphersuite_t *mbedtls_ssl_ciphersuite_from_id( int ciphersuite_id );
 
 #if defined(MBEDTLS_PK_C)
-mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_pk_alg( const mbedtls_ssl_ciphersuite_t *info );
-mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_alg( const mbedtls_ssl_ciphersuite_t *info );
+MBEDTLS_EXPORT mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_pk_alg( const mbedtls_ssl_ciphersuite_t *info );
+MBEDTLS_EXPORT mbedtls_pk_type_t mbedtls_ssl_get_ciphersuite_sig_alg( const mbedtls_ssl_ciphersuite_t *info );
 #endif
 
-int mbedtls_ssl_ciphersuite_uses_ec( const mbedtls_ssl_ciphersuite_t *info );
-int mbedtls_ssl_ciphersuite_uses_psk( const mbedtls_ssl_ciphersuite_t *info );
+MBEDTLS_EXPORT int mbedtls_ssl_ciphersuite_uses_ec( const mbedtls_ssl_ciphersuite_t *info );
+MBEDTLS_EXPORT int mbedtls_ssl_ciphersuite_uses_psk( const mbedtls_ssl_ciphersuite_t *info );
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME_PFS__ENABLED)
 static inline int mbedtls_ssl_ciphersuite_has_pfs( const mbedtls_ssl_ciphersuite_t *info )

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ssl.h"
 
 #if defined(MBEDTLS_THREADING_C)
@@ -73,12 +75,12 @@ typedef struct mbedtls_ssl_cookie_ctx
 /**
  * \brief          Initialize cookie context
  */
-void mbedtls_ssl_cookie_init( mbedtls_ssl_cookie_ctx *ctx );
+MBEDTLS_EXPORT void mbedtls_ssl_cookie_init( mbedtls_ssl_cookie_ctx *ctx );
 
 /**
  * \brief          Setup cookie context (generate keys)
  */
-int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
+MBEDTLS_EXPORT int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng );
 
@@ -91,22 +93,22 @@ int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
  *                 issued in the meantime.
  *                 0 to disable expiration (NOT recommended)
  */
-void mbedtls_ssl_cookie_set_timeout( mbedtls_ssl_cookie_ctx *ctx, unsigned long delay );
+MBEDTLS_EXPORT void mbedtls_ssl_cookie_set_timeout( mbedtls_ssl_cookie_ctx *ctx, unsigned long delay );
 
 /**
  * \brief          Free cookie context
  */
-void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx );
+MBEDTLS_EXPORT void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx );
 
 /**
  * \brief          Generate cookie, see \c mbedtls_ssl_cookie_write_t
  */
-mbedtls_ssl_cookie_write_t mbedtls_ssl_cookie_write;
+MBEDTLS_EXPORT mbedtls_ssl_cookie_write_t mbedtls_ssl_cookie_write;
 
 /**
  * \brief          Verify cookie, see \c mbedtls_ssl_cookie_write_t
  */
-mbedtls_ssl_cookie_check_t mbedtls_ssl_cookie_check;
+MBEDTLS_EXPORT mbedtls_ssl_cookie_check_t mbedtls_ssl_cookie_check;
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ssl.h"
 #include "mbedtls/cipher.h"
 
@@ -748,14 +750,14 @@ struct mbedtls_ssl_flight_item
     defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 
 /* Find an entry in a signature-hash set matching a given hash algorithm. */
-mbedtls_md_type_t mbedtls_ssl_sig_hash_set_find( mbedtls_ssl_sig_hash_set_t *set,
+MBEDTLS_EXPORT mbedtls_md_type_t mbedtls_ssl_sig_hash_set_find( mbedtls_ssl_sig_hash_set_t *set,
                                                  mbedtls_pk_type_t sig_alg );
 /* Add a signature-hash-pair to a signature-hash set */
-void mbedtls_ssl_sig_hash_set_add( mbedtls_ssl_sig_hash_set_t *set,
+MBEDTLS_EXPORT void mbedtls_ssl_sig_hash_set_add( mbedtls_ssl_sig_hash_set_t *set,
                                    mbedtls_pk_type_t sig_alg,
                                    mbedtls_md_type_t md_alg );
 /* Allow exactly one hash algorithm for each signature. */
-void mbedtls_ssl_sig_hash_set_const_hash( mbedtls_ssl_sig_hash_set_t *set,
+MBEDTLS_EXPORT void mbedtls_ssl_sig_hash_set_const_hash( mbedtls_ssl_sig_hash_set_t *set,
                                           mbedtls_md_type_t md_alg );
 
 /* Setup an empty signature-hash set */
@@ -773,7 +775,7 @@ static inline void mbedtls_ssl_sig_hash_set_init( mbedtls_ssl_sig_hash_set_t *se
  *
  * \param transform SSL transform context
  */
-void mbedtls_ssl_transform_free( mbedtls_ssl_transform *transform );
+MBEDTLS_EXPORT void mbedtls_ssl_transform_free( mbedtls_ssl_transform *transform );
 
 /**
  * \brief           Free referenced items in an SSL handshake context and clear
@@ -781,20 +783,20 @@ void mbedtls_ssl_transform_free( mbedtls_ssl_transform *transform );
  *
  * \param ssl       SSL context
  */
-void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl );
-void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_send_fatal_handshake_failure( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_send_fatal_handshake_failure( mbedtls_ssl_context *ssl );
 
-void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl );
-void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_handle_message_type( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
 
 /**
  * \brief       Update record layer
@@ -872,46 +874,46 @@ void mbedtls_ssl_update_handshake_status( mbedtls_ssl_context *ssl );
  *              following the above definition.
  *
  */
-int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl,
                              unsigned update_hs_digest );
-int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want );
+MBEDTLS_EXPORT int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want );
 
-int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush );
-int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush );
+MBEDTLS_EXPORT int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_parse_certificate( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_parse_certificate( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_parse_change_cipher_spec( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_write_change_cipher_spec( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_parse_change_cipher_spec( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_write_change_cipher_spec( mbedtls_ssl_context *ssl );
 
-int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl );
 
-void mbedtls_ssl_optimize_checksum( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_optimize_checksum( mbedtls_ssl_context *ssl,
                             const mbedtls_ssl_ciphersuite_t *ciphersuite_info );
 
 #if defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED)
-int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exchange_type_t key_ex );
+MBEDTLS_EXPORT int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exchange_type_t key_ex );
 #endif
 
 #if defined(MBEDTLS_PK_C)
 unsigned char mbedtls_ssl_sig_from_pk( mbedtls_pk_context *pk );
 unsigned char mbedtls_ssl_sig_from_pk_alg( mbedtls_pk_type_t type );
-mbedtls_pk_type_t mbedtls_ssl_pk_alg_from_sig( unsigned char sig );
+MBEDTLS_EXPORT mbedtls_pk_type_t mbedtls_ssl_pk_alg_from_sig( unsigned char sig );
 #endif
 
-mbedtls_md_type_t mbedtls_ssl_md_alg_from_hash( unsigned char hash );
+MBEDTLS_EXPORT mbedtls_md_type_t mbedtls_ssl_md_alg_from_hash( unsigned char hash );
 unsigned char mbedtls_ssl_hash_from_md_alg( int md );
-int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md );
+MBEDTLS_EXPORT int mbedtls_ssl_set_calc_verify_md( mbedtls_ssl_context *ssl, int md );
 
 #if defined(MBEDTLS_ECP_C)
-int mbedtls_ssl_check_curve( const mbedtls_ssl_context *ssl, mbedtls_ecp_group_id grp_id );
+MBEDTLS_EXPORT int mbedtls_ssl_check_curve( const mbedtls_ssl_context *ssl, mbedtls_ecp_group_id grp_id );
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
-int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_check_sig_hash( const mbedtls_ssl_context *ssl,
                                 mbedtls_md_type_t md );
 #endif
 
@@ -949,15 +951,15 @@ static inline mbedtls_x509_crt *mbedtls_ssl_own_cert( mbedtls_ssl_context *ssl )
  *
  * Return 0 if everything is OK, -1 if not.
  */
-int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt *cert,
+MBEDTLS_EXPORT int mbedtls_ssl_check_cert_usage( const mbedtls_x509_crt *cert,
                           const mbedtls_ssl_ciphersuite_t *ciphersuite,
                           int cert_endpoint,
                           uint32_t *flags );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-void mbedtls_ssl_write_version( int major, int minor, int transport,
+MBEDTLS_EXPORT void mbedtls_ssl_write_version( int major, int minor, int transport,
                         unsigned char ver[2] );
-void mbedtls_ssl_read_version( int *major, int *minor, int transport,
+MBEDTLS_EXPORT void mbedtls_ssl_read_version( int *major, int *minor, int transport,
                        const unsigned char ver[2] );
 
 static inline size_t mbedtls_ssl_in_hdr_len( const mbedtls_ssl_context *ssl )
@@ -995,19 +997,19 @@ static inline size_t mbedtls_ssl_hs_hdr_len( const mbedtls_ssl_context *ssl )
 }
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
-void mbedtls_ssl_send_flight_completed( mbedtls_ssl_context *ssl );
-void mbedtls_ssl_recv_flight_completed( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_resend( mbedtls_ssl_context *ssl );
-int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_send_flight_completed( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_recv_flight_completed( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_resend( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl );
 #endif
 
 /* Visible for testing purposes only */
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
-int mbedtls_ssl_dtls_replay_check( mbedtls_ssl_context const *ssl );
-void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
+MBEDTLS_EXPORT int mbedtls_ssl_dtls_replay_check( mbedtls_ssl_context const *ssl );
+MBEDTLS_EXPORT void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 #endif
 
-int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
+MBEDTLS_EXPORT int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
                               const mbedtls_ssl_session *src );
 
 /* constant-time buffer comparison */
@@ -1032,7 +1034,7 @@ static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t
 
 #if defined(MBEDTLS_SSL_PROTO_SSL3) || defined(MBEDTLS_SSL_PROTO_TLS1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_1)
-int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
                                         unsigned char *output,
                                         unsigned char *data, size_t data_len );
 #endif /* MBEDTLS_SSL_PROTO_SSL3 || MBEDTLS_SSL_PROTO_TLS1 || \
@@ -1041,7 +1043,7 @@ int mbedtls_ssl_get_key_exchange_md_ssl_tls( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_PROTO_TLS1) || defined(MBEDTLS_SSL_PROTO_TLS1_1) || \
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
 /* The hash buffer must have at least MBEDTLS_MD_MAX_SIZE bytes of length. */
-int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
                                             unsigned char *hash, size_t *hashlen,
                                             unsigned char *data, size_t data_len,
                                             mbedtls_md_type_t md_alg );
@@ -1052,13 +1054,13 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2( mbedtls_ssl_context *ssl,
 }
 #endif
 
-void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform );
-int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
+MBEDTLS_EXPORT void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform );
+MBEDTLS_EXPORT int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
                              mbedtls_ssl_transform *transform,
                              mbedtls_record *rec,
                              int (*f_rng)(void *, unsigned char *, size_t),
                              void *p_rng );
-int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
+MBEDTLS_EXPORT int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                              mbedtls_ssl_transform *transform,
                              mbedtls_record *rec );
 

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 /*
  * This implementation of the session ticket callbacks includes key
  * management, rotating the keys periodically in order to preserve forward
@@ -85,7 +87,7 @@ mbedtls_ssl_ticket_context;
  *
  * \param ctx       Context to be initialized
  */
-void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
+MBEDTLS_EXPORT void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
 
 /**
  * \brief           Prepare context to be actually used
@@ -109,7 +111,7 @@ void mbedtls_ssl_ticket_init( mbedtls_ssl_ticket_context *ctx );
  * \return          0 if successful,
  *                  or a specific MBEDTLS_ERR_XXX error code
  */
-int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
+MBEDTLS_EXPORT int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
     mbedtls_cipher_type_t cipher,
     uint32_t lifetime );
@@ -119,21 +121,21 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
  *
  * \note            See \c mbedtls_ssl_ticket_write_t for description
  */
-mbedtls_ssl_ticket_write_t mbedtls_ssl_ticket_write;
+MBEDTLS_EXPORT mbedtls_ssl_ticket_write_t mbedtls_ssl_ticket_write;
 
 /**
  * \brief           Implementation of the ticket parse callback
  *
  * \note            See \c mbedtls_ssl_ticket_parse_t for description
  */
-mbedtls_ssl_ticket_parse_t mbedtls_ssl_ticket_parse;
+MBEDTLS_EXPORT mbedtls_ssl_ticket_parse_t mbedtls_ssl_ticket_parse;
 
 /**
  * \brief           Free a context's content and zeroize it.
  *
  * \param ctx       Context to be cleaned up
  */
-void mbedtls_ssl_ticket_free( mbedtls_ssl_ticket_context *ctx );
+MBEDTLS_EXPORT void mbedtls_ssl_ticket_free( mbedtls_ssl_ticket_context *ctx );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 /**
  * The version number x.y.z is split into three parts.
  * Major, Minor, Patchlevel
@@ -71,7 +73,7 @@ unsigned int mbedtls_version_get_number( void );
  * \param string    The string that will receive the value.
  *                  (Should be at least 9 bytes in size)
  */
-void mbedtls_version_get_string( char *string );
+MBEDTLS_EXPORT void mbedtls_version_get_string( char *string );
 
 /**
  * Get the full version string ("mbed TLS x.y.z").
@@ -82,7 +84,7 @@ void mbedtls_version_get_string( char *string );
  *                  (So the buffer should be at least 18 bytes to receive this
  *                  version string).
  */
-void mbedtls_version_get_string_full( char *string );
+MBEDTLS_EXPORT void mbedtls_version_get_string_full( char *string );
 
 /**
  * \brief           Check if support for a feature was compiled into this
@@ -101,7 +103,7 @@ void mbedtls_version_get_string_full( char *string );
  *                  -2 if support for feature checking as a whole was not
  *                  compiled in.
  */
-int mbedtls_version_check_feature( const char *feature );
+MBEDTLS_EXPORT int mbedtls_version_check_feature( const char *feature );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"
 
@@ -250,7 +252,7 @@ mbedtls_x509_time;
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn );
+MBEDX509_EXPORT int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn );
 
 /**
  * \brief          Store the certificate serial in printable form into buf;
@@ -263,7 +265,7 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn );
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_serial_gets( char *buf, size_t size, const mbedtls_x509_buf *serial );
+MBEDX509_EXPORT int mbedtls_x509_serial_gets( char *buf, size_t size, const mbedtls_x509_buf *serial );
 
 /**
  * \brief          Check a given mbedtls_x509_time against the system time
@@ -277,7 +279,7 @@ int mbedtls_x509_serial_gets( char *buf, size_t size, const mbedtls_x509_buf *se
  * \return         1 if the given time is in the past or an error occurred,
  *                 0 otherwise.
  */
-int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
+MBEDX509_EXPORT int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
 
 /**
  * \brief          Check a given mbedtls_x509_time against the system time
@@ -291,7 +293,7 @@ int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
  * \return         1 if the given time is in the future or an error occurred,
  *                 0 otherwise.
  */
-int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
+MBEDX509_EXPORT int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
 
 #if defined(MBEDTLS_SELF_TEST)
 
@@ -300,7 +302,7 @@ int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_x509_self_test( int verbose );
+MBEDX509_EXPORT int mbedtls_x509_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 
@@ -308,40 +310,40 @@ int mbedtls_x509_self_test( int verbose );
  * Internal module functions. You probably do not want to use these unless you
  * know you do.
  */
-int mbedtls_x509_get_name( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_name( unsigned char **p, const unsigned char *end,
                    mbedtls_x509_name *cur );
-int mbedtls_x509_get_alg_null( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_alg_null( unsigned char **p, const unsigned char *end,
                        mbedtls_x509_buf *alg );
-int mbedtls_x509_get_alg( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_alg( unsigned char **p, const unsigned char *end,
                   mbedtls_x509_buf *alg, mbedtls_x509_buf *params );
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
-int mbedtls_x509_get_rsassa_pss_params( const mbedtls_x509_buf *params,
+MBEDX509_EXPORT int mbedtls_x509_get_rsassa_pss_params( const mbedtls_x509_buf *params,
                                 mbedtls_md_type_t *md_alg, mbedtls_md_type_t *mgf_md,
                                 int *salt_len );
 #endif
-int mbedtls_x509_get_sig( unsigned char **p, const unsigned char *end, mbedtls_x509_buf *sig );
-int mbedtls_x509_get_sig_alg( const mbedtls_x509_buf *sig_oid, const mbedtls_x509_buf *sig_params,
+MBEDX509_EXPORT int mbedtls_x509_get_sig( unsigned char **p, const unsigned char *end, mbedtls_x509_buf *sig );
+MBEDX509_EXPORT int mbedtls_x509_get_sig_alg( const mbedtls_x509_buf *sig_oid, const mbedtls_x509_buf *sig_params,
                       mbedtls_md_type_t *md_alg, mbedtls_pk_type_t *pk_alg,
                       void **sig_opts );
-int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_time( unsigned char **p, const unsigned char *end,
                    mbedtls_x509_time *t );
-int mbedtls_x509_get_serial( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_serial( unsigned char **p, const unsigned char *end,
                      mbedtls_x509_buf *serial );
-int mbedtls_x509_get_ext( unsigned char **p, const unsigned char *end,
+MBEDX509_EXPORT int mbedtls_x509_get_ext( unsigned char **p, const unsigned char *end,
                   mbedtls_x509_buf *ext, int tag );
-int mbedtls_x509_sig_alg_gets( char *buf, size_t size, const mbedtls_x509_buf *sig_oid,
+MBEDX509_EXPORT int mbedtls_x509_sig_alg_gets( char *buf, size_t size, const mbedtls_x509_buf *sig_oid,
                        mbedtls_pk_type_t pk_alg, mbedtls_md_type_t md_alg,
                        const void *sig_opts );
-int mbedtls_x509_key_size_helper( char *buf, size_t buf_size, const char *name );
-int mbedtls_x509_string_to_names( mbedtls_asn1_named_data **head, const char *name );
-int mbedtls_x509_set_extension( mbedtls_asn1_named_data **head, const char *oid, size_t oid_len,
+MBEDX509_EXPORT int mbedtls_x509_key_size_helper( char *buf, size_t buf_size, const char *name );
+MBEDX509_EXPORT int mbedtls_x509_string_to_names( mbedtls_asn1_named_data **head, const char *name );
+MBEDX509_EXPORT int mbedtls_x509_set_extension( mbedtls_asn1_named_data **head, const char *oid, size_t oid_len,
                         int critical, const unsigned char *val,
                         size_t val_len );
-int mbedtls_x509_write_extensions( unsigned char **p, unsigned char *start,
+MBEDX509_EXPORT int mbedtls_x509_write_extensions( unsigned char **p, unsigned char *start,
                            mbedtls_asn1_named_data *first );
-int mbedtls_x509_write_names( unsigned char **p, unsigned char *start,
+MBEDX509_EXPORT int mbedtls_x509_write_names( unsigned char **p, unsigned char *start,
                       mbedtls_asn1_named_data *first );
-int mbedtls_x509_write_sig( unsigned char **p, unsigned char *start,
+MBEDX509_EXPORT int mbedtls_x509_write_sig( unsigned char **p, unsigned char *start,
                     const char *oid, size_t oid_len,
                     unsigned char *sig, size_t size );
 

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/x509.h"
 
 #ifdef __cplusplus
@@ -106,7 +108,7 @@ mbedtls_x509_crl;
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
+MBEDX509_EXPORT int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
                         const unsigned char *buf, size_t buflen );
 /**
  * \brief          Parse one or more CRLs and append them to the chained list
@@ -120,7 +122,7 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, size_t buflen );
+MBEDX509_EXPORT int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, size_t buflen );
 
 #if defined(MBEDTLS_FS_IO)
 /**
@@ -133,7 +135,7 @@ int mbedtls_x509_crl_parse( mbedtls_x509_crl *chain, const unsigned char *buf, s
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const char *path );
+MBEDX509_EXPORT int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**
@@ -147,7 +149,7 @@ int mbedtls_x509_crl_parse_file( mbedtls_x509_crl *chain, const char *path );
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_crl_info( char *buf, size_t size, const char *prefix,
+MBEDX509_EXPORT int mbedtls_x509_crl_info( char *buf, size_t size, const char *prefix,
                    const mbedtls_x509_crl *crl );
 
 /**
@@ -155,14 +157,14 @@ int mbedtls_x509_crl_info( char *buf, size_t size, const char *prefix,
  *
  * \param crl      CRL chain to initialize
  */
-void mbedtls_x509_crl_init( mbedtls_x509_crl *crl );
+MBEDX509_EXPORT void mbedtls_x509_crl_init( mbedtls_x509_crl *crl );
 
 /**
  * \brief          Unallocate all CRL data
  *
  * \param crl      CRL chain to free
  */
-void mbedtls_x509_crl_free( mbedtls_x509_crl *crl );
+MBEDX509_EXPORT void mbedtls_x509_crl_free( mbedtls_x509_crl *crl );
 
 /* \} name */
 /* \} addtogroup x509_module */

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/x509.h"
 #include "mbedtls/x509_crl.h"
 #include "mbedtls/bignum.h"
@@ -266,18 +268,18 @@ typedef void mbedtls_x509_crt_restart_ctx;
  * Default security profile. Should provide a good balance between security
  * and compatibility with current deployments.
  */
-extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_default;
+MBEDX509_EXTERN const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_default;
 
 /**
  * Expected next default profile. Recommended for new deployments.
  * Currently targets a 128-bit security level, except for RSA-2048.
  */
-extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_next;
+MBEDX509_EXTERN const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_next;
 
 /**
  * NSA Suite B profile.
  */
-extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;
+MBEDX509_EXTERN const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;
 
 /**
  * \brief          Parse a single DER formatted certificate and add it
@@ -299,7 +301,7 @@ extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_x509_crt_parse_der( mbedtls_x509_crt *chain,
+MBEDX509_EXPORT int mbedtls_x509_crt_parse_der( mbedtls_x509_crt *chain,
                                 const unsigned char *buf,
                                 size_t buflen );
 
@@ -330,7 +332,7 @@ int mbedtls_x509_crt_parse_der( mbedtls_x509_crt *chain,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_x509_crt_parse_der_nocopy( mbedtls_x509_crt *chain,
+MBEDX509_EXPORT int mbedtls_x509_crt_parse_der_nocopy( mbedtls_x509_crt *chain,
                                        const unsigned char *buf,
                                        size_t buflen );
 
@@ -364,7 +366,7 @@ int mbedtls_x509_crt_parse_der_nocopy( mbedtls_x509_crt *chain,
  * \return         A negative X509 or PEM error code otherwise.
  *
  */
-int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain, const unsigned char *buf, size_t buflen );
+MBEDX509_EXPORT int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain, const unsigned char *buf, size_t buflen );
 
 #if defined(MBEDTLS_FS_IO)
 /**
@@ -380,7 +382,7 @@ int mbedtls_x509_crt_parse( mbedtls_x509_crt *chain, const unsigned char *buf, s
  * \return         0 if all certificates parsed successfully, a positive number
  *                 if partly successful or a specific X509 or PEM error code
  */
-int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const char *path );
+MBEDX509_EXPORT int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const char *path );
 
 /**
  * \brief          Load one or more certificate files from a path and add them
@@ -395,7 +397,7 @@ int mbedtls_x509_crt_parse_file( mbedtls_x509_crt *chain, const char *path );
  * \return         0 if all certificates parsed successfully, a positive number
  *                 if partly successful or a specific X509 or PEM error code
  */
-int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
+MBEDX509_EXPORT int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
 
 #endif /* MBEDTLS_FS_IO */
 /**
@@ -425,7 +427,7 @@ int mbedtls_x509_crt_parse_path( mbedtls_x509_crt *chain, const char *path );
  *                 SAN type.
  * \return         Another negative value for any other failure.
  */
-int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
+MBEDX509_EXPORT int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
                                          mbedtls_x509_subject_alternative_name *san );
 /**
  * \brief          Returns an informational string about the
@@ -439,7 +441,7 @@ int mbedtls_x509_parse_subject_alt_name( const mbedtls_x509_buf *san_buf,
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
+MBEDX509_EXPORT int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
                    const mbedtls_x509_crt *crt );
 
 /**
@@ -454,7 +456,7 @@ int mbedtls_x509_crt_info( char *buf, size_t size, const char *prefix,
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
+MBEDX509_EXPORT int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
                           uint32_t flags );
 
 /**
@@ -520,7 +522,7 @@ int mbedtls_x509_crt_verify_info( char *buf, size_t size, const char *prefix,
  * \return         Another negative error code in case of a fatal error
  *                 encountered during the verification process.
  */
-int mbedtls_x509_crt_verify( mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_verify( mbedtls_x509_crt *crt,
                      mbedtls_x509_crt *trust_ca,
                      mbedtls_x509_crl *ca_crl,
                      const char *cn, uint32_t *flags,
@@ -561,7 +563,7 @@ int mbedtls_x509_crt_verify( mbedtls_x509_crt *crt,
  * \return         Another negative error code in case of a fatal error
  *                 encountered during the verification process.
  */
-int mbedtls_x509_crt_verify_with_profile( mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_verify_with_profile( mbedtls_x509_crt *crt,
                      mbedtls_x509_crt *trust_ca,
                      mbedtls_x509_crl *ca_crl,
                      const mbedtls_x509_crt_profile *profile,
@@ -595,7 +597,7 @@ int mbedtls_x509_crt_verify_with_profile( mbedtls_x509_crt *crt,
  * \return         #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
  *                 operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
-int mbedtls_x509_crt_verify_restartable( mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_verify_restartable( mbedtls_x509_crt *crt,
                      mbedtls_x509_crt *trust_ca,
                      mbedtls_x509_crl *ca_crl,
                      const mbedtls_x509_crt_profile *profile,
@@ -661,7 +663,7 @@ typedef int (*mbedtls_x509_crt_ca_cb_t)( void *p_ctx,
  *
  * \return         See \c mbedtls_crt_verify_with_profile().
  */
-int mbedtls_x509_crt_verify_with_ca_cb( mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_verify_with_ca_cb( mbedtls_x509_crt *crt,
                      mbedtls_x509_crt_ca_cb_t f_ca_cb,
                      void *p_ca_cb,
                      const mbedtls_x509_crt_profile *profile,
@@ -693,7 +695,7 @@ int mbedtls_x509_crt_verify_with_ca_cb( mbedtls_x509_crt *crt,
  *                 (intermediate) CAs the keyUsage extension is automatically
  *                 checked by \c mbedtls_x509_crt_verify().
  */
-int mbedtls_x509_crt_check_key_usage( const mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_check_key_usage( const mbedtls_x509_crt *crt,
                                       unsigned int usage );
 #endif /* MBEDTLS_X509_CHECK_KEY_USAGE) */
 
@@ -711,7 +713,7 @@ int mbedtls_x509_crt_check_key_usage( const mbedtls_x509_crt *crt,
  *
  * \note            Usually only makes sense on leaf certificates.
  */
-int mbedtls_x509_crt_check_extended_key_usage( const mbedtls_x509_crt *crt,
+MBEDX509_EXPORT int mbedtls_x509_crt_check_extended_key_usage( const mbedtls_x509_crt *crt,
                                                const char *usage_oid,
                                                size_t usage_len );
 #endif /* MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE */
@@ -726,7 +728,7 @@ int mbedtls_x509_crt_check_extended_key_usage( const mbedtls_x509_crt *crt,
  * \return         1 if the certificate is revoked, 0 otherwise
  *
  */
-int mbedtls_x509_crt_is_revoked( const mbedtls_x509_crt *crt, const mbedtls_x509_crl *crl );
+MBEDX509_EXPORT int mbedtls_x509_crt_is_revoked( const mbedtls_x509_crt *crt, const mbedtls_x509_crl *crl );
 #endif /* MBEDTLS_X509_CRL_PARSE_C */
 
 /**
@@ -734,25 +736,25 @@ int mbedtls_x509_crt_is_revoked( const mbedtls_x509_crt *crt, const mbedtls_x509
  *
  * \param crt      Certificate chain to initialize
  */
-void mbedtls_x509_crt_init( mbedtls_x509_crt *crt );
+MBEDX509_EXPORT void mbedtls_x509_crt_init( mbedtls_x509_crt *crt );
 
 /**
  * \brief          Unallocate all certificate data
  *
  * \param crt      Certificate chain to free
  */
-void mbedtls_x509_crt_free( mbedtls_x509_crt *crt );
+MBEDX509_EXPORT void mbedtls_x509_crt_free( mbedtls_x509_crt *crt );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /**
  * \brief           Initialize a restart context
  */
-void mbedtls_x509_crt_restart_init( mbedtls_x509_crt_restart_ctx *ctx );
+MBEDX509_EXPORT void mbedtls_x509_crt_restart_init( mbedtls_x509_crt_restart_ctx *ctx );
 
 /**
  * \brief           Free the components of a restart context
  */
-void mbedtls_x509_crt_restart_free( mbedtls_x509_crt_restart_ctx *ctx );
+MBEDX509_EXPORT void mbedtls_x509_crt_restart_free( mbedtls_x509_crt_restart_ctx *ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
@@ -765,7 +767,7 @@ void mbedtls_x509_crt_restart_free( mbedtls_x509_crt_restart_ctx *ctx );
  *
  * \param ctx       CRT context to initialize
  */
-void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx );
+MBEDX509_EXPORT void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx );
 
 /**
  * \brief           Set the verion for a Certificate
@@ -775,7 +777,7 @@ void mbedtls_x509write_crt_init( mbedtls_x509write_cert *ctx );
  * \param version   version to set (MBEDTLS_X509_CRT_VERSION_1, MBEDTLS_X509_CRT_VERSION_2 or
  *                                  MBEDTLS_X509_CRT_VERSION_3)
  */
-void mbedtls_x509write_crt_set_version( mbedtls_x509write_cert *ctx, int version );
+MBEDX509_EXPORT void mbedtls_x509write_crt_set_version( mbedtls_x509write_cert *ctx, int version );
 
 /**
  * \brief           Set the serial number for a Certificate.
@@ -785,7 +787,7 @@ void mbedtls_x509write_crt_set_version( mbedtls_x509write_cert *ctx, int version
  *
  * \return          0 if successful
  */
-int mbedtls_x509write_crt_set_serial( mbedtls_x509write_cert *ctx, const mbedtls_mpi *serial );
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_serial( mbedtls_x509write_cert *ctx, const mbedtls_mpi *serial );
 
 /**
  * \brief           Set the validity period for a Certificate
@@ -801,7 +803,7 @@ int mbedtls_x509write_crt_set_serial( mbedtls_x509write_cert *ctx, const mbedtls
  * \return          0 if timestamp was parsed successfully, or
  *                  a specific error code
  */
-int mbedtls_x509write_crt_set_validity( mbedtls_x509write_cert *ctx, const char *not_before,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_validity( mbedtls_x509write_cert *ctx, const char *not_before,
                                 const char *not_after );
 
 /**
@@ -816,7 +818,7 @@ int mbedtls_x509write_crt_set_validity( mbedtls_x509write_cert *ctx, const char 
  * \return          0 if issuer name was parsed successfully, or
  *                  a specific error code
  */
-int mbedtls_x509write_crt_set_issuer_name( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_issuer_name( mbedtls_x509write_cert *ctx,
                                    const char *issuer_name );
 
 /**
@@ -831,7 +833,7 @@ int mbedtls_x509write_crt_set_issuer_name( mbedtls_x509write_cert *ctx,
  * \return          0 if subject name was parsed successfully, or
  *                  a specific error code
  */
-int mbedtls_x509write_crt_set_subject_name( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_subject_name( mbedtls_x509write_cert *ctx,
                                     const char *subject_name );
 
 /**
@@ -840,7 +842,7 @@ int mbedtls_x509write_crt_set_subject_name( mbedtls_x509write_cert *ctx,
  * \param ctx       CRT context to use
  * \param key       public key to include
  */
-void mbedtls_x509write_crt_set_subject_key( mbedtls_x509write_cert *ctx, mbedtls_pk_context *key );
+MBEDX509_EXPORT void mbedtls_x509write_crt_set_subject_key( mbedtls_x509write_cert *ctx, mbedtls_pk_context *key );
 
 /**
  * \brief           Set the issuer key used for signing the certificate
@@ -848,7 +850,7 @@ void mbedtls_x509write_crt_set_subject_key( mbedtls_x509write_cert *ctx, mbedtls
  * \param ctx       CRT context to use
  * \param key       private key to sign with
  */
-void mbedtls_x509write_crt_set_issuer_key( mbedtls_x509write_cert *ctx, mbedtls_pk_context *key );
+MBEDX509_EXPORT void mbedtls_x509write_crt_set_issuer_key( mbedtls_x509write_cert *ctx, mbedtls_pk_context *key );
 
 /**
  * \brief           Set the MD algorithm to use for the signature
@@ -857,7 +859,7 @@ void mbedtls_x509write_crt_set_issuer_key( mbedtls_x509write_cert *ctx, mbedtls_
  * \param ctx       CRT context to use
  * \param md_alg    MD algorithm to use
  */
-void mbedtls_x509write_crt_set_md_alg( mbedtls_x509write_cert *ctx, mbedtls_md_type_t md_alg );
+MBEDX509_EXPORT void mbedtls_x509write_crt_set_md_alg( mbedtls_x509write_cert *ctx, mbedtls_md_type_t md_alg );
 
 /**
  * \brief           Generic function to add to or replace an extension in the
@@ -872,7 +874,7 @@ void mbedtls_x509write_crt_set_md_alg( mbedtls_x509write_cert *ctx, mbedtls_md_t
  *
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_extension( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_extension( mbedtls_x509write_cert *ctx,
                                  const char *oid, size_t oid_len,
                                  int critical,
                                  const unsigned char *val, size_t val_len );
@@ -888,7 +890,7 @@ int mbedtls_x509write_crt_set_extension( mbedtls_x509write_cert *ctx,
  *
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
                                          int is_ca, int max_pathlen );
 
 #if defined(MBEDTLS_SHA1_C)
@@ -901,7 +903,7 @@ int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
  *
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx );
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx );
 
 /**
  * \brief           Set the authorityKeyIdentifier extension for a CRT
@@ -912,7 +914,7 @@ int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ct
  *
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *ctx );
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *ctx );
 #endif /* MBEDTLS_SHA1_C */
 
 /**
@@ -924,7 +926,7 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
  *
  * \return          0 if successful, or MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_key_usage( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_key_usage( mbedtls_x509write_cert *ctx,
                                          unsigned int key_usage );
 
 /**
@@ -936,7 +938,7 @@ int mbedtls_x509write_crt_set_key_usage( mbedtls_x509write_cert *ctx,
  *
  * \return          0 if successful, or MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_crt_set_ns_cert_type( mbedtls_x509write_cert *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_crt_set_ns_cert_type( mbedtls_x509write_cert *ctx,
                                     unsigned char ns_cert_type );
 
 /**
@@ -944,7 +946,7 @@ int mbedtls_x509write_crt_set_ns_cert_type( mbedtls_x509write_cert *ctx,
  *
  * \param ctx       CRT context to free
  */
-void mbedtls_x509write_crt_free( mbedtls_x509write_cert *ctx );
+MBEDX509_EXPORT void mbedtls_x509write_crt_free( mbedtls_x509write_cert *ctx );
 
 /**
  * \brief           Write a built up certificate to a X509 DER structure
@@ -966,7 +968,7 @@ void mbedtls_x509write_crt_free( mbedtls_x509write_cert *ctx );
  *                  for countermeasures against timing attacks).
  *                  ECDSA signatures always require a non-NULL f_rng.
  */
-int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx, unsigned char *buf, size_t size,
+MBEDX509_EXPORT int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx, unsigned char *buf, size_t size,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng );
 
@@ -987,7 +989,7 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx, unsigned char *buf, 
  *                  for countermeasures against timing attacks).
  *                  ECDSA signatures always require a non-NULL f_rng.
  */
-int mbedtls_x509write_crt_pem( mbedtls_x509write_cert *ctx, unsigned char *buf, size_t size,
+MBEDX509_EXPORT int mbedtls_x509write_crt_pem( mbedtls_x509write_cert *ctx, unsigned char *buf, size_t size,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng );
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/x509.h"
 
 #ifdef __cplusplus
@@ -92,7 +94,7 @@ mbedtls_x509write_csr;
  *
  * \return         0 if successful, or a specific X509 error code
  */
-int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
+MBEDX509_EXPORT int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
                         const unsigned char *buf, size_t buflen );
 
 /**
@@ -107,7 +109,7 @@ int mbedtls_x509_csr_parse_der( mbedtls_x509_csr *csr,
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, size_t buflen );
+MBEDX509_EXPORT int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, size_t buflen );
 
 #if defined(MBEDTLS_FS_IO)
 /**
@@ -120,7 +122,7 @@ int mbedtls_x509_csr_parse( mbedtls_x509_csr *csr, const unsigned char *buf, siz
  *
  * \return         0 if successful, or a specific X509 or PEM error code
  */
-int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const char *path );
+MBEDX509_EXPORT int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
 /**
@@ -135,7 +137,7 @@ int mbedtls_x509_csr_parse_file( mbedtls_x509_csr *csr, const char *path );
  * \return         The length of the string written (not including the
  *                 terminated nul byte), or a negative error code.
  */
-int mbedtls_x509_csr_info( char *buf, size_t size, const char *prefix,
+MBEDX509_EXPORT int mbedtls_x509_csr_info( char *buf, size_t size, const char *prefix,
                    const mbedtls_x509_csr *csr );
 
 /**
@@ -143,14 +145,14 @@ int mbedtls_x509_csr_info( char *buf, size_t size, const char *prefix,
  *
  * \param csr      CSR to initialize
  */
-void mbedtls_x509_csr_init( mbedtls_x509_csr *csr );
+MBEDX509_EXPORT void mbedtls_x509_csr_init( mbedtls_x509_csr *csr );
 
 /**
  * \brief          Unallocate all CSR data
  *
  * \param csr      CSR to free
  */
-void mbedtls_x509_csr_free( mbedtls_x509_csr *csr );
+MBEDX509_EXPORT void mbedtls_x509_csr_free( mbedtls_x509_csr *csr );
 #endif /* MBEDTLS_X509_CSR_PARSE_C */
 
 /* \} name */
@@ -162,7 +164,7 @@ void mbedtls_x509_csr_free( mbedtls_x509_csr *csr );
  *
  * \param ctx       CSR context to initialize
  */
-void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx );
+MBEDX509_EXPORT void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx );
 
 /**
  * \brief           Set the subject name for a CSR
@@ -176,7 +178,7 @@ void mbedtls_x509write_csr_init( mbedtls_x509write_csr *ctx );
  * \return          0 if subject name was parsed successfully, or
  *                  a specific error code
  */
-int mbedtls_x509write_csr_set_subject_name( mbedtls_x509write_csr *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_csr_set_subject_name( mbedtls_x509write_csr *ctx,
                                     const char *subject_name );
 
 /**
@@ -186,7 +188,7 @@ int mbedtls_x509write_csr_set_subject_name( mbedtls_x509write_csr *ctx,
  * \param ctx       CSR context to use
  * \param key       Asymetric key to include
  */
-void mbedtls_x509write_csr_set_key( mbedtls_x509write_csr *ctx, mbedtls_pk_context *key );
+MBEDX509_EXPORT void mbedtls_x509write_csr_set_key( mbedtls_x509write_csr *ctx, mbedtls_pk_context *key );
 
 /**
  * \brief           Set the MD algorithm to use for the signature
@@ -195,7 +197,7 @@ void mbedtls_x509write_csr_set_key( mbedtls_x509write_csr *ctx, mbedtls_pk_conte
  * \param ctx       CSR context to use
  * \param md_alg    MD algorithm to use
  */
-void mbedtls_x509write_csr_set_md_alg( mbedtls_x509write_csr *ctx, mbedtls_md_type_t md_alg );
+MBEDX509_EXPORT void mbedtls_x509write_csr_set_md_alg( mbedtls_x509write_csr *ctx, mbedtls_md_type_t md_alg );
 
 /**
  * \brief           Set the Key Usage Extension flags
@@ -214,7 +216,7 @@ void mbedtls_x509write_csr_set_md_alg( mbedtls_x509write_csr *ctx, mbedtls_md_ty
  *                  #MBEDTLS_X509_KU_DECIPHER_ONLY) cannot be set using this
  *                  function.
  */
-int mbedtls_x509write_csr_set_key_usage( mbedtls_x509write_csr *ctx, unsigned char key_usage );
+MBEDX509_EXPORT int mbedtls_x509write_csr_set_key_usage( mbedtls_x509write_csr *ctx, unsigned char key_usage );
 
 /**
  * \brief           Set the Netscape Cert Type flags
@@ -225,7 +227,7 @@ int mbedtls_x509write_csr_set_key_usage( mbedtls_x509write_csr *ctx, unsigned ch
  *
  * \return          0 if successful, or MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
                                     unsigned char ns_cert_type );
 
 /**
@@ -240,7 +242,7 @@ int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
  *
  * \return          0 if successful, or a MBEDTLS_ERR_X509_ALLOC_FAILED
  */
-int mbedtls_x509write_csr_set_extension( mbedtls_x509write_csr *ctx,
+MBEDX509_EXPORT int mbedtls_x509write_csr_set_extension( mbedtls_x509write_csr *ctx,
                                  const char *oid, size_t oid_len,
                                  const unsigned char *val, size_t val_len );
 
@@ -249,7 +251,7 @@ int mbedtls_x509write_csr_set_extension( mbedtls_x509write_csr *ctx,
  *
  * \param ctx       CSR context to free
  */
-void mbedtls_x509write_csr_free( mbedtls_x509write_csr *ctx );
+MBEDX509_EXPORT void mbedtls_x509write_csr_free( mbedtls_x509write_csr *ctx );
 
 /**
  * \brief           Write a CSR (Certificate Signing Request) to a
@@ -272,7 +274,7 @@ void mbedtls_x509write_csr_free( mbedtls_x509write_csr *ctx );
  *                  for countermeasures against timing attacks).
  *                  ECDSA signatures always require a non-NULL f_rng.
  */
-int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, size_t size,
+MBEDX509_EXPORT int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, size_t size,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng );
 
@@ -294,7 +296,7 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
  *                  for countermeasures against timing attacks).
  *                  ECDSA signatures always require a non-NULL f_rng.
  */
-int mbedtls_x509write_csr_pem( mbedtls_x509write_csr *ctx, unsigned char *buf, size_t size,
+MBEDX509_EXPORT int mbedtls_x509write_csr_pem( mbedtls_x509write_csr *ctx, unsigned char *buf, size_t size,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng );
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -175,17 +175,29 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
 
     add_library(mbedx509 SHARED ${src_x509})
     set_target_properties(mbedx509 PROPERTIES VERSION 2.19.1 SOVERSION 1)
-    target_link_libraries(mbedx509 ${libs} mbedcrypto)
+    target_link_libraries(mbedx509 
+		PUBLIC ${libs} mbedcrypto
+		INTERFACE mbedcrypto
+	)
     target_include_directories(mbedx509
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
+	target_compile_definitions(mbedx509
+		PRIVATE MAKING_SHARED_MBEDX509
+		INTERFACE USING_SHARED_MBEDTLS)
 
     add_library(mbedtls SHARED ${src_tls})
     set_target_properties(mbedtls PROPERTIES VERSION 2.19.1 SOVERSION 13)
-    target_link_libraries(mbedtls ${libs} mbedx509)
+    target_link_libraries(mbedtls 
+		PUBLIC ${libs} mbedx509
+		INTERFACE mbedx509
+	)
     target_include_directories(mbedtls
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
+	target_compile_definitions(mbedtls
+		PRIVATE MAKING_SHARED_MBEDTLS
+		INTERFACE USING_SHARED_MBEDTLS)
 
       install(TARGETS mbedtls mbedx509
               DESTINATION ${LIB_INSTALL_DIR}


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until:
-  The submitter has [accepted the online agreement here with a click through](https://developer.mbed.org/contributor_agreement/) 
   or for companies or those that do not wish to create an mbed account, a slightly different agreement can be found [here](https://www.mbed.com/en/about-mbed/contributor-license-agreements/)
- The PR follows the [mbed TLS coding standards](https://tls.mbed.org/kb/development/mbedtls-coding-standards)
* This is just a template, so feel free to use/remove the unnecessary things
## Description
Add support for compiling shared mbedtls and mbedcrypto libraries with MSVC. This is part 2 of the fix for #470. Due to the mixing of headers and source files between mbedtls, mbedx509 and mbedcrypto this took a bit longer than i expected.

Depends on: https://github.com/ARMmbed/mbed-crypto/pull/329

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO

## Migrations
NO

## Additional comments
This needs to be tested across many compilers, _especially_ embedded compilers which usually are quite far behind with standards.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
1. Attempt to build shared libraries with MSVC.
2. End up with no .lib file to import the dll with.
