### PR TITLE
Fix issues in handling of client reconnecting from the same port

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,14 @@ New deprecations
    * Deprecate MBEDTLS_SSL_HW_RECORD_ACCEL that enables function hooks in the
      SSL module for hardware acceleration of individual records.
 
+Security
+   * Fix issue in DTLS handling of new associations with the same parameters
+     (RFC 6347 section 4.2.8): an attacker able to send forged UDP packets to
+     the server could cause it to drop established associations with
+     legitimate clients, resulting in a Denial of Service. This could only
+     happen when MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE was enabled in config.h
+     (which it is by default).
+
 Bugfix
    * Fix compilation failure when both MBEDTLS_SSL_PROTO_DTLS and
      MBEDTLS_SSL_HW_RECORD_ACCEL are enabled.

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3197,16 +3197,17 @@ static int ssl_check_dtls_clihlo_cookie(
  * that looks like a ClientHello.
  *
  * - if the input looks like a ClientHello without cookies,
- *   send back HelloVerifyRequest, then
- *   return MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED
+ *   send back HelloVerifyRequest, then return 0
  * - if the input looks like a ClientHello with a valid cookie,
  *   reset the session of the current context, and
  *   return MBEDTLS_ERR_SSL_CLIENT_RECONNECT
  * - if anything goes wrong, return a specific error code
  *
- * mbedtls_ssl_read_record() will ignore the record if anything else than
- * MBEDTLS_ERR_SSL_CLIENT_RECONNECT or 0 is returned, although this function
- * cannot not return 0.
+ * This function is called (through ssl_check_client_reconnect()) when an
+ * unexpected record is found in ssl_get_next_record(), which will discard the
+ * record if we return 0, and bubble up the return value otherwise (this
+ * includes the case of MBEDTLS_ERR_SSL_CLIENT_RECONNECT and of unexpected
+ * errors, and is the right thing to do in both cases).
  */
 static int ssl_handle_possible_reconnect( mbedtls_ssl_context *ssl )
 {
@@ -3237,7 +3238,7 @@ static int ssl_handle_possible_reconnect( mbedtls_ssl_context *ssl )
          * If the error is permanent we'll catch it later,
          * if it's not, then hopefully it'll work next time. */
         (void) ssl->f_send( ssl->p_bio, ssl->out_buf, len );
-        ret = 0;
+        return( 0 );
     }
 
     if( ret == 0 )

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -3219,6 +3219,8 @@ static int ssl_handle_possible_reconnect( mbedtls_ssl_context *ssl )
     {
         /* If we can't use cookies to verify reachability of the peer,
          * drop the record. */
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "no cookie callbacks, "
+                                    "can't check reconnect validity" ) );
         return( 0 );
     }
 
@@ -3234,16 +3236,23 @@ static int ssl_handle_possible_reconnect( mbedtls_ssl_context *ssl )
 
     if( ret == MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED )
     {
+        int send_ret;
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "sending HelloVerifyRequest" ) );
+        MBEDTLS_SSL_DEBUG_BUF( 4, "output record sent to network",
+                                  ssl->out_buf, len );
         /* Don't check write errors as we can't do anything here.
          * If the error is permanent we'll catch it later,
          * if it's not, then hopefully it'll work next time. */
-        (void) ssl->f_send( ssl->p_bio, ssl->out_buf, len );
+        send_ret = ssl->f_send( ssl->p_bio, ssl->out_buf, len );
+        MBEDTLS_SSL_DEBUG_RET( 2, "ssl->f_send", send_ret );
+        (void) send_ret;
+
         return( 0 );
     }
 
     if( ret == 0 )
     {
-        /* Got a valid cookie, partially reset context */
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "cookie is valid, resetting context" ) );
         if( ( ret = mbedtls_ssl_session_reset_int( ssl, 1 ) ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_RET( 1, "reset", ret );
@@ -4416,6 +4425,7 @@ static int ssl_get_next_record( mbedtls_ssl_context *ssl )
                 ssl->in_msglen = rec.data_len;
 
                 ret = ssl_check_client_reconnect( ssl );
+                MBEDTLS_SSL_DEBUG_RET( 2, "ssl_check_client_reconnect", ret );
                 if( ret != 0 )
                     return( ret );
 #endif

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -543,12 +543,13 @@ void print_packet( const packet *p, const char *why )
  *
  * We want an explicit state and a place to store the packet.
  */
-static enum {
-    ich_init,       /* haven't seen the first ClientHello yet */
-    ich_cached,     /* cached the initial ClientHello */
-    ich_injected,   /* ClientHello already injected, done */
-} inject_clihlo_state;
+typedef enum {
+    ICH_INIT,       /* haven't seen the first ClientHello yet */
+    ICH_CACHED,     /* cached the initial ClientHello */
+    ICH_INJECTED,   /* ClientHello already injected, done */
+} inject_clihlo_state_t;
 
+static inject_clihlo_state_t inject_clihlo_state;
 static packet initial_clihlo;
 
 int send_packet( const packet *p, const char *why )
@@ -558,11 +559,11 @@ int send_packet( const packet *p, const char *why )
 
     /* save initial ClientHello? */
     if( opt.inject_clihlo != 0 &&
-        inject_clihlo_state == ich_init &&
+        inject_clihlo_state == ICH_INIT &&
         strcmp( p->type, "ClientHello" ) == 0 )
     {
         memcpy( &initial_clihlo, p, sizeof( packet ) );
-        inject_clihlo_state = ich_cached;
+        inject_clihlo_state = ICH_CACHED;
     }
 
     /* insert corrupted CID record? */
@@ -631,7 +632,7 @@ int send_packet( const packet *p, const char *why )
 
     /* Inject ClientHello after first ApplicationData */
     if( opt.inject_clihlo != 0 &&
-        inject_clihlo_state == ich_cached &&
+        inject_clihlo_state == ICH_CACHED &&
         strcmp( p->type, "ApplicationData" ) == 0 )
     {
         print_packet( &initial_clihlo, "injected" );
@@ -643,7 +644,7 @@ int send_packet( const packet *p, const char *why )
             return( ret );
         }
 
-        inject_clihlo_state = ich_injected;
+        inject_clihlo_state = ICH_INJECTED;
     }
 
     return( 0 );

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -133,6 +133,7 @@ int main( void )
     "                        modifying CID in first instance of the packet.\n" \
     "    protect_hvr=0/1     default: 0 (don't protect HelloVerifyRequest)\n" \
     "    protect_len=%%d      default: (don't protect packets of this size)\n" \
+    "    inject_clihlo=0/1   default: 0 (don't inject fake ClientHello)\n"  \
     "\n"                                                                    \
     "    seed=%%d             default: (use current time)\n"                \
     USAGE_PACK                                                              \
@@ -166,6 +167,7 @@ static struct options
     unsigned bad_cid;           /* inject corrupted CID record              */
     int protect_hvr;            /* never drop or delay HelloVerifyRequest   */
     int protect_len;            /* never drop/delay packet of the given size*/
+    int inject_clihlo;          /* inject fake ClientHello after handshake  */
     unsigned pack;              /* merge packets into single datagram for
                                  * at most \c merge milliseconds if > 0     */
     unsigned int seed;          /* seed for "random" events                 */
@@ -312,6 +314,12 @@ static void get_options( int argc, char *argv[] )
         {
             opt.protect_len = atoi( q );
             if( opt.protect_len < 0 )
+                exit_usage( p, q );
+        }
+        else if( strcmp( p, "inject_clihlo" ) == 0 )
+        {
+            opt.inject_clihlo = atoi( q );
+            if( opt.inject_clihlo < 0 || opt.inject_clihlo > 1 )
                 exit_usage( p, q );
         }
         else if( strcmp( p, "seed" ) == 0 )
@@ -523,10 +531,39 @@ void print_packet( const packet *p, const char *why )
     fflush( stdout );
 }
 
+/*
+ * In order to test the server's behaviour when receiving a ClientHello after
+ * the connection is established (this could be a hard reset from the client,
+ * but the server must not drop the existing connection before establishing
+ * client reachability, see RFC 6347 Section 4.2.8), we memorize the first
+ * ClientHello we see (which can't have a cookie), then replay it after the
+ * first ApplicationData record - then we're done.
+ *
+ * This is controlled by the inject_clihlo option.
+ *
+ * We want an explicit state and a place to store the packet.
+ */
+static enum {
+    ich_init,       /* haven't seen the first ClientHello yet */
+    ich_cached,     /* cached the initial ClientHello */
+    ich_injected,   /* ClientHello already injected, done */
+} inject_clihlo_state;
+
+static packet initial_clihlo;
+
 int send_packet( const packet *p, const char *why )
 {
     int ret;
     mbedtls_net_context *dst = p->dst;
+
+    /* save initial ClientHello? */
+    if( opt.inject_clihlo != 0 &&
+        inject_clihlo_state == ich_init &&
+        strcmp( p->type, "ClientHello" ) == 0 )
+    {
+        memcpy( &initial_clihlo, p, sizeof( packet ) );
+        inject_clihlo_state = ich_cached;
+    }
 
     /* insert corrupted CID record? */
     if( opt.bad_cid != 0 &&
@@ -590,6 +627,23 @@ int send_packet( const packet *p, const char *why )
             mbedtls_printf( "  ! dispatch returned %d\n", ret );
             return( ret );
         }
+    }
+
+    /* Inject ClientHello after first ApplicationData */
+    if( opt.inject_clihlo != 0 &&
+        inject_clihlo_state == ich_cached &&
+        strcmp( p->type, "ApplicationData" ) == 0 )
+    {
+        print_packet( &initial_clihlo, "injected" );
+
+        if( ( ret = dispatch_data( dst, initial_clihlo.buf,
+                                        initial_clihlo.len ) ) <= 0 )
+        {
+            mbedtls_printf( "  ! dispatch returned %d\n", ret );
+            return( ret );
+        }
+
+        inject_clihlo_state = ich_injected;
     }
 
     return( 0 );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7318,6 +7318,14 @@ run_test    "DTLS client reconnect from same port: no cookies" \
             -s "The operation timed out" \
             -S "Client initiated reconnection from same port"
 
+run_test    "DTLS client reconnect from same port: attacker-injected" \
+            -p "$P_PXY inject_clihlo=1" \
+            "$P_SRV dtls=1 exchanges=2 debug_level=1" \
+            "$P_CLI dtls=1 exchanges=2" \
+            0 \
+            -s "possible client reconnect from the same port" \
+            -S "Client initiated reconnection from same port"
+
 # Tests for various cases of client authentication with DTLS
 # (focused on handshake flows and message parsing)
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7279,8 +7279,8 @@ run_test    "DTLS cookie: enabled, nbio" \
 
 not_with_valgrind # spurious resend
 run_test    "DTLS client reconnect from same port: reference" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=1000" \
-            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-1000" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -C "resend" \
             -S "The operation timed out" \
@@ -7288,8 +7288,8 @@ run_test    "DTLS client reconnect from same port: reference" \
 
 not_with_valgrind # spurious resend
 run_test    "DTLS client reconnect from same port: reconnect" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=1000" \
-            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-1000 reconnect_hard=1" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000 reconnect_hard=1" \
             0 \
             -C "resend" \
             -S "The operation timed out" \
@@ -8395,8 +8395,8 @@ run_test    "DTLS fragmenting: 3d, openssl client, DTLS 1.0" \
 not_with_valgrind # spurious resend due to timeout
 run_test    "DTLS proxy: reference" \
             -p "$P_PXY" \
-            "$P_SRV dtls=1 debug_level=2" \
-            "$P_CLI dtls=1 debug_level=2" \
+            "$P_SRV dtls=1 debug_level=2 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -C "replayed record" \
             -S "replayed record" \
@@ -8413,8 +8413,8 @@ run_test    "DTLS proxy: reference" \
 not_with_valgrind # spurious resend due to timeout
 run_test    "DTLS proxy: duplicate every packet" \
             -p "$P_PXY duplicate=1" \
-            "$P_SRV dtls=1 dgram_packing=0 debug_level=2" \
-            "$P_CLI dtls=1 dgram_packing=0 debug_level=2" \
+            "$P_SRV dtls=1 dgram_packing=0 debug_level=2 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 dgram_packing=0 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -c "replayed record" \
             -s "replayed record" \


### PR DESCRIPTION
## Description

This PR fixes several issues related to server-side handling of client re-connecting with the same UDP quartet while we already have an active established connection for that same UDP quartet (our `config.h` option `MBEDTLS_SSL_CLIENT_PORT_REUSE`, implementing [RFC 6347 Section 4.2.8](https://tools.ietf.org/html/rfc6347#section-4.2.8)):

1. We did not actually establish client reachability by verifying the ClientHello cookie before destroying the existing association, which violates the RFC and opens the door to a DoS - see the commit message for details.
2. An indirect side-effect of the previous point is we had a race condition in our tests for that feature in `ssl-opt.sh`, causing one of them to fail quite frequently in the CI (or indeed locally) - see below for details.
3. The timeout values in those `ssl-opt.sh` tests were also a bit too low, which was a secondary (and much less frequent) cause of random failures - see the commit message for details.

While at it the PR also improves debug logging in that area.

### The race condition in the test and how it relates to the bug

The bug in the library was quickly discovered by code review while investigating the intermittent failures of the reconnect test in `ssl-opt.sh` (the client needs to resend a packet, while the test case asserts this shouldn't happen, see below for a convenient way to reproduce those locally), but it was initially unclear how the two were related.

In order to study the intermittent failures, a few ad-hoc modifications to the code were made in a [temporary branch](https://github.com/mpg/mbedtls/tree/debug-timer). Reviewers may check out this branch in order to view the raw logs (and scripts used to generated them) on which the following analysis is based.

#### What happens with no bug (for context)

In the library: when the server has an established connection but receives an
unexpected record (in `ssl_get_next_record()`), it checks (by calling `ssl_check_client_reconnect()` if that record looks like a ClientHello, and if so, it if has a valid cookie in it.

- if the record doesn't look like a ClientHello, it is simply discarded
- if it looks like a ClientHello but doesn't have a valid cookie, we send a HelloVerifyRequest and the discard the record
- if it looks like a ClientHello and has a valid cookie, we destroy the current association but keep the ClientHello in the SSL input buffer, and inform the application by returning `MBEDTLS_ERR_SSL_CLIENT_RECONNECT`.

In `ssl_server2.c`: when `mbedtls_ssl_read()` returns `MBEDTLS_ERR_SSL_CLIENT_RECONNECT` (the other two conditions above are transparent to the application), we print a message an immediately jump to performing a new handshake. Since the SSL context already has a ClientHello with a valid cooking in its input buffer, it accepts it and the handshake continues normally.

In `ssl_client2.c`: after establishing a connection, we fully reset the SSL context but keep the underlying UDP socked connected (to preserve the quartet), the start a handshake. The first ClientHello we send doesn't have a valid cookie, so the library internally sends us a HelloVerifyRequest, to which we reply with a ClientHello with a valid cookie, which causes the library to inform the application and `ssl_server2` to jump to a new handshake.

#### What happened with the bug when the test was passing

In the library sever-side, one case wasn't handled properly:

- if the unexpected record looks like a ClientHello but doesn't have a valid cookie, send a HelloVerifyRequest bu then destroy the association and return `MBEDTLS_ERR_SSL_CLIENT_RECONNECT` to the application.

When the server starts a new handshake, the library will notice the ClientHello doesn't have a valid cookie, so it will send a HelloVerifyRequest (which is now the second one) and `mbedtls_ssl_handshake()` will return `MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED`).

In `ssl_server2.c`: after jumping to a new handshake, and getting the `MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED` we jump to the `reset` label where we:

- close the underlying UDP socket
- fully reset the SSL context
- wait for a new connection

When that new connection arrives (with a valid cookie in the ClientHello), the handshake succeeds.

In the library client-side: during the new handshake, when we receive the second `HelloVerifyRequest`, we discard it as a duplicated record (same record sequence number

In `ssl_client2.c`: when re-establishing the connection, the handshake succeeds.

The order of events is as follows:

1. Server receives ClientHello without cookie.
2. Server sends HelloVerifyRequest (received by client), partially resets context and jumps to handshake, then finds cookie missing, sends second HelloVerifyRequest, stops handshake.
3. Server closes socket, resets context, then waits for new connection.
4. ClientHello with cookie (sent by client in response to the first
  HelloVerifyRequest) is delivered to the server.
5. Server sees that as a new connection and proceeds to a successful handshake.

#### What happened with the bug when the test was failing

Initially things are the same but with a different ordering of events (3 and 4
swapped), then things diverge and finally converge again:

1. Server receives ClientHello without cookie.
2. Server sends HelloVerifyRequest (received by client), partially resets context and jumps to handshake, then finds cookie missing, sends second HelloVerifyRequest, stops handshake.
3. ClientHello with cookie (sent by client in response to the first
  HelloVerifyRequest) is delivered to the server.
4. Server closes socket, resets context, then waits for new connection.
5. Client waits for ServerHello until it times out, then resends it ClientHello (with cookie) - this step causes the test to fail by violating the assertion that the client does not need to restransmit
6. Server sees that as a new connection and proceeds to a successful handshake.

From looking at the proxy and server logs, it is clear that the first ClientHello with cookie was never seen by the server.

#### Root causes of the race condition

Several factors contribute to this race condition:

1. The way we handle UDP sockets (one unconnected "listening" socket, plus one connected (ie, associated to a quartet) "client" socket). While the client socket is open, all datagrams that arrive with the source IP and port associated to it will be delivered to that socket, and when it's closed the datagrams that arrive afterwards are delivered to the listening socket, and seen as new connections.
2. The fact that when `ssl_server2.c` receives a ClientHello without a valid cookie, it closes the client socket (this is where the ClientHello with a cookie is lost when the test fails) - but in general freeing all resources after receiving a cookieless ClientHello is the right thing to do, as doing otherwise gives attackers an easy resource DoS.
3. The bug means that we reach a point where the server will terminate handshake and close the client socket after processor a ClientHello without a valid cookie.

This PR removes the 3rd factor, which was a side-effect of not verifying the cookie when we should: by the time the server reaches handshake again, the SSL input buffer should hold a ClientHello with a valid cookie, so there will be no race at all after that.

Note: the first two points are sufficient to create in principle a race condition for any handshake with a HelloVerifyRequest (can the ClientHello with cookie arrive before the server closes the socket?), which means most DTLS handshakes. However that race only matters for tests that assert that the client does not retransmit - the "hard reconnect" tests do assert that as a means of ensuring that the server indeed keeps the ClientHello with a valid cookie around (ie that the SSL context is partially but not fully reset).

(Also, but this is more speculative, in an initial handshake the server seems more likely to win the race (close the socket before the second ClientHello was delivered, so that it's not lost), as after sending the HelloVerifyRequest it directly jumps to closing the socket, while the client needs to receive the HelloVerifyRequest, parse it, construct a ClientHello with the cookie and send it. Here the fact that a HelloVerifyRequest was sent before the server starts processing the cookieless ClientHello gives the client more time to send its ClientHello with cookie, so it's more likely to arrive before the server closes the client socket, hence be effectively lost.)

A deeper issue (well outside the scope of this PR) seems to be that we're building a connected protocol (DTLS) on top of a connectionless protocol (UDP), and then having tests with several DTLS connections in close succession plus some relatively precise assertions (such as "no resend" here).

Note: we've recently fixed an issue (which we [called DTLS connection overbleed](https://github.com/ARMmbed/mbedtls/pull/3050)) that was sort of the flip side of this one: a datagram from the client (its CloseNotify) sometimes arrived after the server closed the client socket, so it was seen as a new (invalid) connection. Here a client datagram (the cookiefull ClienHello) sometimes arrives before the server closed the client socket, so it's lost rather than beeing seen as a new connection.

## Status

**READY**

## Requires Backporting

NO for the bug fix, YES for the test improvements

The bug itself is not present in any of the LTS branches, so the fix doesn't require backporting.

(The bug was introduced in 2fddd3765ea998bb9f40b52dc1baaf843b9889bf while developing [record checking](https://github.com/ARMmbed/mbedtls/pull/2790), which being a new feature wasn't backported, and the first release that contains it is Mbed TLS 2.19.0.)

However we probably want to backport the non-regression test as well as the change of timeout values in order to keep testing more uniform across maintained branches.

Note: while not present in any LTS branch, the bug is present in the baremetal branch so we probably want to backport the fix there too.

I'll start creating backports once this PR has received enough review:

- [x] 2.16 tests only: #3142 
- [x] 2.7 tests only: #3145
- [x] baremetal bug fix and tests: #3149

## Steps to test or reproduce

Regarding the bug in the library, see the test added in ssl-opt.sh. The effectiveness of that test can be checked by reverting the commit that fixes the bug and observing that the test correctly fails when the bug is present.

Regarding unreliability of the existing reconnect test, I used the following script locally:


```sh
#!/bin/sh

set -e

make lib && (cd programs && make ssl/ssl_client2 ssl/ssl_server2 test/udp_proxy)

fail=0
pass=0
for i in $(seq 1 100); do
    if tests/ssl-opt.sh -p -f 'reconnect$' >/dev/null 2>&1; then
        pass=$(( pass + 1 ))
        printf '.'
    else
        fail=$(( fail + 1 ))
        printf 'x'
    fi
done

printf "\npass: $pass, fail: $fail"
```

- Before this PR, on a lightly loaded machine, failure rate is around 10-15%
- After fixing the library bug, on a lightly loaded machine, there are no more failures.
- But on a loaded machine (ran two instances of `all.sh` in parallel) there are still occasional failures (less than 1%) that were verified in the logs to be purely due to the timeout values being too low (the resend happened at various points in the handshake, including the initial handshake, so it not related to the "reconnect from the same port" part of the test)
- After adjusting the timeouts, I was not able to get the test to fail on my machine.

