### PR TITLE
[Backport baremetal] Fix issues in handling of client reconnecting from the same port

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5273,7 +5273,7 @@ static int ssl_handle_possible_reconnect( mbedtls_ssl_context *ssl )
         /* Don't check write errors as we can't do anything here.
          * If the error is permanent we'll catch it later,
          * if it's not, then hopefully it'll work next time. */
-        send_ret = ssl->f_send( ssl->p_bio, ssl->out_buf, len );
+        send_ret = mbedtls_ssl_get_send( ssl )( ssl->p_bio, ssl->out_buf, len );
         MBEDTLS_SSL_DEBUG_RET( 2, "ssl->f_send", send_ret );
         (void) send_ret;
 

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -146,6 +146,7 @@ int mbedtls_hardware_poll( void *data, unsigned char *output,
     "                        modifying CID in first instance of the packet.\n" \
     "    protect_hvr=0/1     default: 0 (don't protect HelloVerifyRequest)\n" \
     "    protect_len=%%d      default: (don't protect packets of this size)\n" \
+    "    inject_clihlo=0/1   default: 0 (don't inject fake ClientHello)\n"  \
     "\n"                                                                    \
     "    seed=%%d             default: (use current time)\n"                \
     USAGE_PACK                                                              \
@@ -179,6 +180,7 @@ static struct options
     unsigned bad_cid;           /* inject corrupted CID record              */
     int protect_hvr;            /* never drop or delay HelloVerifyRequest   */
     int protect_len;            /* never drop/delay packet of the given size*/
+    int inject_clihlo;          /* inject fake ClientHello after handshake  */
     unsigned pack;              /* merge packets into single datagram for
                                  * at most \c merge milliseconds if > 0     */
     unsigned int seed;          /* seed for "random" events                 */
@@ -325,6 +327,12 @@ static void get_options( int argc, char *argv[] )
         {
             opt.protect_len = atoi( q );
             if( opt.protect_len < 0 )
+                exit_usage( p, q );
+        }
+        else if( strcmp( p, "inject_clihlo" ) == 0 )
+        {
+            opt.inject_clihlo = atoi( q );
+            if( opt.inject_clihlo < 0 || opt.inject_clihlo > 1 )
                 exit_usage( p, q );
         }
         else if( strcmp( p, "seed" ) == 0 )
@@ -536,10 +544,39 @@ void print_packet( const packet *p, const char *why )
     fflush( stdout );
 }
 
+/*
+ * In order to test the server's behaviour when receiving a ClientHello after
+ * the connection is established (this could be a hard reset from the client,
+ * but the server must not drop the existing connection before establishing
+ * client reachability, see RFC 6347 Section 4.2.8), we memorize the first
+ * ClientHello we see (which can't have a cookie), then replay it after the
+ * first ApplicationData record - then we're done.
+ *
+ * This is controlled by the inject_clihlo option.
+ *
+ * We want an explicit state and a place to store the packet.
+ */
+static enum {
+    ich_init,       /* haven't seen the first ClientHello yet */
+    ich_cached,     /* cached the initial ClientHello */
+    ich_injected,   /* ClientHello already injected, done */
+} inject_clihlo_state;
+
+static packet initial_clihlo;
+
 int send_packet( const packet *p, const char *why )
 {
     int ret;
     mbedtls_net_context *dst = p->dst;
+
+    /* save initial ClientHello? */
+    if( opt.inject_clihlo != 0 &&
+        inject_clihlo_state == ich_init &&
+        strcmp( p->type, "ClientHello" ) == 0 )
+    {
+        memcpy( &initial_clihlo, p, sizeof( packet ) );
+        inject_clihlo_state = ich_cached;
+    }
 
     /* insert corrupted CID record? */
     if( opt.bad_cid != 0 &&
@@ -603,6 +640,23 @@ int send_packet( const packet *p, const char *why )
             mbedtls_printf( "  ! dispatch returned %d\n", ret );
             return( ret );
         }
+    }
+
+    /* Inject ClientHello after first ApplicationData */
+    if( opt.inject_clihlo != 0 &&
+        inject_clihlo_state == ich_cached &&
+        strcmp( p->type, "ApplicationData" ) == 0 )
+    {
+        print_packet( &initial_clihlo, "injected" );
+
+        if( ( ret = dispatch_data( dst, initial_clihlo.buf,
+                                        initial_clihlo.len ) ) <= 0 )
+        {
+            mbedtls_printf( "  ! dispatch returned %d\n", ret );
+            return( ret );
+        }
+
+        inject_clihlo_state = ich_injected;
     }
 
     return( 0 );

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -556,12 +556,13 @@ void print_packet( const packet *p, const char *why )
  *
  * We want an explicit state and a place to store the packet.
  */
-static enum {
-    ich_init,       /* haven't seen the first ClientHello yet */
-    ich_cached,     /* cached the initial ClientHello */
-    ich_injected,   /* ClientHello already injected, done */
-} inject_clihlo_state;
+typedef enum {
+    ICH_INIT,       /* haven't seen the first ClientHello yet */
+    ICH_CACHED,     /* cached the initial ClientHello */
+    ICH_INJECTED,   /* ClientHello already injected, done */
+} inject_clihlo_state_t;
 
+static inject_clihlo_state_t inject_clihlo_state;
 static packet initial_clihlo;
 
 int send_packet( const packet *p, const char *why )
@@ -571,11 +572,11 @@ int send_packet( const packet *p, const char *why )
 
     /* save initial ClientHello? */
     if( opt.inject_clihlo != 0 &&
-        inject_clihlo_state == ich_init &&
+        inject_clihlo_state == ICH_INIT &&
         strcmp( p->type, "ClientHello" ) == 0 )
     {
         memcpy( &initial_clihlo, p, sizeof( packet ) );
-        inject_clihlo_state = ich_cached;
+        inject_clihlo_state = ICH_CACHED;
     }
 
     /* insert corrupted CID record? */
@@ -644,7 +645,7 @@ int send_packet( const packet *p, const char *why )
 
     /* Inject ClientHello after first ApplicationData */
     if( opt.inject_clihlo != 0 &&
-        inject_clihlo_state == ich_cached &&
+        inject_clihlo_state == ICH_CACHED &&
         strcmp( p->type, "ApplicationData" ) == 0 )
     {
         print_packet( &initial_clihlo, "injected" );
@@ -656,7 +657,7 @@ int send_packet( const packet *p, const char *why )
             return( ret );
         }
 
-        inject_clihlo_state = ich_injected;
+        inject_clihlo_state = ICH_INJECTED;
     }
 
     return( 0 );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7097,6 +7097,7 @@ run_test    "DTLS cookie: enabled, nbio" \
 
 not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reference" \
             "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000" \
@@ -7107,6 +7108,7 @@ run_test    "DTLS client reconnect from same port: reference" \
 
 not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reconnect" \
             "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000 reconnect_hard=1" \
@@ -7117,6 +7119,7 @@ run_test    "DTLS client reconnect from same port: reconnect" \
 
 not_with_valgrind # server/client too slow to respond in time (next test has higher timeouts)
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reconnect, nbio, no valgrind" \
             "$P_SRV dtls=1 exchanges=2 read_timeout=1000 nbio=2" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-1000 reconnect_hard=1" \
@@ -7126,6 +7129,7 @@ run_test    "DTLS client reconnect from same port: reconnect, nbio, no valgrind"
 
 only_with_valgrind # Only with valgrind, do previous test but with higher read_timeout and hs_timeout
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reconnect, nbio, valgrind" \
             "$P_SRV dtls=1 exchanges=2 read_timeout=2000 nbio=2 hs_timeout=1500-6000" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=1500-3000 reconnect_hard=1" \
@@ -7134,6 +7138,7 @@ run_test    "DTLS client reconnect from same port: reconnect, nbio, valgrind" \
             -s "Client initiated reconnection from same port"
 
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: no cookies" \
             "$P_SRV dtls=1 exchanges=2 read_timeout=1000 cookies=0" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-8000 reconnect_hard=1" \
@@ -7141,6 +7146,7 @@ run_test    "DTLS client reconnect from same port: no cookies" \
             -s "The operation timed out" \
             -S "Client initiated reconnection from same port"
 
+requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: attacker-injected" \
             -p "$P_PXY inject_clihlo=1" \
             "$P_SRV dtls=1 exchanges=2 debug_level=1" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7098,8 +7098,8 @@ run_test    "DTLS cookie: enabled, nbio" \
 not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
 run_test    "DTLS client reconnect from same port: reference" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=1000" \
-            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-1000" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -C "resend" \
             -S "The operation timed out" \
@@ -7108,8 +7108,8 @@ run_test    "DTLS client reconnect from same port: reference" \
 not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
 run_test    "DTLS client reconnect from same port: reconnect" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=1000" \
-            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=500-1000 reconnect_hard=1" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000 reconnect_hard=1" \
             0 \
             -C "resend" \
             -S "The operation timed out" \
@@ -8249,8 +8249,8 @@ run_test    "DTLS fragmenting: 3d, openssl client, DTLS 1.0" \
 not_with_valgrind # spurious resend due to timeout
 run_test    "DTLS proxy: reference" \
             -p "$P_PXY" \
-            "$P_SRV dtls=1 debug_level=2" \
-            "$P_CLI dtls=1 debug_level=2" \
+            "$P_SRV dtls=1 debug_level=2 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -C "replayed record" \
             -S "replayed record" \
@@ -8267,8 +8267,8 @@ run_test    "DTLS proxy: reference" \
 not_with_valgrind # spurious resend due to timeout
 run_test    "DTLS proxy: duplicate every packet" \
             -p "$P_PXY duplicate=1" \
-            "$P_SRV dtls=1 dgram_packing=0 debug_level=2 anti_replay=1" \
-            "$P_CLI dtls=1 dgram_packing=0 debug_level=2" \
+            "$P_SRV dtls=1 dgram_packing=0 debug_level=2 anti_replay=1 hs_timeout=10000-20000" \
+            "$P_CLI dtls=1 dgram_packing=0 debug_level=2 hs_timeout=10000-20000" \
             0 \
             -c "replayed record" \
             -s "replayed record" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7141,6 +7141,14 @@ run_test    "DTLS client reconnect from same port: no cookies" \
             -s "The operation timed out" \
             -S "Client initiated reconnection from same port"
 
+run_test    "DTLS client reconnect from same port: attacker-injected" \
+            -p "$P_PXY inject_clihlo=1" \
+            "$P_SRV dtls=1 exchanges=2 debug_level=1" \
+            "$P_CLI dtls=1 exchanges=2" \
+            0 \
+            -s "possible client reconnect from the same port" \
+            -S "Client initiated reconnection from same port"
+
 # Tests for various cases of client authentication with DTLS
 # (focused on handshake flows and message parsing)
 


### PR DESCRIPTION
This is the backport of #3132 to the baremetal branch.

Usually the baremetal branch gets its bug fixes backported via the 2.16 branch by regularly merging back from it. But in this instance, the bug was introduced in 2.19 (as a foward port to development of the [record checking](https://github.com/ARMmbed/mbedtls/pull/2790) feature that was first introduced in baremetal), so we need a direct backport of the fix.

This also improves tests and debug logging, which was also backported to 2.16. Due to differences in this area between baremetal and 2.16 (linked to the new features in baremetal), it's possible that git may have trouble resolving conflits next time you merge 2.16 to baremetal - in that case, keep the version in the baremetal branch, which has everything that the 2.16 backport has, and more.