### PR TITLE
[baremetal] Re-enable hardened SCA mem functions

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -142,10 +142,7 @@ int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
 
 uint32_t mbedtls_platform_random_in_range( size_t num )
 {
-    /* Temporary force the dummy version - drawing directly from the HRNG
-     * seems to be causing issues, avoid doing that until we understood the
-     * issue, and perhaps we'll need to draw from a DRBG instead. */
-#if 1 || !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     (void) num;
     return 0;
 #else


### PR DESCRIPTION
## Description
This reverts commit 1e96b46b032aa27d9388e395c3591b8c33005b4f from https://github.com/ARMmbed/mbedtls/pull/2930 that was created to temporarily disable usage of hardened SCA memory functions.

## Status
**READY**