### PR TITLE
[baremetal] Coverity fix: dead error condition removed from ecc.c

### DIFF
--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -1015,13 +1015,10 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 			 uECC_word_t *k1)
 {
-
-	wordcount_t num_n_words = NUM_ECC_WORDS;
 	bitcount_t num_n_bits = NUM_ECC_BITS;
 
 	uECC_word_t carry = uECC_vli_add(k0, k, curve_n) ||
-			     (num_n_bits < ((bitcount_t)num_n_words * uECC_WORD_SIZE * 8) &&
-			     uECC_vli_testBit(k0, num_n_bits));
+			     uECC_vli_testBit(k0, num_n_bits);
 
 	uECC_vli_add(k1, k0, curve_n);
 


### PR DESCRIPTION
## Description
Removed coverity finding of condition which is always false.

(num_n_bits < ((bitcount_t)num_n_words * uECC_WORD_SIZE * 8)
would always be
256 < 8 * 4 * 8
256 < 256

__Impact on code-size:__

| | ARMC5 |
| --- | --- |
| `libmbedcrypto.a` before | 18659|
| `libmbedcrypto.a` after | 18673|
| gain in bytes Crypto | -14 |

## Status
**READY**
