### PR TITLE
Fix intermittent crash in test suites with outcome file enabled

### DIFF
--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -425,7 +425,7 @@ static void write_outcome_entry( FILE *outcome_file,
  */
 static void write_outcome_result( FILE *outcome_file,
                                   size_t unmet_dep_count,
-                                  char *unmet_dependencies[],
+                                  int unmet_dependencies[],
                                   int ret,
                                   const test_info_t *info )
 {
@@ -443,7 +443,7 @@ static void write_outcome_result( FILE *outcome_file,
                 mbedtls_fprintf( outcome_file, "SKIP" );
                 for( i = 0; i < unmet_dep_count; i++ )
                 {
-                    mbedtls_fprintf( outcome_file, "%c%s",
+                    mbedtls_fprintf( outcome_file, "%c%d",
                                      i == 0 ? ';' : ':',
                                      unmet_dependencies[i] );
                 }
@@ -598,7 +598,7 @@ int execute_tests( int argc , const char ** argv )
           testfile_index++ )
     {
         size_t unmet_dep_count = 0;
-        char *unmet_dependencies[20];
+        int unmet_dependencies[20];
 
         test_filename = test_files[ testfile_index ];
 
@@ -647,19 +647,7 @@ int execute_tests( int argc , const char ** argv )
                     int dep_id = strtol( params[i], NULL, 10 );
                     if( dep_check( dep_id ) != DEPENDENCY_SUPPORTED )
                     {
-                        if( 0 == option_verbose )
-                        {
-                            /* Only one count is needed if not verbose */
-                            unmet_dep_count++;
-                            break;
-                        }
-
-                        unmet_dependencies[ unmet_dep_count ] = strdup( params[i] );
-                        if(  unmet_dependencies[ unmet_dep_count ] == NULL )
-                        {
-                            mbedtls_fprintf( stderr, "FATAL: Out of memory\n" );
-                            mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-                        }
+                        unmet_dependencies[unmet_dep_count] = dep_id;
                         unmet_dep_count++;
                     }
                 }
@@ -730,9 +718,8 @@ int execute_tests( int argc , const char ** argv )
                     mbedtls_fprintf( stdout, "\n   Unmet dependencies: " );
                     for( i = 0; i < unmet_dep_count; i++ )
                     {
-                        mbedtls_fprintf( stdout, "%s  ",
+                        mbedtls_fprintf( stdout, "%d ",
                                         unmet_dependencies[i] );
-                        free( unmet_dependencies[i] );
                     }
                 }
                 mbedtls_fprintf( stdout, "\n" );
@@ -783,10 +770,6 @@ int execute_tests( int argc , const char ** argv )
                 total_errors++;
         }
         fclose( file );
-
-        /* In case we encounter early end of file */
-        for( i = 0; i < unmet_dep_count; i++ )
-            free( unmet_dependencies[i] );
     }
 
     if( outcome_file != NULL )


### PR DESCRIPTION
Fix an intermittent crash when running test suites in non-verbose
mode (i.e. with -v off) and with the outcome file enabled. The
array unmet_dependencies was only filled in verbose mode, but was used
in write_outcome_result regardless.

Since unmet_dependencies only ever contains strings that are integers
written out in decimal, store the integer instead. Do this
unconditionally since it doesn't cost any extra memory.

It would be better to record the dependency names, both in the verbose
output and in the outcome file. But the dependency names are not
currently available at runtime, and adding them would be beyond the scope of this PR.

Backports: not needed since the outcome file only exists on development. However I think we should make a partial 2.16 backport to change `unmet_dependencies` to `int`, because that would make the code more robust (and save a little heap memory, too). Not applicable at all to 2.7 where `unmet_dependencies` directly stores `MBEDTLS_xxx` strings and not integers.
