### PR TITLE
hkdf_expand: explicitly initialize t

### DIFF
--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -115,7 +115,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
 
     n = okm_len / hash_len;
 
-    if( (okm_len % hash_len) != 0 )
+    if( okm_len % hash_len != 0 )
     {
         n++;
     }
@@ -131,7 +131,7 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
 
     mbedtls_md_init( &ctx );
 
-    if( (ret = mbedtls_md_setup( &ctx, md, 1) ) != 0 )
+    if( ( ret = mbedtls_md_setup( &ctx, md, 1 ) ) != 0 )
     {
         goto exit;
     }

--- a/library/hkdf.c
+++ b/library/hkdf.c
@@ -136,6 +136,8 @@ int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
         goto exit;
     }
 
+    memset( t, 0, hash_len );
+
     /*
      * Compute T = T(1) | T(2) | T(3) | ... | T(N)
      * Where T(N) is defined in RFC 5869 Section 2.3


### PR DESCRIPTION
There's no behavior change. This just makes the code more robust and removes a potential false positive in static analysis.

Since there's no bug and this change increases the code size by a few bytes, I don't think this should be backported.

Originally reported in https://github.com/ARMmbed/mbedtls/pull/2942.