### PR TITLE
[baremetal] Add SCA countermeasures to get/put -methods on secret data

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -541,7 +541,7 @@ static int aes_sca_cm_data_randomize( uint8_t *tbl, uint8_t tbl_len )
     int num;
 #endif
 
-    memset( tbl, 0, tbl_len );
+    mbedtls_platform_memset( tbl, 0, tbl_len );
 
 #if AES_SCA_CM_ROUNDS != 0
     // Randomize SCA CM positions to tbl


### PR DESCRIPTION
This PR adds SCA countermeasures to AES module on places where
get/put_uint32 on secret data is used.

When reading the input, the buffer will be initialised with random data
and the reading will start from a random offset. When writing the data,
the output will be initialised with random data and the writing will
start from a random offset.

## Status
**READY**

## Additional comments
Needs preceding PRs to be merged: ~~#2886 and #2948~~
