### PR TITLE
[Backport 2.16] Fix incrementing pointer instead of value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.16.5 branch released xxxx-xx-xx
+
+Security
+   * Fix potential memory overread when performing an ECDSA signature
+     operation. The overread only happens with cryptographically low
+     probability (of the order of 2^-n where n is the bitsize of the curve)
+     unless the RNG is broken, and could result in information disclosure or
+     denial of service (application crash or extra resource consumption).
+     Reported by Peter and Auke (found using static analysis).
+
 = mbed TLS 2.16.4 branch released 2020-01-15
 
 Security

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -297,7 +297,7 @@ static int ecdsa_sign_restartable( mbedtls_ecp_group *grp,
     *p_sign_tries = 0;
     do
     {
-        if( *p_sign_tries++ > 10 )
+        if( (*p_sign_tries)++ > 10 )
         {
             ret = MBEDTLS_ERR_ECP_RANDOM_FAILED;
             goto cleanup;
@@ -310,7 +310,7 @@ static int ecdsa_sign_restartable( mbedtls_ecp_group *grp,
         *p_key_tries = 0;
         do
         {
-            if( *p_key_tries++ > 10 )
+            if( (*p_key_tries)++ > 10 )
             {
                 ret = MBEDTLS_ERR_ECP_RANDOM_FAILED;
                 goto cleanup;


### PR DESCRIPTION
This is the backport to Mbed TLS 2.16 of https://github.com/ARMmbed/mbed-crypto/pull/354

In addition to the original, it has a ChangeLog entry. Reviewers, please review carefully that this entry correctly reflects the security impact of the issue.

## TODO

- [ ] Fix attribution (full names and affiliation) in ChangeLog entry.
