### PR TITLE
Allow loading symlinked certificates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS X.X.X branch released XXXX-XX-XX
+
+Bugfix
+   * Allow loading symlinked certificates. Fixes #3005. Reported and fixed
+     by Jonathan Bennett <JBennett@incomsystems.biz> via #3008.
+
 = mbed TLS 2.20.0 branch released 2020-01-15
 
 Bugfix

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1613,7 +1613,7 @@ cleanup:
             goto cleanup;
         }
 
-        if( !S_ISREG( sb.st_mode ) )
+        if( !( S_ISREG( sb.st_mode ) || S_ISLNK( sb.st_mode ) ) )
             continue;
 
         // Ignore parse errors


### PR DESCRIPTION
When mbedtls_x509_crt_parse_path() checks each object in the supplied path, it only processes regular files. This change makes it also accept a symlink to a file. Fixes #3005.

This was observed to be a problem on Fedora/CentOS/RHEL systems, where the ca-bundle in the default location is actually a symlink.