### PR TITLE
Add checks for maximum allocation being exceeded

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -260,7 +260,7 @@ typedef enum
     do                                                            \
     {                                                             \
         TEST_ASSERT( ( pointer ) == NULL );                       \
-        if( ( length ) != 0 )                                     \
+        if( ( length ) != 0 && ( length ) < SIZE_MAX )             \
         {                                                         \
             ( pointer ) = mbedtls_calloc( sizeof( *( pointer ) ), \
                                           ( length ) );           \


### PR DESCRIPTION
## Description
This is adds bounds checks on use of `calloc` to ensure the maximum possible allocation is not exceeded.

This change isn't needed to fix a warning or issue, but is added to mirror an equivalent fix in `mbed-crypto` which were causing a warning (specifically `-Werror=alloc-size-larger-than` in GCC 7. That was addressed in PR [#377](https://github.com/ARMmbed/mbed-crypto/pull/377).

## Status
**READY**

## Requires Backporting
NO  - Mbed Crypto isn't present in LTS branches, and this issue wasn't causing an issue, so is an enhancement.

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
