### PR TITLE
Backport 2.16: Allow loading symlinked certificates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
+= mbed TLS 2.16.X branch released XXXX-XX-XX
+
+Bugfix
+   * Allow loading symlinked certificates. Fixes #3005. Reported and fixed
+     by Jonathan Bennett <JBennett@incomsystems.biz> via #3008.
+
 = mbed TLS 2.16.5 branch released xxxx-xx-xx
 
 Security

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1366,7 +1366,7 @@ cleanup:
             goto cleanup;
         }
 
-        if( !S_ISREG( sb.st_mode ) )
+        if( !( S_ISREG( sb.st_mode ) || S_ISLNK( sb.st_mode ) ) )
             continue;
 
         // Ignore parse errors


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3008

CC @jp-bennett