### PR TITLE
Add zlib tests and fix runtime bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
+     Jack Lloyd in #2859. Fix submitted by jiblime in #2963.
+
 = mbed TLS 2.20.0 branch released 2020-01-15
 
 Bugfix

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1880,7 +1880,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     /* Allocate compression buffer */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
+    if( ssl->session_negotiate->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
         ssl->compress_buf == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -708,6 +708,17 @@ component_test_zlib_make() {
     msg "test: ssl-opt.sh (zlib, make)"
     if_build_succeeded tests/ssl-opt.sh
 }
+support_test_zlib_make () {
+    base=support_test_zlib_$$
+    cat <<'EOF' > ${base}.c
+#include "zlib.h"
+int main(void) { return 0; }
+EOF
+    gcc -o ${base}.exe ${base}.c -lz 2>/dev/null
+    ret=$?
+    rm -f ${base}.*
+    return $ret
+}
 
 component_test_zlib_cmake() {
     msg "build: zlib enabled, cmake"
@@ -720,6 +731,9 @@ component_test_zlib_cmake() {
 
     msg "test: ssl-opt.sh (zlib, cmake)"
     if_build_succeeded tests/ssl-opt.sh
+}
+support_test_zlib_cmake () {
+    support_test_zlib_make "$@"
 }
 
 component_test_ref_configs () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -697,6 +697,31 @@ component_test_full_cmake_gcc_asan () {
     if_build_succeeded tests/compat.sh
 }
 
+component_test_zlib_make() {
+    msg "build: zlib enabled, make"
+    scripts/config.py set MBEDTLS_ZLIB_SUPPORT
+    make ZLIB=1 CFLAGS='-Werror -O1'
+
+    msg "test: main suites (zlib, make)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, make)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
+component_test_zlib_cmake() {
+    msg "build: zlib enabled, cmake"
+    scripts/config.py set MBEDTLS_ZLIB_SUPPORT
+    cmake -D ENABLE_ZLIB_SUPPORT=On -D CMAKE_BUILD_TYPE:String=Check .
+    make
+
+    msg "test: main suites (zlib, cmake)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, cmake)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
 component_test_ref_configs () {
     msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -996,6 +996,18 @@ run_test    "Default, DTLS" \
             -s "Protocol is DTLSv1.2" \
             -s "Ciphersuite is TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256"
 
+requires_config_enabled MBEDTLS_ZLIB_SUPPORT
+run_test    "Default (compression enabled)" \
+            "$P_SRV debug_level=3" \
+            "$P_CLI debug_level=3" \
+            0 \
+            -s "Allocating compression buffer" \
+            -c "Allocating compression buffer" \
+            -s "Record expansion is unknown (compression)" \
+            -c "Record expansion is unknown (compression)" \
+            -S "error" \
+            -C "error"
+
 requires_config_enabled MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
 run_test    "CA callback on client" \
             "$P_SRV debug_level=3" \


### PR DESCRIPTION
## Description

This PR fixes a gap in our testing: we didn't test any build with zlib (for TLS record compression) enabled. This is a deprecated option but it should nonetheless be tested until it's removed for real.

The usefulness of these tests is illustrated by the fact that in their absence, we introduced two bug in 2.19 that caused us to fail to build or run with zlib enabled: #2859 plus another one that was found by the tests and is fixed in this PR.

__Dependencies:__ This PR is based on #2963 which fixes a bug in building with zlib - the added test obviously wouldn't pass without that fix.

## Status
**READY**

## Requires Backporting

Yes - for the tests (the bugfix is only applicable to development, the LTS branches are free from the bug as the tests show).

- [x] Mbed TLS 2.16 https://github.com/ARMmbed/mbedtls/pull/2972
- [x] Mbed TLS 2.7 https://github.com/ARMmbed/mbedtls/pull/2976

## Migrations

NO

## Additional comments

No ChangeLog entry as this is only a change in tests, not in the library, and the runtime bug probably doesn't need it own entry as it was hidden by the compile bug.

## Steps to test or reproduce

Run `tests/scripts/all.sh 'test_zlib*'` and observe the result, in particular the two lines with `Default (compression enabled)` in the output of `ssl-opt.sh`.
