### PR TITLE
[2.16] Add zlib tests

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -652,6 +652,31 @@ component_test_full_cmake_gcc_asan () {
     if_build_succeeded tests/compat.sh
 }
 
+component_test_zlib_make() {
+    msg "build: zlib enabled, make"
+    scripts/config.pl set MBEDTLS_ZLIB_SUPPORT
+    make ZLIB=1 CFLAGS='-Werror -O1'
+
+    msg "test: main suites (zlib, make)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, make)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
+component_test_zlib_cmake() {
+    msg "build: zlib enabled, cmake"
+    scripts/config.pl set MBEDTLS_ZLIB_SUPPORT
+    cmake -D ENABLE_ZLIB_SUPPORT=On -D CMAKE_BUILD_TYPE:String=Check .
+    make
+
+    msg "test: main suites (zlib, cmake)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, cmake)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
 component_test_ref_configs () {
     msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -663,6 +663,17 @@ component_test_zlib_make() {
     msg "test: ssl-opt.sh (zlib, make)"
     if_build_succeeded tests/ssl-opt.sh
 }
+support_test_zlib_make () {
+    base=support_test_zlib_$$
+    cat <<'EOF' > ${base}.c
+#include "zlib.h"
+int main(void) { return 0; }
+EOF
+    gcc -o ${base}.exe ${base}.c -lz 2>/dev/null
+    ret=$?
+    rm -f ${base}.*
+    return $ret
+}
 
 component_test_zlib_cmake() {
     msg "build: zlib enabled, cmake"
@@ -675,6 +686,9 @@ component_test_zlib_cmake() {
 
     msg "test: ssl-opt.sh (zlib, cmake)"
     if_build_succeeded tests/ssl-opt.sh
+}
+support_test_zlib_cmake () {
+    support_test_zlib_make "$@"
 }
 
 component_test_ref_configs () {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -905,6 +905,18 @@ run_test    "Default, DTLS" \
             -s "Protocol is DTLSv1.2" \
             -s "Ciphersuite is TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256"
 
+requires_config_enabled MBEDTLS_ZLIB_SUPPORT
+run_test    "Default (compression enabled)" \
+            "$P_SRV debug_level=3" \
+            "$P_CLI debug_level=3" \
+            0 \
+            -s "Allocating compression buffer" \
+            -c "Allocating compression buffer" \
+            -s "Record expansion is unknown (compression)" \
+            -c "Record expansion is unknown (compression)" \
+            -S "error" \
+            -C "error"
+
 # Test current time in ServerHello
 requires_config_enabled MBEDTLS_HAVE_TIME
 run_test    "ServerHello contains gmt_unix_time" \


### PR DESCRIPTION
## Description

This PR fixes a gap in our testing: we didn't test any build with zlib (for TLS record compression) enabled. This is a deprecated option but it should nonetheless be tested until it's removed for real.

The usefulness of these tests is illustrated by the fact that in their absence, we introduced a bug in 2.19 that caused us to fail to build with zlib enabled: https://github.com/ARMmbed/mbedtls/issues/2859

## Status
**READY**

## Requires Backporting

This is the 2.16 backport of https://github.com/ARMmbed/mbedtls/pull/2975

## Migrations

NO

## Additional comments

No ChangeLog entry as this is only a change in tests, not in the library.

## Steps to test or reproduce

`tests/scripts/all.sh 'test_zlib*'`