### PR TITLE
Fix remaining occurrences of config.pl in all.sh

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1185,8 +1185,8 @@ component_test_platform_calloc_macro () {
 
 component_test_malloc_0_null () {
     msg "build: malloc(0) returns NULL (ASan+UBSan build)"
-    scripts/config.pl full
-    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
+    scripts/config.py full
+    scripts/config.py unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
     make CC=gcc CFLAGS="'-DMBEDTLS_CONFIG_FILE=\"$PWD/tests/configs/config-wrapper-malloc-0-null.h\"' -O -Werror -Wall -Wextra -fsanitize=address,undefined" LDFLAGS='-fsanitize=address,undefined'
 
     msg "test: malloc(0) returns NULL (ASan+UBSan build)"
@@ -1235,12 +1235,12 @@ test_build_opt () {
 }
 
 component_test_clang_opt () {
-    scripts/config.pl full
+    scripts/config.py full
     test_build_opt 'full config' clang -O0 -Os -O2
 }
 
 component_test_gcc_opt () {
-    scripts/config.pl full
+    scripts/config.py full
     test_build_opt 'full config' gcc -O0 -Os -O2
 }
 


### PR DESCRIPTION
## Description

The .pl version is now a compat wrapper around the .py script. Better call the .py script directly.

This PR is intended to remove a few simple merge conflicts when merging crypto back, by making sure both sides use .py everywhere.

## Status
**READY**

## Requires Backporting

NO - the TLS branches don't have config.py

