### PR TITLE
[Backport 2.16] Improve some test names in ssl-opt.sh

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1387,7 +1387,7 @@ run_test    "Encrypt then MAC: empty application data record" \
             -s "dumping 'input payload after decrypt' (0 bytes)" \
             -c "0 bytes written in 1 fragments"
 
-run_test    "Default, no Encrypt then MAC: empty application data record" \
+run_test    "Encrypt then MAC: disabled, empty application data record" \
             "$P_SRV auth_mode=none debug_level=4 etm=0" \
             "$P_CLI auth_mode=none etm=0 request_size=0" \
             0 \
@@ -1402,7 +1402,7 @@ run_test    "Encrypt then MAC, DTLS: empty application data record" \
             -s "dumping 'input payload after decrypt' (0 bytes)" \
             -c "0 bytes written in 1 fragments"
 
-run_test    "Default, no Encrypt then MAC, DTLS: empty application data record" \
+run_test    "Encrypt then MAC, DTLS: disabled, empty application data record" \
             "$P_SRV auth_mode=none debug_level=4 etm=0 dtls=1" \
             "$P_CLI auth_mode=none etm=0 request_size=0 dtls=1" \
             0 \


### PR DESCRIPTION
This is the 2.16 backport of #3113
