### PR TITLE
Backport 2.7: Enhance the `output_env.sh` script with GBD and Distro version

### DIFF
--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -23,11 +23,15 @@ print_version()
     shift
     ARGS="$1"
     shift
-    FAIL_MSG="$1"
+    VARIANT=$1
     shift
 
+    if [ ! -z $VARIANT ]; then
+        VARIANT=" ($VARIANT)"
+    fi
+
     if ! `type "$BIN" > /dev/null 2>&1`; then
-        echo "* $FAIL_MSG"
+        echo " * ${BIN##*/}$VARIANT: Not found."
         return 0
     fi
 
@@ -41,76 +45,93 @@ print_version()
         VERSION_STR=`echo "$VERSION_STR" | $FILTER`
     done
 
-    echo "* ${BIN##*/}: $BIN: $VERSION_STR"
+    echo " * ${BIN##*/}$VARIANT: ${BIN} : ${VERSION_STR} "
 }
 
-print_version "uname" "-a" ""
+echo "Platform:\n"
+if `type "lsb_release" > /dev/null 2>&1`; then
+    echo "Linux variant"
+    lsb_release -d -c
+else
+    echo "Unknown Unix variant"
+fi
+
 echo
+
+print_version "uname" "-a" ""
+echo "\n"
+echo "Tool Versions:\n"
 
 if [ "${RUN_ARMCC:-1}" -ne 0 ]; then
     : "${ARMC5_CC:=armcc}"
-    print_version "$ARMC5_CC" "--vsn" "armcc not found!" "head -n 2"
+    print_version "$ARMC5_CC" "--vsn" "" "head -n 2"
     echo
 
     : "${ARMC6_CC:=armclang}"
-    print_version "$ARMC6_CC" "--vsn" "armclang not found!" "head -n 2"
+    print_version "$ARMC6_CC" "--vsn" "" "head -n 2"
     echo
 fi
 
-print_version "arm-none-eabi-gcc" "--version" "gcc-arm not found!" "head -n 1"
+print_version "arm-none-eabi-gcc" "--version" "" "head -n 1"
 echo
 
-print_version "gcc" "--version" "gcc not found!" "head -n 1"
+print_version "gcc" "--version" "" "head -n 1"
 echo
 
-print_version "clang" "--version" "clang not found" "head -n 2"
+print_version "clang" "--version" "" "head -n 2"
 echo
 
-print_version "ldd" "--version"                     \
-    "No ldd present: can't determine libc version!" \
-    "head -n 1"
+print_version "ldd" "--version" "" "head -n 1"
 echo
 
-print_version "valgrind" "--version" "valgrind not found!"
+print_version "valgrind" "--version" ""
+echo
+
+print_version "gdb" "--version" "" "head -n 1"
 echo
 
 : ${OPENSSL:=openssl}
-print_version "$OPENSSL" "version" "openssl not found!"
+print_version "$OPENSSL" "version" "default"
 echo
 
 if [ -n "${OPENSSL_LEGACY+set}" ]; then
-    print_version "$OPENSSL_LEGACY" "version" "openssl legacy version not found!"
-    echo
+    print_version "$OPENSSL_LEGACY" "version" "legacy"
+else
+    echo " * openssl (legacy): Not configured."
 fi
+echo
 
 : ${GNUTLS_CLI:=gnutls-cli}
-print_version "$GNUTLS_CLI" "--version" "gnuTLS client not found!" "head -n 1"
+print_version "$GNUTLS_CLI" "--version" "default" "head -n 1"
 echo
 
 : ${GNUTLS_SERV:=gnutls-serv}
-print_version "$GNUTLS_SERV" "--version" "gnuTLS server not found!" "head -n 1"
+print_version "$GNUTLS_SERV" "--version" "default" "head -n 1"
 echo
 
 if [ -n "${GNUTLS_LEGACY_CLI+set}" ]; then
-    print_version "$GNUTLS_LEGACY_CLI" "--version" \
-        "gnuTLS client legacy version not found!"  \
-        "head -n 1"
-    echo
+    print_version "$GNUTLS_LEGACY_CLI" "--version" "legacy" "head -n 1"
+else
+     echo " * gnutls-cli (legacy): Not configured."
 fi
+echo
 
 if [ -n "${GNUTLS_LEGACY_SERV+set}" ]; then
-    print_version "$GNUTLS_LEGACY_SERV" "--version" \
-        "gnuTLS server legacy version not found!"   \
-        "head -n 1"
-    echo
+    print_version "$GNUTLS_LEGACY_SERV" "--version" "legacy" "head -n 1"
+else
+    echo " * gnutls-serv (legacy): Not configured."
 fi
+echo
 
-if `hash dpkg > /dev/null 2>&1`; then
-    echo "* asan:"
+echo " * Installed asan versions:"
+if `hash dpkg > /dev/null 2>&1` && `dpkg --get-selections|grep libasan > /dev/null` ; then
+    dpkg -s libasan5 2> /dev/null | grep -i version
+    dpkg -s libasan4 2> /dev/null | grep -i version
+    dpkg -s libasan3 2> /dev/null | grep -i version
     dpkg -s libasan2 2> /dev/null | grep -i version
     dpkg -s libasan1 2> /dev/null | grep -i version
     dpkg -s libasan0 2> /dev/null | grep -i version
 else
-    echo "* No dpkg present: can't determine asan version!"
+    echo "   Either dpkg not present or no asan versions installed."
 fi
 echo


### PR DESCRIPTION
## Description

This is backport of PR #3072.

This pull request adds additional information to be outputted by the `output_env.sh` script of:
  * the Linux distribution version (if available)
  * the GDB version (if available)

It also makes some information clearer:
  * the type of OpenSSL/GNUTLS version (legacy/default)
  * and whether certain versions are not installed, or not configured

And it simplifies the error messages for absent tools.

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
