### PR TITLE
[baremetal] Fix mbedtls_strerror to work with all wanted codes

### DIFF
--- a/library/error.c
+++ b/library/error.c
@@ -224,9 +224,9 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     if( ret < 0 )
         ret = -ret;
 
-    if( ret & 0xFF80 )
+    if( ret & 0xFFFF80 )
     {
-        use_ret = ret & 0xFF80;
+        use_ret = ret & 0xFFFF80;
 
         // High level error codes
         //
@@ -580,7 +580,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
     }
 
-    use_ret = ret & ~0xFF80;
+    use_ret = ret & ~0xFFFF80;
 
     if( use_ret == 0 )
         return;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -57,9 +57,9 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     if( ret < 0 )
         ret = -ret;
 
-    if( ret & 0xFF80 )
+    if( ret & 0xFFFF80 )
     {
-        use_ret = ret & 0xFF80;
+        use_ret = ret & 0xFFFF80;
 
         // High level error codes
         //
@@ -71,7 +71,7 @@ HIGH_LEVEL_CODE_CHECKS
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
     }
 
-    use_ret = ret & ~0xFF80;
+    use_ret = ret & ~0xFFFF80;
 
     if( use_ret == 0 )
         return;


### PR DESCRIPTION
Defines MBEDTLS_ERR_SSL_WANT_READ and MBEDTLS_ERR_SSL_WANT_WRITE were more than 0xFF80 so raised value which error is ANDed to 0xFFFF80.