### PR TITLE
makefile: remove unneeded priority dependency from library makefile

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -201,8 +201,6 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	echo "  LD    $@"
 	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS_CRYPTO) -lws2_32 -lwinmm -lgdi32 -static-libgcc $(LOCAL_LDFLAGS) $(LDFLAGS)
 
-libmbedcrypto.$(DLEXT): | libmbedcrypto.a
-
 .c.o:
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<


### PR DESCRIPTION
This change was first introduced in 8af3923 - see this commit for more background.
After the removal of crypto directory, there are no targets that require a crypto library with the directory prefix, so there's also no need for the priority dependency to be declared. This PR removes it.

This PR resolves https://github.com/ARMmbed/mbedtls/issues/3109.
