### PR TITLE
Backport baremetal: Add zlib tests and fix runtime bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ mbed TLS ChangeLog (Sorted per branch, date)
 
 = mbed TLS "baremetal" branch
 
+Bugfix
+   * Fix build failure with MBEDTLS_ZLIB_SUPPORT enabled. Reported by
+     Jack Lloyd in #2859. Fix submitted by jiblime in #2963.
+
 Features
    * Add new configuration option MBEDTLS_SSL_NO_SESSION_CACHE that enables
      code size savings in configurations where cache-based session resumption is

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5587,7 +5587,7 @@ static int ssl_check_client_reconnect( mbedtls_ssl_context *ssl )
 #endif /* MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE && MBEDTLS_SSL_SRV_C */
 
 /*
- * If applicable, decrypt (and decompress) record content
+ * If applicable, decrypt record content
  */
 static int ssl_prepare_record_content( mbedtls_ssl_context *ssl,
                                        mbedtls_record *rec )
@@ -5709,18 +5709,6 @@ static int ssl_prepare_record_content( mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_PROTO_TLS */
 
     }
-
-#if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( ssl->transform_in != NULL &&
-        ssl->session_in->compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
-    {
-        if( ( ret = ssl_decompress_buf( ssl ) ) != 0 )
-        {
-            MBEDTLS_SSL_DEBUG_RET( 1, "ssl_decompress_buf", ret );
-            return( ret );
-        }
-    }
-#endif /* MBEDTLS_ZLIB_SUPPORT */
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
     if( MBEDTLS_SSL_TRANSPORT_IS_DTLS( ssl->conf->transport ) )
@@ -6608,6 +6596,26 @@ static int ssl_get_next_record( mbedtls_ssl_context *ssl )
     ssl->in_msg    = rec.buf + rec.data_offset;
     ssl->in_msglen = rec.data_len;
     (void)mbedtls_platform_put_uint16_be( ssl->in_len, rec.data_len );
+
+#if defined(MBEDTLS_ZLIB_SUPPORT)
+    if( ssl->transform_in != NULL &&
+        ssl->session_in->compression == MBEDTLS_SSL_COMPRESS_DEFLATE )
+    {
+        if( ( ret = ssl_decompress_buf( ssl ) ) != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_RET( 1, "ssl_decompress_buf", ret );
+            return( ret );
+        }
+
+        /* Check actual (decompress) record content length against
+         * configured maximum. */
+        if( ssl->in_msglen > MBEDTLS_SSL_IN_CONTENT_LEN )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad message length" ) );
+            return( MBEDTLS_ERR_SSL_INVALID_RECORD );
+        }
+    }
+#endif /* MBEDTLS_ZLIB_SUPPORT */
 
     return( 0 );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1960,7 +1960,7 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 
     /* Allocate compression buffer */
 #if defined(MBEDTLS_ZLIB_SUPPORT)
-    if( session->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
+    if( ssl->session_negotiate->compression == MBEDTLS_SSL_COMPRESS_DEFLATE &&
         ssl->compress_buf == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "Allocating compression buffer" ) );

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -651,6 +651,31 @@ component_test_full_cmake_gcc_asan () {
     if_build_succeeded tests/compat.sh
 }
 
+component_test_zlib_make() {
+    msg "build: zlib enabled, make"
+    scripts/config.pl set MBEDTLS_ZLIB_SUPPORT
+    make ZLIB=1 CFLAGS='-Werror -O1'
+
+    msg "test: main suites (zlib, make)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, make)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
+component_test_zlib_cmake() {
+    msg "build: zlib enabled, cmake"
+    scripts/config.pl set MBEDTLS_ZLIB_SUPPORT
+    cmake -D ENABLE_ZLIB_SUPPORT=On -D CMAKE_BUILD_TYPE:String=Check .
+    make
+
+    msg "test: main suites (zlib, cmake)"
+    make test
+
+    msg "test: ssl-opt.sh (zlib, cmake)"
+    if_build_succeeded tests/ssl-opt.sh
+}
+
 component_test_ref_configs () {
     msg "test/build: ref-configs (ASan build)" # ~ 6 min 20s
     CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -662,6 +662,17 @@ component_test_zlib_make() {
     msg "test: ssl-opt.sh (zlib, make)"
     if_build_succeeded tests/ssl-opt.sh
 }
+support_test_zlib_make () {
+    base=support_test_zlib_$$
+    cat <<'EOF' > ${base}.c
+#include "zlib.h"
+int main(void) { return 0; }
+EOF
+    gcc -o ${base}.exe ${base}.c -lz 2>/dev/null
+    ret=$?
+    rm -f ${base}.*
+    return $ret
+}
 
 component_test_zlib_cmake() {
     msg "build: zlib enabled, cmake"
@@ -674,6 +685,9 @@ component_test_zlib_cmake() {
 
     msg "test: ssl-opt.sh (zlib, cmake)"
     if_build_succeeded tests/ssl-opt.sh
+}
+support_test_zlib_cmake () {
+    support_test_zlib_make "$@"
 }
 
 component_test_ref_configs () {

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1150,6 +1150,18 @@ run_test    "Default, choose highest security suite and hash, DTLS" \
             -s "client hello v3, signature_algorithm ext: 6" \
             -s "ECDHE curve: secp521r1"
 
+requires_config_enabled MBEDTLS_ZLIB_SUPPORT
+run_test    "Default (compression enabled)" \
+            "$P_SRV debug_level=3" \
+            "$P_CLI debug_level=3" \
+            0 \
+            -s "Allocating compression buffer" \
+            -c "Allocating compression buffer" \
+            -s "Record expansion is unknown (compression)" \
+            -c "Record expansion is unknown (compression)" \
+            -S "error" \
+            -C "error"
+
 # Test current time in ServerHello
 requires_config_enabled MBEDTLS_HAVE_TIME
 run_test    "ServerHello contains gmt_unix_time" \


### PR DESCRIPTION
## Description

This is a backport of PR #2975, 'Add zlib tests and fix runtime bug' to the `baremetal` branch. This is necessary as whilst the fix was already backported to `mbedtls2.16`, which will be merged into `baremetal`, that backport only included the extra tests, not the actual fix as the bug wasn't present in `mbedtls-2.16`.

For whatever reason the bug *is* present in `baremetal`, so this second backport of PR #2975 includes the fix as well as the tests.

Once that's merged, `mbedtls-2.16` can be merged into `baremetal`. Unfortunately it can't be merged before, as including the tests (already present on `mbedtls-2.16` branch) before the fix will just cause the CI to fail.

This PR fixes a gap in our testing: we didn't test any build with zlib (for TLS record compression) enabled. This is a deprecated option but it should nonetheless be tested until it's removed for real.

The usefulness of these tests is illustrated by the fact that in their absence, we introduced two bug in 2.19 that caused us to fail to build or run with zlib enabled: #2859 plus another one that was found by the tests and is fixed in this PR.

__Dependencies:__ This PR is based on #2963 which fixes a bug in building with zlib - the added test obviously wouldn't pass without that fix.

## Status
**READY**

## Migrations

NO

## Additional comments

No ChangeLog entry as this is only a change in tests, not in the library, and the runtime bug probably doesn't need it own entry as it was hidden by the compile bug.

## Steps to test or reproduce

Run `tests/scripts/all.sh 'test_zlib*'` and observe the result, in particular the two lines with `Default (compression enabled)` in the output of `ssl-opt.sh`.
