### PR TITLE
Fix definition error for the deprecated zlib support if enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
+     Jack Lloyd in #2859. Fix submitted by jiblime in #2963.
+
 = mbed TLS 2.20.0 branch released 2020-01-15
 
 Bugfix

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1880,7 +1880,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     /* Allocate compression buffer */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
+    if( ssl->session_negotiate->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
         ssl->compress_buf == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );


### PR DESCRIPTION
When `MBEDTLS_ZLIB_SUPPORT` is defined and `-DENABLE_ZLIB_SUPPORT=1` is enabled,  mbedtls will build with zlib support but now has an issue starting with 2.19.1.

100% tests passed, 0 tests failed out of 85 for both the current development branch and 2.19.1

Previous implementations of zlib did not use session_negotiate: [2.17.0](https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.17.0/library/ssl_tls.c#L1348) [2.18.1](https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.18.1/library/ssl_tls.c#L1594)

https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.19.1/library/ssl_tls.c#L1842

```
#if defined(MBEDTLS_ZLIB_SUPPORT)
                                  ssl->session_negotiate->compression,
#endif
```
[Problem line here](https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.19.1/library/ssl_tls.c#L1862)

I don't understand why not just combine it instead of making it implicit.


Fixes #2859 (edited by mpg for [github keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords))

Despite it being deprecated, the test suite should allow zlib inclusion to be tested.

https://github.com/ARMmbed/mbedtls/blob/development/tests/Makefile#L60




## Status
**READY**

## Requires Backporting
NO - none of the LTS branches are affected (edited by mpg).

2.19.1 -- https://github.com/jiblime/mbedtls/blob/mbedtls-2.19.1-zlib-fix/library/ssl_tls.c#L1862
```
diff --git a/library/ssl_tls.c b/library/ssl_tls.c
index a7facb81a..8893e2c3c 100644
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1859,7 +1859,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     /* Allocate compression buffer */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
+    if( ssl->session_negotiate->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
         ssl->compress_buf == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );
```

## Todos
- [x] Tests - added in a separate PR: https://github.com/ARMmbed/mbedtls/pull/2975
- [ ] Changelog updated


## Steps to test or reproduce
Configure mbedtls with `#define MBEDTLS_ZLIB_SUPPORT` uncommented in include/mbedtls/config.h and `-DENABLE_ZLIB_SUPPORT=1`, then compile. Result:

```
net-libs/mbedtls-2.19.1/work/mbedtls-mbedtls-2.19.1/library/ssl_tls.c: In function ‘mbedtls_ssl_derive_keys’:
net-libs/mbedtls-2.19.1/work/mbedtls-mbedtls-2.19.1/library/ssl_tls.c:1862:9: error: ‘session’ undeclared (first use in this function)
 1862 |     if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
      |         ^~~~~~~
```
Reproducible always.
