### PR TITLE
Fix fuzz_pubkey on valid RSA keys

### DIFF
--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -44,7 +44,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         else
 #endif
 #if defined(MBEDTLS_ECP_C)
-        if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY )
+        if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY ||
+            mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY_DH )
         {
             mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( pk );
             mbedtls_ecp_group_id grp_id = ecp->grp.id;

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -59,9 +59,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         }
         else
 #endif
-            {
-                ret = 0;
-            }
+        {
+            /* The key is valid but is not of a supported type.
+             * This should not happen. */
+            abort( );
+        }
     }
     mbedtls_pk_free( &pk );
 #else

--- a/programs/fuzz/fuzz_privkey.c
+++ b/programs/fuzz/fuzz_privkey.c
@@ -46,12 +46,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #if defined(MBEDTLS_ECP_C)
         if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY )
         {
-            mbedtls_ecp_keypair *ecp;
+            mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( pk );
+            mbedtls_ecp_group_id grp_id = ecp->grp.id;
+            const mbedtls_ecp_curve_info *curve_info =
+                mbedtls_ecp_curve_info_from_grp_id( grp_id );
 
-            ecp = mbedtls_pk_ec( pk );
-            if (ecp) {
-                ret = 0;
-            }
+            /* If the curve is not supported, the key should not have been
+             * accepted. */
+            if( curve_info == NULL )
+                abort( );
         }
         else
 #endif

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -21,7 +21,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             mbedtls_mpi_init( &DQ ); mbedtls_mpi_init( &QP );
 
             rsa = mbedtls_pk_rsa( pk );
-            if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != 0 ) {
+            if ( mbedtls_rsa_export( rsa, &N, NULL, NULL, NULL, &E ) != 0 ) {
+                abort();
+            }
+            if ( mbedtls_rsa_export( rsa, &N, &P, &Q, &D, &E ) != MBEDTLS_ERR_RSA_BAD_INPUT_DATA ) {
                 abort();
             }
             if ( mbedtls_rsa_export_crt( rsa, &DP, &DQ, &QP ) != MBEDTLS_ERR_RSA_BAD_INPUT_DATA ) {

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -39,7 +39,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         else
 #endif
 #if defined(MBEDTLS_ECP_C)
-        if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY )
+        if( mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY ||
+            mbedtls_pk_get_type( &pk ) == MBEDTLS_PK_ECKEY_DH )
         {
             mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( pk );
             mbedtls_ecp_group_id grp_id = ecp->grp.id;

--- a/programs/fuzz/fuzz_pubkey.c
+++ b/programs/fuzz/fuzz_pubkey.c
@@ -60,7 +60,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         else
 #endif
         {
-            ret = 0;
+            /* The key is valid but is not of a supported type.
+             * This should not happen. */
+            abort( );
         }
     }
     mbedtls_pk_free( &pk );


### PR DESCRIPTION
`fuzz_pubkey` was systematically failing on valid RSA keys, due to a bug in the sanity checks performed as part of the fuzzed code. Fix this.

Also improve the sanity checks on non-RSA keys.
