### PR TITLE
[2.7 only] Note that unmet_dependencies is only filled in verbose mode

### DIFF
--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -348,7 +348,7 @@ int main(int argc, const char *argv[])
           testfile_index++ )
     {
         int unmet_dep_count = 0;
-        char *unmet_dependencies[20];
+        char *unmet_dependencies[20]; /* only filled when verbose != 0 */
 
         test_filename = test_files[ testfile_index ];
 
@@ -369,6 +369,7 @@ int main(int argc, const char *argv[])
                 mbedtls_exit( MBEDTLS_EXIT_FAILURE );
             }
             unmet_dep_count = 0;
+            memset( unmet_dependencies, 0, sizeof( unmet_dependencies ) );
 
             if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
                 break;
@@ -391,18 +392,16 @@ int main(int argc, const char *argv[])
                 {
                     if( dep_check( params[i] ) != DEPENDENCY_SUPPORTED )
                     {
-                        if( 0 == option_verbose )
+                        if( 0 != option_verbose )
                         {
-                            /* Only one count is needed if not verbose */
-                            unmet_dep_count++;
-                            break;
-                        }
-
-                        unmet_dependencies[ unmet_dep_count ] = strdup(params[i]);
-                        if(  unmet_dependencies[ unmet_dep_count ] == NULL )
-                        {
-                            mbedtls_fprintf( stderr, "FATAL: Out of memory\n" );
-                            mbedtls_exit( MBEDTLS_EXIT_FAILURE );
+                            unmet_dependencies[unmet_dep_count] =
+                                strdup( params[i] );
+                            if(  unmet_dependencies[unmet_dep_count] == NULL )
+                            {
+                                mbedtls_fprintf( stderr,
+                                                 "FATAL: Out of memory\n" );
+                                mbedtls_exit( MBEDTLS_EXIT_FAILURE );
+                            }
                         }
                         unmet_dep_count++;
                     }


### PR DESCRIPTION
Warn about a gotcha that caused a bug in development.

Even in non-verbose mode, unmet_dep_count can be 1. In this case
ensure that unmet_dependencies[0] is initialized (to NULL).

Partial backport of https://github.com/ARMmbed/mbedtls/pull/3140: there's no bug in 2.7 but there is the fragile bit of code.
