### PR TITLE
ssl_srv.c: initialize flags on each iteration of the loop

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -840,6 +840,7 @@ static int ssl_pick_cert( mbedtls_ssl_context *ssl,
 
     for( cur = list; cur != NULL; cur = cur->next )
     {
+        flags = 0;
         MBEDTLS_SSL_DEBUG_CRT( 3, "candidate certificate chain, certificate",
                           cur->cert );
 


### PR DESCRIPTION
This PR fixes #2444.
Although the 'flags' variable is not checked or used after a call to mbedtls_ssl_check_cert_usage, it might be in the future. With this fix, after each iteration, the flags will apply only to the most recent certificate, not to any of the previous ones checked. This fix also stops any reads and writes via a '|=' from/to an uninitialized variable happening.