### PR TITLE
Backport 2.16: Change the use of pylint to optionally use pylint3

### DIFF
--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -105,7 +105,16 @@ echo
 print_version "python" "--version" "" "head -n 1"
 echo
 
-print_version "pylint3" "--version" "" "sed /^.*config/d" "grep pylint"
+# Find the installed version of Pylint. Installed as a distro package this can
+# be pylint3 and as a PEP egg, pylint. In test scripts We prefer pylint over
+# pylint3
+if type pylint >/dev/null 2>/dev/null; then
+    print_version "pylint" "--version" "" "sed /^.*config/d" "grep pylint"
+elif type pylint3 >/dev/null 2>/dev/null; then
+    print_version "pylint3" "--version" "" "sed /^.*config/d" "grep pylint"
+else
+    echo " * pylint or pylint3: Not found."
+fi
 echo
 
 : ${OPENSSL:=openssl}

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1410,7 +1410,13 @@ component_test_zeroize () {
 }
 
 support_check_python_files () {
-    type pylint3 >/dev/null 2>/dev/null
+    # Find the installed version of Pylint. Installed as a distro package this can
+    # be pylint3 and as a PEP egg, pylint.
+    if type pylint >/dev/null 2>/dev/null || type pylint3 >/dev/null 2>/dev/null; then
+        true;
+    else
+        false;
+    fi
 }
 component_check_python_files () {
     msg "Lint: Python scripts"

--- a/tests/scripts/check-python-files.sh
+++ b/tests/scripts/check-python-files.sh
@@ -9,4 +9,15 @@
 # Run 'pylint' on Python files for programming errors and helps enforcing
 # PEP8 coding standards.
 
-pylint3 -j 2 scripts/*.py tests/scripts/*.py
+# Find the installed version of Pylint. Installed as a distro package this can
+# be pylint3 and as a PEP egg, pylint. We prefer pylint over pylint3
+if type pylint >/dev/null 2>/dev/null; then
+    PYLINT=pylint
+elif type pylint3 >/dev/null 2>/dev/null; then
+    PYLINT=pylint3
+else
+    echo 'Pylint was not found.'
+    exit 1
+fi
+
+$PYLINT -j 2 scripts/*.py tests/scripts/*.py


### PR DESCRIPTION
## Description

This is a backport of PR #3100 to `mbedtls-2.16`.

Pylint when installed as a distro package can be installed as `pylint3`, whilst as a PEP egg or directly from the `pylint` website, it can be installed as `pylint`.

This pull request changes the scripts to first use `pylint` if installed, and optionally look for `pylint3` if not installed. This is to allow a preference for the PEP version over the distro version, assuming the PEP one is more likely to be the correct one.

I'll do the back ports once this PR has been reviewed and approved, and thereby approving the approach.

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
