### PR TITLE
Checks mbedtls_rsa_export return in fuzz targets

### DIFF
--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -29,7 +29,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             mbedtls_mpi_init( &DQ ); mbedtls_mpi_init( &QP );
 
             rsa = mbedtls_pk_rsa( pk );
-            mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E );
+            if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != 0 ) {
+                abort();
+            }
             mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP );
 
             mbedtls_mpi_free( &N ); mbedtls_mpi_free( &P ); mbedtls_mpi_free( &Q );

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdlib.h>
 #include "mbedtls/pk.h"
 
 //4 Kb should be enough for every bug ;-)

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -32,7 +32,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != 0 ) {
                 abort();
             }
-            mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP );
+            if ( mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) != 0 ) {
+                abort();
+            }
 
             mbedtls_mpi_free( &N ); mbedtls_mpi_free( &P ); mbedtls_mpi_free( &Q );
             mbedtls_mpi_free( &D ); mbedtls_mpi_free( &E ); mbedtls_mpi_free( &DP );

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -20,7 +20,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             mbedtls_mpi_init( &DQ ); mbedtls_mpi_init( &QP );
 
             rsa = mbedtls_pk_rsa( pk );
-            ret = mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E );
+            if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != 0 ) {
+                abort();
+            }
             ret = mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP );
 
             mbedtls_mpi_free( &N ); mbedtls_mpi_free( &P ); mbedtls_mpi_free( &Q );

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdlib.h>
 #include "mbedtls/pk.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -23,7 +23,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != 0 ) {
                 abort();
             }
-            ret = mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP );
+            if ( mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) != MBEDTLS_ERR_RSA_BAD_INPUT_DATA ) {
+                abort();
+            }
 
             mbedtls_mpi_free( &N ); mbedtls_mpi_free( &P ); mbedtls_mpi_free( &Q );
             mbedtls_mpi_free( &D ); mbedtls_mpi_free( &E ); mbedtls_mpi_free( &DP );


### PR DESCRIPTION
## Description
Checks `mbedtls_rsa_export` return in fuzz targets
It should always return 0
cf https://github.com/ARMmbed/mbedtls/pull/1622#discussion_r369109172


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Should I add a Changelog entry ?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
