### PR TITLE
Sort changelog entries by their merge date

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -260,6 +260,15 @@ def remove_merged_entries(files_to_remove):
     for filename in files_to_remove:
         os.remove(filename)
 
+def list_files_to_merge(options):
+    """List the entry files to merge, oldest first.
+
+    A file is considered older if it was merged earlier. See
+    `FileMergeTimestamp` for details.
+    """
+    files_to_merge = glob.glob(os.path.join(options.dir, '*.md'))
+    return files_to_merge
+
 def merge_entries(options):
     """Merge changelog entries into the changelog file.
 
@@ -270,7 +279,7 @@ def merge_entries(options):
     """
     with open(options.input, 'rb') as input_file:
         changelog = ChangeLog(input_file)
-    files_to_merge = glob.glob(os.path.join(options.dir, '*.md'))
+    files_to_merge = list_files_to_merge(options)
     if not files_to_merge:
         sys.stderr.write('There are no pending changelog entries.\n')
         return

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Assemble Mbed Crypto change log entries into the change log file.
+"""Assemble Mbed TLS change log entries into the change log file.
 
 Add changelog entries to the first level-2 section.
 Create a new level-2 section for unreleased changes if needed.
@@ -33,7 +33,7 @@ You must run this program from within a git working directory.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This file is part of Mbed Crypto (https://tls.mbed.org)
+# This file is part of Mbed TLS (https://tls.mbed.org)
 
 import argparse
 from collections import OrderedDict
@@ -70,7 +70,7 @@ STANDARD_SECTIONS = (
 )
 
 class ChangeLog:
-    """An Mbed Crypto changelog.
+    """An Mbed TLS changelog.
 
     A changelog is a file in Markdown format. Each level 2 section title
     starts a version, and versions are sorted in reverse chronological

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -261,12 +261,14 @@ class EntryFileSortKey:
         Return None if the file was never checked into git.
         """
         hashes = subprocess.check_output(['git', 'log', '--format=%H', '--', filename])
-        if not hashes:
-            # The file was never checked in.
+        m = re.search(b'(.+)$', hashes)
+        if not m:
+            # The git output is empty. This means that the file was
+            # never checked in.
             return None
-        hashes = hashes.rstrip(b'\n')
-        last_hash = hashes[hashes.rfind(b'\n')+1:]
-        return last_hash
+        # The last commit in the log is the oldest one, which is when the
+        # file was created.
+        return m.group(0)
 
     @staticmethod
     def list_merges(some_hash, target, *options):

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -400,7 +400,7 @@ def list_files_to_merge(options):
     "Oldest" is defined by `EntryFileSortKey`.
     """
     files_to_merge = glob.glob(os.path.join(options.dir, '*.md'))
-    files_to_merge.sort(key=lambda f: EntryFileSortKey(f).sort_key())
+    files_to_merge.sort(key=EntryFileSortKey)
     return files_to_merge
 
 def merge_entries(options):

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -260,7 +260,9 @@ class EntryFileSortKey:
 
         Return None if the file was never checked into git.
         """
-        hashes = subprocess.check_output(['git', 'log', '--format=%H', '--', filename])
+        hashes = subprocess.check_output(['git', 'log', '--format=%H',
+                                          '--follow',
+                                          '--', filename])
         m = re.search(b'(.+)$', hashes)
         if not m:
             # The git output is empty. This means that the file was


### PR DESCRIPTION
In `assemble_changelog.py`, sort changelog entries by their merge date. More precisely: look for the git commit where the entry file was created, and look where this commit was merged into the current branch. List older merges first. List never-merged commits in date order after all the merged ones. List never-committed files in file timestamp order after all the committed ones.

~Follow-up of https://github.com/ARMmbed/mbedtls/pull/3126, the first new commit is "Factor out list_files_to_merge".~ (#3126 has been merged.)