### PR TITLE
[backport 2.16] Improve ctags invocation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ endif
 
 ## Editor navigation files
 C_SOURCE_FILES = $(wildcard include/*/*.h library/*.[hc] programs/*/*.[hc] tests/suites/*.function)
+# Exuberant-ctags invocation. Other ctags implementations may require different options.
+CTAGS = ctags --langmap=c:+.h.function -o
 tags: $(C_SOURCE_FILES)
-	ctags -o $@ --langmap=c:+.h.function $(C_SOURCE_FILES)
+	$(CTAGS) $@ $(C_SOURCE_FILES)
 TAGS: $(C_SOURCE_FILES)
 	etags -o $@ $(C_SOURCE_FILES)
 GPATH GRTAGS GSYMS GTAGS: $(C_SOURCE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ endif
 ## Editor navigation files
 C_SOURCE_FILES = $(wildcard include/*/*.h library/*.[hc] programs/*/*.[hc] tests/suites/*.function)
 tags: $(C_SOURCE_FILES)
-	ctags -o $@ $(C_SOURCE_FILES)
+	ctags -o $@ --langmap=c:+.h.function $(C_SOURCE_FILES)
 TAGS: $(C_SOURCE_FILES)
 	etags -o $@ $(C_SOURCE_FILES)
 GPATH GRTAGS GSYMS GTAGS: $(C_SOURCE_FILES)


### PR DESCRIPTION
This is the 2.16 backport of #3156.