### PR TITLE
Improve ctags invocation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,10 @@ endif
 
 ## Editor navigation files
 C_SOURCE_FILES = $(wildcard include/*/*.h library/*.[hc] programs/*/*.[hc] tests/suites/*.function)
+# Exuberant-ctags invocation. Other ctags implementations may require different options.
+CTAGS = ctags --langmap=c:+.h.function -o
 tags: $(C_SOURCE_FILES)
-	ctags -o $@ --langmap=c:+.h.function $(C_SOURCE_FILES)
+	$(CTAGS) $@ $(C_SOURCE_FILES)
 TAGS: $(C_SOURCE_FILES)
 	etags -o $@ $(C_SOURCE_FILES)
 GPATH GRTAGS GSYMS GTAGS: $(C_SOURCE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ endif
 ## Editor navigation files
 C_SOURCE_FILES = $(wildcard include/*/*.h library/*.[hc] programs/*/*.[hc] tests/suites/*.function)
 tags: $(C_SOURCE_FILES)
-	ctags -o $@ $(C_SOURCE_FILES)
+	ctags -o $@ --langmap=c:+.h.function $(C_SOURCE_FILES)
 TAGS: $(C_SOURCE_FILES)
 	etags -o $@ $(C_SOURCE_FILES)
 GPATH GRTAGS GSYMS GTAGS: $(C_SOURCE_FILES)


### PR DESCRIPTION
## Description

Adding .function was necessary, as otherwise ctags would have no idea what to do with those files.

Adding .h may not be necessary, as by default ctags considers them C++ which is probably good enough, but since we're tuning the mapping anyway...

## Status
**READY**

## Requires Backporting

Yes - developer comfort should be available in all branches :)  

- [x] 2.16 - #3157 
- [x] 2.7 - #3158
