### PR TITLE
[baremetal] [tinycrypt] fix bug in RNG access in ECDSA SCA counter-measure

### DIFF
--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -68,12 +68,6 @@
 #include <tinycrypt/ecc_dsa.h>
 #include "mbedtls/platform_util.h"
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
-
 static void bits2int(uECC_word_t *native, const uint8_t *bits,
 		     unsigned bits_size, uECC_Curve curve)
 {
@@ -132,7 +126,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* If an RNG function was specified, get a random number
 	to prevent side channel analysis of k. */
-	if (!g_rng_function) {
+	if (!uECC_get_rng()) {
 		uECC_vli_clear(tmp);
 		tmp[0] = 1;
 	}


### PR DESCRIPTION
## Description

Duplicating the g_rng_function variable in ecc_dsa.c means it's not the same
as set in ecc.c, resulting if no randomisation here. The proper way to access
the RNG function from outside ecc.c is uECC_get_rng(), so use that.

This is a side-port of upstream commit https://github.com/intel/tinycrypt/commit/87d74dd8d64a99aaa188961fe763d0841c5abfef

I've verified that there are no other occurrences (the duplication of
g_rng_function in ecc_dh.c had already been removed earlier when centralising
projective coordinate randomisation to mult_safer()).

## Status
**READY**

## Migrations
NO

