### PR TITLE
Revert "Merge pull request #3008 from jp-bennett/development"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,8 +8,6 @@ New deprecations
    * Deprecate MBEDTLS_SSL_PROTO_SSL3 that enables support for SSLv3.
 
 Bugfix
-   * Allow loading symlinked certificates. Fixes #3005. Reported and fixed
-     by Jonathan Bennett <JBennett@incomsystems.biz> via #3008.
    * Fix an unchecked call to mbedtls_md() in the x509write module.
    * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
      Jack Lloyd in #2859. Fix submitted by jiblime in #2963.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1613,7 +1613,7 @@ cleanup:
             goto cleanup;
         }
 
-        if( !( S_ISREG( sb.st_mode ) || S_ISLNK( sb.st_mode ) ) )
+        if( !S_ISREG( sb.st_mode ) )
             continue;
 
         // Ignore parse errors


### PR DESCRIPTION
## Description

> The changes I suggested can be reverted. stat() will never return S_IFLNK as the file type, as stat() explicitly follows symlinks.

See #3005.

## Status
**READY**

## Requires Backporting

Yes, 2.16 and 2.7  

