### PR TITLE
[baremetal] Clear internal decrypted buffer after read

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -11119,6 +11119,9 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
     mbedtls_platform_memcpy( buf, ssl->in_offt, n );
     ssl->in_msglen -= n;
 
+    // clear incoming data after it's copied to buffer
+    mbedtls_platform_memset(ssl->in_offt, 0, n);
+
     if( ssl->in_msglen == 0 )
     {
         /* all bytes consumed */


### PR DESCRIPTION
Clear memory from internal decrypted buffers with memset.