### PR TITLE
Fix minor defects found by Coverity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS x.x.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix an unchecked call to mbedtls_md() in the x509write module.
+
 = mbed TLS 2.20.0 branch released 2020-01-15
 
 Bugfix

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -214,7 +214,9 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
         return( MBEDTLS_ERR_X509_FATAL_ERROR );
     }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
-    mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    if( ret != 0 )
+        return( ret );
 #endif
     if( ( ret = mbedtls_pk_sign( ctx->key, ctx->md_alg, hash, 0, sig, &sig_len,
                                  f_rng, p_rng ) ) != 0 )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -619,6 +619,7 @@ static int nss_keylog_export( void *p_expkey,
         if( fwrite( nss_keylog_line, 1, len, f ) != len )
         {
             ret = -1;
+            fclose( f );
             goto exit;
         }
 

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -525,15 +525,6 @@ int execute_tests( int argc , const char ** argv )
     mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof( alloc_buf ) );
 #endif
 
-    if( outcome_file_name != NULL )
-    {
-        outcome_file = fopen( outcome_file_name, "a" );
-        if( outcome_file == NULL )
-        {
-            mbedtls_fprintf( stderr, "Unable to open outcome file. Continuing anyway.\n" );
-        }
-    }
-
     /*
      * The C standard doesn't guarantee that all-bits-0 is the representation
      * of a NULL pointer. We do however use that in our code for initializing
@@ -553,6 +544,15 @@ int execute_tests( int argc , const char ** argv )
     {
         mbedtls_fprintf( stderr, "the snprintf implementation is broken\n" );
         return( 1 );
+    }
+
+    if( outcome_file_name != NULL )
+    {
+        outcome_file = fopen( outcome_file_name, "a" );
+        if( outcome_file == NULL )
+        {
+            mbedtls_fprintf( stderr, "Unable to open outcome file. Continuing anyway.\n" );
+        }
     }
 
     while( arg_index < argc )
@@ -607,6 +607,8 @@ int execute_tests( int argc , const char ** argv )
         {
             mbedtls_fprintf( stderr, "Failed to open test file: %s\n",
                              test_filename );
+            if( outcome_file != NULL )
+                fclose( outcome_file );
             return( 1 );
         }
 


### PR DESCRIPTION
* A missing return code check in X509, which could happen on hardware accelerator failure.
* Some resource leaks in corner cases in test programs.

The missing return code check should be backported.

### Backports

- 2.16 #3001 
- 2.7 #3002 