### PR TITLE
[baremetal] Add random delay function to platform utils

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -249,15 +249,8 @@ uint32_t mbedtls_platform_random_in_range( size_t num );
  *
  * \note        Currently the function is dependent of hardware providing an
  *              rng with MBEDTLS_ENTROPY_HARDWARE_ALT.
- *
- * \param num   Max-value for the number of local variable increments, must be
- *              less than INT_MAX. Total number of variable increment will be
- *              randomized between 1 and num.
- *
- * \return      In success number of increments made.
- * \return      Negative value in case of errors.
  */
-int mbedtls_platform_random_delay( size_t num );
+void mbedtls_platform_random_delay( void );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -259,16 +259,6 @@ uint32_t mbedtls_platform_random_in_range( size_t num );
  */
 int mbedtls_platform_random_delay( size_t num );
 
-/**
- * \brief       This function can be inserted between successive reads to a
- *              volatile local variable to prevent compilers from optimizing
- *              them away. In addition, this function will spent a small random
- *              time in a busy loop as a counter-measure to fault injection
- *              attack.
- *
- */
-void mbedtls_platform_enforce_volatile_reads( void );
-
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -241,15 +241,21 @@ uint32_t mbedtls_platform_random_in_range( size_t num );
 /**
  * \brief       Random delay function.
  *
- *              Function implements random delay by incrementing local variable
- *              randomized number of times.
+ *              Function implements a random delay by incrementing a local
+ *              variable randomized number of times (busy-looping).
+ *
+ *              Duration of the delay is random as number of variable increments
+ *              is randomized.
  *
  * \note        Currently the function is dependent of hardware providing an
  *              rng with MBEDTLS_ENTROPY_HARDWARE_ALT.
  *
- * \param num   Max-value for the local variable increments.
+ * \param num   Max-value for the number of local variable increments, must be
+ *              less than INT_MAX. Total number of variable increment will be
+ *              randomized between 1 and num.
  *
- * \return      In success number of increments, -1 in case of errors.
+ * \return      In success number of increments made.
+ * \return      Negative value in case of errors.
  */
 int mbedtls_platform_random_delay( size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -260,9 +260,12 @@ uint32_t mbedtls_platform_random_in_range( size_t num );
 int mbedtls_platform_random_delay( size_t num );
 
 /**
- * \brief       This function does nothing, but can be inserted between
- *              successive reads to a volatile local variable to prevent
- *              compilers from optimizing them away.
+ * \brief       This function can be inserted between successive reads to a
+ *              volatile local variable to prevent compilers from optimizing
+ *              them away. In addition, this function will spent a small random
+ *              time in a busy loop as a counter-measure to fault injection
+ *              attack.
+ *
  */
 void mbedtls_platform_enforce_volatile_reads( void );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -239,6 +239,21 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
 uint32_t mbedtls_platform_random_in_range( size_t num );
 
 /**
+ * \brief       Random delay function.
+ *
+ *              Function implements random delay by incrementing local variable
+ *              randomized number of times.
+ *
+ * \note        Currently the function is dependent of hardware providing an
+ *              rng with MBEDTLS_ENTROPY_HARDWARE_ALT.
+ *
+ * \param num   Max-value for the local variable increments.
+ *
+ * \return      In success number of increments, -1 in case of errors.
+ */
+int mbedtls_platform_random_delay( size_t num );
+
+/**
  * \brief       This function does nothing, but can be inserted between
  *              successive reads to a volatile local variable to prevent
  *              compilers from optimizing them away.

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -273,7 +273,7 @@ static int entropy_gather_internal( mbedtls_entropy_context *ctx )
         volatile int strong_fi = ctx->source[i].strong;
         if( strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
 
             if( strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
                 have_one_strong_fi = MBEDTLS_ENTROPY_SOURCE_STRONG;
@@ -305,7 +305,7 @@ cleanup:
 
     if( have_one_strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( have_one_strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
         {
             return( ret );

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -273,7 +273,7 @@ static int entropy_gather_internal( mbedtls_entropy_context *ctx )
         volatile int strong_fi = ctx->source[i].strong;
         if( strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
 
             if( strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
                 have_one_strong_fi = MBEDTLS_ENTROPY_SOURCE_STRONG;
@@ -305,7 +305,7 @@ cleanup:
 
     if( have_one_strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( have_one_strong_fi == MBEDTLS_ENTROPY_SOURCE_STRONG )
         {
             return( ret );

--- a/library/pk.c
+++ b/library/pk.c
@@ -597,7 +597,7 @@ static int uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     if( ret_fi == UECC_SUCCESS )
     {
-        mbedtls_platform_random_delay( 50 );
+        mbedtls_platform_random_delay();
         if( ret_fi == UECC_SUCCESS )
             return( 0 );
         else
@@ -1553,7 +1553,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
 
     if( verify_ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( verify_ret == 0 )
         {
             return( verify_ret );

--- a/library/pk.c
+++ b/library/pk.c
@@ -597,7 +597,7 @@ static int uecc_eckey_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     if( ret_fi == UECC_SUCCESS )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay( 50 );
         if( ret_fi == UECC_SUCCESS )
             return( 0 );
         else

--- a/library/pk.c
+++ b/library/pk.c
@@ -1553,7 +1553,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
 
     if( verify_ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( verify_ret == 0 )
         {
             return( verify_ret );

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -175,16 +175,17 @@ int mbedtls_platform_random_delay( size_t max_rand )
     volatile size_t i = 0;
     if( max_rand == 0 || max_rand > INT_MAX )
     {
-        return -1;
+        return( -1 );
     }
 
     random_number = mbedtls_platform_random_in_range( max_rand );
 
-    do {
+    do
+    {
         i++;
-    } while ( i < random_number );
+    } while( i < random_number );
 
-    return (int) i;
+    return( (int)i );
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
 }
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -198,12 +198,6 @@ int mbedtls_platform_random_delay( size_t max_rand )
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
 }
 
-void mbedtls_platform_enforce_volatile_reads( void )
-{
-    // Add a small random delay as a counter-measure to fault injection attack.
-    mbedtls_platform_random_delay( 50 );
-}
-
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
 #include <time.h>
 #if !defined(_WIN32) && (defined(unix) || \

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -45,6 +45,9 @@
 #include <stddef.h>
 #include <string.h>
 
+/* Max number of loops for mbedtls_platform_random_delay */
+#define MBEDTLS_MAX_RAND_DELAY  100
+
 #if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 /*
  * This implementation should never be optimized out by the compiler
@@ -165,21 +168,16 @@ uint32_t mbedtls_platform_random_in_range( size_t num )
 #endif
 }
 
-int mbedtls_platform_random_delay( size_t max_rand )
+void mbedtls_platform_random_delay( void )
 {
 #if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
-    (void) max_rand;
-    return -1;
+    return;
 #else
     size_t rn_1, rn_2, rn_3;
     volatile size_t i = 0;
     uint8_t shift;
-    if( max_rand == 0 || max_rand > INT_MAX )
-    {
-        return( -1 );
-    }
 
-    rn_1 = mbedtls_platform_random_in_range( max_rand );
+    rn_1 = mbedtls_platform_random_in_range( MBEDTLS_MAX_RAND_DELAY );
     rn_2 = mbedtls_platform_random_in_range( 0xffffffff ) + 1;
     rn_3 = mbedtls_platform_random_in_range( 0xffffffff ) + 1;
 
@@ -194,7 +192,7 @@ int mbedtls_platform_random_delay( size_t max_rand )
         rn_2 ^= rn_3;
     } while( i < rn_1 || rn_2 == 0 || rn_3 == 0 );
 
-    return( (int)i );
+    return;
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
 }
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -46,7 +46,7 @@
 #include <string.h>
 
 /* Max number of loops for mbedtls_platform_random_delay */
-#define MBEDTLS_MAX_RAND_DELAY  100
+#define MAX_RAND_DELAY  100
 
 #if !defined(MBEDTLS_PLATFORM_ZEROIZE_ALT)
 /*
@@ -177,7 +177,7 @@ void mbedtls_platform_random_delay( void )
     volatile size_t i = 0;
     uint8_t shift;
 
-    rn_1 = mbedtls_platform_random_in_range( MBEDTLS_MAX_RAND_DELAY );
+    rn_1 = mbedtls_platform_random_in_range( MAX_RAND_DELAY );
     rn_2 = mbedtls_platform_random_in_range( 0xffffffff ) + 1;
     rn_3 = mbedtls_platform_random_in_range( 0xffffffff ) + 1;
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -165,6 +165,29 @@ uint32_t mbedtls_platform_random_in_range( size_t num )
 #endif
 }
 
+int mbedtls_platform_random_delay( size_t max_rand )
+{
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+    (void) max_rand;
+    return -1;
+#else
+    size_t random_number;
+    volatile size_t i = 0;
+    if( max_rand == 0 || max_rand > INT_MAX )
+    {
+        return -1;
+    }
+
+    random_number = mbedtls_platform_random_in_range( max_rand );
+
+    do {
+        i++;
+    } while ( i < random_number );
+
+    return (int) i;
+#endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
+}
+
 /* Some compilers (armcc 5 for example) optimize away successive reads from a
  * volatile local variable (which we use as a counter-measure to fault
  * injection attacks), unless there is a call to an external function between

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -189,13 +189,10 @@ int mbedtls_platform_random_delay( size_t max_rand )
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
 }
 
-/* Some compilers (armcc 5 for example) optimize away successive reads from a
- * volatile local variable (which we use as a counter-measure to fault
- * injection attacks), unless there is a call to an external function between
- * them. This functions doesn't need to do anything, it just needs to be
- * in another compilation unit. So here's a function that does nothing. */
 void mbedtls_platform_enforce_volatile_reads( void )
 {
+    // Add a small random delay as a counter-measure to fault injection attack.
+    mbedtls_platform_random_delay( 50 );
 }
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -717,7 +717,7 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
             ( mbedtls_ssl_conf_get_prng( ssl->conf ), p, 28 );
     if( ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ret == 0 )
         {
             ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2369,7 +2369,7 @@ static int ssl_rsa_generate_partial_pms( mbedtls_ssl_context *ssl,
 
     if( ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ret == 0 )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2442,7 +2442,7 @@ static int ssl_rsa_encrypt_partial_pms( mbedtls_ssl_context *ssl,
 
     if( ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ret == 0 )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -3071,7 +3071,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
 
         if( ret == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
 
             if( ret == 0 )
             {

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -717,7 +717,7 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
             ( mbedtls_ssl_conf_get_prng( ssl->conf ), p, 28 );
     if( ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ret == 0 )
         {
             ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2369,7 +2369,7 @@ static int ssl_rsa_generate_partial_pms( mbedtls_ssl_context *ssl,
 
     if( ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ret == 0 )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2442,7 +2442,7 @@ static int ssl_rsa_encrypt_partial_pms( mbedtls_ssl_context *ssl,
 
     if( ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ret == 0 )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -3071,7 +3071,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
 
         if( ret == 0 )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
 
             if( ret == 0 )
             {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -4064,7 +4064,7 @@ static int ssl_parse_encrypted_pms( mbedtls_ssl_context *ssl,
 
     if( pmscounter == ssl->handshake->pmslen )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( pmscounter == ssl->handshake->pmslen )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -4651,7 +4651,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
 
     if( ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
 
         if( ret == 0 )
         {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -4064,7 +4064,7 @@ static int ssl_parse_encrypted_pms( mbedtls_ssl_context *ssl,
 
     if( pmscounter == ssl->handshake->pmslen )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( pmscounter == ssl->handshake->pmslen )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -4651,7 +4651,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
 
     if( ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
 
         if( ret == 0 )
         {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1929,7 +1929,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                   ssl );
     if( ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ret == 0 )
         {
             ssl->handshake->key_derivation_done = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2011,7 +2011,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                                       mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2054,7 +2054,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                                        mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2085,7 +2085,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
             mbedtls_ssl_suite_get_key_exchange( ciphersuite_info ) );
         if( ret == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2114,7 +2114,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                 mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay(50);
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -7346,7 +7346,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
 
     if( verify_ret == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( verify_ret == 0 )
         {
             flow_counter++;
@@ -7436,7 +7436,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
         ( verify_ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED ||
           verify_ret == MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE ) )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( authmode == MBEDTLS_SSL_VERIFY_OPTIONAL &&
             ( verify_ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED ||
               verify_ret == MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE ) )
@@ -7502,7 +7502,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
         flow_counter == 4 )
 #endif
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( verify_ret == 0 &&
 #if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_USE_TINYCRYPT)
             flow_counter == 5 )
@@ -7989,7 +7989,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         1 )
 #endif
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( authmode == MBEDTLS_SSL_VERIFY_NONE ||
             authmode == MBEDTLS_SSL_VERIFY_OPTIONAL ||
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
@@ -8010,7 +8010,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
 #if !defined(MBEDTLS_SSL_NO_SESSION_RESUMPTION)
     if( ssl->handshake->resume == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ssl->handshake->resume == MBEDTLS_SSL_FI_FLAG_SET )
         {
             /* When doing session resume, no premaster or peer authentication */
@@ -8027,7 +8027,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
 
     if( ssl->handshake->peer_authenticated == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ssl->handshake->peer_authenticated == MBEDTLS_SSL_FI_FLAG_SET )
         {
             ret = 0;
@@ -8048,7 +8048,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         ssl->handshake->key_derivation_done == MBEDTLS_SSL_FI_FLAG_SET &&
         ssl->handshake->premaster_generated == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay(50);
         if( ssl->handshake->hello_random_set == MBEDTLS_SSL_FI_FLAG_SET &&
             ssl->handshake->key_derivation_done == MBEDTLS_SSL_FI_FLAG_SET &&
             ssl->handshake->premaster_generated == MBEDTLS_SSL_FI_FLAG_SET )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1929,7 +1929,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
                   ssl );
     if( ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ret == 0 )
         {
             ssl->handshake->key_derivation_done = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2011,7 +2011,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                                       mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2054,7 +2054,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                                        mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2085,7 +2085,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
             mbedtls_ssl_suite_get_key_exchange( ciphersuite_info ) );
         if( ret == 0 )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -2114,7 +2114,7 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
                 mbedtls_ssl_conf_get_prng( ssl->conf ) );
         if( ret == 0 )
         {
-            mbedtls_platform_random_delay(50);
+            mbedtls_platform_random_delay();
             if( ret == 0 )
             {
                 ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
@@ -7346,7 +7346,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
 
     if( verify_ret == 0 )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( verify_ret == 0 )
         {
             flow_counter++;
@@ -7436,7 +7436,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
         ( verify_ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED ||
           verify_ret == MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE ) )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( authmode == MBEDTLS_SSL_VERIFY_OPTIONAL &&
             ( verify_ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED ||
               verify_ret == MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE ) )
@@ -7502,7 +7502,7 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl,
         flow_counter == 4 )
 #endif
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( verify_ret == 0 &&
 #if defined(MBEDTLS_ECP_C) || defined(MBEDTLS_USE_TINYCRYPT)
             flow_counter == 5 )
@@ -7989,7 +7989,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         1 )
 #endif
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( authmode == MBEDTLS_SSL_VERIFY_NONE ||
             authmode == MBEDTLS_SSL_VERIFY_OPTIONAL ||
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
@@ -8010,7 +8010,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
 #if !defined(MBEDTLS_SSL_NO_SESSION_RESUMPTION)
     if( ssl->handshake->resume == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ssl->handshake->resume == MBEDTLS_SSL_FI_FLAG_SET )
         {
             /* When doing session resume, no premaster or peer authentication */
@@ -8027,7 +8027,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
 
     if( ssl->handshake->peer_authenticated == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ssl->handshake->peer_authenticated == MBEDTLS_SSL_FI_FLAG_SET )
         {
             ret = 0;
@@ -8048,7 +8048,7 @@ int mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         ssl->handshake->key_derivation_done == MBEDTLS_SSL_FI_FLAG_SET &&
         ssl->handshake->premaster_generated == MBEDTLS_SSL_FI_FLAG_SET )
     {
-        mbedtls_platform_random_delay(50);
+        mbedtls_platform_random_delay();
         if( ssl->handshake->hello_random_set == MBEDTLS_SSL_FI_FLAG_SET &&
             ssl->handshake->key_derivation_done == MBEDTLS_SSL_FI_FLAG_SET &&
             ssl->handshake->premaster_generated == MBEDTLS_SSL_FI_FLAG_SET )

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -3043,7 +3043,7 @@ check_signature:
 
         if( ret_fi == 0 )
         {
-            mbedtls_platform_random_delay( 50 );
+            mbedtls_platform_random_delay();
             if( ret_fi == 0 )
                 signature_is_good = X509_SIGNATURE_IS_GOOD;
         }
@@ -3549,7 +3549,7 @@ find_parent:
         if( signature_is_good_fi != X509_SIGNATURE_IS_GOOD )
             *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED | X509_BADCERT_FI_EXTRA;
 
-        mbedtls_platform_random_delay( 50 );
+        mbedtls_platform_random_delay();
         if( signature_is_good_fi != X509_SIGNATURE_IS_GOOD )
             *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED | X509_BADCERT_FI_EXTRA;
 
@@ -3861,7 +3861,7 @@ exit:
     flags_fi = *flags;
     if( flags_fi == 0 )
     {
-        mbedtls_platform_random_delay( 50 );
+        mbedtls_platform_random_delay();
         if( flags_fi == 0 )
             return( 0 );
     }

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -3043,7 +3043,7 @@ check_signature:
 
         if( ret_fi == 0 )
         {
-            mbedtls_platform_enforce_volatile_reads();
+            mbedtls_platform_random_delay( 50 );
             if( ret_fi == 0 )
                 signature_is_good = X509_SIGNATURE_IS_GOOD;
         }
@@ -3549,7 +3549,7 @@ find_parent:
         if( signature_is_good_fi != X509_SIGNATURE_IS_GOOD )
             *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED | X509_BADCERT_FI_EXTRA;
 
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay( 50 );
         if( signature_is_good_fi != X509_SIGNATURE_IS_GOOD )
             *flags |= MBEDTLS_X509_BADCERT_NOT_TRUSTED | X509_BADCERT_FI_EXTRA;
 
@@ -3861,7 +3861,7 @@ exit:
     flags_fi = *flags;
     if( flags_fi == 0 )
     {
-        mbedtls_platform_enforce_volatile_reads();
+        mbedtls_platform_random_delay( 50 );
         if( flags_fi == 0 )
             return( 0 );
     }

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -168,7 +168,7 @@ static int uECC_check_curve_integrity(void)
 	}
 
 	/* i should be 32 */
-	mbedtls_platform_random_delay( 10 );
+	mbedtls_platform_random_delay();
 	diff |= (unsigned char) i ^ 32;
 
 	return diff;
@@ -296,7 +296,7 @@ uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right)
 	}
 
 	/* i should be -1 now */
-	mbedtls_platform_random_delay( 10 );
+	mbedtls_platform_random_delay();
 	diff |= i ^ -1;
 
 	return diff;
@@ -1046,7 +1046,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 	if (problem != 0) {
 		return UECC_FAULT_DETECTED;
 	}
-	mbedtls_platform_random_delay( 50 );
+	mbedtls_platform_random_delay();
 	if (problem != 0) {
 		return UECC_FAULT_DETECTED;
 	}
@@ -1058,7 +1058,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		/* invalid input, can happen without fault */
 		return UECC_FAILURE;
 	}
-	mbedtls_platform_random_delay( 50 );
+	mbedtls_platform_random_delay();
 	if (problem != 0) {
 		/* failure on second check means fault, though */
 		return UECC_FAULT_DETECTED;
@@ -1088,7 +1088,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
 	}
-	mbedtls_platform_random_delay( 10 );
+	mbedtls_platform_random_delay();
 	if (problem != 0) {
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
@@ -1101,7 +1101,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
 	}
-	mbedtls_platform_random_delay( 10 );
+	mbedtls_platform_random_delay();
 	if (problem != 0) {
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
@@ -1198,7 +1198,7 @@ int uECC_valid_point(const uECC_word_t *point)
 	/* Make sure that y^2 == x^3 + ax + b */
 	diff = uECC_vli_equal(tmp1, tmp2);
 	if (diff == 0) {
-	    mbedtls_platform_random_delay( 10 );
+	    mbedtls_platform_random_delay();
 		if (diff == 0) {
 			return 0;
 		}

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -168,7 +168,7 @@ static int uECC_check_curve_integrity(void)
 	}
 
 	/* i should be 32 */
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 10 );
 	diff |= (unsigned char) i ^ 32;
 
 	return diff;
@@ -296,7 +296,7 @@ uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right)
 	}
 
 	/* i should be -1 now */
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 10 );
 	diff |= i ^ -1;
 
 	return diff;
@@ -1046,7 +1046,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 	if (problem != 0) {
 		return UECC_FAULT_DETECTED;
 	}
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 50 );
 	if (problem != 0) {
 		return UECC_FAULT_DETECTED;
 	}
@@ -1058,7 +1058,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		/* invalid input, can happen without fault */
 		return UECC_FAILURE;
 	}
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 50 );
 	if (problem != 0) {
 		/* failure on second check means fault, though */
 		return UECC_FAULT_DETECTED;
@@ -1088,7 +1088,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
 	}
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 10 );
 	if (problem != 0) {
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
@@ -1101,7 +1101,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
 	}
-	mbedtls_platform_enforce_volatile_reads();
+	mbedtls_platform_random_delay( 10 );
 	if (problem != 0) {
 		r = UECC_FAULT_DETECTED;
 		goto clear_and_out;
@@ -1198,7 +1198,7 @@ int uECC_valid_point(const uECC_word_t *point)
 	/* Make sure that y^2 == x^3 + ax + b */
 	diff = uECC_vli_equal(tmp1, tmp2);
 	if (diff == 0) {
-		mbedtls_platform_enforce_volatile_reads();
+	    mbedtls_platform_random_delay( 10 );
 		if (diff == 0) {
 			return 0;
 		}

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -299,7 +299,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	/* Accept only if v == r. */
 	diff = uECC_vli_equal(rx, r);
 	if (diff == 0) {
-	    mbedtls_platform_random_delay( 50 );
+	    mbedtls_platform_random_delay();
 		if (diff == 0) {
 			return UECC_SUCCESS;
 		}

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -299,7 +299,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	/* Accept only if v == r. */
 	diff = uECC_vli_equal(rx, r);
 	if (diff == 0) {
-		mbedtls_platform_enforce_volatile_reads();
+	    mbedtls_platform_random_delay( 50 );
 		if (diff == 0) {
 			return UECC_SUCCESS;
 		}


### PR DESCRIPTION
## Description

Add delay function `mbedtls_platform_random_delay` to platform_utils. The function will delay
program execution by incrementing local variable and doing xor byte operations a randomised number of times.

This PR contains an API break, function `mbedtls_platform_enforce_volatile_reads` is removed. The same kind of behaviour is achieved by using function `mbedtls_platform_random_delay(0)`.

__Impact on code-size:__

| | ARMC5 |
| --- | --- |
| `libmbedcrypto.a` before | 18659 |
| `libmbedcrypto.a` after | 18699 |
| gain in bytes Crypto | -40 |


## Status
**READY**
