### PR TITLE
Bump version 2.16.5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 mbed TLS ChangeLog (Sorted per branch, date)
 
-= mbed TLS 2.16.X branch released XXXX-XX-XX
+= mbed TLS 2.16.5 branch released 2020-02-20
 
 Security
    * Fix potential memory overread when performing an ECDSA signature

--- a/doxygen/input/doc_mainpage.h
+++ b/doxygen/input/doc_mainpage.h
@@ -24,7 +24,7 @@
  */
 
 /**
- * @mainpage mbed TLS v2.16.4 source code documentation
+ * @mainpage mbed TLS v2.16.5 source code documentation
  *
  * This documentation describes the internal structure of mbed TLS.  It was
  * automatically generated from specially formatted comment blocks in

--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.16.4"
+PROJECT_NAME           = "mbed TLS v2.16.5"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -40,16 +40,16 @@
  */
 #define MBEDTLS_VERSION_MAJOR  2
 #define MBEDTLS_VERSION_MINOR  16
-#define MBEDTLS_VERSION_PATCH  4
+#define MBEDTLS_VERSION_PATCH  5
 
 /**
  * The single version number has the following structure:
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02100400
-#define MBEDTLS_VERSION_STRING         "2.16.4"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.16.4"
+#define MBEDTLS_VERSION_NUMBER         0x02100500
+#define MBEDTLS_VERSION_STRING         "2.16.5"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.16.5"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -165,15 +165,15 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.16.4 SOVERSION 3)
+    set_target_properties(mbedcrypto PROPERTIES VERSION 2.16.5 SOVERSION 3)
     target_link_libraries(mbedcrypto ${libs})
 
     add_library(mbedx509 SHARED ${src_x509})
-    set_target_properties(mbedx509 PROPERTIES VERSION 2.16.4 SOVERSION 0)
+    set_target_properties(mbedx509 PROPERTIES VERSION 2.16.5 SOVERSION 0)
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
 
     add_library(mbedtls SHARED ${src_tls})
-    set_target_properties(mbedtls PROPERTIES VERSION 2.16.4 SOVERSION 12)
+    set_target_properties(mbedtls PROPERTIES VERSION 2.16.5 SOVERSION 12)
     target_link_libraries(mbedtls ${libs} mbedx509)
 
     install(TARGETS mbedtls mbedx509 mbedcrypto

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.16.4"
+check_compiletime_version:"2.16.5"
 
 Check runtime library version
-check_runtime_version:"2.16.4"
+check_runtime_version:"2.16.5"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
This PR does the following two changes:
- Updates Mbed TLS version.
- Updates the release information in the ChangeLog header