### PR TITLE
Message transport mocks in ssl tests

### DIFF
--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -64,6 +64,21 @@ ssl_mock_tcp_interleaving:0:0x0FB1:0
 Test mock non-blocking TCP connection: both peers would block (interleaving)
 ssl_mock_tcp_interleaving:0:0x1111:0xEEEE
 
+Message queue - sanity
+ssl_message_queue_sanity:
+
+Message queue - basic test
+ssl_message_queue_basic:
+
+Message queue - overflow/underflow
+ssl_message_queue_overflow_underflow:
+
+Message queue - interleaved
+ssl_message_queue_interleaved:
+
+Message queue - insufficient buffer
+ssl_message_queue_insufficient_buffer:
+
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -79,6 +79,30 @@ ssl_message_queue_interleaved:
 Message queue - insufficient buffer
 ssl_message_queue_insufficient_buffer:
 
+Message transport mock - uninitialized structures
+ssl_message_mock_uninitialized:
+
+Message transport mock - basic test
+ssl_message_mock_basic:
+
+Message transport mock - queue overflow/underflow
+ssl_message_mock_queue_overflow_underflow:
+
+Message transport mock - socket overflow
+ssl_message_mock_socket_overflow:
+
+Message transport mock - truncated message
+ssl_message_mock_truncated:
+
+Message transport mock - socket read error
+ssl_message_mock_socket_read_error:
+
+Message transport mock - one-way interleaved sends/reads
+ssl_message_mock_interleaved_one_way:
+
+Message transport mock - two-way interleaved sends/reads
+ssl_message_mock_interleaved_two_ways:
+
 SSL DTLS replay: initial state, seqnum 0
 ssl_dtls_replay:"":"000000000000":0
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -471,6 +471,165 @@ int mbedtls_mock_tcp_recv_nb( void *ctx, unsigned char *buf, size_t len )
     return mbedtls_test_buffer_get( socket->input, buf, len );
 }
 
+/* Errors used in the message socket mocks */
+
+#define MBEDTLS_TEST_ERROR_CONTEXT_ERROR -55
+#define MBEDTLS_TEST_ERROR_SEND_FAILED -66
+#define MBEDTLS_TEST_ERROR_RECV_FAILED -77
+
+/*
+ * Structure used as an addon, or a wrapper, around the mocked sockets.
+ * Contains an input queue, to which the other socket pushes metadata,
+ * and an output queue, to which this one pushes metadata. This context is
+ * considered as an owner of the input queue only, which is initialized and
+ * freed in the respective setup and free calls.
+ */
+typedef struct mbedtls_test_message_socket_context
+{
+    mbedtls_test_message_queue* queue_input;
+    mbedtls_test_message_queue* queue_output;
+    mbedtls_mock_socket* socket;
+} mbedtls_test_message_socket_context;
+
+/*
+ * Setup a given mesasge socket context including initialization of
+ * input/output queues to a chosen capacity of messages. Also set the
+ * corresponding mock socket.
+ *
+ * \retval  0, if everything succeeds.
+ * \retval  MBEDTLS_ERR_SSL_ALLOC_FAILED, if allocation of a message
+ *          queue failed.
+ */
+int mbedtls_message_socket_setup( mbedtls_test_message_queue* queue_input,
+                                  mbedtls_test_message_queue* queue_output,
+                                  size_t queue_capacity,
+                                  mbedtls_mock_socket* socket,
+                                  mbedtls_test_message_socket_context* ctx )
+{
+    int ret = mbedtls_test_message_queue_setup( queue_input, queue_capacity );
+    if( ret != 0 )
+        return ret;
+    ctx->queue_input = queue_input;
+    ctx->queue_output = queue_output;
+    ctx->socket = socket;
+    mbedtls_mock_socket_init( socket );
+
+    return 0;
+}
+
+/*
+ * Close a given message socket context, along with the socket itself. Free the
+ * memory allocated by the input queue.
+ */
+void mbedtls_message_socket_close( mbedtls_test_message_socket_context* ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    mbedtls_test_message_queue_free( ctx->queue_input );
+    mbedtls_mock_socket_close( ctx->socket );
+    memset( ctx, 0, sizeof( *ctx ) );
+}
+
+/*
+ * Send one message through a given message socket context.
+ *
+ * \retval  \p len, if everything succeeds.
+ * \retval  MBEDTLS_TEST_ERROR_CONTEXT_ERROR, if any of the needed context
+ *          elements or the context itself is null.
+ * \retval  MBEDTLS_TEST_ERROR_SEND_FAILED if mbedtls_mock_tcp_send_b failed.
+ * \retval  MBEDTLS_TEST_ERROR_QUEUE_FULL, if the output queue is full.
+ *
+ * This function will also return any error from
+ * mbedtls_test_message_queue_push_info.
+ */
+int mbedtls_mock_tcp_send_msg( void *ctx, const unsigned char *buf, size_t len )
+{
+    mbedtls_test_message_queue* queue;
+    mbedtls_mock_socket* socket;
+    mbedtls_test_message_socket_context *context = (mbedtls_test_message_socket_context*) ctx;
+
+    if( context == NULL || context->socket == NULL
+        || context->queue_output == NULL )
+    {
+        return MBEDTLS_TEST_ERROR_CONTEXT_ERROR;
+    }
+
+    queue = context->queue_output;
+    socket = context->socket;
+
+    if( queue->num >= queue->capacity )
+        return MBEDTLS_TEST_ERROR_QUEUE_FULL;
+
+    if( mbedtls_mock_tcp_send_b( socket, buf, len ) != (int) len )
+        return MBEDTLS_TEST_ERROR_SEND_FAILED;
+
+    return mbedtls_test_message_queue_push_info( queue, len );
+}
+
+/*
+ * Receive one message from a given message socket context and return message
+ * length or an error.
+ *
+ * \retval  message length, if everything succeeds.
+ * \retval  MBEDTLS_TEST_ERROR_CONTEXT_ERROR, if any of the needed context
+ *          elements or the context itself is null.
+ * \retval  MBEDTLS_TEST_ERROR_RECV_FAILED if mbedtls_mock_tcp_recv_b failed.
+ *
+ * This function will also return any error other than
+ * MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED from mbedtls_test_message_queue_peek_info.
+ */
+int mbedtls_mock_tcp_recv_msg( void *ctx, unsigned char *buf, size_t buf_len )
+{
+    mbedtls_test_message_queue* queue;
+    mbedtls_mock_socket* socket;
+    mbedtls_test_message_socket_context *context = (mbedtls_test_message_socket_context*) ctx;
+    size_t drop_len;
+    size_t msg_len;
+    int ret;
+
+    if( context == NULL || context->socket == NULL
+        || context->queue_input == NULL )
+    {
+        return MBEDTLS_TEST_ERROR_CONTEXT_ERROR;
+    }
+
+    queue = context->queue_input;
+    socket = context->socket;
+
+    /* Peek first, so that in case of a socket error the data remains in
+     * the queue. */
+    ret = mbedtls_test_message_queue_peek_info( queue, buf_len, &msg_len );
+    if( ret == MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED )
+    {
+        /* Calculate how much to drop */
+        drop_len = msg_len - buf_len;
+
+        /* Set the requested message len to be buffer length */
+        msg_len = buf_len;
+    } else if( ret != 0 )
+    {
+        return ret;
+    }
+
+    if( mbedtls_mock_tcp_recv_b( socket, buf, msg_len ) != (int) msg_len )
+        return MBEDTLS_TEST_ERROR_RECV_FAILED;
+
+    if( ret == MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED )
+    {
+        /* Drop the remaining part of the message */
+        if( mbedtls_mock_tcp_recv_b( socket, NULL, drop_len ) != (int) drop_len )
+        {
+          /* Inconsistent state - part of the message was read,
+           * and a part couldn't. Not much we can do here, but it should not
+           * happen in test environment, unless forced manually. */
+        }
+    }
+    mbedtls_test_message_queue_pop_info( queue, buf_len );
+
+    return msg_len;
+}
+
 /*
  * Helper function setting up inverse record transformations
  * using given cipher, hash, EtM mode, authentication tag length,
@@ -1387,6 +1546,457 @@ void ssl_message_queue_insufficient_buffer( )
                  == (int) buffer_len );
 exit:
     mbedtls_test_message_queue_free( &queue );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_uninitialized( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    /* Send with a NULL context */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( NULL, message, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_CONTEXT_ERROR );
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( NULL, message, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_CONTEXT_ERROR );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 1,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 1,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_SEND_FAILED );
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+
+    /* Push directly to a queue to later simulate a disconnected behavior */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &server_queue, MSGLEN )
+                 == MSGLEN );
+
+    /* Test if there's an error when trying to read from a disconnected
+     * socket */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_RECV_FAILED );
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_basic( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 1,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 1,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN ) );
+
+    /* Send the message to the server */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN ) == MSGLEN );
+
+    /* Read from the server */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MSGLEN );
+
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+    memset( received, 0, MSGLEN );
+
+    /* Send the message to the client */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &server_context, message,
+                                            MSGLEN ) == MSGLEN );
+
+    /* Read from the client */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &client_context, received, MSGLEN )
+                 == MSGLEN );
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_queue_overflow_underflow( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 2,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 2,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN*2 ) );
+
+    /* Send three message to the server, last one with an error */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN - 1 ) == MSGLEN - 1 );
+
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN ) == MSGLEN );
+
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_FULL );
+
+    /* Read three messages from the server, last one with an error */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received,
+                                            MSGLEN - 1 ) == MSGLEN - 1 );
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MSGLEN );
+
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_socket_overflow( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 2,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 2,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN ) );
+
+    /* Send two message to the server, second one with an error */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN ) == MSGLEN );
+
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN )
+                 == MBEDTLS_TEST_ERROR_SEND_FAILED );
+
+    /* Read the only message from the server */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MSGLEN );
+
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_truncated( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 2,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 2,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    memset( received, 0, MSGLEN );
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   2 * MSGLEN ) );
+
+    /* Send two messages to the server, the second one small enough to fit in the
+     * receiver's buffer. */
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN ) == MSGLEN );
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN / 2 ) == MSGLEN / 2 );
+    /* Read a truncated message from the server */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN/2 )
+                 == MSGLEN/2 );
+
+    /* Test that the first half of the message is valid, and second one isn't */
+    TEST_ASSERT( memcmp( message, received, MSGLEN/2 ) == 0 );
+    TEST_ASSERT( memcmp( message + MSGLEN/2, received + MSGLEN/2, MSGLEN/2 )
+                 != 0 );
+    memset( received, 0, MSGLEN );
+
+    /* Read a full message from the server */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN/2 )
+                 == MSGLEN / 2 );
+
+    /* Test that the first half of the message is valid */
+    TEST_ASSERT( memcmp( message, received, MSGLEN/2 ) == 0 );
+
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_socket_read_error( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 1,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 1,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN ) );
+
+    TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                            MSGLEN ) == MSGLEN );
+
+    /* Force a read error by disconnecting the socket by hand */
+    server.status = 0;
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_RECV_FAILED );
+    /* Return to a valid state */
+    server.status = MBEDTLS_MOCK_SOCKET_CONNECTED;
+
+    memset( received, 0, sizeof( received ) );
+
+    /* Test that even though the server tried to read once disconnected, the
+     * continuity is preserved */
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MSGLEN );
+
+    TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_interleaved_one_way( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 3,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 3,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN*3 ) );
+
+    /* Interleaved test - [2 sends, 1 read] twice, and then two reads
+     * (to wrap around the buffer) */
+    for( i = 0; i < 2; i++ )
+    {
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received,
+                                                MSGLEN ) == MSGLEN );
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+        memset( received, 0, sizeof( received ) );
+    }
+
+    for( i = 0; i < 2; i++ )
+    {
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+    }
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_mock_interleaved_two_ways( )
+{
+    enum { MSGLEN = 10 };
+    unsigned char message[MSGLEN], received[MSGLEN];
+    mbedtls_mock_socket client, server;
+    unsigned i;
+    mbedtls_test_message_queue server_queue, client_queue;
+    mbedtls_test_message_socket_context server_context, client_context;
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &server_queue, &client_queue, 3,
+                                               &server,
+                                               &server_context ) == 0 );
+
+    TEST_ASSERT( mbedtls_message_socket_setup( &client_queue, &server_queue, 3,
+                                               &client,
+                                               &client_context ) == 0 );
+
+    /* Fill up the buffer with structured data so that unwanted changes
+     * can be detected */
+    for( i = 0; i < MSGLEN; i++ )
+    {
+        message[i] = i & 0xFF;
+    }
+    TEST_ASSERT( 0 == mbedtls_mock_socket_connect( &client, &server,
+                                                   MSGLEN*3 ) );
+
+    /* Interleaved test - [2 sends, 1 read] twice, both ways, and then two reads
+     * (to wrap around the buffer) both ways. */
+    for( i = 0; i < 2; i++ )
+    {
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &client_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &server_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_send_msg( &server_context, message,
+                                                MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received,
+                     MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+        memset( received, 0, sizeof( received ) );
+
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &client_context, received,
+                     MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+
+        memset( received, 0, sizeof( received ) );
+    }
+
+    for( i = 0; i < 2; i++ )
+    {
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received,
+                    MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+        memset( received, 0, sizeof( received ) );
+
+        TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &client_context, received,
+                     MSGLEN ) == MSGLEN );
+
+        TEST_ASSERT( memcmp( message, received, MSGLEN ) == 0 );
+        memset( received, 0, sizeof( received ) );
+    }
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &server_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+
+    TEST_ASSERT( mbedtls_mock_tcp_recv_msg( &client_context, received, MSGLEN )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+    exit:
+    mbedtls_message_socket_close( &server_context );
+    mbedtls_message_socket_close( &client_context );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -95,16 +95,16 @@ int mbedtls_test_buffer_put( mbedtls_test_buffer *buf,
 }
 
 /*
- * Gets \p output_len bytes from the \p output buffer into the ring buffer
- * \p buf.
+ * Gets \p output_len bytes from the ring buffer \p buf into the
+ * \p output buffer. The output buffer can be NULL, in this case a part of the
+ * ring buffer will be dropped, if the requested length is available.
  *
  * \p buf must have been initialized and set up by calling
  * `mbedtls_test_buffer_init()` and `mbedtls_test_buffer_setup()`.
  *
  * \retval  \p output_len, if the data is available.
  * \retval  0 <= value < \p output_len, if the data is not available.
- * \retval  -1, if \buf is NULL, it hasn't been set up or \p output_len is not
- *          zero and \p output is NULL
+ * \retval  -1, if \buf is NULL or it hasn't been set up.
  */
 int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
                              unsigned char* output, size_t output_len )
@@ -114,10 +114,8 @@ int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
     if( ( buf == NULL ) || ( buf->buffer == NULL ) )
         return -1;
 
-    if( output == NULL )
-    {
-        return ( output_len == 0 ) ? 0 : -1;
-    }
+    if( output == NULL && output_len == 0 )
+        return 0;
 
     if( buf->content_length < output_len )
         output_len = buf->content_length;
@@ -129,8 +127,12 @@ int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
         overflow = ( buf->start + output_len ) % buf->capacity;
     }
 
-    memcpy( output, buf->buffer + buf->start, output_len - overflow );
-    memcpy( output + output_len - overflow, buf->buffer, overflow );
+    if( output != NULL )
+    {
+        memcpy( output, buf->buffer + buf->start, output_len - overflow );
+        memcpy( output + output_len - overflow, buf->buffer, overflow );
+    }
+
     buf->content_length -= output_len;
     buf->start = ( buf->start + output_len ) % buf->capacity;
 
@@ -714,8 +716,7 @@ void test_callback_buffer_sanity()
     TEST_ASSERT( mbedtls_test_buffer_get( NULL, output, sizeof( output ) )
                     == -1 );
     TEST_ASSERT( mbedtls_test_buffer_put( NULL, NULL, sizeof( input ) ) == -1 );
-    TEST_ASSERT( mbedtls_test_buffer_get( NULL, NULL, sizeof( output ) )
-                    == -1 );
+
     TEST_ASSERT( mbedtls_test_buffer_put( NULL, NULL, 0 ) == -1 );
     TEST_ASSERT( mbedtls_test_buffer_get( NULL, NULL, 0 ) == -1 );
 
@@ -727,19 +728,20 @@ void test_callback_buffer_sanity()
     TEST_ASSERT( mbedtls_test_buffer_get( &buf, output, sizeof( output ) )
                     == -1 );
     TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, sizeof( input ) ) == -1 );
-    TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, sizeof( output ) )
-                    == -1 );
+
     TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, 0 ) == -1 );
     TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, 0 ) == -1 );
 
-    /* Make sure calling put end get on NULL input and output only results in
-     * error if the length is not zero. */
+    /* Make sure calling put and get on NULL input only results in
+     * error if the length is not zero, and that a NULL output is valid for data
+     * dropping.
+     */
 
     TEST_ASSERT( mbedtls_test_buffer_setup( &buf, sizeof( input ) ) == 0 );
 
     TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, sizeof( input ) ) == -1 );
     TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, sizeof( output ) )
-                    == -1 );
+                    == 0 );
     TEST_ASSERT( mbedtls_test_buffer_put( &buf, NULL, 0 ) == 0 );
     TEST_ASSERT( mbedtls_test_buffer_get( &buf, NULL, 0 ) == 0 );
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -140,6 +140,136 @@ int mbedtls_test_buffer_get( mbedtls_test_buffer *buf,
 }
 
 /*
+ * Errors used in the message transport mock tests
+ */
+ #define MBEDTLS_TEST_ERROR_ARG_NULL -11
+ #define MBEDTLS_TEST_ERROR_QUEUE_FULL -22
+ #define MBEDTLS_TEST_ERROR_QUEUE_EMPTY -33
+ #define MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED -44
+
+/*
+ * Context for a message metadata queue (fifo) that is on top of the ring buffer.
+ */
+typedef struct mbedtls_test_message_queue
+{
+    size_t *messages;
+    int pos;
+    int num;
+    int capacity;
+} mbedtls_test_message_queue;
+
+/*
+ * Setup and free functions for the message metadata queue.
+ *
+ * \p capacity describes the number of message metadata chunks that can be held
+ *    within the queue.
+ *
+ * \retval  0, if a metadata queue of a given length can be allocated.
+ * \retval  MBEDTLS_ERR_SSL_ALLOC_FAILED, if allocation failed.
+ */
+int mbedtls_test_message_queue_setup( mbedtls_test_message_queue *queue,
+                                      size_t capacity )
+{
+    queue->messages = (size_t*) mbedtls_calloc( capacity, sizeof(size_t) );
+    if( NULL == queue->messages )
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+
+    queue->capacity = capacity;
+    queue->pos = 0;
+    queue->num = 0;
+
+    return 0;
+}
+
+void mbedtls_test_message_queue_free( mbedtls_test_message_queue *queue )
+{
+    if( queue == NULL )
+        return;
+
+    if( queue->messages != NULL )
+        mbedtls_free( queue->messages );
+
+    memset( queue, 0, sizeof( *queue ) );
+}
+
+/*
+ * Push message length information onto the message metadata queue.
+ * This will become the last element to leave it (fifo).
+ *
+ * \retval  MBEDTLS_TEST_ERROR_ARG_NULL, if the queue is null.
+ * \retval  MBEDTLS_TEST_ERROR_QUEUE_FULL, if the queue is full.
+ * \retval  \p len, if the push was successful.
+ */
+int mbedtls_test_message_queue_push_info( mbedtls_test_message_queue *queue,
+                                          size_t len )
+{
+    int place;
+    if( queue == NULL )
+        return MBEDTLS_TEST_ERROR_ARG_NULL;
+
+    if( queue->num >= queue->capacity )
+        return MBEDTLS_TEST_ERROR_QUEUE_FULL;
+
+    place = ( queue->pos + queue->num ) % queue->capacity;
+    queue->messages[place] = len;
+    queue->num++;
+    return len;
+}
+
+/*
+ * Pop information about the next message length from the queue. This will be
+ * the oldest inserted message length(fifo). \p msg_len can be null, in which
+ * case the data will be popped from the queue but not copied anywhere.
+ *
+ * \retval  MBEDTLS_TEST_ERROR_ARG_NULL, if the queue is null.
+ * \retval  MBEDTLS_TEST_ERROR_QUEUE_EMPTY, if the queue is empty.
+ * \retval  message length, if the pop was successful, up to the given
+            \p buf_len.
+ */
+int mbedtls_test_message_queue_pop_info( mbedtls_test_message_queue *queue,
+                                         size_t buf_len )
+{
+    size_t message_length;
+    if( queue == NULL )
+        return MBEDTLS_TEST_ERROR_ARG_NULL;
+    if( queue->num == 0 )
+        return MBEDTLS_TEST_ERROR_QUEUE_EMPTY;
+
+    message_length = queue->messages[queue->pos];
+    queue->messages[queue->pos] = 0;
+    queue->num--;
+    queue->pos++;
+    queue->pos %= queue->capacity;
+    if( queue->pos < 0 )
+        queue->pos += queue->capacity;
+
+    return ( message_length > buf_len ) ? buf_len : message_length;
+}
+
+/*
+ * Take a peek on the info about the next message length from the queue.
+ * This will be the oldest inserted message length(fifo).
+ *
+ * \retval  MBEDTLS_TEST_ERROR_ARG_NULL, if the queue is null.
+ * \retval  MBEDTLS_TEST_ERROR_QUEUE_EMPTY, if the queue is empty.
+ * \retval  0, if the peek was successful.
+ * \retval  MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED, if the given buffer length is
+ *          too small to fit the message. In this case the \p msg_len will be
+ *          set to the full message length so that the
+ *          caller knows what portion of the message can be dropped.
+ */
+int mbedtls_test_message_queue_peek_info( mbedtls_test_message_queue *queue,
+                                          size_t buf_len, size_t* msg_len )
+{
+    if( queue == NULL || msg_len == NULL )
+        return MBEDTLS_TEST_ERROR_ARG_NULL;
+    if( queue->num == 0 )
+        return MBEDTLS_TEST_ERROR_QUEUE_EMPTY;
+
+    *msg_len = queue->messages[queue->pos];
+    return ( *msg_len > buf_len ) ? MBEDTLS_TEST_ERROR_MESSAGE_TRUNCATED : 0;
+}
+/*
  * Context for the I/O callbacks simulating network connection.
  */
 
@@ -1131,6 +1261,132 @@ exit:
 
     mbedtls_mock_socket_close( &client );
     mbedtls_mock_socket_close( &server );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_queue_sanity( )
+{
+    mbedtls_test_message_queue queue;
+
+    /* Trying to push/pull to an empty queue */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( NULL, 1 )
+                 == MBEDTLS_TEST_ERROR_ARG_NULL );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( NULL, 1 )
+                 == MBEDTLS_TEST_ERROR_ARG_NULL );
+
+    mbedtls_test_message_queue_setup( &queue, 3 );
+    TEST_ASSERT( queue.capacity == 3 );
+    TEST_ASSERT( queue.num == 0 );
+
+exit:
+    mbedtls_test_message_queue_free( &queue );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_queue_basic( )
+{
+    mbedtls_test_message_queue queue;
+
+    mbedtls_test_message_queue_setup( &queue, 3 );
+
+    /* Sanity test - 3 pushes and 3 pops with sufficient space */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( queue.capacity == 3 );
+    TEST_ASSERT( queue.num == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( queue.capacity == 3 );
+    TEST_ASSERT( queue.num == 2 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 2 ) == 2 );
+    TEST_ASSERT( queue.capacity == 3 );
+    TEST_ASSERT( queue.num == 3 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 2 ) == 2 );
+
+exit:
+    mbedtls_test_message_queue_free( &queue );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_queue_overflow_underflow( )
+{
+    mbedtls_test_message_queue queue;
+
+    mbedtls_test_message_queue_setup( &queue, 3 );
+
+    /* 4 pushes (last one with an error), 4 pops (last one with an error) */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 2 ) == 2 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 3 )
+                 == MBEDTLS_TEST_ERROR_QUEUE_FULL );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 2 ) == 2 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 )
+                 == MBEDTLS_TEST_ERROR_QUEUE_EMPTY );
+
+exit:
+    mbedtls_test_message_queue_free( &queue );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_queue_interleaved( )
+{
+    mbedtls_test_message_queue queue;
+
+    mbedtls_test_message_queue_setup( &queue, 3 );
+
+    /* Interleaved test - [2 pushes, 1 pop] twice, and then two pops
+     * (to wrap around the buffer) */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 2 ) == 2 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 3 ) == 3 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 1 ) == 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 2 ) == 2 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 5 ) == 5 );
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 8 ) == 8 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 3 ) == 3 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 5 ) == 5 );
+
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, 8 ) == 8 );
+
+exit:
+    mbedtls_test_message_queue_free( &queue );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ssl_message_queue_insufficient_buffer( )
+{
+    mbedtls_test_message_queue queue;
+    size_t message_len = 10;
+    size_t buffer_len = 5;
+
+    mbedtls_test_message_queue_setup( &queue, 1 );
+
+    /* Popping without a sufficient buffer */
+    TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, message_len )
+                 == (int) message_len );
+    TEST_ASSERT( mbedtls_test_message_queue_pop_info( &queue, buffer_len )
+                 == (int) buffer_len );
+exit:
+    mbedtls_test_message_queue_free( &queue );
 }
 /* END_CASE */
 


### PR DESCRIPTION
This PR is an implementation of  IOTSSL-2958.
It adds tests for a message-based connection. An additional layer of metadata is laid on the base of I/O callbacks to perform as a message queue. The receive function had to be modified to enable data dropping.
The changes themselves can be divided into two (as are the tests for them):
- The metadata layer only, which can operate separately from the connection itself (this lets the developers to approach it in a more TDD way);
- The integration layer, which uses the underlying mocked sends/reads and the metadata layer to provide a compound functionality, hidden behind `mbedtls_message_socket_setup`, `mbedtls_mock_tcp_send_msg`, `mbedtls_mock_tcp_recv_msg`, and `mbedtls_message_socket_close`. 

The only function that's used from the lower, socket mock layer is `mbedtls_mock_socket_connect`, but since, if it was to be hidden, the function that would be hiding it would only consist of a single line calling `mbedtls_mock_socket_connect` - I figured it wouldn't be necessary, especially for tests.