### PR TITLE
USE_PSA_CRYPTO: update elliptic curve encoding

### DIFF
--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -319,7 +319,8 @@ struct mbedtls_ssl_handshake_params
     mbedtls_ecdh_context ecdh_ctx;              /*!<  ECDH key exchange       */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_ecc_curve_t ecdh_psa_curve;
+    psa_key_type_t ecdh_psa_type;
+    uint16_t ecdh_bits;
     psa_key_handle_t ecdh_psa_privkey;
     unsigned char ecdh_psa_peerkey[MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH];
     size_t ecdh_psa_peerkey_len;


### PR DESCRIPTION
Update the SSL client code for ECDH using PSA crypto to the new elliptic curve key type encoding in https://github.com/ARMmbed/mbed-crypto/pull/330.

This pull request and https://github.com/ARMmbed/mbed-crypto/pull/330 need to be merged close together because the crypto PR breaks mbedtls. To merge:

- [x] 1. Merge the mbed-crypto PR.
- [x] 2. Amend the crypto submodule update commit in the mbedtls PR.
- [ ] 3. Merge the mbedtls PR.
- [ ] 4. Update mbedtls in mbed-os and update the mbed-os code that depends on EC curve encodings (PR forthcoming).
