### PR TITLE
Add crypto-only preset configurations

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -230,6 +230,35 @@ def baremetal_adapter(name, active, section):
         return True
     return include_in_full(name) and keep_in_baremetal(name)
 
+def include_in_crypto(name):
+    """Rules for symbols in a crypto configuration."""
+    if name.startswith('MBEDTLS_X509_') or \
+       name.startswith('MBEDTLS_SSL_') or \
+       name.startswith('MBEDTLS_KEY_EXCHANGE_'):
+        return False
+    if name in [
+            'MBEDTLS_CERTS_C',
+            'MBEDTLS_DEBUG_C',
+            'MBEDTLS_NET_C',
+            'MBEDTLS_PKCS11_C',
+    ]:
+        return False
+    return True
+
+def crypto_adapter(adapter):
+    """Modify an adapter to disable non-crypto symbols.
+
+    ``crypto_adapter(adapter)(name, active, section)`` is like
+    ``adapter(name, active, section)``, but unsets all X.509 and TLS symbols.
+    """
+    def continuation(name, active, section):
+        if not include_in_crypto(name):
+            return False
+        if adapter is None:
+            return active
+        return adapter(name, active, section)
+    return continuation
+
 class ConfigFile(Config):
     """Representation of the Mbed TLS configuration read for a file.
 
@@ -394,6 +423,14 @@ if __name__ == '__main__':
         add_adapter('realfull', realfull_adapter,
                     """Uncomment all boolean #defines.
                     Suitable for generating documentation, but not for building.""")
+        add_adapter('crypto', crypto_adapter(None),
+                    """Only include crypto features. Exclude X.509 and TLS.""")
+        add_adapter('crypto_baremetal', crypto_adapter(baremetal_adapter),
+                    """Like baremetal, but with only crypto features,
+                    excluding X.509 and TLS.""")
+        add_adapter('crypto_full', crypto_adapter(full_adapter),
+                    """Like full, but with only crypto features,
+                    excluding X.509 and TLS.""")
 
         args = parser.parse_args()
         config = ConfigFile(args.file)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -899,6 +899,33 @@ component_build_deprecated () {
     make CC=clang CFLAGS='-O -Werror -Wall -Wextra -Wno-unused-function' tests
 }
 
+# Check that the specified libraries exist and are empty.
+are_empty_libraries () {
+  nm "$@" >/dev/null 2>/dev/null
+  ! nm "$@" 2>/dev/null | grep -v ':$' | grep .
+}
+
+component_build_crypto_default () {
+  msg "build: make, crypto only"
+  scripts/config.py crypto
+  make CFLAGS='-O0'
+  if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
+}
+
+component_build_crypto_full () {
+  msg "build: make, crypto only, full config"
+  scripts/config.py crypto_full
+  make CFLAGS='-O0'
+  if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
+}
+
+component_build_crypto_baremetal () {
+  msg "build: make, crypto only, baremetal config"
+  scripts/config.py crypto_baremetal
+  make CFLAGS='-O0 -Werror'
+  if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
+}
+
 component_test_depends_curves () {
     msg "test/build: curves.pl (gcc)" # ~ 4 min
     record_status tests/scripts/curves.pl

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -908,21 +908,21 @@ are_empty_libraries () {
 component_build_crypto_default () {
   msg "build: make, crypto only"
   scripts/config.py crypto
-  make CFLAGS='-O0'
+  make CFLAGS='-O1 -Werror'
   if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 
 component_build_crypto_full () {
   msg "build: make, crypto only, full config"
   scripts/config.py crypto_full
-  make CFLAGS='-O0'
+  make CFLAGS='-O1 -Werror'
   if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 
 component_build_crypto_baremetal () {
   msg "build: make, crypto only, baremetal config"
   scripts/config.py crypto_baremetal
-  make CFLAGS='-O0 -Werror'
+  make CFLAGS='-O1 -Werror'
   if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -33,7 +33,8 @@ size_t mbedtls_rsa_key_len_func( void *ctx )
 }
 #endif /* MBEDTLS_RSA_C */
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_USE_PSA_CRYPTO) && \
+    defined(MBEDTLS_PEM_WRITE_C) && defined(MBEDTLS_X509_CSR_WRITE_C)
 static int x509_crt_verifycsr( const unsigned char *buf, size_t buflen )
 {
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
@@ -70,7 +71,7 @@ cleanup:
     mbedtls_x509_csr_free( &csr );
     return( ret );
 }
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#endif /* MBEDTLS_USE_PSA_CRYPTO && MBEDTLS_PEM_WRITE_C && MBEDTLS_X509_CSR_WRITE_C */
 
 /* END_HEADER */
 


### PR DESCRIPTION
To build only the crypto parts of Mbed TLS, run
```
scripts/config.py crypto
make
```

This is essentially equivalent to building Mbed Crypto.
