### PR TITLE
test_suite_ssl: check for errors during queue setup

### DIFF
--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2380,7 +2380,7 @@ void ssl_message_queue_sanity( )
     TEST_ASSERT( mbedtls_test_message_queue_pop_info( NULL, 1 )
                  == MBEDTLS_TEST_ERROR_ARG_NULL );
 
-    mbedtls_test_message_queue_setup( &queue, 3 );
+    TEST_ASSERT( mbedtls_test_message_queue_setup( &queue, 3 ) == 0 );
     TEST_ASSERT( queue.capacity == 3 );
     TEST_ASSERT( queue.num == 0 );
 
@@ -2394,7 +2394,7 @@ void ssl_message_queue_basic( )
 {
     mbedtls_test_message_queue queue;
 
-    mbedtls_test_message_queue_setup( &queue, 3 );
+    TEST_ASSERT( mbedtls_test_message_queue_setup( &queue, 3 ) == 0 );
 
     /* Sanity test - 3 pushes and 3 pops with sufficient space */
     TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
@@ -2421,7 +2421,7 @@ void ssl_message_queue_overflow_underflow( )
 {
     mbedtls_test_message_queue queue;
 
-    mbedtls_test_message_queue_setup( &queue, 3 );
+    TEST_ASSERT( mbedtls_test_message_queue_setup( &queue, 3 ) == 0 );
 
     /* 4 pushes (last one with an error), 4 pops (last one with an error) */
     TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, 1 ) == 1 );
@@ -2447,7 +2447,7 @@ void ssl_message_queue_interleaved( )
 {
     mbedtls_test_message_queue queue;
 
-    mbedtls_test_message_queue_setup( &queue, 3 );
+    TEST_ASSERT( mbedtls_test_message_queue_setup( &queue, 3 ) == 0 );
 
     /* Interleaved test - [2 pushes, 1 pop] twice, and then two pops
      * (to wrap around the buffer) */
@@ -2483,7 +2483,7 @@ void ssl_message_queue_insufficient_buffer( )
     size_t message_len = 10;
     size_t buffer_len = 5;
 
-    mbedtls_test_message_queue_setup( &queue, 1 );
+    TEST_ASSERT( mbedtls_test_message_queue_setup( &queue, 1 ) == 0 );
 
     /* Popping without a sufficient buffer */
     TEST_ASSERT( mbedtls_test_message_queue_push_info( &queue, message_len )


### PR DESCRIPTION
This PR fixes gcc7 warnings about uninitialized queue members.