### PR TITLE
Update the VS version in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are currently three active build systems used within Mbed TLS releases:
 
 -   GNU Make
 -   CMake
--   Microsoft Visual Studio (Microsoft Visual Studio 2010 or later)
+-   Microsoft Visual Studio (Microsoft Visual Studio 2012 or later)
 
 The main systems used for development are CMake and GNU Make. Those systems are always complete and up-to-date. The others should reflect all changes present in the CMake and Make build system, although features may not be ported there automatically.
 
@@ -154,7 +154,7 @@ subproject.
 
 ### Microsoft Visual Studio
 
-The build files for Microsoft Visual Studio are generated for Visual Studio 2010.
+The build files for Microsoft Visual Studio are generated for Visual Studio 2012.
 
 The solution file `mbedTLS.sln` contains all the basic projects needed to build the library and all the programs. The files in tests are not generated and compiled, as these need Python and perl environments as well. However, the selftest program in `programs/test/` is still available.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are currently three active build systems used within Mbed TLS releases:
 
 -   GNU Make
 -   CMake
--   Microsoft Visual Studio (Microsoft Visual Studio 2012 or later)
+-   Microsoft Visual Studio (Microsoft Visual Studio 2013 or later)
 
 The main systems used for development are CMake and GNU Make. Those systems are always complete and up-to-date. The others should reflect all changes present in the CMake and Make build system, although features may not be ported there automatically.
 
@@ -154,7 +154,7 @@ subproject.
 
 ### Microsoft Visual Studio
 
-The build files for Microsoft Visual Studio are generated for Visual Studio 2012.
+The build files for Microsoft Visual Studio are generated for Visual Studio 2010.
 
 The solution file `mbedTLS.sln` contains all the basic projects needed to build the library and all the programs. The files in tests are not generated and compiled, as these need Python and perl environments as well. However, the selftest program in `programs/test/` is still available.
 


### PR DESCRIPTION
## Description
Update the VS version in the README file to 2012, as this is the
minimal version supported.

## Status
**READY**

## Requires Backporting
NO  - The Minimal VS version was updated since 2.18


## Migrations
 NO


## Todos
- [ ] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


##additional comments

Partly addresses #2896 