### PR TITLE
[mbedtls-2.16] Typo fix in test_suite_asn1write.function

### DIFF
--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -78,7 +78,7 @@ void mbedtls_asn1_write_ia5_string( char * str, data_t * asn1,
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ASN1PARSE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_ASN1_PARSE_C */
 void mbedtls_asn1_write_len( int len, data_t * asn1, int buf_len,
                              int result )
 {


### PR DESCRIPTION
This PR fixes #2782 , spotted by tmarti2.
This issue does not exist on development, it has been fixed in the so called meantime.
Signed-off-by: Andrzej Kurek <andrzej.kurek@arm.com>
