### PR TITLE
Backport 2.7: Fix minor defects found by Coverity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.7.x branch released xxxx-xx-xx
+
+Bugfix
+   * Fix an unchecked call to mbedtls_md() in the x509write module.
+
 = mbed TLS 2.7.13 branch released 2020-01-15
 
 Security

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -282,6 +282,10 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
 
     *olen = 0;
     block_size = mbedtls_cipher_get_block_size( ctx );
+    if ( 0 == block_size )
+    {
+        return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
+    }
 
     if( ctx->cipher_info->mode == MBEDTLS_MODE_ECB )
     {
@@ -307,11 +311,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
                            output );
     }
 #endif
-
-    if ( 0 == block_size )
-    {
-        return MBEDTLS_ERR_CIPHER_INVALID_CONTEXT;
-    }
 
     if( input == output &&
        ( ctx->unprocessed_len != 0 || ilen % block_size ) )
@@ -371,11 +370,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
          */
         if( 0 != ilen )
         {
-            if( 0 == block_size )
-            {
-                return MBEDTLS_ERR_CIPHER_INVALID_CONTEXT;
-            }
-
             /* Encryption: only cache partial blocks
              * Decryption w/ padding: always keep at least one whole block
              * Decryption w/o padding: only cache partial blocks

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -230,7 +230,9 @@ int mbedtls_x509write_csr_der( mbedtls_x509write_csr *ctx, unsigned char *buf, s
     /*
      * Prepare signature
      */
-    mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );
+    if( ret != 0 )
+        return( ret );
 
     if( ( ret = mbedtls_pk_sign( ctx->key, ctx->md_alg, hash, 0, sig, &sig_len,
                                  f_rng, p_rng ) ) != 0 )

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -345,8 +345,8 @@ void mbedtls_mpi_lt_mpi_ct( int size_X, char * input_X,
     TEST_ASSERT( mbedtls_mpi_read_string( &X, 16, input_X ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, 16, input_Y ) == 0 );
 
-    mbedtls_mpi_grow( &X, size_X );
-    mbedtls_mpi_grow( &Y, size_Y );
+    TEST_ASSERT( mbedtls_mpi_grow( &X, size_X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_grow( &Y, size_Y ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_lt_mpi_ct( &X, &Y, &ret ) == input_err );
     if( input_err == 0 )


### PR DESCRIPTION
Straightforward backport of the applicable parts of https://github.com/ARMmbed/mbed-crypto/pull/349 and https://github.com/ARMmbed/mbedtls/pull/2995
