### PR TITLE
Backport 2.16: Fix some pylint warnings

### DIFF
--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -310,7 +310,10 @@ class MbedTlsTest(BaseHostTest):
 
         param_bytes, length = self.test_vector_to_bytes(function_id,
                                                         dependencies, args)
-        self.send_kv(''.join('{:02x}'.format(x) for x in length), ''.join('{:02x}'.format(x) for x in param_bytes))
+        self.send_kv(
+            ''.join('{:02x}'.format(x) for x in length),
+            ''.join('{:02x}'.format(x) for x in param_bytes)
+        )
 
     @staticmethod
     def get_result(value):


### PR DESCRIPTION
Backport of the relevant part of https://github.com/ARMmbed/mbed-crypto/pull/334

This PR fixes a warning that the check_python_files component of all.sh was complaining about.