### PR TITLE
Add support for const error description strings

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -128,28 +128,32 @@ extern "C" {
 void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
 
 /**
- * \brief Translate high level part of a mbed TLS error code into a string
+ * \brief Translate the high-level part of an Mbed TLS error code into a string
  *        representation.
  *
  * This function returns a const pointer to an un-modifiable string. The caller
- * must not try to modify the string and use it only for logging purposes.
+ * must not try to modify the string. It is intended to be used mostly for
+ * logging purposes.
  *
  * \param error_code    error code
  *
- * \return The string representation of the error code.
+ * \return The string representation of the error code, or \c NULL if the error
+ *         code is unknown.
  */
 const char * mbedtls_high_level_strerr( int error_code );
 
 /**
- * \brief Translate low level part of a mbed TLS error code into a string
+ * \brief Translate the low-level part of an Mbed TLS error code into a string
  *        representation.
  *
  * This function returns a const pointer to an un-modifiable string. The caller
- * must not try to modify the string and use it only for logging purposes.
+ * must not try to modify the string. It is intended to be used mostly for
+ * logging purposes.
  *
  * \param error_code    error code
  *
- * \return The string representation of the error code.
+ * \return The string representation of the error code, or \c NULL if the error
+ *         code is unknown.
  */
 const char * mbedtls_low_level_strerr( int error_code );
 

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -132,7 +132,7 @@ void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
  *        representation.
  *
  * This function returns a const pointer to an un-modifiable string. The caller
- * must not try to modify the string use it only for logging purposes.
+ * must not try to modify the string and use it only for logging purposes.
  *
  * \param error_code    error code
  *

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -127,6 +127,32 @@ extern "C" {
  */
 void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
 
+/**
+ * \brief Translate high level part of a mbed TLS error code into a string
+ *        representation.
+ *
+ * This function returns a const pointer to an un-modifiable string. The caller
+ * must not try to modify the string use it only for logging purposes.
+ *
+ * \param error_code    error code
+ *
+ * \return The string representation of the error code.
+ */
+const char * mbedtls_high_level_strerr( int error_code );
+
+/**
+ * \brief Translate low level part of a mbed TLS error code into a string
+ *        representation.
+ *
+ * This function returns a const pointer to an un-modifiable string. The caller
+ * must not try to modify the string and use it only for logging purposes.
+ *
+ * \param error_code    error code
+ *
+ * \return The string representation of the error code.
+ */
+const char * mbedtls_low_level_strerr( int error_code );
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/error.c
+++ b/library/error.c
@@ -215,9 +215,16 @@
 
 const char * mbedtls_high_level_strerr( int error_code )
 {
+    int high_level_error_code;
     const char *error_description = NULL;
 
-    switch( error_code )
+    if( error_code < 0 )
+        error_code = -error_code;
+
+    /* Extract the high-level part from the error code. */
+    high_level_error_code = error_code & 0xFF80;
+
+    switch( high_level_error_code )
     {
         /* Begin Auto-Generated Code. */
 #if defined(MBEDTLS_CIPHER_C)
@@ -725,9 +732,16 @@ const char * mbedtls_high_level_strerr( int error_code )
 
 const char * mbedtls_low_level_strerr( int error_code )
 {
+    int low_level_error_code;
     const char *error_description = NULL;
 
-    switch( error_code )
+    if( error_code < 0 )
+        error_code = -error_code;
+
+    /* Extract the low-level part from the error code. */
+    low_level_error_code = error_code & ~0xFF80;
+
+    switch( low_level_error_code )
     {
         /* Begin Auto-Generated Code. */
 #if defined(MBEDTLS_AES_C)
@@ -1154,7 +1168,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         use_ret = ret & 0xFF80;
 
         // Translate high level error code.
-        high_level_error_description = mbedtls_high_level_strerr(use_ret);
+        high_level_error_description = mbedtls_high_level_strerr( ret );
 
         if( high_level_error_description == NULL )
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
@@ -1191,7 +1205,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     }
 
     // Translate low level error code.
-    low_level_error_description = mbedtls_low_level_strerr( use_ret );
+    low_level_error_description = mbedtls_low_level_strerr( ret );
 
     if( low_level_error_description == NULL )
         mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );

--- a/library/error.c
+++ b/library/error.c
@@ -213,419 +213,509 @@
 #endif
 
 
-typedef struct mbedtls_error
+const char * mbedtls_high_level_strerr( int error_code )
 {
-    int code;                   /* Error code. */
-    const char * description;   /* Error description. */
-} mbedtls_error_t;
+    const char *error_description = NULL;
 
-static mbedtls_error_t high_level_errors[] =
-{
+    switch( error_code )
+    {
 #if defined(MBEDTLS_CIPHER_C)
-    {.code = -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE), .description="CIPHER - The selected feature is not available"},
-    {.code = -(MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA), .description="CIPHER - Bad input parameters"},
-    {.code = -(MBEDTLS_ERR_CIPHER_ALLOC_FAILED), .description="CIPHER - Failed to allocate memory"},
-    {.code = -(MBEDTLS_ERR_CIPHER_INVALID_PADDING), .description="CIPHER - Input data contains invalid padding and is rejected"},
-    {.code = -(MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED), .description="CIPHER - Decryption of block requires a full block"},
-    {.code = -(MBEDTLS_ERR_CIPHER_AUTH_FAILED), .description="CIPHER - Authentication failed (for AEAD modes)"},
-    {.code = -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT), .description="CIPHER - The context is invalid. For example, because it was freed"},
-    {.code = -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED), .description="CIPHER - Cipher hardware accelerator failed"},
+        case -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE):
+            error_description = "CIPHER - The selected feature is not available";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA):
+            error_description = "CIPHER - Bad input parameters";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_ALLOC_FAILED):
+            error_description = "CIPHER - Failed to allocate memory";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_INVALID_PADDING):
+            error_description = "CIPHER - Input data contains invalid padding and is rejected";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED):
+            error_description = "CIPHER - Decryption of block requires a full block";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_AUTH_FAILED):
+            error_description = "CIPHER - Authentication failed (for AEAD modes)";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT):
+            error_description = "CIPHER - The context is invalid. For example, because it was freed";
+            break;
+        case -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED):
+            error_description = "CIPHER - Cipher hardware accelerator failed";
+            break;
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_DHM_C)
-    {.code = -(MBEDTLS_ERR_DHM_BAD_INPUT_DATA), .description="DHM - Bad input parameters"},
-    {.code = -(MBEDTLS_ERR_DHM_READ_PARAMS_FAILED), .description="DHM - Reading of the DHM parameters failed"},
-    {.code = -(MBEDTLS_ERR_DHM_MAKE_PARAMS_FAILED), .description="DHM - Making of the DHM parameters failed"},
-    {.code = -(MBEDTLS_ERR_DHM_READ_PUBLIC_FAILED), .description="DHM - Reading of the public values failed"},
-    {.code = -(MBEDTLS_ERR_DHM_MAKE_PUBLIC_FAILED), .description="DHM - Making of the public value failed"},
-    {.code = -(MBEDTLS_ERR_DHM_CALC_SECRET_FAILED), .description="DHM - Calculation of the DHM secret failed"},
-    {.code = -(MBEDTLS_ERR_DHM_INVALID_FORMAT), .description="DHM - The ASN.1 data is not formatted correctly"},
-    {.code = -(MBEDTLS_ERR_DHM_ALLOC_FAILED), .description="DHM - Allocation of memory failed"},
-    {.code = -(MBEDTLS_ERR_DHM_FILE_IO_ERROR), .description="DHM - Read or write of file failed"},
-    {.code = -(MBEDTLS_ERR_DHM_HW_ACCEL_FAILED), .description="DHM - DHM hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_DHM_SET_GROUP_FAILED), .description="DHM - Setting the modulus and generator failed"},
+        case -(MBEDTLS_ERR_DHM_BAD_INPUT_DATA):
+            error_description = "DHM - Bad input parameters";
+            break;
+        case -(MBEDTLS_ERR_DHM_READ_PARAMS_FAILED):
+            error_description = "DHM - Reading of the DHM parameters failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_MAKE_PARAMS_FAILED):
+            error_description = "DHM - Making of the DHM parameters failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_READ_PUBLIC_FAILED):
+            error_description = "DHM - Reading of the public values failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_MAKE_PUBLIC_FAILED):
+            error_description = "DHM - Making of the public value failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_CALC_SECRET_FAILED):
+            error_description = "DHM - Calculation of the DHM secret failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_INVALID_FORMAT):
+            error_description = "DHM - The ASN.1 data is not formatted correctly";
+            break;
+        case -(MBEDTLS_ERR_DHM_ALLOC_FAILED):
+            error_description = "DHM - Allocation of memory failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_FILE_IO_ERROR):
+            error_description = "DHM - Read or write of file failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_HW_ACCEL_FAILED):
+            error_description = "DHM - DHM hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_DHM_SET_GROUP_FAILED):
+            error_description = "DHM - Setting the modulus and generator failed";
+            break;
 #endif /* MBEDTLS_DHM_C */
 
 #if defined(MBEDTLS_ECP_C)
-    {.code = -(MBEDTLS_ERR_ECP_BAD_INPUT_DATA), .description="ECP - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL), .description="ECP - The buffer is too small to write to"},
-    {.code = -(MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE), .description="ECP - The requested feature is not available, for example, the requested curve is not supported"},
-    {.code = -(MBEDTLS_ERR_ECP_VERIFY_FAILED), .description="ECP - The signature is not valid"},
-    {.code = -(MBEDTLS_ERR_ECP_ALLOC_FAILED), .description="ECP - Memory allocation failed"},
-    {.code = -(MBEDTLS_ERR_ECP_RANDOM_FAILED), .description="ECP - Generation of random value, such as ephemeral key, failed"},
-    {.code = -(MBEDTLS_ERR_ECP_INVALID_KEY), .description="ECP - Invalid private or public key"},
-    {.code = -(MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH), .description="ECP - The buffer contains a valid signature followed by more data"},
-    {.code = -(MBEDTLS_ERR_ECP_HW_ACCEL_FAILED), .description="ECP - The ECP hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_ECP_IN_PROGRESS), .description="ECP - Operation in progress, call again with the same parameters to continue"},
+        case -(MBEDTLS_ERR_ECP_BAD_INPUT_DATA):
+            error_description = "ECP - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL):
+            error_description = "ECP - The buffer is too small to write to";
+            break;
+        case -(MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE):
+            error_description = "ECP - The requested feature is not available, for example, the requested curve is not supported";
+            break;
+        case -(MBEDTLS_ERR_ECP_VERIFY_FAILED):
+            error_description = "ECP - The signature is not valid";
+            break;
+        case -(MBEDTLS_ERR_ECP_ALLOC_FAILED):
+            error_description = "ECP - Memory allocation failed";
+            break;
+        case -(MBEDTLS_ERR_ECP_RANDOM_FAILED):
+            error_description = "ECP - Generation of random value, such as ephemeral key, failed";
+            break;
+        case -(MBEDTLS_ERR_ECP_INVALID_KEY):
+            error_description = "ECP - Invalid private or public key";
+            break;
+        case -(MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH):
+            error_description = "ECP - The buffer contains a valid signature followed by more data";
+            break;
+        case -(MBEDTLS_ERR_ECP_HW_ACCEL_FAILED):
+            error_description = "ECP - The ECP hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_ECP_IN_PROGRESS):
+            error_description = "ECP - Operation in progress, call again with the same parameters to continue";
+            break;
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_MD_C)
-    {.code = -(MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE), .description="MD - The selected feature is not available"},
-    {.code = -(MBEDTLS_ERR_MD_BAD_INPUT_DATA), .description="MD - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_MD_ALLOC_FAILED), .description="MD - Failed to allocate memory"},
-    {.code = -(MBEDTLS_ERR_MD_FILE_IO_ERROR), .description="MD - Opening or reading of file failed"},
-    {.code = -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED), .description="MD - MD hardware accelerator failed"},
+        case -(MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE):
+            error_description = "MD - The selected feature is not available";
+            break;
+        case -(MBEDTLS_ERR_MD_BAD_INPUT_DATA):
+            error_description = "MD - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_MD_ALLOC_FAILED):
+            error_description = "MD - Failed to allocate memory";
+            break;
+        case -(MBEDTLS_ERR_MD_FILE_IO_ERROR):
+            error_description = "MD - Opening or reading of file failed";
+            break;
+        case -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED):
+            error_description = "MD - MD hardware accelerator failed";
+            break;
 #endif /* MBEDTLS_MD_C */
 
 #if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
-    {.code = -(MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT), .description="PEM - No PEM header or footer found"},
-    {.code = -(MBEDTLS_ERR_PEM_INVALID_DATA), .description="PEM - PEM string is not as expected"},
-    {.code = -(MBEDTLS_ERR_PEM_ALLOC_FAILED), .description="PEM - Failed to allocate memory"},
-    {.code = -(MBEDTLS_ERR_PEM_INVALID_ENC_IV), .description="PEM - RSA IV is not in hex-format"},
-    {.code = -(MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG), .description="PEM - Unsupported key encryption algorithm"},
-    {.code = -(MBEDTLS_ERR_PEM_PASSWORD_REQUIRED), .description="PEM - Private key password can't be empty"},
-    {.code = -(MBEDTLS_ERR_PEM_PASSWORD_MISMATCH), .description="PEM - Given private key password does not allow for correct decryption"},
-    {.code = -(MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE), .description="PEM - Unavailable feature, e.g. hashing/encryption combination"},
-    {.code = -(MBEDTLS_ERR_PEM_BAD_INPUT_DATA), .description="PEM - Bad input parameters to function"},
+        case -(MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT):
+            error_description = "PEM - No PEM header or footer found";
+            break;
+        case -(MBEDTLS_ERR_PEM_INVALID_DATA):
+            error_description = "PEM - PEM string is not as expected";
+            break;
+        case -(MBEDTLS_ERR_PEM_ALLOC_FAILED):
+            error_description = "PEM - Failed to allocate memory";
+            break;
+        case -(MBEDTLS_ERR_PEM_INVALID_ENC_IV):
+            error_description = "PEM - RSA IV is not in hex-format";
+            break;
+        case -(MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG):
+            error_description = "PEM - Unsupported key encryption algorithm";
+            break;
+        case -(MBEDTLS_ERR_PEM_PASSWORD_REQUIRED):
+            error_description = "PEM - Private key password can't be empty";
+            break;
+        case -(MBEDTLS_ERR_PEM_PASSWORD_MISMATCH):
+            error_description = "PEM - Given private key password does not allow for correct decryption";
+            break;
+        case -(MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE):
+            error_description = "PEM - Unavailable feature, e.g. hashing/encryption combination";
+            break;
+        case -(MBEDTLS_ERR_PEM_BAD_INPUT_DATA):
+            error_description = "PEM - Bad input parameters to function";
+            break;
 #endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */
 
 #if defined(MBEDTLS_PK_C)
-    {.code = -(MBEDTLS_ERR_PK_ALLOC_FAILED), .description="PK - Memory allocation failed"},
-    {.code = -(MBEDTLS_ERR_PK_TYPE_MISMATCH), .description="PK - Type mismatch, eg attempt to encrypt with an ECDSA key"},
-    {.code = -(MBEDTLS_ERR_PK_BAD_INPUT_DATA), .description="PK - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_PK_FILE_IO_ERROR), .description="PK - Read/write of file failed"},
-    {.code = -(MBEDTLS_ERR_PK_KEY_INVALID_VERSION), .description="PK - Unsupported key version"},
-    {.code = -(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT), .description="PK - Invalid key tag or value"},
-    {.code = -(MBEDTLS_ERR_PK_UNKNOWN_PK_ALG), .description="PK - Key algorithm is unsupported (only RSA and EC are supported)"},
-    {.code = -(MBEDTLS_ERR_PK_PASSWORD_REQUIRED), .description="PK - Private key password can't be empty"},
-    {.code = -(MBEDTLS_ERR_PK_PASSWORD_MISMATCH), .description="PK - Given private key password does not allow for correct decryption"},
-    {.code = -(MBEDTLS_ERR_PK_INVALID_PUBKEY), .description="PK - The pubkey tag or value is invalid (only RSA and EC are supported)"},
-    {.code = -(MBEDTLS_ERR_PK_INVALID_ALG), .description="PK - The algorithm tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE), .description="PK - Elliptic curve is unsupported (only NIST curves are supported)"},
-    {.code = -(MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE), .description="PK - Unavailable feature, e.g. RSA disabled for RSA key"},
-    {.code = -(MBEDTLS_ERR_PK_SIG_LEN_MISMATCH), .description="PK - The buffer contains a valid signature followed by more data"},
-    {.code = -(MBEDTLS_ERR_PK_HW_ACCEL_FAILED), .description="PK - PK hardware accelerator failed"},
+        case -(MBEDTLS_ERR_PK_ALLOC_FAILED):
+            error_description = "PK - Memory allocation failed";
+            break;
+        case -(MBEDTLS_ERR_PK_TYPE_MISMATCH):
+            error_description = "PK - Type mismatch, eg attempt to encrypt with an ECDSA key";
+            break;
+        case -(MBEDTLS_ERR_PK_BAD_INPUT_DATA):
+            error_description = "PK - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_PK_FILE_IO_ERROR):
+            error_description = "PK - Read/write of file failed";
+            break;
+        case -(MBEDTLS_ERR_PK_KEY_INVALID_VERSION):
+            error_description = "PK - Unsupported key version";
+            break;
+        case -(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT):
+            error_description = "PK - Invalid key tag or value";
+            break;
+        case -(MBEDTLS_ERR_PK_UNKNOWN_PK_ALG):
+            error_description = "PK - Key algorithm is unsupported (only RSA and EC are supported)";
+            break;
+        case -(MBEDTLS_ERR_PK_PASSWORD_REQUIRED):
+            error_description = "PK - Private key password can't be empty";
+            break;
+        case -(MBEDTLS_ERR_PK_PASSWORD_MISMATCH):
+            error_description = "PK - Given private key password does not allow for correct decryption";
+            break;
+        case -(MBEDTLS_ERR_PK_INVALID_PUBKEY):
+            error_description = "PK - The pubkey tag or value is invalid (only RSA and EC are supported)";
+            break;
+        case -(MBEDTLS_ERR_PK_INVALID_ALG):
+            error_description = "PK - The algorithm tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE):
+            error_description = "PK - Elliptic curve is unsupported (only NIST curves are supported)";
+            break;
+        case -(MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE):
+            error_description = "PK - Unavailable feature, e.g. RSA disabled for RSA key";
+            break;
+        case -(MBEDTLS_ERR_PK_SIG_LEN_MISMATCH):
+            error_description = "PK - The buffer contains a valid signature followed by more data";
+            break;
+        case -(MBEDTLS_ERR_PK_HW_ACCEL_FAILED):
+            error_description = "PK - PK hardware accelerator failed";
+            break;
 #endif /* MBEDTLS_PK_C */
 
 #if defined(MBEDTLS_PKCS12_C)
-    {.code = -(MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA), .description="PKCS12 - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE), .description="PKCS12 - Feature not available, e.g. unsupported encryption scheme"},
-    {.code = -(MBEDTLS_ERR_PKCS12_PBE_INVALID_FORMAT), .description="PKCS12 - PBE ASN.1 data not as expected"},
-    {.code = -(MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH), .description="PKCS12 - Given private key password does not allow for correct decryption"},
+        case -(MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA):
+            error_description = "PKCS12 - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE):
+            error_description = "PKCS12 - Feature not available, e.g. unsupported encryption scheme";
+            break;
+        case -(MBEDTLS_ERR_PKCS12_PBE_INVALID_FORMAT):
+            error_description = "PKCS12 - PBE ASN.1 data not as expected";
+            break;
+        case -(MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH):
+            error_description = "PKCS12 - Given private key password does not allow for correct decryption";
+            break;
 #endif /* MBEDTLS_PKCS12_C */
 
 #if defined(MBEDTLS_PKCS5_C)
-    {.code = -(MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA), .description="PKCS5 - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_PKCS5_INVALID_FORMAT), .description="PKCS5 - Unexpected ASN.1 data"},
-    {.code = -(MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE), .description="PKCS5 - Requested encryption or digest alg not available"},
-    {.code = -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH), .description="PKCS5 - Given private key password does not allow for correct decryption"},
+        case -(MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA):
+            error_description = "PKCS5 - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_PKCS5_INVALID_FORMAT):
+            error_description = "PKCS5 - Unexpected ASN.1 data";
+            break;
+        case -(MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE):
+            error_description = "PKCS5 - Requested encryption or digest alg not available";
+            break;
+        case -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH):
+            error_description = "PKCS5 - Given private key password does not allow for correct decryption";
+            break;
 #endif /* MBEDTLS_PKCS5_C */
 
 #if defined(MBEDTLS_RSA_C)
-    {.code = -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA), .description="RSA - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_RSA_INVALID_PADDING), .description="RSA - Input data contains invalid padding and is rejected"},
-    {.code = -(MBEDTLS_ERR_RSA_KEY_GEN_FAILED), .description="RSA - Something failed during generation of a key"},
-    {.code = -(MBEDTLS_ERR_RSA_KEY_CHECK_FAILED), .description="RSA - Key failed to pass the validity check of the library"},
-    {.code = -(MBEDTLS_ERR_RSA_PUBLIC_FAILED), .description="RSA - The public key operation failed"},
-    {.code = -(MBEDTLS_ERR_RSA_PRIVATE_FAILED), .description="RSA - The private key operation failed"},
-    {.code = -(MBEDTLS_ERR_RSA_VERIFY_FAILED), .description="RSA - The PKCS#1 verification failed"},
-    {.code = -(MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE), .description="RSA - The output buffer for decryption is not large enough"},
-    {.code = -(MBEDTLS_ERR_RSA_RNG_FAILED), .description="RSA - The random generator failed to generate non-zeros"},
-    {.code = -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION), .description="RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality"},
-    {.code = -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED), .description="RSA - RSA hardware accelerator failed"},
+        case -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA):
+            error_description = "RSA - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_RSA_INVALID_PADDING):
+            error_description = "RSA - Input data contains invalid padding and is rejected";
+            break;
+        case -(MBEDTLS_ERR_RSA_KEY_GEN_FAILED):
+            error_description = "RSA - Something failed during generation of a key";
+            break;
+        case -(MBEDTLS_ERR_RSA_KEY_CHECK_FAILED):
+            error_description = "RSA - Key failed to pass the validity check of the library";
+            break;
+        case -(MBEDTLS_ERR_RSA_PUBLIC_FAILED):
+            error_description = "RSA - The public key operation failed";
+            break;
+        case -(MBEDTLS_ERR_RSA_PRIVATE_FAILED):
+            error_description = "RSA - The private key operation failed";
+            break;
+        case -(MBEDTLS_ERR_RSA_VERIFY_FAILED):
+            error_description = "RSA - The PKCS#1 verification failed";
+            break;
+        case -(MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE):
+            error_description = "RSA - The output buffer for decryption is not large enough";
+            break;
+        case -(MBEDTLS_ERR_RSA_RNG_FAILED):
+            error_description = "RSA - The random generator failed to generate non-zeros";
+            break;
+        case -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION):
+            error_description = "RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality";
+            break;
+        case -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED):
+            error_description = "RSA - RSA hardware accelerator failed";
+            break;
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_SSL_TLS_C)
-    {.code = -(MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE), .description="SSL - The requested feature is not available"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_INPUT_DATA), .description="SSL - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_SSL_INVALID_MAC), .description="SSL - Verification of the message MAC failed"},
-    {.code = -(MBEDTLS_ERR_SSL_INVALID_RECORD), .description="SSL - An invalid SSL record was received"},
-    {.code = -(MBEDTLS_ERR_SSL_CONN_EOF), .description="SSL - The connection indicated an EOF"},
-    {.code = -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER), .description="SSL - An unknown cipher was received"},
-    {.code = -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN), .description="SSL - The server has no ciphersuites in common with the client"},
-    {.code = -(MBEDTLS_ERR_SSL_NO_RNG), .description="SSL - No RNG was provided to the SSL module"},
-    {.code = -(MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE), .description="SSL - No client certification received from the client, but required by the authentication mode"},
-    {.code = -(MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE), .description="SSL - Our own certificate(s) is/are too large to send in an SSL message"},
-    {.code = -(MBEDTLS_ERR_SSL_CERTIFICATE_REQUIRED), .description="SSL - The own certificate is not set, but needed by the server"},
-    {.code = -(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED), .description="SSL - The own private key or pre-shared key is not set, but needed"},
-    {.code = -(MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED), .description="SSL - No CA Chain is set, but required to operate"},
-    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE), .description="SSL - An unexpected message was received from our peer"},
-    {.code = -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE), .description="SSL - A fatal alert message was received from our peer"},
-    {.code = -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED), .description="SSL - Verification of our peer failed"},
-    {.code = -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY), .description="SSL - The peer notified us that the connection is going to be closed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO), .description="SSL - Processing of the ClientHello handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO), .description="SSL - Processing of the ServerHello handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE), .description="SSL - Processing of the Certificate handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST), .description="SSL - Processing of the CertificateRequest handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE), .description="SSL - Processing of the ServerKeyExchange handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE), .description="SSL - Processing of the ServerHelloDone handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE), .description="SSL - Processing of the ClientKeyExchange handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_RP), .description="SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Read Public"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_CS), .description="SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Calculate Secret"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY), .description="SSL - Processing of the CertificateVerify handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC), .description="SSL - Processing of the ChangeCipherSpec handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_FINISHED), .description="SSL - Processing of the Finished handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_ALLOC_FAILED), .description="SSL - Memory allocation failed"},
-    {.code = -(MBEDTLS_ERR_SSL_HW_ACCEL_FAILED), .description="SSL - Hardware acceleration function returned with error"},
-    {.code = -(MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH), .description="SSL - Hardware acceleration function skipped / left alone data"},
-    {.code = -(MBEDTLS_ERR_SSL_COMPRESSION_FAILED), .description="SSL - Processing of the compression / decompression failed"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION), .description="SSL - Handshake protocol not within min/max boundaries"},
-    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET), .description="SSL - Processing of the NewSessionTicket handshake message failed"},
-    {.code = -(MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED), .description="SSL - Session ticket has expired"},
-    {.code = -(MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH), .description="SSL - Public key type mismatch (eg, asked for RSA key exchange and presented EC key)"},
-    {.code = -(MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY), .description="SSL - Unknown identity received (eg, PSK identity)"},
-    {.code = -(MBEDTLS_ERR_SSL_INTERNAL_ERROR), .description="SSL - Internal error (eg, unexpected failure in lower-level module)"},
-    {.code = -(MBEDTLS_ERR_SSL_COUNTER_WRAPPING), .description="SSL - A counter would wrap (eg, too many messages exchanged)"},
-    {.code = -(MBEDTLS_ERR_SSL_WAITING_SERVER_HELLO_RENEGO), .description="SSL - Unexpected message at ServerHello in renegotiation"},
-    {.code = -(MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED), .description="SSL - DTLS client must retry for hello verification"},
-    {.code = -(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL), .description="SSL - A buffer is too small to receive or write a message"},
-    {.code = -(MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE), .description="SSL - None of the common ciphersuites is usable (eg, no suitable certificate, see debug messages)"},
-    {.code = -(MBEDTLS_ERR_SSL_WANT_READ), .description="SSL - No data of requested type currently available on underlying transport"},
-    {.code = -(MBEDTLS_ERR_SSL_WANT_WRITE), .description="SSL - Connection requires a write call"},
-    {.code = -(MBEDTLS_ERR_SSL_TIMEOUT), .description="SSL - The operation timed out"},
-    {.code = -(MBEDTLS_ERR_SSL_CLIENT_RECONNECT), .description="SSL - The client initiated a reconnect from the same port"},
-    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD), .description="SSL - Record header looks valid but is not expected"},
-    {.code = -(MBEDTLS_ERR_SSL_NON_FATAL), .description="SSL - The alert message received indicates a non-fatal error"},
-    {.code = -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH), .description="SSL - Couldn't set the hash for verifying CertificateVerify"},
-    {.code = -(MBEDTLS_ERR_SSL_CONTINUE_PROCESSING), .description="SSL - Internal-only message signaling that further message-processing should be done"},
-    {.code = -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS), .description="SSL - The asynchronous operation is not completed yet"},
-    {.code = -(MBEDTLS_ERR_SSL_EARLY_MESSAGE), .description="SSL - Internal-only message signaling that a message arrived early"},
-    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_CID), .description="SSL - An encrypted DTLS-frame with an unexpected CID was received"},
-    {.code = -(MBEDTLS_ERR_SSL_VERSION_MISMATCH), .description="SSL - An operation failed due to an unexpected version or configuration"},
-    {.code = -(MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS), .description="SSL - A cryptographic operation is in progress. Try again later"},
+        case -(MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE):
+            error_description = "SSL - The requested feature is not available";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_INPUT_DATA):
+            error_description = "SSL - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_SSL_INVALID_MAC):
+            error_description = "SSL - Verification of the message MAC failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_INVALID_RECORD):
+            error_description = "SSL - An invalid SSL record was received";
+            break;
+        case -(MBEDTLS_ERR_SSL_CONN_EOF):
+            error_description = "SSL - The connection indicated an EOF";
+            break;
+        case -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER):
+            error_description = "SSL - An unknown cipher was received";
+            break;
+        case -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN):
+            error_description = "SSL - The server has no ciphersuites in common with the client";
+            break;
+        case -(MBEDTLS_ERR_SSL_NO_RNG):
+            error_description = "SSL - No RNG was provided to the SSL module";
+            break;
+        case -(MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE):
+            error_description = "SSL - No client certification received from the client, but required by the authentication mode";
+            break;
+        case -(MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE):
+            error_description = "SSL - Our own certificate(s) is/are too large to send in an SSL message";
+            break;
+        case -(MBEDTLS_ERR_SSL_CERTIFICATE_REQUIRED):
+            error_description = "SSL - The own certificate is not set, but needed by the server";
+            break;
+        case -(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED):
+            error_description = "SSL - The own private key or pre-shared key is not set, but needed";
+            break;
+        case -(MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED):
+            error_description = "SSL - No CA Chain is set, but required to operate";
+            break;
+        case -(MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE):
+            error_description = "SSL - An unexpected message was received from our peer";
+            break;
+        case -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE):
+            error_description = "SSL - A fatal alert message was received from our peer";
+            break;
+        case -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED):
+            error_description = "SSL - Verification of our peer failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY):
+            error_description = "SSL - The peer notified us that the connection is going to be closed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO):
+            error_description = "SSL - Processing of the ClientHello handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO):
+            error_description = "SSL - Processing of the ServerHello handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE):
+            error_description = "SSL - Processing of the Certificate handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST):
+            error_description = "SSL - Processing of the CertificateRequest handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE):
+            error_description = "SSL - Processing of the ServerKeyExchange handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE):
+            error_description = "SSL - Processing of the ServerHelloDone handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE):
+            error_description = "SSL - Processing of the ClientKeyExchange handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_RP):
+            error_description = "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Read Public";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_CS):
+            error_description = "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Calculate Secret";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY):
+            error_description = "SSL - Processing of the CertificateVerify handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC):
+            error_description = "SSL - Processing of the ChangeCipherSpec handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_FINISHED):
+            error_description = "SSL - Processing of the Finished handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_ALLOC_FAILED):
+            error_description = "SSL - Memory allocation failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_HW_ACCEL_FAILED):
+            error_description = "SSL - Hardware acceleration function returned with error";
+            break;
+        case -(MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH):
+            error_description = "SSL - Hardware acceleration function skipped / left alone data";
+            break;
+        case -(MBEDTLS_ERR_SSL_COMPRESSION_FAILED):
+            error_description = "SSL - Processing of the compression / decompression failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION):
+            error_description = "SSL - Handshake protocol not within min/max boundaries";
+            break;
+        case -(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET):
+            error_description = "SSL - Processing of the NewSessionTicket handshake message failed";
+            break;
+        case -(MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED):
+            error_description = "SSL - Session ticket has expired";
+            break;
+        case -(MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH):
+            error_description = "SSL - Public key type mismatch (eg, asked for RSA key exchange and presented EC key)";
+            break;
+        case -(MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY):
+            error_description = "SSL - Unknown identity received (eg, PSK identity)";
+            break;
+        case -(MBEDTLS_ERR_SSL_INTERNAL_ERROR):
+            error_description = "SSL - Internal error (eg, unexpected failure in lower-level module)";
+            break;
+        case -(MBEDTLS_ERR_SSL_COUNTER_WRAPPING):
+            error_description = "SSL - A counter would wrap (eg, too many messages exchanged)";
+            break;
+        case -(MBEDTLS_ERR_SSL_WAITING_SERVER_HELLO_RENEGO):
+            error_description = "SSL - Unexpected message at ServerHello in renegotiation";
+            break;
+        case -(MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED):
+            error_description = "SSL - DTLS client must retry for hello verification";
+            break;
+        case -(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL):
+            error_description = "SSL - A buffer is too small to receive or write a message";
+            break;
+        case -(MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE):
+            error_description = "SSL - None of the common ciphersuites is usable (eg, no suitable certificate, see debug messages)";
+            break;
+        case -(MBEDTLS_ERR_SSL_WANT_READ):
+            error_description = "SSL - No data of requested type currently available on underlying transport";
+            break;
+        case -(MBEDTLS_ERR_SSL_WANT_WRITE):
+            error_description = "SSL - Connection requires a write call";
+            break;
+        case -(MBEDTLS_ERR_SSL_TIMEOUT):
+            error_description = "SSL - The operation timed out";
+            break;
+        case -(MBEDTLS_ERR_SSL_CLIENT_RECONNECT):
+            error_description = "SSL - The client initiated a reconnect from the same port";
+            break;
+        case -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD):
+            error_description = "SSL - Record header looks valid but is not expected";
+            break;
+        case -(MBEDTLS_ERR_SSL_NON_FATAL):
+            error_description = "SSL - The alert message received indicates a non-fatal error";
+            break;
+        case -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH):
+            error_description = "SSL - Couldn't set the hash for verifying CertificateVerify";
+            break;
+        case -(MBEDTLS_ERR_SSL_CONTINUE_PROCESSING):
+            error_description = "SSL - Internal-only message signaling that further message-processing should be done";
+            break;
+        case -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS):
+            error_description = "SSL - The asynchronous operation is not completed yet";
+            break;
+        case -(MBEDTLS_ERR_SSL_EARLY_MESSAGE):
+            error_description = "SSL - Internal-only message signaling that a message arrived early";
+            break;
+        case -(MBEDTLS_ERR_SSL_UNEXPECTED_CID):
+            error_description = "SSL - An encrypted DTLS-frame with an unexpected CID was received";
+            break;
+        case -(MBEDTLS_ERR_SSL_VERSION_MISMATCH):
+            error_description = "SSL - An operation failed due to an unexpected version or configuration";
+            break;
+        case -(MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS):
+            error_description = "SSL - A cryptographic operation is in progress. Try again later";
+            break;
 #endif /* MBEDTLS_SSL_TLS_C */
 
 #if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
-    {.code = -(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE), .description="X509 - Unavailable feature, e.g. RSA hashing/encryption combination"},
-    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_OID), .description="X509 - Requested OID is unknown"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_FORMAT), .description="X509 - The CRT/CRL/CSR format is invalid, e.g. different type expected"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_VERSION), .description="X509 - The CRT/CRL/CSR version element is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_SERIAL), .description="X509 - The serial tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_ALG), .description="X509 - The algorithm tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_NAME), .description="X509 - The name tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_DATE), .description="X509 - The date tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_SIGNATURE), .description="X509 - The signature tag or value invalid"},
-    {.code = -(MBEDTLS_ERR_X509_INVALID_EXTENSIONS), .description="X509 - The extension tag or value is invalid"},
-    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_VERSION), .description="X509 - CRT/CRL/CSR has an unsupported version number"},
-    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG), .description="X509 - Signature algorithm (oid) is unsupported"},
-    {.code = -(MBEDTLS_ERR_X509_SIG_MISMATCH), .description="X509 - Signature algorithms do not match. (see \\c ::mbedtls_x509_crt sig_oid)"},
-    {.code = -(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED), .description="X509 - Certificate verification failed, e.g. CRL, CA or signature check failed"},
-    {.code = -(MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT), .description="X509 - Format not recognized as DER or PEM"},
-    {.code = -(MBEDTLS_ERR_X509_BAD_INPUT_DATA), .description="X509 - Input invalid"},
-    {.code = -(MBEDTLS_ERR_X509_ALLOC_FAILED), .description="X509 - Allocation of memory failed"},
-    {.code = -(MBEDTLS_ERR_X509_FILE_IO_ERROR), .description="X509 - Read/write of file failed"},
-    {.code = -(MBEDTLS_ERR_X509_BUFFER_TOO_SMALL), .description="X509 - Destination buffer is too small"},
-    {.code = -(MBEDTLS_ERR_X509_FATAL_ERROR), .description="X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed"},
-#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
-};
-
-#define NUM_HIGH_LEVEL_ERRORS ( sizeof(high_level_errors)/sizeof(mbedtls_error_t) )
-
-static mbedtls_error_t low_level_errors[] =
-{
-#if defined(MBEDTLS_AES_C)
-    {.code = -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH), .description="AES - Invalid key length"},
-    {.code = -(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH), .description="AES - Invalid data input length"},
-    {.code = -(MBEDTLS_ERR_AES_BAD_INPUT_DATA), .description="AES - Invalid input data"},
-    {.code = -(MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE), .description="AES - Feature not available. For example, an unsupported AES key size"},
-    {.code = -(MBEDTLS_ERR_AES_HW_ACCEL_FAILED), .description="AES - AES hardware accelerator failed"},
-#endif /* MBEDTLS_AES_C */
-
-#if defined(MBEDTLS_ARC4_C)
-    {.code = -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED), .description="ARC4 - ARC4 hardware accelerator failed"},
-#endif /* MBEDTLS_ARC4_C */
-
-#if defined(MBEDTLS_ARIA_C)
-    {.code = -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA), .description="ARIA - Bad input data"},
-    {.code = -(MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH), .description="ARIA - Invalid data input length"},
-    {.code = -(MBEDTLS_ERR_ARIA_FEATURE_UNAVAILABLE), .description="ARIA - Feature not available. For example, an unsupported ARIA key size"},
-    {.code = -(MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED), .description="ARIA - ARIA hardware accelerator failed"},
-#endif /* MBEDTLS_ARIA_C */
-
-#if defined(MBEDTLS_ASN1_PARSE_C)
-    {.code = -(MBEDTLS_ERR_ASN1_OUT_OF_DATA), .description="ASN1 - Out of data when parsing an ASN1 data structure"},
-    {.code = -(MBEDTLS_ERR_ASN1_UNEXPECTED_TAG), .description="ASN1 - ASN1 tag was of an unexpected value"},
-    {.code = -(MBEDTLS_ERR_ASN1_INVALID_LENGTH), .description="ASN1 - Error when trying to determine the length or invalid length"},
-    {.code = -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH), .description="ASN1 - Actual length differs from expected length"},
-    {.code = -(MBEDTLS_ERR_ASN1_INVALID_DATA), .description="ASN1 - Data is invalid"},
-    {.code = -(MBEDTLS_ERR_ASN1_ALLOC_FAILED), .description="ASN1 - Memory allocation failed"},
-    {.code = -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL), .description="ASN1 - Buffer too small when writing ASN.1 data structure"},
-#endif /* MBEDTLS_ASN1_PARSE_C */
-
-#if defined(MBEDTLS_BASE64_C)
-    {.code = -(MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL), .description="BASE64 - Output buffer too small"},
-    {.code = -(MBEDTLS_ERR_BASE64_INVALID_CHARACTER), .description="BASE64 - Invalid character in input"},
-#endif /* MBEDTLS_BASE64_C */
-
-#if defined(MBEDTLS_BIGNUM_C)
-    {.code = -(MBEDTLS_ERR_MPI_FILE_IO_ERROR), .description="BIGNUM - An error occurred while reading from or writing to a file"},
-    {.code = -(MBEDTLS_ERR_MPI_BAD_INPUT_DATA), .description="BIGNUM - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_MPI_INVALID_CHARACTER), .description="BIGNUM - There is an invalid character in the digit string"},
-    {.code = -(MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL), .description="BIGNUM - The buffer is too small to write to"},
-    {.code = -(MBEDTLS_ERR_MPI_NEGATIVE_VALUE), .description="BIGNUM - The input arguments are negative or result in illegal output"},
-    {.code = -(MBEDTLS_ERR_MPI_DIVISION_BY_ZERO), .description="BIGNUM - The input argument for division is zero, which is not allowed"},
-    {.code = -(MBEDTLS_ERR_MPI_NOT_ACCEPTABLE), .description="BIGNUM - The input arguments are not acceptable"},
-    {.code = -(MBEDTLS_ERR_MPI_ALLOC_FAILED), .description="BIGNUM - Memory allocation failed"},
-#endif /* MBEDTLS_BIGNUM_C */
-
-#if defined(MBEDTLS_BLOWFISH_C)
-    {.code = -(MBEDTLS_ERR_BLOWFISH_BAD_INPUT_DATA), .description="BLOWFISH - Bad input data"},
-    {.code = -(MBEDTLS_ERR_BLOWFISH_INVALID_INPUT_LENGTH), .description="BLOWFISH - Invalid data input length"},
-    {.code = -(MBEDTLS_ERR_BLOWFISH_HW_ACCEL_FAILED), .description="BLOWFISH - Blowfish hardware accelerator failed"},
-#endif /* MBEDTLS_BLOWFISH_C */
-
-#if defined(MBEDTLS_CAMELLIA_C)
-    {.code = -(MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA), .description="CAMELLIA - Bad input data"},
-    {.code = -(MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH), .description="CAMELLIA - Invalid data input length"},
-    {.code = -(MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED), .description="CAMELLIA - Camellia hardware accelerator failed"},
-#endif /* MBEDTLS_CAMELLIA_C */
-
-#if defined(MBEDTLS_CCM_C)
-    {.code = -(MBEDTLS_ERR_CCM_BAD_INPUT), .description="CCM - Bad input parameters to the function"},
-    {.code = -(MBEDTLS_ERR_CCM_AUTH_FAILED), .description="CCM - Authenticated decryption failed"},
-    {.code = -(MBEDTLS_ERR_CCM_HW_ACCEL_FAILED), .description="CCM - CCM hardware accelerator failed"},
-#endif /* MBEDTLS_CCM_C */
-
-#if defined(MBEDTLS_CHACHA20_C)
-    {.code = -(MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA), .description="CHACHA20 - Invalid input parameter(s)"},
-    {.code = -(MBEDTLS_ERR_CHACHA20_FEATURE_UNAVAILABLE), .description="CHACHA20 - Feature not available. For example, s part of the API is not implemented"},
-    {.code = -(MBEDTLS_ERR_CHACHA20_HW_ACCEL_FAILED), .description="CHACHA20 - Chacha20 hardware accelerator failed"},
-#endif /* MBEDTLS_CHACHA20_C */
-
-#if defined(MBEDTLS_CHACHAPOLY_C)
-    {.code = -(MBEDTLS_ERR_CHACHAPOLY_BAD_STATE), .description="CHACHAPOLY - The requested operation is not permitted in the current state"},
-    {.code = -(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED), .description="CHACHAPOLY - Authenticated decryption failed: data was not authentic"},
-#endif /* MBEDTLS_CHACHAPOLY_C */
-
-#if defined(MBEDTLS_CMAC_C)
-    {.code = -(MBEDTLS_ERR_CMAC_HW_ACCEL_FAILED), .description="CMAC - CMAC hardware accelerator failed"},
-#endif /* MBEDTLS_CMAC_C */
-
-#if defined(MBEDTLS_CTR_DRBG_C)
-    {.code = -(MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED), .description="CTR_DRBG - The entropy source failed"},
-    {.code = -(MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG), .description="CTR_DRBG - The requested random buffer length is too big"},
-    {.code = -(MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG), .description="CTR_DRBG - The input (entropy + additional data) is too large"},
-    {.code = -(MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR), .description="CTR_DRBG - Read or write error in file"},
-#endif /* MBEDTLS_CTR_DRBG_C */
-
-#if defined(MBEDTLS_DES_C)
-    {.code = -(MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH), .description="DES - The data input has an invalid length"},
-    {.code = -(MBEDTLS_ERR_DES_HW_ACCEL_FAILED), .description="DES - DES hardware accelerator failed"},
-#endif /* MBEDTLS_DES_C */
-
-#if defined(MBEDTLS_ENTROPY_C)
-    {.code = -(MBEDTLS_ERR_ENTROPY_SOURCE_FAILED), .description="ENTROPY - Critical entropy source failure"},
-    {.code = -(MBEDTLS_ERR_ENTROPY_MAX_SOURCES), .description="ENTROPY - No more sources can be added"},
-    {.code = -(MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED), .description="ENTROPY - No sources have been added to poll"},
-    {.code = -(MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE), .description="ENTROPY - No strong sources have been added to poll"},
-    {.code = -(MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR), .description="ENTROPY - Read/write error in file"},
-#endif /* MBEDTLS_ENTROPY_C */
-
-#if defined(MBEDTLS_ERROR_C)
-    {.code = -(MBEDTLS_ERR_ERROR_GENERIC_ERROR), .description="ERROR - Generic error"},
-    {.code = -(MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED), .description="ERROR - This is a bug in the library"},
-#endif /* MBEDTLS_ERROR_C */
-
-#if defined(MBEDTLS_GCM_C)
-    {.code = -(MBEDTLS_ERR_GCM_AUTH_FAILED), .description="GCM - Authenticated decryption failed"},
-    {.code = -(MBEDTLS_ERR_GCM_HW_ACCEL_FAILED), .description="GCM - GCM hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_GCM_BAD_INPUT), .description="GCM - Bad input parameters to function"},
-#endif /* MBEDTLS_GCM_C */
-
-#if defined(MBEDTLS_HKDF_C)
-    {.code = -(MBEDTLS_ERR_HKDF_BAD_INPUT_DATA), .description="HKDF - Bad input parameters to function"},
-#endif /* MBEDTLS_HKDF_C */
-
-#if defined(MBEDTLS_HMAC_DRBG_C)
-    {.code = -(MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG), .description="HMAC_DRBG - Too many random requested in single call"},
-    {.code = -(MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG), .description="HMAC_DRBG - Input too large (Entropy + additional)"},
-    {.code = -(MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR), .description="HMAC_DRBG - Read/write error in file"},
-    {.code = -(MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED), .description="HMAC_DRBG - The entropy source failed"},
-#endif /* MBEDTLS_HMAC_DRBG_C */
-
-#if defined(MBEDTLS_MD2_C)
-    {.code = -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED), .description="MD2 - MD2 hardware accelerator failed"},
-#endif /* MBEDTLS_MD2_C */
-
-#if defined(MBEDTLS_MD4_C)
-    {.code = -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED), .description="MD4 - MD4 hardware accelerator failed"},
-#endif /* MBEDTLS_MD4_C */
-
-#if defined(MBEDTLS_MD5_C)
-    {.code = -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED), .description="MD5 - MD5 hardware accelerator failed"},
-#endif /* MBEDTLS_MD5_C */
-
-#if defined(MBEDTLS_NET_C)
-    {.code = -(MBEDTLS_ERR_NET_SOCKET_FAILED), .description="NET - Failed to open a socket"},
-    {.code = -(MBEDTLS_ERR_NET_CONNECT_FAILED), .description="NET - The connection to the given server / port failed"},
-    {.code = -(MBEDTLS_ERR_NET_BIND_FAILED), .description="NET - Binding of the socket failed"},
-    {.code = -(MBEDTLS_ERR_NET_LISTEN_FAILED), .description="NET - Could not listen on the socket"},
-    {.code = -(MBEDTLS_ERR_NET_ACCEPT_FAILED), .description="NET - Could not accept the incoming connection"},
-    {.code = -(MBEDTLS_ERR_NET_RECV_FAILED), .description="NET - Reading information from the socket failed"},
-    {.code = -(MBEDTLS_ERR_NET_SEND_FAILED), .description="NET - Sending information through the socket failed"},
-    {.code = -(MBEDTLS_ERR_NET_CONN_RESET), .description="NET - Connection was reset by peer"},
-    {.code = -(MBEDTLS_ERR_NET_UNKNOWN_HOST), .description="NET - Failed to get an IP address for the given hostname"},
-    {.code = -(MBEDTLS_ERR_NET_BUFFER_TOO_SMALL), .description="NET - Buffer is too small to hold the data"},
-    {.code = -(MBEDTLS_ERR_NET_INVALID_CONTEXT), .description="NET - The context is invalid, eg because it was free()ed"},
-    {.code = -(MBEDTLS_ERR_NET_POLL_FAILED), .description="NET - Polling the net context failed"},
-    {.code = -(MBEDTLS_ERR_NET_BAD_INPUT_DATA), .description="NET - Input invalid"},
-#endif /* MBEDTLS_NET_C */
-
-#if defined(MBEDTLS_OID_C)
-    {.code = -(MBEDTLS_ERR_OID_NOT_FOUND), .description="OID - OID is not found"},
-    {.code = -(MBEDTLS_ERR_OID_BUF_TOO_SMALL), .description="OID - output buffer is too small"},
-#endif /* MBEDTLS_OID_C */
-
-#if defined(MBEDTLS_PADLOCK_C)
-    {.code = -(MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED), .description="PADLOCK - Input data should be aligned"},
-#endif /* MBEDTLS_PADLOCK_C */
-
-#if defined(MBEDTLS_PLATFORM_C)
-    {.code = -(MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED), .description="PLATFORM - Hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED), .description="PLATFORM - The requested feature is not supported by the platform"},
-#endif /* MBEDTLS_PLATFORM_C */
-
-#if defined(MBEDTLS_POLY1305_C)
-    {.code = -(MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA), .description="POLY1305 - Invalid input parameter(s)"},
-    {.code = -(MBEDTLS_ERR_POLY1305_FEATURE_UNAVAILABLE), .description="POLY1305 - Feature not available. For example, s part of the API is not implemented"},
-    {.code = -(MBEDTLS_ERR_POLY1305_HW_ACCEL_FAILED), .description="POLY1305 - Poly1305 hardware accelerator failed"},
-#endif /* MBEDTLS_POLY1305_C */
-
-#if defined(MBEDTLS_RIPEMD160_C)
-    {.code = -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED), .description="RIPEMD160 - RIPEMD160 hardware accelerator failed"},
-#endif /* MBEDTLS_RIPEMD160_C */
-
-#if defined(MBEDTLS_SHA1_C)
-    {.code = -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED), .description="SHA1 - SHA-1 hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA), .description="SHA1 - SHA-1 input data was malformed"},
-#endif /* MBEDTLS_SHA1_C */
-
-#if defined(MBEDTLS_SHA256_C)
-    {.code = -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED), .description="SHA256 - SHA-256 hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA), .description="SHA256 - SHA-256 input data was malformed"},
-#endif /* MBEDTLS_SHA256_C */
-
-#if defined(MBEDTLS_SHA512_C)
-    {.code = -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED), .description="SHA512 - SHA-512 hardware accelerator failed"},
-    {.code = -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA), .description="SHA512 - SHA-512 input data was malformed"},
-#endif /* MBEDTLS_SHA512_C */
-
-#if defined(MBEDTLS_THREADING_C)
-    {.code = -(MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE), .description="THREADING - The selected feature is not available"},
-    {.code = -(MBEDTLS_ERR_THREADING_BAD_INPUT_DATA), .description="THREADING - Bad input parameters to function"},
-    {.code = -(MBEDTLS_ERR_THREADING_MUTEX_ERROR), .description="THREADING - Locking / unlocking / free failed with error code"},
-#endif /* MBEDTLS_THREADING_C */
-
-#if defined(MBEDTLS_XTEA_C)
-    {.code = -(MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH), .description="XTEA - The data input has an invalid length"},
-    {.code = -(MBEDTLS_ERR_XTEA_HW_ACCEL_FAILED), .description="XTEA - XTEA hardware accelerator failed"},
-#endif /* MBEDTLS_XTEA_C */
-};
-
-#define NUM_LOW_LEVEL_ERRORS  ( sizeof(low_level_errors)/sizeof(mbedtls_error_t) )
-
-const char * mbedtls_high_level_strerr( int error_code )
-{
-    size_t i;
-    const char *error_description = NULL;
-
-    for(i = 0; i < NUM_HIGH_LEVEL_ERRORS; i++ )
-    {
-        if( high_level_errors[i].code == error_code )
-        {
-            error_description = high_level_errors[i].description;
+        case -(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE):
+            error_description = "X509 - Unavailable feature, e.g. RSA hashing/encryption combination";
             break;
-        }
+        case -(MBEDTLS_ERR_X509_UNKNOWN_OID):
+            error_description = "X509 - Requested OID is unknown";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_FORMAT):
+            error_description = "X509 - The CRT/CRL/CSR format is invalid, e.g. different type expected";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_VERSION):
+            error_description = "X509 - The CRT/CRL/CSR version element is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_SERIAL):
+            error_description = "X509 - The serial tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_ALG):
+            error_description = "X509 - The algorithm tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_NAME):
+            error_description = "X509 - The name tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_DATE):
+            error_description = "X509 - The date tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_SIGNATURE):
+            error_description = "X509 - The signature tag or value invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_INVALID_EXTENSIONS):
+            error_description = "X509 - The extension tag or value is invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_UNKNOWN_VERSION):
+            error_description = "X509 - CRT/CRL/CSR has an unsupported version number";
+            break;
+        case -(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG):
+            error_description = "X509 - Signature algorithm (oid) is unsupported";
+            break;
+        case -(MBEDTLS_ERR_X509_SIG_MISMATCH):
+            error_description = "X509 - Signature algorithms do not match. (see \\c ::mbedtls_x509_crt sig_oid)";
+            break;
+        case -(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED):
+            error_description = "X509 - Certificate verification failed, e.g. CRL, CA or signature check failed";
+            break;
+        case -(MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT):
+            error_description = "X509 - Format not recognized as DER or PEM";
+            break;
+        case -(MBEDTLS_ERR_X509_BAD_INPUT_DATA):
+            error_description = "X509 - Input invalid";
+            break;
+        case -(MBEDTLS_ERR_X509_ALLOC_FAILED):
+            error_description = "X509 - Allocation of memory failed";
+            break;
+        case -(MBEDTLS_ERR_X509_FILE_IO_ERROR):
+            error_description = "X509 - Read/write of file failed";
+            break;
+        case -(MBEDTLS_ERR_X509_BUFFER_TOO_SMALL):
+            error_description = "X509 - Destination buffer is too small";
+            break;
+        case -(MBEDTLS_ERR_X509_FATAL_ERROR):
+            error_description = "X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed";
+            break;
+#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
+
+        default:
+            break;
     }
 
     return error_description;
@@ -633,16 +723,408 @@ const char * mbedtls_high_level_strerr( int error_code )
 
 const char * mbedtls_low_level_strerr( int error_code )
 {
-    size_t i;
     const char *error_description = NULL;
 
-    for(i = 0; i < NUM_LOW_LEVEL_ERRORS; i++ )
+    switch( error_code )
     {
-        if( low_level_errors[i].code == error_code )
-        {
-            error_description = low_level_errors[i].description;
+#if defined(MBEDTLS_AES_C)
+        case -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH):
+            error_description = "AES - Invalid key length";
             break;
-        }
+        case -(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH):
+            error_description = "AES - Invalid data input length";
+            break;
+        case -(MBEDTLS_ERR_AES_BAD_INPUT_DATA):
+            error_description = "AES - Invalid input data";
+            break;
+        case -(MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE):
+            error_description = "AES - Feature not available. For example, an unsupported AES key size";
+            break;
+        case -(MBEDTLS_ERR_AES_HW_ACCEL_FAILED):
+            error_description = "AES - AES hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_AES_C */
+
+#if defined(MBEDTLS_ARC4_C)
+        case -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED):
+            error_description = "ARC4 - ARC4 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_ARC4_C */
+
+#if defined(MBEDTLS_ARIA_C)
+        case -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA):
+            error_description = "ARIA - Bad input data";
+            break;
+        case -(MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH):
+            error_description = "ARIA - Invalid data input length";
+            break;
+        case -(MBEDTLS_ERR_ARIA_FEATURE_UNAVAILABLE):
+            error_description = "ARIA - Feature not available. For example, an unsupported ARIA key size";
+            break;
+        case -(MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED):
+            error_description = "ARIA - ARIA hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_ARIA_C */
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
+        case -(MBEDTLS_ERR_ASN1_OUT_OF_DATA):
+            error_description = "ASN1 - Out of data when parsing an ASN1 data structure";
+            break;
+        case -(MBEDTLS_ERR_ASN1_UNEXPECTED_TAG):
+            error_description = "ASN1 - ASN1 tag was of an unexpected value";
+            break;
+        case -(MBEDTLS_ERR_ASN1_INVALID_LENGTH):
+            error_description = "ASN1 - Error when trying to determine the length or invalid length";
+            break;
+        case -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH):
+            error_description = "ASN1 - Actual length differs from expected length";
+            break;
+        case -(MBEDTLS_ERR_ASN1_INVALID_DATA):
+            error_description = "ASN1 - Data is invalid";
+            break;
+        case -(MBEDTLS_ERR_ASN1_ALLOC_FAILED):
+            error_description = "ASN1 - Memory allocation failed";
+            break;
+        case -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL):
+            error_description = "ASN1 - Buffer too small when writing ASN.1 data structure";
+            break;
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
+#if defined(MBEDTLS_BASE64_C)
+        case -(MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL):
+            error_description = "BASE64 - Output buffer too small";
+            break;
+        case -(MBEDTLS_ERR_BASE64_INVALID_CHARACTER):
+            error_description = "BASE64 - Invalid character in input";
+            break;
+#endif /* MBEDTLS_BASE64_C */
+
+#if defined(MBEDTLS_BIGNUM_C)
+        case -(MBEDTLS_ERR_MPI_FILE_IO_ERROR):
+            error_description = "BIGNUM - An error occurred while reading from or writing to a file";
+            break;
+        case -(MBEDTLS_ERR_MPI_BAD_INPUT_DATA):
+            error_description = "BIGNUM - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_MPI_INVALID_CHARACTER):
+            error_description = "BIGNUM - There is an invalid character in the digit string";
+            break;
+        case -(MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL):
+            error_description = "BIGNUM - The buffer is too small to write to";
+            break;
+        case -(MBEDTLS_ERR_MPI_NEGATIVE_VALUE):
+            error_description = "BIGNUM - The input arguments are negative or result in illegal output";
+            break;
+        case -(MBEDTLS_ERR_MPI_DIVISION_BY_ZERO):
+            error_description = "BIGNUM - The input argument for division is zero, which is not allowed";
+            break;
+        case -(MBEDTLS_ERR_MPI_NOT_ACCEPTABLE):
+            error_description = "BIGNUM - The input arguments are not acceptable";
+            break;
+        case -(MBEDTLS_ERR_MPI_ALLOC_FAILED):
+            error_description = "BIGNUM - Memory allocation failed";
+            break;
+#endif /* MBEDTLS_BIGNUM_C */
+
+#if defined(MBEDTLS_BLOWFISH_C)
+        case -(MBEDTLS_ERR_BLOWFISH_BAD_INPUT_DATA):
+            error_description = "BLOWFISH - Bad input data";
+            break;
+        case -(MBEDTLS_ERR_BLOWFISH_INVALID_INPUT_LENGTH):
+            error_description = "BLOWFISH - Invalid data input length";
+            break;
+        case -(MBEDTLS_ERR_BLOWFISH_HW_ACCEL_FAILED):
+            error_description = "BLOWFISH - Blowfish hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_BLOWFISH_C */
+
+#if defined(MBEDTLS_CAMELLIA_C)
+        case -(MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA):
+            error_description = "CAMELLIA - Bad input data";
+            break;
+        case -(MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH):
+            error_description = "CAMELLIA - Invalid data input length";
+            break;
+        case -(MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED):
+            error_description = "CAMELLIA - Camellia hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_CAMELLIA_C */
+
+#if defined(MBEDTLS_CCM_C)
+        case -(MBEDTLS_ERR_CCM_BAD_INPUT):
+            error_description = "CCM - Bad input parameters to the function";
+            break;
+        case -(MBEDTLS_ERR_CCM_AUTH_FAILED):
+            error_description = "CCM - Authenticated decryption failed";
+            break;
+        case -(MBEDTLS_ERR_CCM_HW_ACCEL_FAILED):
+            error_description = "CCM - CCM hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_CCM_C */
+
+#if defined(MBEDTLS_CHACHA20_C)
+        case -(MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA):
+            error_description = "CHACHA20 - Invalid input parameter(s)";
+            break;
+        case -(MBEDTLS_ERR_CHACHA20_FEATURE_UNAVAILABLE):
+            error_description = "CHACHA20 - Feature not available. For example, s part of the API is not implemented";
+            break;
+        case -(MBEDTLS_ERR_CHACHA20_HW_ACCEL_FAILED):
+            error_description = "CHACHA20 - Chacha20 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_CHACHA20_C */
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+        case -(MBEDTLS_ERR_CHACHAPOLY_BAD_STATE):
+            error_description = "CHACHAPOLY - The requested operation is not permitted in the current state";
+            break;
+        case -(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED):
+            error_description = "CHACHAPOLY - Authenticated decryption failed: data was not authentic";
+            break;
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+#if defined(MBEDTLS_CMAC_C)
+        case -(MBEDTLS_ERR_CMAC_HW_ACCEL_FAILED):
+            error_description = "CMAC - CMAC hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_CMAC_C */
+
+#if defined(MBEDTLS_CTR_DRBG_C)
+        case -(MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED):
+            error_description = "CTR_DRBG - The entropy source failed";
+            break;
+        case -(MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG):
+            error_description = "CTR_DRBG - The requested random buffer length is too big";
+            break;
+        case -(MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG):
+            error_description = "CTR_DRBG - The input (entropy + additional data) is too large";
+            break;
+        case -(MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR):
+            error_description = "CTR_DRBG - Read or write error in file";
+            break;
+#endif /* MBEDTLS_CTR_DRBG_C */
+
+#if defined(MBEDTLS_DES_C)
+        case -(MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH):
+            error_description = "DES - The data input has an invalid length";
+            break;
+        case -(MBEDTLS_ERR_DES_HW_ACCEL_FAILED):
+            error_description = "DES - DES hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_DES_C */
+
+#if defined(MBEDTLS_ENTROPY_C)
+        case -(MBEDTLS_ERR_ENTROPY_SOURCE_FAILED):
+            error_description = "ENTROPY - Critical entropy source failure";
+            break;
+        case -(MBEDTLS_ERR_ENTROPY_MAX_SOURCES):
+            error_description = "ENTROPY - No more sources can be added";
+            break;
+        case -(MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED):
+            error_description = "ENTROPY - No sources have been added to poll";
+            break;
+        case -(MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE):
+            error_description = "ENTROPY - No strong sources have been added to poll";
+            break;
+        case -(MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR):
+            error_description = "ENTROPY - Read/write error in file";
+            break;
+#endif /* MBEDTLS_ENTROPY_C */
+
+#if defined(MBEDTLS_ERROR_C)
+        case -(MBEDTLS_ERR_ERROR_GENERIC_ERROR):
+            error_description = "ERROR - Generic error";
+            break;
+        case -(MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED):
+            error_description = "ERROR - This is a bug in the library";
+            break;
+#endif /* MBEDTLS_ERROR_C */
+
+#if defined(MBEDTLS_GCM_C)
+        case -(MBEDTLS_ERR_GCM_AUTH_FAILED):
+            error_description = "GCM - Authenticated decryption failed";
+            break;
+        case -(MBEDTLS_ERR_GCM_HW_ACCEL_FAILED):
+            error_description = "GCM - GCM hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_GCM_BAD_INPUT):
+            error_description = "GCM - Bad input parameters to function";
+            break;
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_HKDF_C)
+        case -(MBEDTLS_ERR_HKDF_BAD_INPUT_DATA):
+            error_description = "HKDF - Bad input parameters to function";
+            break;
+#endif /* MBEDTLS_HKDF_C */
+
+#if defined(MBEDTLS_HMAC_DRBG_C)
+        case -(MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG):
+            error_description = "HMAC_DRBG - Too many random requested in single call";
+            break;
+        case -(MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG):
+            error_description = "HMAC_DRBG - Input too large (Entropy + additional)";
+            break;
+        case -(MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR):
+            error_description = "HMAC_DRBG - Read/write error in file";
+            break;
+        case -(MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED):
+            error_description = "HMAC_DRBG - The entropy source failed";
+            break;
+#endif /* MBEDTLS_HMAC_DRBG_C */
+
+#if defined(MBEDTLS_MD2_C)
+        case -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED):
+            error_description = "MD2 - MD2 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_MD2_C */
+
+#if defined(MBEDTLS_MD4_C)
+        case -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED):
+            error_description = "MD4 - MD4 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_MD4_C */
+
+#if defined(MBEDTLS_MD5_C)
+        case -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED):
+            error_description = "MD5 - MD5 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_MD5_C */
+
+#if defined(MBEDTLS_NET_C)
+        case -(MBEDTLS_ERR_NET_SOCKET_FAILED):
+            error_description = "NET - Failed to open a socket";
+            break;
+        case -(MBEDTLS_ERR_NET_CONNECT_FAILED):
+            error_description = "NET - The connection to the given server / port failed";
+            break;
+        case -(MBEDTLS_ERR_NET_BIND_FAILED):
+            error_description = "NET - Binding of the socket failed";
+            break;
+        case -(MBEDTLS_ERR_NET_LISTEN_FAILED):
+            error_description = "NET - Could not listen on the socket";
+            break;
+        case -(MBEDTLS_ERR_NET_ACCEPT_FAILED):
+            error_description = "NET - Could not accept the incoming connection";
+            break;
+        case -(MBEDTLS_ERR_NET_RECV_FAILED):
+            error_description = "NET - Reading information from the socket failed";
+            break;
+        case -(MBEDTLS_ERR_NET_SEND_FAILED):
+            error_description = "NET - Sending information through the socket failed";
+            break;
+        case -(MBEDTLS_ERR_NET_CONN_RESET):
+            error_description = "NET - Connection was reset by peer";
+            break;
+        case -(MBEDTLS_ERR_NET_UNKNOWN_HOST):
+            error_description = "NET - Failed to get an IP address for the given hostname";
+            break;
+        case -(MBEDTLS_ERR_NET_BUFFER_TOO_SMALL):
+            error_description = "NET - Buffer is too small to hold the data";
+            break;
+        case -(MBEDTLS_ERR_NET_INVALID_CONTEXT):
+            error_description = "NET - The context is invalid, eg because it was free()ed";
+            break;
+        case -(MBEDTLS_ERR_NET_POLL_FAILED):
+            error_description = "NET - Polling the net context failed";
+            break;
+        case -(MBEDTLS_ERR_NET_BAD_INPUT_DATA):
+            error_description = "NET - Input invalid";
+            break;
+#endif /* MBEDTLS_NET_C */
+
+#if defined(MBEDTLS_OID_C)
+        case -(MBEDTLS_ERR_OID_NOT_FOUND):
+            error_description = "OID - OID is not found";
+            break;
+        case -(MBEDTLS_ERR_OID_BUF_TOO_SMALL):
+            error_description = "OID - output buffer is too small";
+            break;
+#endif /* MBEDTLS_OID_C */
+
+#if defined(MBEDTLS_PADLOCK_C)
+        case -(MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED):
+            error_description = "PADLOCK - Input data should be aligned";
+            break;
+#endif /* MBEDTLS_PADLOCK_C */
+
+#if defined(MBEDTLS_PLATFORM_C)
+        case -(MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED):
+            error_description = "PLATFORM - Hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED):
+            error_description = "PLATFORM - The requested feature is not supported by the platform";
+            break;
+#endif /* MBEDTLS_PLATFORM_C */
+
+#if defined(MBEDTLS_POLY1305_C)
+        case -(MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA):
+            error_description = "POLY1305 - Invalid input parameter(s)";
+            break;
+        case -(MBEDTLS_ERR_POLY1305_FEATURE_UNAVAILABLE):
+            error_description = "POLY1305 - Feature not available. For example, s part of the API is not implemented";
+            break;
+        case -(MBEDTLS_ERR_POLY1305_HW_ACCEL_FAILED):
+            error_description = "POLY1305 - Poly1305 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_POLY1305_C */
+
+#if defined(MBEDTLS_RIPEMD160_C)
+        case -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED):
+            error_description = "RIPEMD160 - RIPEMD160 hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_RIPEMD160_C */
+
+#if defined(MBEDTLS_SHA1_C)
+        case -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED):
+            error_description = "SHA1 - SHA-1 hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA):
+            error_description = "SHA1 - SHA-1 input data was malformed";
+            break;
+#endif /* MBEDTLS_SHA1_C */
+
+#if defined(MBEDTLS_SHA256_C)
+        case -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED):
+            error_description = "SHA256 - SHA-256 hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA):
+            error_description = "SHA256 - SHA-256 input data was malformed";
+            break;
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+        case -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED):
+            error_description = "SHA512 - SHA-512 hardware accelerator failed";
+            break;
+        case -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA):
+            error_description = "SHA512 - SHA-512 input data was malformed";
+            break;
+#endif /* MBEDTLS_SHA512_C */
+
+#if defined(MBEDTLS_THREADING_C)
+        case -(MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE):
+            error_description = "THREADING - The selected feature is not available";
+            break;
+        case -(MBEDTLS_ERR_THREADING_BAD_INPUT_DATA):
+            error_description = "THREADING - Bad input parameters to function";
+            break;
+        case -(MBEDTLS_ERR_THREADING_MUTEX_ERROR):
+            error_description = "THREADING - Locking / unlocking / free failed with error code";
+            break;
+#endif /* MBEDTLS_THREADING_C */
+
+#if defined(MBEDTLS_XTEA_C)
+        case -(MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH):
+            error_description = "XTEA - The data input has an invalid length";
+            break;
+        case -(MBEDTLS_ERR_XTEA_HW_ACCEL_FAILED):
+            error_description = "XTEA - XTEA hardware accelerator failed";
+            break;
+#endif /* MBEDTLS_XTEA_C */
+
+        default:
+            break;
     }
 
     return error_description;
@@ -675,10 +1157,12 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         else
             mbedtls_snprintf( buf, buflen, "%s", high_level_error_description );
 
+#if defined(MBEDTLS_SSL_TLS_C)
         // Early return in case of a fatal error - do not try to translate low
         // level code.
         if(use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE))
             return;
+#endif /* MBEDTLS_SSL_TLS_C */
     }
 
     use_ret = ret & ~0xFF80;

--- a/library/error.c
+++ b/library/error.c
@@ -219,6 +219,7 @@ const char * mbedtls_high_level_strerr( int error_code )
 
     switch( error_code )
     {
+        /* Begin Auto-Generated Code. */
 #if defined(MBEDTLS_CIPHER_C)
         case -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE):
             error_description = "CIPHER - The selected feature is not available";
@@ -713,6 +714,7 @@ const char * mbedtls_high_level_strerr( int error_code )
             error_description = "X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed";
             break;
 #endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
+        /* End Auto-Generated Code. */
 
         default:
             break;
@@ -727,6 +729,7 @@ const char * mbedtls_low_level_strerr( int error_code )
 
     switch( error_code )
     {
+        /* Begin Auto-Generated Code. */
 #if defined(MBEDTLS_AES_C)
         case -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH):
             error_description = "AES - Invalid key length";
@@ -1122,6 +1125,7 @@ const char * mbedtls_low_level_strerr( int error_code )
             error_description = "XTEA - XTEA hardware accelerator failed";
             break;
 #endif /* MBEDTLS_XTEA_C */
+        /* End Auto-Generated Code. */
 
         default:
             break;

--- a/library/error.c
+++ b/library/error.c
@@ -213,10 +213,447 @@
 #endif
 
 
+typedef struct mbedtls_error
+{
+    int code;                   /* Error code. */
+    const char * description;   /* Error description. */
+} mbedtls_error_t;
+
+static mbedtls_error_t high_level_errors[] =
+{
+#if defined(MBEDTLS_CIPHER_C)
+    {.code = -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE), .description="CIPHER - The selected feature is not available"},
+    {.code = -(MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA), .description="CIPHER - Bad input parameters"},
+    {.code = -(MBEDTLS_ERR_CIPHER_ALLOC_FAILED), .description="CIPHER - Failed to allocate memory"},
+    {.code = -(MBEDTLS_ERR_CIPHER_INVALID_PADDING), .description="CIPHER - Input data contains invalid padding and is rejected"},
+    {.code = -(MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED), .description="CIPHER - Decryption of block requires a full block"},
+    {.code = -(MBEDTLS_ERR_CIPHER_AUTH_FAILED), .description="CIPHER - Authentication failed (for AEAD modes)"},
+    {.code = -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT), .description="CIPHER - The context is invalid. For example, because it was freed"},
+    {.code = -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED), .description="CIPHER - Cipher hardware accelerator failed"},
+#endif /* MBEDTLS_CIPHER_C */
+
+#if defined(MBEDTLS_DHM_C)
+    {.code = -(MBEDTLS_ERR_DHM_BAD_INPUT_DATA), .description="DHM - Bad input parameters"},
+    {.code = -(MBEDTLS_ERR_DHM_READ_PARAMS_FAILED), .description="DHM - Reading of the DHM parameters failed"},
+    {.code = -(MBEDTLS_ERR_DHM_MAKE_PARAMS_FAILED), .description="DHM - Making of the DHM parameters failed"},
+    {.code = -(MBEDTLS_ERR_DHM_READ_PUBLIC_FAILED), .description="DHM - Reading of the public values failed"},
+    {.code = -(MBEDTLS_ERR_DHM_MAKE_PUBLIC_FAILED), .description="DHM - Making of the public value failed"},
+    {.code = -(MBEDTLS_ERR_DHM_CALC_SECRET_FAILED), .description="DHM - Calculation of the DHM secret failed"},
+    {.code = -(MBEDTLS_ERR_DHM_INVALID_FORMAT), .description="DHM - The ASN.1 data is not formatted correctly"},
+    {.code = -(MBEDTLS_ERR_DHM_ALLOC_FAILED), .description="DHM - Allocation of memory failed"},
+    {.code = -(MBEDTLS_ERR_DHM_FILE_IO_ERROR), .description="DHM - Read or write of file failed"},
+    {.code = -(MBEDTLS_ERR_DHM_HW_ACCEL_FAILED), .description="DHM - DHM hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_DHM_SET_GROUP_FAILED), .description="DHM - Setting the modulus and generator failed"},
+#endif /* MBEDTLS_DHM_C */
+
+#if defined(MBEDTLS_ECP_C)
+    {.code = -(MBEDTLS_ERR_ECP_BAD_INPUT_DATA), .description="ECP - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL), .description="ECP - The buffer is too small to write to"},
+    {.code = -(MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE), .description="ECP - The requested feature is not available, for example, the requested curve is not supported"},
+    {.code = -(MBEDTLS_ERR_ECP_VERIFY_FAILED), .description="ECP - The signature is not valid"},
+    {.code = -(MBEDTLS_ERR_ECP_ALLOC_FAILED), .description="ECP - Memory allocation failed"},
+    {.code = -(MBEDTLS_ERR_ECP_RANDOM_FAILED), .description="ECP - Generation of random value, such as ephemeral key, failed"},
+    {.code = -(MBEDTLS_ERR_ECP_INVALID_KEY), .description="ECP - Invalid private or public key"},
+    {.code = -(MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH), .description="ECP - The buffer contains a valid signature followed by more data"},
+    {.code = -(MBEDTLS_ERR_ECP_HW_ACCEL_FAILED), .description="ECP - The ECP hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_ECP_IN_PROGRESS), .description="ECP - Operation in progress, call again with the same parameters to continue"},
+#endif /* MBEDTLS_ECP_C */
+
+#if defined(MBEDTLS_MD_C)
+    {.code = -(MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE), .description="MD - The selected feature is not available"},
+    {.code = -(MBEDTLS_ERR_MD_BAD_INPUT_DATA), .description="MD - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_MD_ALLOC_FAILED), .description="MD - Failed to allocate memory"},
+    {.code = -(MBEDTLS_ERR_MD_FILE_IO_ERROR), .description="MD - Opening or reading of file failed"},
+    {.code = -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED), .description="MD - MD hardware accelerator failed"},
+#endif /* MBEDTLS_MD_C */
+
+#if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
+    {.code = -(MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT), .description="PEM - No PEM header or footer found"},
+    {.code = -(MBEDTLS_ERR_PEM_INVALID_DATA), .description="PEM - PEM string is not as expected"},
+    {.code = -(MBEDTLS_ERR_PEM_ALLOC_FAILED), .description="PEM - Failed to allocate memory"},
+    {.code = -(MBEDTLS_ERR_PEM_INVALID_ENC_IV), .description="PEM - RSA IV is not in hex-format"},
+    {.code = -(MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG), .description="PEM - Unsupported key encryption algorithm"},
+    {.code = -(MBEDTLS_ERR_PEM_PASSWORD_REQUIRED), .description="PEM - Private key password can't be empty"},
+    {.code = -(MBEDTLS_ERR_PEM_PASSWORD_MISMATCH), .description="PEM - Given private key password does not allow for correct decryption"},
+    {.code = -(MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE), .description="PEM - Unavailable feature, e.g. hashing/encryption combination"},
+    {.code = -(MBEDTLS_ERR_PEM_BAD_INPUT_DATA), .description="PEM - Bad input parameters to function"},
+#endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */
+
+#if defined(MBEDTLS_PK_C)
+    {.code = -(MBEDTLS_ERR_PK_ALLOC_FAILED), .description="PK - Memory allocation failed"},
+    {.code = -(MBEDTLS_ERR_PK_TYPE_MISMATCH), .description="PK - Type mismatch, eg attempt to encrypt with an ECDSA key"},
+    {.code = -(MBEDTLS_ERR_PK_BAD_INPUT_DATA), .description="PK - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_PK_FILE_IO_ERROR), .description="PK - Read/write of file failed"},
+    {.code = -(MBEDTLS_ERR_PK_KEY_INVALID_VERSION), .description="PK - Unsupported key version"},
+    {.code = -(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT), .description="PK - Invalid key tag or value"},
+    {.code = -(MBEDTLS_ERR_PK_UNKNOWN_PK_ALG), .description="PK - Key algorithm is unsupported (only RSA and EC are supported)"},
+    {.code = -(MBEDTLS_ERR_PK_PASSWORD_REQUIRED), .description="PK - Private key password can't be empty"},
+    {.code = -(MBEDTLS_ERR_PK_PASSWORD_MISMATCH), .description="PK - Given private key password does not allow for correct decryption"},
+    {.code = -(MBEDTLS_ERR_PK_INVALID_PUBKEY), .description="PK - The pubkey tag or value is invalid (only RSA and EC are supported)"},
+    {.code = -(MBEDTLS_ERR_PK_INVALID_ALG), .description="PK - The algorithm tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE), .description="PK - Elliptic curve is unsupported (only NIST curves are supported)"},
+    {.code = -(MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE), .description="PK - Unavailable feature, e.g. RSA disabled for RSA key"},
+    {.code = -(MBEDTLS_ERR_PK_SIG_LEN_MISMATCH), .description="PK - The buffer contains a valid signature followed by more data"},
+    {.code = -(MBEDTLS_ERR_PK_HW_ACCEL_FAILED), .description="PK - PK hardware accelerator failed"},
+#endif /* MBEDTLS_PK_C */
+
+#if defined(MBEDTLS_PKCS12_C)
+    {.code = -(MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA), .description="PKCS12 - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE), .description="PKCS12 - Feature not available, e.g. unsupported encryption scheme"},
+    {.code = -(MBEDTLS_ERR_PKCS12_PBE_INVALID_FORMAT), .description="PKCS12 - PBE ASN.1 data not as expected"},
+    {.code = -(MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH), .description="PKCS12 - Given private key password does not allow for correct decryption"},
+#endif /* MBEDTLS_PKCS12_C */
+
+#if defined(MBEDTLS_PKCS5_C)
+    {.code = -(MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA), .description="PKCS5 - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_PKCS5_INVALID_FORMAT), .description="PKCS5 - Unexpected ASN.1 data"},
+    {.code = -(MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE), .description="PKCS5 - Requested encryption or digest alg not available"},
+    {.code = -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH), .description="PKCS5 - Given private key password does not allow for correct decryption"},
+#endif /* MBEDTLS_PKCS5_C */
+
+#if defined(MBEDTLS_RSA_C)
+    {.code = -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA), .description="RSA - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_RSA_INVALID_PADDING), .description="RSA - Input data contains invalid padding and is rejected"},
+    {.code = -(MBEDTLS_ERR_RSA_KEY_GEN_FAILED), .description="RSA - Something failed during generation of a key"},
+    {.code = -(MBEDTLS_ERR_RSA_KEY_CHECK_FAILED), .description="RSA - Key failed to pass the validity check of the library"},
+    {.code = -(MBEDTLS_ERR_RSA_PUBLIC_FAILED), .description="RSA - The public key operation failed"},
+    {.code = -(MBEDTLS_ERR_RSA_PRIVATE_FAILED), .description="RSA - The private key operation failed"},
+    {.code = -(MBEDTLS_ERR_RSA_VERIFY_FAILED), .description="RSA - The PKCS#1 verification failed"},
+    {.code = -(MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE), .description="RSA - The output buffer for decryption is not large enough"},
+    {.code = -(MBEDTLS_ERR_RSA_RNG_FAILED), .description="RSA - The random generator failed to generate non-zeros"},
+    {.code = -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION), .description="RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality"},
+    {.code = -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED), .description="RSA - RSA hardware accelerator failed"},
+#endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_SSL_TLS_C)
+    {.code = -(MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE), .description="SSL - The requested feature is not available"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_INPUT_DATA), .description="SSL - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_SSL_INVALID_MAC), .description="SSL - Verification of the message MAC failed"},
+    {.code = -(MBEDTLS_ERR_SSL_INVALID_RECORD), .description="SSL - An invalid SSL record was received"},
+    {.code = -(MBEDTLS_ERR_SSL_CONN_EOF), .description="SSL - The connection indicated an EOF"},
+    {.code = -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER), .description="SSL - An unknown cipher was received"},
+    {.code = -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN), .description="SSL - The server has no ciphersuites in common with the client"},
+    {.code = -(MBEDTLS_ERR_SSL_NO_RNG), .description="SSL - No RNG was provided to the SSL module"},
+    {.code = -(MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE), .description="SSL - No client certification received from the client, but required by the authentication mode"},
+    {.code = -(MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE), .description="SSL - Our own certificate(s) is/are too large to send in an SSL message"},
+    {.code = -(MBEDTLS_ERR_SSL_CERTIFICATE_REQUIRED), .description="SSL - The own certificate is not set, but needed by the server"},
+    {.code = -(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED), .description="SSL - The own private key or pre-shared key is not set, but needed"},
+    {.code = -(MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED), .description="SSL - No CA Chain is set, but required to operate"},
+    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE), .description="SSL - An unexpected message was received from our peer"},
+    {.code = -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE), .description="SSL - A fatal alert message was received from our peer"},
+    {.code = -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED), .description="SSL - Verification of our peer failed"},
+    {.code = -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY), .description="SSL - The peer notified us that the connection is going to be closed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO), .description="SSL - Processing of the ClientHello handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO), .description="SSL - Processing of the ServerHello handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE), .description="SSL - Processing of the Certificate handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST), .description="SSL - Processing of the CertificateRequest handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE), .description="SSL - Processing of the ServerKeyExchange handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE), .description="SSL - Processing of the ServerHelloDone handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE), .description="SSL - Processing of the ClientKeyExchange handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_RP), .description="SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Read Public"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_CS), .description="SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Calculate Secret"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY), .description="SSL - Processing of the CertificateVerify handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC), .description="SSL - Processing of the ChangeCipherSpec handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_FINISHED), .description="SSL - Processing of the Finished handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_ALLOC_FAILED), .description="SSL - Memory allocation failed"},
+    {.code = -(MBEDTLS_ERR_SSL_HW_ACCEL_FAILED), .description="SSL - Hardware acceleration function returned with error"},
+    {.code = -(MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH), .description="SSL - Hardware acceleration function skipped / left alone data"},
+    {.code = -(MBEDTLS_ERR_SSL_COMPRESSION_FAILED), .description="SSL - Processing of the compression / decompression failed"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION), .description="SSL - Handshake protocol not within min/max boundaries"},
+    {.code = -(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET), .description="SSL - Processing of the NewSessionTicket handshake message failed"},
+    {.code = -(MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED), .description="SSL - Session ticket has expired"},
+    {.code = -(MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH), .description="SSL - Public key type mismatch (eg, asked for RSA key exchange and presented EC key)"},
+    {.code = -(MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY), .description="SSL - Unknown identity received (eg, PSK identity)"},
+    {.code = -(MBEDTLS_ERR_SSL_INTERNAL_ERROR), .description="SSL - Internal error (eg, unexpected failure in lower-level module)"},
+    {.code = -(MBEDTLS_ERR_SSL_COUNTER_WRAPPING), .description="SSL - A counter would wrap (eg, too many messages exchanged)"},
+    {.code = -(MBEDTLS_ERR_SSL_WAITING_SERVER_HELLO_RENEGO), .description="SSL - Unexpected message at ServerHello in renegotiation"},
+    {.code = -(MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED), .description="SSL - DTLS client must retry for hello verification"},
+    {.code = -(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL), .description="SSL - A buffer is too small to receive or write a message"},
+    {.code = -(MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE), .description="SSL - None of the common ciphersuites is usable (eg, no suitable certificate, see debug messages)"},
+    {.code = -(MBEDTLS_ERR_SSL_WANT_READ), .description="SSL - No data of requested type currently available on underlying transport"},
+    {.code = -(MBEDTLS_ERR_SSL_WANT_WRITE), .description="SSL - Connection requires a write call"},
+    {.code = -(MBEDTLS_ERR_SSL_TIMEOUT), .description="SSL - The operation timed out"},
+    {.code = -(MBEDTLS_ERR_SSL_CLIENT_RECONNECT), .description="SSL - The client initiated a reconnect from the same port"},
+    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD), .description="SSL - Record header looks valid but is not expected"},
+    {.code = -(MBEDTLS_ERR_SSL_NON_FATAL), .description="SSL - The alert message received indicates a non-fatal error"},
+    {.code = -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH), .description="SSL - Couldn't set the hash for verifying CertificateVerify"},
+    {.code = -(MBEDTLS_ERR_SSL_CONTINUE_PROCESSING), .description="SSL - Internal-only message signaling that further message-processing should be done"},
+    {.code = -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS), .description="SSL - The asynchronous operation is not completed yet"},
+    {.code = -(MBEDTLS_ERR_SSL_EARLY_MESSAGE), .description="SSL - Internal-only message signaling that a message arrived early"},
+    {.code = -(MBEDTLS_ERR_SSL_UNEXPECTED_CID), .description="SSL - An encrypted DTLS-frame with an unexpected CID was received"},
+    {.code = -(MBEDTLS_ERR_SSL_VERSION_MISMATCH), .description="SSL - An operation failed due to an unexpected version or configuration"},
+    {.code = -(MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS), .description="SSL - A cryptographic operation is in progress. Try again later"},
+#endif /* MBEDTLS_SSL_TLS_C */
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
+    {.code = -(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE), .description="X509 - Unavailable feature, e.g. RSA hashing/encryption combination"},
+    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_OID), .description="X509 - Requested OID is unknown"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_FORMAT), .description="X509 - The CRT/CRL/CSR format is invalid, e.g. different type expected"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_VERSION), .description="X509 - The CRT/CRL/CSR version element is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_SERIAL), .description="X509 - The serial tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_ALG), .description="X509 - The algorithm tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_NAME), .description="X509 - The name tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_DATE), .description="X509 - The date tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_SIGNATURE), .description="X509 - The signature tag or value invalid"},
+    {.code = -(MBEDTLS_ERR_X509_INVALID_EXTENSIONS), .description="X509 - The extension tag or value is invalid"},
+    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_VERSION), .description="X509 - CRT/CRL/CSR has an unsupported version number"},
+    {.code = -(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG), .description="X509 - Signature algorithm (oid) is unsupported"},
+    {.code = -(MBEDTLS_ERR_X509_SIG_MISMATCH), .description="X509 - Signature algorithms do not match. (see \\c ::mbedtls_x509_crt sig_oid)"},
+    {.code = -(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED), .description="X509 - Certificate verification failed, e.g. CRL, CA or signature check failed"},
+    {.code = -(MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT), .description="X509 - Format not recognized as DER or PEM"},
+    {.code = -(MBEDTLS_ERR_X509_BAD_INPUT_DATA), .description="X509 - Input invalid"},
+    {.code = -(MBEDTLS_ERR_X509_ALLOC_FAILED), .description="X509 - Allocation of memory failed"},
+    {.code = -(MBEDTLS_ERR_X509_FILE_IO_ERROR), .description="X509 - Read/write of file failed"},
+    {.code = -(MBEDTLS_ERR_X509_BUFFER_TOO_SMALL), .description="X509 - Destination buffer is too small"},
+    {.code = -(MBEDTLS_ERR_X509_FATAL_ERROR), .description="X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed"},
+#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
+};
+
+#define NUM_HIGH_LEVEL_ERRORS ( sizeof(high_level_errors)/sizeof(mbedtls_error_t) )
+
+static mbedtls_error_t low_level_errors[] =
+{
+#if defined(MBEDTLS_AES_C)
+    {.code = -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH), .description="AES - Invalid key length"},
+    {.code = -(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH), .description="AES - Invalid data input length"},
+    {.code = -(MBEDTLS_ERR_AES_BAD_INPUT_DATA), .description="AES - Invalid input data"},
+    {.code = -(MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE), .description="AES - Feature not available. For example, an unsupported AES key size"},
+    {.code = -(MBEDTLS_ERR_AES_HW_ACCEL_FAILED), .description="AES - AES hardware accelerator failed"},
+#endif /* MBEDTLS_AES_C */
+
+#if defined(MBEDTLS_ARC4_C)
+    {.code = -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED), .description="ARC4 - ARC4 hardware accelerator failed"},
+#endif /* MBEDTLS_ARC4_C */
+
+#if defined(MBEDTLS_ARIA_C)
+    {.code = -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA), .description="ARIA - Bad input data"},
+    {.code = -(MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH), .description="ARIA - Invalid data input length"},
+    {.code = -(MBEDTLS_ERR_ARIA_FEATURE_UNAVAILABLE), .description="ARIA - Feature not available. For example, an unsupported ARIA key size"},
+    {.code = -(MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED), .description="ARIA - ARIA hardware accelerator failed"},
+#endif /* MBEDTLS_ARIA_C */
+
+#if defined(MBEDTLS_ASN1_PARSE_C)
+    {.code = -(MBEDTLS_ERR_ASN1_OUT_OF_DATA), .description="ASN1 - Out of data when parsing an ASN1 data structure"},
+    {.code = -(MBEDTLS_ERR_ASN1_UNEXPECTED_TAG), .description="ASN1 - ASN1 tag was of an unexpected value"},
+    {.code = -(MBEDTLS_ERR_ASN1_INVALID_LENGTH), .description="ASN1 - Error when trying to determine the length or invalid length"},
+    {.code = -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH), .description="ASN1 - Actual length differs from expected length"},
+    {.code = -(MBEDTLS_ERR_ASN1_INVALID_DATA), .description="ASN1 - Data is invalid"},
+    {.code = -(MBEDTLS_ERR_ASN1_ALLOC_FAILED), .description="ASN1 - Memory allocation failed"},
+    {.code = -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL), .description="ASN1 - Buffer too small when writing ASN.1 data structure"},
+#endif /* MBEDTLS_ASN1_PARSE_C */
+
+#if defined(MBEDTLS_BASE64_C)
+    {.code = -(MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL), .description="BASE64 - Output buffer too small"},
+    {.code = -(MBEDTLS_ERR_BASE64_INVALID_CHARACTER), .description="BASE64 - Invalid character in input"},
+#endif /* MBEDTLS_BASE64_C */
+
+#if defined(MBEDTLS_BIGNUM_C)
+    {.code = -(MBEDTLS_ERR_MPI_FILE_IO_ERROR), .description="BIGNUM - An error occurred while reading from or writing to a file"},
+    {.code = -(MBEDTLS_ERR_MPI_BAD_INPUT_DATA), .description="BIGNUM - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_MPI_INVALID_CHARACTER), .description="BIGNUM - There is an invalid character in the digit string"},
+    {.code = -(MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL), .description="BIGNUM - The buffer is too small to write to"},
+    {.code = -(MBEDTLS_ERR_MPI_NEGATIVE_VALUE), .description="BIGNUM - The input arguments are negative or result in illegal output"},
+    {.code = -(MBEDTLS_ERR_MPI_DIVISION_BY_ZERO), .description="BIGNUM - The input argument for division is zero, which is not allowed"},
+    {.code = -(MBEDTLS_ERR_MPI_NOT_ACCEPTABLE), .description="BIGNUM - The input arguments are not acceptable"},
+    {.code = -(MBEDTLS_ERR_MPI_ALLOC_FAILED), .description="BIGNUM - Memory allocation failed"},
+#endif /* MBEDTLS_BIGNUM_C */
+
+#if defined(MBEDTLS_BLOWFISH_C)
+    {.code = -(MBEDTLS_ERR_BLOWFISH_BAD_INPUT_DATA), .description="BLOWFISH - Bad input data"},
+    {.code = -(MBEDTLS_ERR_BLOWFISH_INVALID_INPUT_LENGTH), .description="BLOWFISH - Invalid data input length"},
+    {.code = -(MBEDTLS_ERR_BLOWFISH_HW_ACCEL_FAILED), .description="BLOWFISH - Blowfish hardware accelerator failed"},
+#endif /* MBEDTLS_BLOWFISH_C */
+
+#if defined(MBEDTLS_CAMELLIA_C)
+    {.code = -(MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA), .description="CAMELLIA - Bad input data"},
+    {.code = -(MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH), .description="CAMELLIA - Invalid data input length"},
+    {.code = -(MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED), .description="CAMELLIA - Camellia hardware accelerator failed"},
+#endif /* MBEDTLS_CAMELLIA_C */
+
+#if defined(MBEDTLS_CCM_C)
+    {.code = -(MBEDTLS_ERR_CCM_BAD_INPUT), .description="CCM - Bad input parameters to the function"},
+    {.code = -(MBEDTLS_ERR_CCM_AUTH_FAILED), .description="CCM - Authenticated decryption failed"},
+    {.code = -(MBEDTLS_ERR_CCM_HW_ACCEL_FAILED), .description="CCM - CCM hardware accelerator failed"},
+#endif /* MBEDTLS_CCM_C */
+
+#if defined(MBEDTLS_CHACHA20_C)
+    {.code = -(MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA), .description="CHACHA20 - Invalid input parameter(s)"},
+    {.code = -(MBEDTLS_ERR_CHACHA20_FEATURE_UNAVAILABLE), .description="CHACHA20 - Feature not available. For example, s part of the API is not implemented"},
+    {.code = -(MBEDTLS_ERR_CHACHA20_HW_ACCEL_FAILED), .description="CHACHA20 - Chacha20 hardware accelerator failed"},
+#endif /* MBEDTLS_CHACHA20_C */
+
+#if defined(MBEDTLS_CHACHAPOLY_C)
+    {.code = -(MBEDTLS_ERR_CHACHAPOLY_BAD_STATE), .description="CHACHAPOLY - The requested operation is not permitted in the current state"},
+    {.code = -(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED), .description="CHACHAPOLY - Authenticated decryption failed: data was not authentic"},
+#endif /* MBEDTLS_CHACHAPOLY_C */
+
+#if defined(MBEDTLS_CMAC_C)
+    {.code = -(MBEDTLS_ERR_CMAC_HW_ACCEL_FAILED), .description="CMAC - CMAC hardware accelerator failed"},
+#endif /* MBEDTLS_CMAC_C */
+
+#if defined(MBEDTLS_CTR_DRBG_C)
+    {.code = -(MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED), .description="CTR_DRBG - The entropy source failed"},
+    {.code = -(MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG), .description="CTR_DRBG - The requested random buffer length is too big"},
+    {.code = -(MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG), .description="CTR_DRBG - The input (entropy + additional data) is too large"},
+    {.code = -(MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR), .description="CTR_DRBG - Read or write error in file"},
+#endif /* MBEDTLS_CTR_DRBG_C */
+
+#if defined(MBEDTLS_DES_C)
+    {.code = -(MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH), .description="DES - The data input has an invalid length"},
+    {.code = -(MBEDTLS_ERR_DES_HW_ACCEL_FAILED), .description="DES - DES hardware accelerator failed"},
+#endif /* MBEDTLS_DES_C */
+
+#if defined(MBEDTLS_ENTROPY_C)
+    {.code = -(MBEDTLS_ERR_ENTROPY_SOURCE_FAILED), .description="ENTROPY - Critical entropy source failure"},
+    {.code = -(MBEDTLS_ERR_ENTROPY_MAX_SOURCES), .description="ENTROPY - No more sources can be added"},
+    {.code = -(MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED), .description="ENTROPY - No sources have been added to poll"},
+    {.code = -(MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE), .description="ENTROPY - No strong sources have been added to poll"},
+    {.code = -(MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR), .description="ENTROPY - Read/write error in file"},
+#endif /* MBEDTLS_ENTROPY_C */
+
+#if defined(MBEDTLS_ERROR_C)
+    {.code = -(MBEDTLS_ERR_ERROR_GENERIC_ERROR), .description="ERROR - Generic error"},
+    {.code = -(MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED), .description="ERROR - This is a bug in the library"},
+#endif /* MBEDTLS_ERROR_C */
+
+#if defined(MBEDTLS_GCM_C)
+    {.code = -(MBEDTLS_ERR_GCM_AUTH_FAILED), .description="GCM - Authenticated decryption failed"},
+    {.code = -(MBEDTLS_ERR_GCM_HW_ACCEL_FAILED), .description="GCM - GCM hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_GCM_BAD_INPUT), .description="GCM - Bad input parameters to function"},
+#endif /* MBEDTLS_GCM_C */
+
+#if defined(MBEDTLS_HKDF_C)
+    {.code = -(MBEDTLS_ERR_HKDF_BAD_INPUT_DATA), .description="HKDF - Bad input parameters to function"},
+#endif /* MBEDTLS_HKDF_C */
+
+#if defined(MBEDTLS_HMAC_DRBG_C)
+    {.code = -(MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG), .description="HMAC_DRBG - Too many random requested in single call"},
+    {.code = -(MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG), .description="HMAC_DRBG - Input too large (Entropy + additional)"},
+    {.code = -(MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR), .description="HMAC_DRBG - Read/write error in file"},
+    {.code = -(MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED), .description="HMAC_DRBG - The entropy source failed"},
+#endif /* MBEDTLS_HMAC_DRBG_C */
+
+#if defined(MBEDTLS_MD2_C)
+    {.code = -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED), .description="MD2 - MD2 hardware accelerator failed"},
+#endif /* MBEDTLS_MD2_C */
+
+#if defined(MBEDTLS_MD4_C)
+    {.code = -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED), .description="MD4 - MD4 hardware accelerator failed"},
+#endif /* MBEDTLS_MD4_C */
+
+#if defined(MBEDTLS_MD5_C)
+    {.code = -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED), .description="MD5 - MD5 hardware accelerator failed"},
+#endif /* MBEDTLS_MD5_C */
+
+#if defined(MBEDTLS_NET_C)
+    {.code = -(MBEDTLS_ERR_NET_SOCKET_FAILED), .description="NET - Failed to open a socket"},
+    {.code = -(MBEDTLS_ERR_NET_CONNECT_FAILED), .description="NET - The connection to the given server / port failed"},
+    {.code = -(MBEDTLS_ERR_NET_BIND_FAILED), .description="NET - Binding of the socket failed"},
+    {.code = -(MBEDTLS_ERR_NET_LISTEN_FAILED), .description="NET - Could not listen on the socket"},
+    {.code = -(MBEDTLS_ERR_NET_ACCEPT_FAILED), .description="NET - Could not accept the incoming connection"},
+    {.code = -(MBEDTLS_ERR_NET_RECV_FAILED), .description="NET - Reading information from the socket failed"},
+    {.code = -(MBEDTLS_ERR_NET_SEND_FAILED), .description="NET - Sending information through the socket failed"},
+    {.code = -(MBEDTLS_ERR_NET_CONN_RESET), .description="NET - Connection was reset by peer"},
+    {.code = -(MBEDTLS_ERR_NET_UNKNOWN_HOST), .description="NET - Failed to get an IP address for the given hostname"},
+    {.code = -(MBEDTLS_ERR_NET_BUFFER_TOO_SMALL), .description="NET - Buffer is too small to hold the data"},
+    {.code = -(MBEDTLS_ERR_NET_INVALID_CONTEXT), .description="NET - The context is invalid, eg because it was free()ed"},
+    {.code = -(MBEDTLS_ERR_NET_POLL_FAILED), .description="NET - Polling the net context failed"},
+    {.code = -(MBEDTLS_ERR_NET_BAD_INPUT_DATA), .description="NET - Input invalid"},
+#endif /* MBEDTLS_NET_C */
+
+#if defined(MBEDTLS_OID_C)
+    {.code = -(MBEDTLS_ERR_OID_NOT_FOUND), .description="OID - OID is not found"},
+    {.code = -(MBEDTLS_ERR_OID_BUF_TOO_SMALL), .description="OID - output buffer is too small"},
+#endif /* MBEDTLS_OID_C */
+
+#if defined(MBEDTLS_PADLOCK_C)
+    {.code = -(MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED), .description="PADLOCK - Input data should be aligned"},
+#endif /* MBEDTLS_PADLOCK_C */
+
+#if defined(MBEDTLS_PLATFORM_C)
+    {.code = -(MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED), .description="PLATFORM - Hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED), .description="PLATFORM - The requested feature is not supported by the platform"},
+#endif /* MBEDTLS_PLATFORM_C */
+
+#if defined(MBEDTLS_POLY1305_C)
+    {.code = -(MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA), .description="POLY1305 - Invalid input parameter(s)"},
+    {.code = -(MBEDTLS_ERR_POLY1305_FEATURE_UNAVAILABLE), .description="POLY1305 - Feature not available. For example, s part of the API is not implemented"},
+    {.code = -(MBEDTLS_ERR_POLY1305_HW_ACCEL_FAILED), .description="POLY1305 - Poly1305 hardware accelerator failed"},
+#endif /* MBEDTLS_POLY1305_C */
+
+#if defined(MBEDTLS_RIPEMD160_C)
+    {.code = -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED), .description="RIPEMD160 - RIPEMD160 hardware accelerator failed"},
+#endif /* MBEDTLS_RIPEMD160_C */
+
+#if defined(MBEDTLS_SHA1_C)
+    {.code = -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED), .description="SHA1 - SHA-1 hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA), .description="SHA1 - SHA-1 input data was malformed"},
+#endif /* MBEDTLS_SHA1_C */
+
+#if defined(MBEDTLS_SHA256_C)
+    {.code = -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED), .description="SHA256 - SHA-256 hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA), .description="SHA256 - SHA-256 input data was malformed"},
+#endif /* MBEDTLS_SHA256_C */
+
+#if defined(MBEDTLS_SHA512_C)
+    {.code = -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED), .description="SHA512 - SHA-512 hardware accelerator failed"},
+    {.code = -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA), .description="SHA512 - SHA-512 input data was malformed"},
+#endif /* MBEDTLS_SHA512_C */
+
+#if defined(MBEDTLS_THREADING_C)
+    {.code = -(MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE), .description="THREADING - The selected feature is not available"},
+    {.code = -(MBEDTLS_ERR_THREADING_BAD_INPUT_DATA), .description="THREADING - Bad input parameters to function"},
+    {.code = -(MBEDTLS_ERR_THREADING_MUTEX_ERROR), .description="THREADING - Locking / unlocking / free failed with error code"},
+#endif /* MBEDTLS_THREADING_C */
+
+#if defined(MBEDTLS_XTEA_C)
+    {.code = -(MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH), .description="XTEA - The data input has an invalid length"},
+    {.code = -(MBEDTLS_ERR_XTEA_HW_ACCEL_FAILED), .description="XTEA - XTEA hardware accelerator failed"},
+#endif /* MBEDTLS_XTEA_C */
+};
+
+#define NUM_LOW_LEVEL_ERRORS  ( sizeof(low_level_errors)/sizeof(mbedtls_error_t) )
+
+const char * mbedtls_high_level_strerr( int error_code )
+{
+    size_t i;
+    const char *error_description = NULL;
+
+    for(i = 0; i < NUM_HIGH_LEVEL_ERRORS; i++ )
+    {
+        if( high_level_errors[i].code == error_code )
+        {
+            error_description = high_level_errors[i].description;
+            break;
+        }
+    }
+
+    return error_description;
+}
+
+const char * mbedtls_low_level_strerr( int error_code )
+{
+    size_t i;
+    const char *error_description = NULL;
+
+    for(i = 0; i < NUM_LOW_LEVEL_ERRORS; i++ )
+    {
+        if( low_level_errors[i].code == error_code )
+        {
+            error_description = low_level_errors[i].description;
+            break;
+        }
+    }
+
+    return error_description;
+}
+
 void mbedtls_strerror( int ret, char *buf, size_t buflen )
 {
     size_t len;
     int use_ret;
+    const char * high_level_error_description = NULL;
+    const char * low_level_error_description = NULL;
 
     if( buflen == 0 )
         return;
@@ -230,356 +667,18 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     {
         use_ret = ret & 0xFF80;
 
-        // High level error codes
-        //
-        // BEGIN generated code
-#if defined(MBEDTLS_CIPHER_C)
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - The selected feature is not available" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Bad input parameters" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Failed to allocate memory" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_INVALID_PADDING) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Input data contains invalid padding and is rejected" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Decryption of block requires a full block" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_AUTH_FAILED) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Authentication failed (for AEAD modes)" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - The context is invalid. For example, because it was freed" );
-        if( use_ret == -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "CIPHER - Cipher hardware accelerator failed" );
-#endif /* MBEDTLS_CIPHER_C */
+        // Translate high level error code.
+        high_level_error_description = mbedtls_high_level_strerr(use_ret);
 
-#if defined(MBEDTLS_DHM_C)
-        if( use_ret == -(MBEDTLS_ERR_DHM_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "DHM - Bad input parameters" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_READ_PARAMS_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Reading of the DHM parameters failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_MAKE_PARAMS_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Making of the DHM parameters failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_READ_PUBLIC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Reading of the public values failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_MAKE_PUBLIC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Making of the public value failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_CALC_SECRET_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Calculation of the DHM secret failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_INVALID_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "DHM - The ASN.1 data is not formatted correctly" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Allocation of memory failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_FILE_IO_ERROR) )
-            mbedtls_snprintf( buf, buflen, "DHM - Read or write of file failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - DHM hardware accelerator failed" );
-        if( use_ret == -(MBEDTLS_ERR_DHM_SET_GROUP_FAILED) )
-            mbedtls_snprintf( buf, buflen, "DHM - Setting the modulus and generator failed" );
-#endif /* MBEDTLS_DHM_C */
-
-#if defined(MBEDTLS_ECP_C)
-        if( use_ret == -(MBEDTLS_ERR_ECP_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "ECP - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL) )
-            mbedtls_snprintf( buf, buflen, "ECP - The buffer is too small to write to" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "ECP - The requested feature is not available, for example, the requested curve is not supported" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_VERIFY_FAILED) )
-            mbedtls_snprintf( buf, buflen, "ECP - The signature is not valid" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "ECP - Memory allocation failed" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_RANDOM_FAILED) )
-            mbedtls_snprintf( buf, buflen, "ECP - Generation of random value, such as ephemeral key, failed" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_INVALID_KEY) )
-            mbedtls_snprintf( buf, buflen, "ECP - Invalid private or public key" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "ECP - The buffer contains a valid signature followed by more data" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "ECP - The ECP hardware accelerator failed" );
-        if( use_ret == -(MBEDTLS_ERR_ECP_IN_PROGRESS) )
-            mbedtls_snprintf( buf, buflen, "ECP - Operation in progress, call again with the same parameters to continue" );
-#endif /* MBEDTLS_ECP_C */
-
-#if defined(MBEDTLS_MD_C)
-        if( use_ret == -(MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "MD - The selected feature is not available" );
-        if( use_ret == -(MBEDTLS_ERR_MD_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "MD - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_MD_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "MD - Failed to allocate memory" );
-        if( use_ret == -(MBEDTLS_ERR_MD_FILE_IO_ERROR) )
-            mbedtls_snprintf( buf, buflen, "MD - Opening or reading of file failed" );
-        if( use_ret == -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "MD - MD hardware accelerator failed" );
-#endif /* MBEDTLS_MD_C */
-
-#if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
-        if( use_ret == -(MBEDTLS_ERR_PEM_NO_HEADER_FOOTER_PRESENT) )
-            mbedtls_snprintf( buf, buflen, "PEM - No PEM header or footer found" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_INVALID_DATA) )
-            mbedtls_snprintf( buf, buflen, "PEM - PEM string is not as expected" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "PEM - Failed to allocate memory" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_INVALID_ENC_IV) )
-            mbedtls_snprintf( buf, buflen, "PEM - RSA IV is not in hex-format" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG) )
-            mbedtls_snprintf( buf, buflen, "PEM - Unsupported key encryption algorithm" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_PASSWORD_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "PEM - Private key password can't be empty" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_PASSWORD_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PEM - Given private key password does not allow for correct decryption" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "PEM - Unavailable feature, e.g. hashing/encryption combination" );
-        if( use_ret == -(MBEDTLS_ERR_PEM_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "PEM - Bad input parameters to function" );
-#endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */
-
-#if defined(MBEDTLS_PK_C)
-        if( use_ret == -(MBEDTLS_ERR_PK_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "PK - Memory allocation failed" );
-        if( use_ret == -(MBEDTLS_ERR_PK_TYPE_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PK - Type mismatch, eg attempt to encrypt with an ECDSA key" );
-        if( use_ret == -(MBEDTLS_ERR_PK_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "PK - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_PK_FILE_IO_ERROR) )
-            mbedtls_snprintf( buf, buflen, "PK - Read/write of file failed" );
-        if( use_ret == -(MBEDTLS_ERR_PK_KEY_INVALID_VERSION) )
-            mbedtls_snprintf( buf, buflen, "PK - Unsupported key version" );
-        if( use_ret == -(MBEDTLS_ERR_PK_KEY_INVALID_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "PK - Invalid key tag or value" );
-        if( use_ret == -(MBEDTLS_ERR_PK_UNKNOWN_PK_ALG) )
-            mbedtls_snprintf( buf, buflen, "PK - Key algorithm is unsupported (only RSA and EC are supported)" );
-        if( use_ret == -(MBEDTLS_ERR_PK_PASSWORD_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "PK - Private key password can't be empty" );
-        if( use_ret == -(MBEDTLS_ERR_PK_PASSWORD_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PK - Given private key password does not allow for correct decryption" );
-        if( use_ret == -(MBEDTLS_ERR_PK_INVALID_PUBKEY) )
-            mbedtls_snprintf( buf, buflen, "PK - The pubkey tag or value is invalid (only RSA and EC are supported)" );
-        if( use_ret == -(MBEDTLS_ERR_PK_INVALID_ALG) )
-            mbedtls_snprintf( buf, buflen, "PK - The algorithm tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_PK_UNKNOWN_NAMED_CURVE) )
-            mbedtls_snprintf( buf, buflen, "PK - Elliptic curve is unsupported (only NIST curves are supported)" );
-        if( use_ret == -(MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "PK - Unavailable feature, e.g. RSA disabled for RSA key" );
-        if( use_ret == -(MBEDTLS_ERR_PK_SIG_LEN_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PK - The buffer contains a valid signature followed by more data" );
-        if( use_ret == -(MBEDTLS_ERR_PK_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "PK - PK hardware accelerator failed" );
-#endif /* MBEDTLS_PK_C */
-
-#if defined(MBEDTLS_PKCS12_C)
-        if( use_ret == -(MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "PKCS12 - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS12_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "PKCS12 - Feature not available, e.g. unsupported encryption scheme" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS12_PBE_INVALID_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "PKCS12 - PBE ASN.1 data not as expected" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS12_PASSWORD_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PKCS12 - Given private key password does not allow for correct decryption" );
-#endif /* MBEDTLS_PKCS12_C */
-
-#if defined(MBEDTLS_PKCS5_C)
-        if( use_ret == -(MBEDTLS_ERR_PKCS5_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "PKCS5 - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS5_INVALID_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "PKCS5 - Unexpected ASN.1 data" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS5_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "PKCS5 - Requested encryption or digest alg not available" );
-        if( use_ret == -(MBEDTLS_ERR_PKCS5_PASSWORD_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "PKCS5 - Given private key password does not allow for correct decryption" );
-#endif /* MBEDTLS_PKCS5_C */
-
-#if defined(MBEDTLS_RSA_C)
-        if( use_ret == -(MBEDTLS_ERR_RSA_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "RSA - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_INVALID_PADDING) )
-            mbedtls_snprintf( buf, buflen, "RSA - Input data contains invalid padding and is rejected" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_KEY_GEN_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - Something failed during generation of a key" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_KEY_CHECK_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - Key failed to pass the validity check of the library" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_PUBLIC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - The public key operation failed" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_PRIVATE_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - The private key operation failed" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_VERIFY_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - The PKCS#1 verification failed" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE) )
-            mbedtls_snprintf( buf, buflen, "RSA - The output buffer for decryption is not large enough" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_RNG_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - The random generator failed to generate non-zeros" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION) )
-            mbedtls_snprintf( buf, buflen, "RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality" );
-        if( use_ret == -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "RSA - RSA hardware accelerator failed" );
-#endif /* MBEDTLS_RSA_C */
-
-#if defined(MBEDTLS_SSL_TLS_C)
-        if( use_ret == -(MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "SSL - The requested feature is not available" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "SSL - Bad input parameters to function" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_MAC) )
-            mbedtls_snprintf( buf, buflen, "SSL - Verification of the message MAC failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_RECORD) )
-            mbedtls_snprintf( buf, buflen, "SSL - An invalid SSL record was received" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CONN_EOF) )
-            mbedtls_snprintf( buf, buflen, "SSL - The connection indicated an EOF" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER) )
-            mbedtls_snprintf( buf, buflen, "SSL - An unknown cipher was received" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN) )
-            mbedtls_snprintf( buf, buflen, "SSL - The server has no ciphersuites in common with the client" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_NO_RNG) )
-            mbedtls_snprintf( buf, buflen, "SSL - No RNG was provided to the SSL module" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE) )
-            mbedtls_snprintf( buf, buflen, "SSL - No client certification received from the client, but required by the authentication mode" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Our own certificate(s) is/are too large to send in an SSL message" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CERTIFICATE_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "SSL - The own certificate is not set, but needed by the server" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_PRIVATE_KEY_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "SSL - The own private key or pre-shared key is not set, but needed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "SSL - No CA Chain is set, but required to operate" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE) )
-            mbedtls_snprintf( buf, buflen, "SSL - An unexpected message was received from our peer" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE) )
-        {
-            mbedtls_snprintf( buf, buflen, "SSL - A fatal alert message was received from our peer" );
-            return;
-        }
-        if( use_ret == -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Verification of our peer failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) )
-            mbedtls_snprintf( buf, buflen, "SSL - The peer notified us that the connection is going to be closed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientHello handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerHello handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the Certificate handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the CertificateRequest handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerKeyExchange handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ServerHelloDone handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_RP) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Read Public" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE_CS) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ClientKeyExchange handshake message failed in DHM / ECDH Calculate Secret" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_VERIFY) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the CertificateVerify handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the ChangeCipherSpec handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_FINISHED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the Finished handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Memory allocation failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_HW_ACCEL_FAILED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Hardware acceleration function returned with error" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_HW_ACCEL_FALLTHROUGH) )
-            mbedtls_snprintf( buf, buflen, "SSL - Hardware acceleration function skipped / left alone data" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_COMPRESSION_FAILED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the compression / decompression failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_PROTOCOL_VERSION) )
-            mbedtls_snprintf( buf, buflen, "SSL - Handshake protocol not within min/max boundaries" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BAD_HS_NEW_SESSION_TICKET) )
-            mbedtls_snprintf( buf, buflen, "SSL - Processing of the NewSessionTicket handshake message failed" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED) )
-            mbedtls_snprintf( buf, buflen, "SSL - Session ticket has expired" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_PK_TYPE_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "SSL - Public key type mismatch (eg, asked for RSA key exchange and presented EC key)" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY) )
-            mbedtls_snprintf( buf, buflen, "SSL - Unknown identity received (eg, PSK identity)" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_INTERNAL_ERROR) )
-            mbedtls_snprintf( buf, buflen, "SSL - Internal error (eg, unexpected failure in lower-level module)" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_COUNTER_WRAPPING) )
-            mbedtls_snprintf( buf, buflen, "SSL - A counter would wrap (eg, too many messages exchanged)" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_WAITING_SERVER_HELLO_RENEGO) )
-            mbedtls_snprintf( buf, buflen, "SSL - Unexpected message at ServerHello in renegotiation" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED) )
-            mbedtls_snprintf( buf, buflen, "SSL - DTLS client must retry for hello verification" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL) )
-            mbedtls_snprintf( buf, buflen, "SSL - A buffer is too small to receive or write a message" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE) )
-            mbedtls_snprintf( buf, buflen, "SSL - None of the common ciphersuites is usable (eg, no suitable certificate, see debug messages)" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_WANT_READ) )
-            mbedtls_snprintf( buf, buflen, "SSL - No data of requested type currently available on underlying transport" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_WANT_WRITE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Connection requires a write call" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_TIMEOUT) )
-            mbedtls_snprintf( buf, buflen, "SSL - The operation timed out" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CLIENT_RECONNECT) )
-            mbedtls_snprintf( buf, buflen, "SSL - The client initiated a reconnect from the same port" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) )
-            mbedtls_snprintf( buf, buflen, "SSL - Record header looks valid but is not expected" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_NON_FATAL) )
-            mbedtls_snprintf( buf, buflen, "SSL - The alert message received indicates a non-fatal error" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_INVALID_VERIFY_HASH) )
-            mbedtls_snprintf( buf, buflen, "SSL - Couldn't set the hash for verifying CertificateVerify" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CONTINUE_PROCESSING) )
-            mbedtls_snprintf( buf, buflen, "SSL - Internal-only message signaling that further message-processing should be done" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) )
-            mbedtls_snprintf( buf, buflen, "SSL - The asynchronous operation is not completed yet" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_EARLY_MESSAGE) )
-            mbedtls_snprintf( buf, buflen, "SSL - Internal-only message signaling that a message arrived early" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_UNEXPECTED_CID) )
-            mbedtls_snprintf( buf, buflen, "SSL - An encrypted DTLS-frame with an unexpected CID was received" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_VERSION_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "SSL - An operation failed due to an unexpected version or configuration" );
-        if( use_ret == -(MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) )
-            mbedtls_snprintf( buf, buflen, "SSL - A cryptographic operation is in progress. Try again later" );
-#endif /* MBEDTLS_SSL_TLS_C */
-
-#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_X509_CREATE_C)
-        if( use_ret == -(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE) )
-            mbedtls_snprintf( buf, buflen, "X509 - Unavailable feature, e.g. RSA hashing/encryption combination" );
-        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_OID) )
-            mbedtls_snprintf( buf, buflen, "X509 - Requested OID is unknown" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "X509 - The CRT/CRL/CSR format is invalid, e.g. different type expected" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_VERSION) )
-            mbedtls_snprintf( buf, buflen, "X509 - The CRT/CRL/CSR version element is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_SERIAL) )
-            mbedtls_snprintf( buf, buflen, "X509 - The serial tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_ALG) )
-            mbedtls_snprintf( buf, buflen, "X509 - The algorithm tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_NAME) )
-            mbedtls_snprintf( buf, buflen, "X509 - The name tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_DATE) )
-            mbedtls_snprintf( buf, buflen, "X509 - The date tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_SIGNATURE) )
-            mbedtls_snprintf( buf, buflen, "X509 - The signature tag or value invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_INVALID_EXTENSIONS) )
-            mbedtls_snprintf( buf, buflen, "X509 - The extension tag or value is invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_VERSION) )
-            mbedtls_snprintf( buf, buflen, "X509 - CRT/CRL/CSR has an unsupported version number" );
-        if( use_ret == -(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG) )
-            mbedtls_snprintf( buf, buflen, "X509 - Signature algorithm (oid) is unsupported" );
-        if( use_ret == -(MBEDTLS_ERR_X509_SIG_MISMATCH) )
-            mbedtls_snprintf( buf, buflen, "X509 - Signature algorithms do not match. (see \\c ::mbedtls_x509_crt sig_oid)" );
-        if( use_ret == -(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) )
-            mbedtls_snprintf( buf, buflen, "X509 - Certificate verification failed, e.g. CRL, CA or signature check failed" );
-        if( use_ret == -(MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT) )
-            mbedtls_snprintf( buf, buflen, "X509 - Format not recognized as DER or PEM" );
-        if( use_ret == -(MBEDTLS_ERR_X509_BAD_INPUT_DATA) )
-            mbedtls_snprintf( buf, buflen, "X509 - Input invalid" );
-        if( use_ret == -(MBEDTLS_ERR_X509_ALLOC_FAILED) )
-            mbedtls_snprintf( buf, buflen, "X509 - Allocation of memory failed" );
-        if( use_ret == -(MBEDTLS_ERR_X509_FILE_IO_ERROR) )
-            mbedtls_snprintf( buf, buflen, "X509 - Read/write of file failed" );
-        if( use_ret == -(MBEDTLS_ERR_X509_BUFFER_TOO_SMALL) )
-            mbedtls_snprintf( buf, buflen, "X509 - Destination buffer is too small" );
-        if( use_ret == -(MBEDTLS_ERR_X509_FATAL_ERROR) )
-            mbedtls_snprintf( buf, buflen, "X509 - A fatal error occurred, eg the chain is too long or the vrfy callback failed" );
-#endif /* MBEDTLS_X509_USE_C || MBEDTLS_X509_CREATE_C */
-        // END generated code
-
-        if( strlen( buf ) == 0 )
+        if( high_level_error_description == NULL )
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+        else
+            mbedtls_snprintf( buf, buflen, "%s", high_level_error_description );
+
+        // Early return in case of a fatal error - do not try to translate low
+        // level code.
+        if(use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE))
+            return;
     }
 
     use_ret = ret & ~0xFF80;
@@ -603,311 +702,13 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         buflen -= len + 3;
     }
 
-    // Low level error codes
-    //
-    // BEGIN generated code
-#if defined(MBEDTLS_AES_C)
-    if( use_ret == -(MBEDTLS_ERR_AES_INVALID_KEY_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "AES - Invalid key length" );
-    if( use_ret == -(MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "AES - Invalid data input length" );
-    if( use_ret == -(MBEDTLS_ERR_AES_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "AES - Invalid input data" );
-    if( use_ret == -(MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE) )
-        mbedtls_snprintf( buf, buflen, "AES - Feature not available. For example, an unsupported AES key size" );
-    if( use_ret == -(MBEDTLS_ERR_AES_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "AES - AES hardware accelerator failed" );
-#endif /* MBEDTLS_AES_C */
+    // Translate low level error code.
+    low_level_error_description = mbedtls_low_level_strerr( use_ret );
 
-#if defined(MBEDTLS_ARC4_C)
-    if( use_ret == -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "ARC4 - ARC4 hardware accelerator failed" );
-#endif /* MBEDTLS_ARC4_C */
-
-#if defined(MBEDTLS_ARIA_C)
-    if( use_ret == -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "ARIA - Bad input data" );
-    if( use_ret == -(MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "ARIA - Invalid data input length" );
-    if( use_ret == -(MBEDTLS_ERR_ARIA_FEATURE_UNAVAILABLE) )
-        mbedtls_snprintf( buf, buflen, "ARIA - Feature not available. For example, an unsupported ARIA key size" );
-    if( use_ret == -(MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "ARIA - ARIA hardware accelerator failed" );
-#endif /* MBEDTLS_ARIA_C */
-
-#if defined(MBEDTLS_ASN1_PARSE_C)
-    if( use_ret == -(MBEDTLS_ERR_ASN1_OUT_OF_DATA) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Out of data when parsing an ASN1 data structure" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - ASN1 tag was of an unexpected value" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_INVALID_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Error when trying to determine the length or invalid length" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_LENGTH_MISMATCH) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Actual length differs from expected length" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_INVALID_DATA) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Data is invalid" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_ALLOC_FAILED) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Memory allocation failed" );
-    if( use_ret == -(MBEDTLS_ERR_ASN1_BUF_TOO_SMALL) )
-        mbedtls_snprintf( buf, buflen, "ASN1 - Buffer too small when writing ASN.1 data structure" );
-#endif /* MBEDTLS_ASN1_PARSE_C */
-
-#if defined(MBEDTLS_BASE64_C)
-    if( use_ret == -(MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) )
-        mbedtls_snprintf( buf, buflen, "BASE64 - Output buffer too small" );
-    if( use_ret == -(MBEDTLS_ERR_BASE64_INVALID_CHARACTER) )
-        mbedtls_snprintf( buf, buflen, "BASE64 - Invalid character in input" );
-#endif /* MBEDTLS_BASE64_C */
-
-#if defined(MBEDTLS_BIGNUM_C)
-    if( use_ret == -(MBEDTLS_ERR_MPI_FILE_IO_ERROR) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - An error occurred while reading from or writing to a file" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - Bad input parameters to function" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_INVALID_CHARACTER) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - There is an invalid character in the digit string" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - The buffer is too small to write to" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_NEGATIVE_VALUE) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - The input arguments are negative or result in illegal output" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_DIVISION_BY_ZERO) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - The input argument for division is zero, which is not allowed" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_NOT_ACCEPTABLE) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - The input arguments are not acceptable" );
-    if( use_ret == -(MBEDTLS_ERR_MPI_ALLOC_FAILED) )
-        mbedtls_snprintf( buf, buflen, "BIGNUM - Memory allocation failed" );
-#endif /* MBEDTLS_BIGNUM_C */
-
-#if defined(MBEDTLS_BLOWFISH_C)
-    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "BLOWFISH - Bad input data" );
-    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "BLOWFISH - Invalid data input length" );
-    if( use_ret == -(MBEDTLS_ERR_BLOWFISH_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "BLOWFISH - Blowfish hardware accelerator failed" );
-#endif /* MBEDTLS_BLOWFISH_C */
-
-#if defined(MBEDTLS_CAMELLIA_C)
-    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "CAMELLIA - Bad input data" );
-    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "CAMELLIA - Invalid data input length" );
-    if( use_ret == -(MBEDTLS_ERR_CAMELLIA_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CAMELLIA - Camellia hardware accelerator failed" );
-#endif /* MBEDTLS_CAMELLIA_C */
-
-#if defined(MBEDTLS_CCM_C)
-    if( use_ret == -(MBEDTLS_ERR_CCM_BAD_INPUT) )
-        mbedtls_snprintf( buf, buflen, "CCM - Bad input parameters to the function" );
-    if( use_ret == -(MBEDTLS_ERR_CCM_AUTH_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CCM - Authenticated decryption failed" );
-    if( use_ret == -(MBEDTLS_ERR_CCM_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CCM - CCM hardware accelerator failed" );
-#endif /* MBEDTLS_CCM_C */
-
-#if defined(MBEDTLS_CHACHA20_C)
-    if( use_ret == -(MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "CHACHA20 - Invalid input parameter(s)" );
-    if( use_ret == -(MBEDTLS_ERR_CHACHA20_FEATURE_UNAVAILABLE) )
-        mbedtls_snprintf( buf, buflen, "CHACHA20 - Feature not available. For example, s part of the API is not implemented" );
-    if( use_ret == -(MBEDTLS_ERR_CHACHA20_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CHACHA20 - Chacha20 hardware accelerator failed" );
-#endif /* MBEDTLS_CHACHA20_C */
-
-#if defined(MBEDTLS_CHACHAPOLY_C)
-    if( use_ret == -(MBEDTLS_ERR_CHACHAPOLY_BAD_STATE) )
-        mbedtls_snprintf( buf, buflen, "CHACHAPOLY - The requested operation is not permitted in the current state" );
-    if( use_ret == -(MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CHACHAPOLY - Authenticated decryption failed: data was not authentic" );
-#endif /* MBEDTLS_CHACHAPOLY_C */
-
-#if defined(MBEDTLS_CMAC_C)
-    if( use_ret == -(MBEDTLS_ERR_CMAC_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CMAC - CMAC hardware accelerator failed" );
-#endif /* MBEDTLS_CMAC_C */
-
-#if defined(MBEDTLS_CTR_DRBG_C)
-    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED) )
-        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The entropy source failed" );
-    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG) )
-        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The requested random buffer length is too big" );
-    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG) )
-        mbedtls_snprintf( buf, buflen, "CTR_DRBG - The input (entropy + additional data) is too large" );
-    if( use_ret == -(MBEDTLS_ERR_CTR_DRBG_FILE_IO_ERROR) )
-        mbedtls_snprintf( buf, buflen, "CTR_DRBG - Read or write error in file" );
-#endif /* MBEDTLS_CTR_DRBG_C */
-
-#if defined(MBEDTLS_DES_C)
-    if( use_ret == -(MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "DES - The data input has an invalid length" );
-    if( use_ret == -(MBEDTLS_ERR_DES_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "DES - DES hardware accelerator failed" );
-#endif /* MBEDTLS_DES_C */
-
-#if defined(MBEDTLS_ENTROPY_C)
-    if( use_ret == -(MBEDTLS_ERR_ENTROPY_SOURCE_FAILED) )
-        mbedtls_snprintf( buf, buflen, "ENTROPY - Critical entropy source failure" );
-    if( use_ret == -(MBEDTLS_ERR_ENTROPY_MAX_SOURCES) )
-        mbedtls_snprintf( buf, buflen, "ENTROPY - No more sources can be added" );
-    if( use_ret == -(MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED) )
-        mbedtls_snprintf( buf, buflen, "ENTROPY - No sources have been added to poll" );
-    if( use_ret == -(MBEDTLS_ERR_ENTROPY_NO_STRONG_SOURCE) )
-        mbedtls_snprintf( buf, buflen, "ENTROPY - No strong sources have been added to poll" );
-    if( use_ret == -(MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR) )
-        mbedtls_snprintf( buf, buflen, "ENTROPY - Read/write error in file" );
-#endif /* MBEDTLS_ENTROPY_C */
-
-#if defined(MBEDTLS_ERROR_C)
-    if( use_ret == -(MBEDTLS_ERR_ERROR_GENERIC_ERROR) )
-        mbedtls_snprintf( buf, buflen, "ERROR - Generic error" );
-    if( use_ret == -(MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED) )
-        mbedtls_snprintf( buf, buflen, "ERROR - This is a bug in the library" );
-#endif /* MBEDTLS_ERROR_C */
-
-#if defined(MBEDTLS_GCM_C)
-    if( use_ret == -(MBEDTLS_ERR_GCM_AUTH_FAILED) )
-        mbedtls_snprintf( buf, buflen, "GCM - Authenticated decryption failed" );
-    if( use_ret == -(MBEDTLS_ERR_GCM_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "GCM - GCM hardware accelerator failed" );
-    if( use_ret == -(MBEDTLS_ERR_GCM_BAD_INPUT) )
-        mbedtls_snprintf( buf, buflen, "GCM - Bad input parameters to function" );
-#endif /* MBEDTLS_GCM_C */
-
-#if defined(MBEDTLS_HKDF_C)
-    if( use_ret == -(MBEDTLS_ERR_HKDF_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "HKDF - Bad input parameters to function" );
-#endif /* MBEDTLS_HKDF_C */
-
-#if defined(MBEDTLS_HMAC_DRBG_C)
-    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG) )
-        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Too many random requested in single call" );
-    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG) )
-        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Input too large (Entropy + additional)" );
-    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_FILE_IO_ERROR) )
-        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - Read/write error in file" );
-    if( use_ret == -(MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED) )
-        mbedtls_snprintf( buf, buflen, "HMAC_DRBG - The entropy source failed" );
-#endif /* MBEDTLS_HMAC_DRBG_C */
-
-#if defined(MBEDTLS_MD2_C)
-    if( use_ret == -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "MD2 - MD2 hardware accelerator failed" );
-#endif /* MBEDTLS_MD2_C */
-
-#if defined(MBEDTLS_MD4_C)
-    if( use_ret == -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "MD4 - MD4 hardware accelerator failed" );
-#endif /* MBEDTLS_MD4_C */
-
-#if defined(MBEDTLS_MD5_C)
-    if( use_ret == -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "MD5 - MD5 hardware accelerator failed" );
-#endif /* MBEDTLS_MD5_C */
-
-#if defined(MBEDTLS_NET_C)
-    if( use_ret == -(MBEDTLS_ERR_NET_SOCKET_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Failed to open a socket" );
-    if( use_ret == -(MBEDTLS_ERR_NET_CONNECT_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - The connection to the given server / port failed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_BIND_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Binding of the socket failed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_LISTEN_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Could not listen on the socket" );
-    if( use_ret == -(MBEDTLS_ERR_NET_ACCEPT_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Could not accept the incoming connection" );
-    if( use_ret == -(MBEDTLS_ERR_NET_RECV_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Reading information from the socket failed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_SEND_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Sending information through the socket failed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_CONN_RESET) )
-        mbedtls_snprintf( buf, buflen, "NET - Connection was reset by peer" );
-    if( use_ret == -(MBEDTLS_ERR_NET_UNKNOWN_HOST) )
-        mbedtls_snprintf( buf, buflen, "NET - Failed to get an IP address for the given hostname" );
-    if( use_ret == -(MBEDTLS_ERR_NET_BUFFER_TOO_SMALL) )
-        mbedtls_snprintf( buf, buflen, "NET - Buffer is too small to hold the data" );
-    if( use_ret == -(MBEDTLS_ERR_NET_INVALID_CONTEXT) )
-        mbedtls_snprintf( buf, buflen, "NET - The context is invalid, eg because it was free()ed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_POLL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "NET - Polling the net context failed" );
-    if( use_ret == -(MBEDTLS_ERR_NET_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "NET - Input invalid" );
-#endif /* MBEDTLS_NET_C */
-
-#if defined(MBEDTLS_OID_C)
-    if( use_ret == -(MBEDTLS_ERR_OID_NOT_FOUND) )
-        mbedtls_snprintf( buf, buflen, "OID - OID is not found" );
-    if( use_ret == -(MBEDTLS_ERR_OID_BUF_TOO_SMALL) )
-        mbedtls_snprintf( buf, buflen, "OID - output buffer is too small" );
-#endif /* MBEDTLS_OID_C */
-
-#if defined(MBEDTLS_PADLOCK_C)
-    if( use_ret == -(MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED) )
-        mbedtls_snprintf( buf, buflen, "PADLOCK - Input data should be aligned" );
-#endif /* MBEDTLS_PADLOCK_C */
-
-#if defined(MBEDTLS_PLATFORM_C)
-    if( use_ret == -(MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "PLATFORM - Hardware accelerator failed" );
-    if( use_ret == -(MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED) )
-        mbedtls_snprintf( buf, buflen, "PLATFORM - The requested feature is not supported by the platform" );
-#endif /* MBEDTLS_PLATFORM_C */
-
-#if defined(MBEDTLS_POLY1305_C)
-    if( use_ret == -(MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "POLY1305 - Invalid input parameter(s)" );
-    if( use_ret == -(MBEDTLS_ERR_POLY1305_FEATURE_UNAVAILABLE) )
-        mbedtls_snprintf( buf, buflen, "POLY1305 - Feature not available. For example, s part of the API is not implemented" );
-    if( use_ret == -(MBEDTLS_ERR_POLY1305_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "POLY1305 - Poly1305 hardware accelerator failed" );
-#endif /* MBEDTLS_POLY1305_C */
-
-#if defined(MBEDTLS_RIPEMD160_C)
-    if( use_ret == -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "RIPEMD160 - RIPEMD160 hardware accelerator failed" );
-#endif /* MBEDTLS_RIPEMD160_C */
-
-#if defined(MBEDTLS_SHA1_C)
-    if( use_ret == -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "SHA1 - SHA-1 hardware accelerator failed" );
-    if( use_ret == -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "SHA1 - SHA-1 input data was malformed" );
-#endif /* MBEDTLS_SHA1_C */
-
-#if defined(MBEDTLS_SHA256_C)
-    if( use_ret == -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "SHA256 - SHA-256 hardware accelerator failed" );
-    if( use_ret == -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "SHA256 - SHA-256 input data was malformed" );
-#endif /* MBEDTLS_SHA256_C */
-
-#if defined(MBEDTLS_SHA512_C)
-    if( use_ret == -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "SHA512 - SHA-512 hardware accelerator failed" );
-    if( use_ret == -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "SHA512 - SHA-512 input data was malformed" );
-#endif /* MBEDTLS_SHA512_C */
-
-#if defined(MBEDTLS_THREADING_C)
-    if( use_ret == -(MBEDTLS_ERR_THREADING_FEATURE_UNAVAILABLE) )
-        mbedtls_snprintf( buf, buflen, "THREADING - The selected feature is not available" );
-    if( use_ret == -(MBEDTLS_ERR_THREADING_BAD_INPUT_DATA) )
-        mbedtls_snprintf( buf, buflen, "THREADING - Bad input parameters to function" );
-    if( use_ret == -(MBEDTLS_ERR_THREADING_MUTEX_ERROR) )
-        mbedtls_snprintf( buf, buflen, "THREADING - Locking / unlocking / free failed with error code" );
-#endif /* MBEDTLS_THREADING_C */
-
-#if defined(MBEDTLS_XTEA_C)
-    if( use_ret == -(MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH) )
-        mbedtls_snprintf( buf, buflen, "XTEA - The data input has an invalid length" );
-    if( use_ret == -(MBEDTLS_ERR_XTEA_HW_ACCEL_FAILED) )
-        mbedtls_snprintf( buf, buflen, "XTEA - XTEA hardware accelerator failed" );
-#endif /* MBEDTLS_XTEA_C */
-    // END generated code
-
-    if( strlen( buf ) != 0 )
-        return;
-
-    mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    if( low_level_error_description == NULL )
+        mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    else
+        mbedtls_snprintf( buf, buflen, "%s", low_level_error_description );
 }
 
 #else /* MBEDTLS_ERROR_C */

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -48,7 +48,9 @@ const char * mbedtls_high_level_strerr( int error_code )
 
     switch( error_code )
     {
+        /* Begin Auto-Generated Code. */
 HIGH_LEVEL_CODE_CHECKS
+        /* End Auto-Generated Code. */
 
         default:
             break;
@@ -63,7 +65,9 @@ const char * mbedtls_low_level_strerr( int error_code )
 
     switch( error_code )
     {
+        /* Begin Auto-Generated Code. */
 LOW_LEVEL_CODE_CHECKS
+        /* End Auto-Generated Code. */
 
         default:
             break;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -42,10 +42,66 @@
 
 HEADER_INCLUDED
 
+typedef struct mbedtls_error
+{
+    int code;                   /* Error code. */
+    const char * description;   /* Error description. */
+} mbedtls_error_t;
+
+static mbedtls_error_t high_level_errors[] =
+{
+HIGH_LEVEL_CODE_CHECKS
+};
+
+#define NUM_HIGH_LEVEL_ERRORS ( sizeof(high_level_errors)/sizeof(mbedtls_error_t) )
+
+static mbedtls_error_t low_level_errors[] =
+{
+LOW_LEVEL_CODE_CHECKS
+};
+
+#define NUM_LOW_LEVEL_ERRORS  ( sizeof(low_level_errors)/sizeof(mbedtls_error_t) )
+
+const char * mbedtls_high_level_strerr( int error_code )
+{
+    size_t i;
+    const char *error_description = NULL;
+
+    for(i = 0; i < NUM_HIGH_LEVEL_ERRORS; i++ )
+    {
+        if( high_level_errors[i].code == error_code )
+        {
+            error_description = high_level_errors[i].description;
+            break;
+        }
+    }
+
+    return error_description;
+}
+
+const char * mbedtls_low_level_strerr( int error_code )
+{
+    size_t i;
+    const char *error_description = NULL;
+
+    for(i = 0; i < NUM_LOW_LEVEL_ERRORS; i++ )
+    {
+        if( low_level_errors[i].code == error_code )
+        {
+            error_description = low_level_errors[i].description;
+            break;
+        }
+    }
+
+    return error_description;
+}
+
 void mbedtls_strerror( int ret, char *buf, size_t buflen )
 {
     size_t len;
     int use_ret;
+    const char * high_level_error_description = NULL;
+    const char * low_level_error_description = NULL;
 
     if( buflen == 0 )
         return;
@@ -59,14 +115,18 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     {
         use_ret = ret & 0xFF80;
 
-        // High level error codes
-        //
-        // BEGIN generated code
-HIGH_LEVEL_CODE_CHECKS
-        // END generated code
+        // Translate high level error code.
+        high_level_error_description = mbedtls_high_level_strerr(use_ret);
 
-        if( strlen( buf ) == 0 )
+        if( high_level_error_description == NULL )
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+        else
+            mbedtls_snprintf( buf, buflen, "%s", high_level_error_description );
+
+        // Early return in case of a fatal error - do not try to translate low
+        // level code.
+        if(use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE))
+            return;
     }
 
     use_ret = ret & ~0xFF80;
@@ -90,16 +150,13 @@ HIGH_LEVEL_CODE_CHECKS
         buflen -= len + 3;
     }
 
-    // Low level error codes
-    //
-    // BEGIN generated code
-LOW_LEVEL_CODE_CHECKS
-    // END generated code
+    // Translate low level error code.
+    low_level_error_description = mbedtls_low_level_strerr( use_ret );
 
-    if( strlen( buf ) != 0 )
-        return;
-
-    mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    if( low_level_error_description == NULL )
+        mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    else
+        mbedtls_snprintf( buf, buflen, "%s", low_level_error_description );
 }
 
 #else /* MBEDTLS_ERROR_C */

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -42,38 +42,16 @@
 
 HEADER_INCLUDED
 
-typedef struct mbedtls_error
-{
-    int code;                   /* Error code. */
-    const char * description;   /* Error description. */
-} mbedtls_error_t;
-
-static mbedtls_error_t high_level_errors[] =
-{
-HIGH_LEVEL_CODE_CHECKS
-};
-
-#define NUM_HIGH_LEVEL_ERRORS ( sizeof(high_level_errors)/sizeof(mbedtls_error_t) )
-
-static mbedtls_error_t low_level_errors[] =
-{
-LOW_LEVEL_CODE_CHECKS
-};
-
-#define NUM_LOW_LEVEL_ERRORS  ( sizeof(low_level_errors)/sizeof(mbedtls_error_t) )
-
 const char * mbedtls_high_level_strerr( int error_code )
 {
-    size_t i;
     const char *error_description = NULL;
 
-    for(i = 0; i < NUM_HIGH_LEVEL_ERRORS; i++ )
+    switch( error_code )
     {
-        if( high_level_errors[i].code == error_code )
-        {
-            error_description = high_level_errors[i].description;
+HIGH_LEVEL_CODE_CHECKS
+
+        default:
             break;
-        }
     }
 
     return error_description;
@@ -81,16 +59,14 @@ const char * mbedtls_high_level_strerr( int error_code )
 
 const char * mbedtls_low_level_strerr( int error_code )
 {
-    size_t i;
     const char *error_description = NULL;
 
-    for(i = 0; i < NUM_LOW_LEVEL_ERRORS; i++ )
+    switch( error_code )
     {
-        if( low_level_errors[i].code == error_code )
-        {
-            error_description = low_level_errors[i].description;
+LOW_LEVEL_CODE_CHECKS
+
+        default:
             break;
-        }
     }
 
     return error_description;
@@ -123,10 +99,12 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         else
             mbedtls_snprintf( buf, buflen, "%s", high_level_error_description );
 
+#if defined(MBEDTLS_SSL_TLS_C)
         // Early return in case of a fatal error - do not try to translate low
         // level code.
         if(use_ret == -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE))
             return;
+#endif /* MBEDTLS_SSL_TLS_C */
     }
 
     use_ret = ret & ~0xFF80;

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -44,9 +44,16 @@ HEADER_INCLUDED
 
 const char * mbedtls_high_level_strerr( int error_code )
 {
+    int high_level_error_code;
     const char *error_description = NULL;
 
-    switch( error_code )
+    if( error_code < 0 )
+        error_code = -error_code;
+
+    /* Extract the high-level part from the error code. */
+    high_level_error_code = error_code & 0xFF80;
+
+    switch( high_level_error_code )
     {
         /* Begin Auto-Generated Code. */
 HIGH_LEVEL_CODE_CHECKS
@@ -61,9 +68,16 @@ HIGH_LEVEL_CODE_CHECKS
 
 const char * mbedtls_low_level_strerr( int error_code )
 {
+    int low_level_error_code;
     const char *error_description = NULL;
 
-    switch( error_code )
+    if( error_code < 0 )
+        error_code = -error_code;
+
+    /* Extract the low-level part from the error code. */
+    low_level_error_code = error_code & ~0xFF80;
+
+    switch( low_level_error_code )
     {
         /* Begin Auto-Generated Code. */
 LOW_LEVEL_CODE_CHECKS
@@ -96,7 +110,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         use_ret = ret & 0xFF80;
 
         // Translate high level error code.
-        high_level_error_description = mbedtls_high_level_strerr(use_ret);
+        high_level_error_description = mbedtls_high_level_strerr( ret );
 
         if( high_level_error_description == NULL )
             mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
@@ -133,7 +147,7 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
     }
 
     // Translate low level error code.
-    low_level_error_description = mbedtls_low_level_strerr( use_ret );
+    low_level_error_description = mbedtls_low_level_strerr( ret );
 
     if( low_level_error_description == NULL )
         mbedtls_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -119,13 +119,13 @@ foreach my $line (@matches)
     {
         $code_check = \$ll_code_check;
         $old_define = \$ll_old_define;
-        $white_space = '    ';
+        $white_space = '        ';
     }
     else
     {
         $code_check = \$hl_code_check;
         $old_define = \$hl_old_define;
-        $white_space = '    ';
+        $white_space = '        ';
     }
 
     if ($define_name ne ${$old_define})
@@ -160,7 +160,9 @@ foreach my $line (@matches)
         ${$old_define} = $define_name;
     }
 
-    ${$code_check} .= "${white_space}\{.code = -($error_name), .description=\"$module_name - $description\"},\n";
+    ${$code_check} .= "${white_space}case -($error_name):\n".
+                      "${white_space}    error_description = \"$module_name - $description\";\n".
+                      "${white_space}    break;\n"
 };
 
 if ($ll_old_define ne "")

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -125,7 +125,7 @@ foreach my $line (@matches)
     {
         $code_check = \$hl_code_check;
         $old_define = \$hl_old_define;
-        $white_space = '        ';
+        $white_space = '    ';
     }
 
     if ($define_name ne ${$old_define})
@@ -160,19 +160,7 @@ foreach my $line (@matches)
         ${$old_define} = $define_name;
     }
 
-    if ($error_name eq "MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE")
-    {
-        ${$code_check} .= "${white_space}if( use_ret == -($error_name) )\n".
-                          "${white_space}\{\n".
-                          "${white_space}    mbedtls_snprintf( buf, buflen, \"$module_name - $description\" );\n".
-                          "${white_space}    return;\n".
-                          "${white_space}}\n"
-    }
-    else
-    {
-        ${$code_check} .= "${white_space}if( use_ret == -($error_name) )\n".
-                          "${white_space}    mbedtls_snprintf( buf, buflen, \"$module_name - $description\" );\n"
-    }
+    ${$code_check} .= "${white_space}\{.code = -($error_name), .description=\"$module_name - $description\"},\n";
 };
 
 if ($ll_old_define ne "")


### PR DESCRIPTION
Problem
-------
```mbedtls_strerror``` is a utility function which converts an mbedTLS error code into a human readable string. It requires the caller to allocate a buffer every time an error code needs to be converted to a string. It is an overkill and a waste of RAM for resource constrained microcontrollers - where the most common use case is to use these strings for logging.

Solution
--------
The proposed commit adds two functions:

```c
const char * mbedtls_high_level_strerr( int error_code );
const char * mbedtls_low_level_strerr( int error_code );
```

The above two functions convert the high level and low level parts of an mbedTLS error code to human readable strings. They return a const pointer to an unmodifiable string which is not supposed to be modified by the caller and only to be used for logging purposes. The caller no longer needs to allocate a buffer.

Status
---------
**READY**

Requires Backporting
----------------------
NO

The proposed change is completely backward compatible as it does not change the existing mbedtls_strerror function and ensures that it continues to behave the same way.

Files
------
Modified Files: 
* include/mbedtls/error.h
* scripts/data_files/error.fmt
* scripts/generate_errors.pl

Auto Generated File: 
* library/error.c

The ```library/error.c``` is generated by running ```scripts/generate_errors.pl``` (which seems to be the way it is generated).

Testing
---------
```
./test_suite_error 

Single low error .................................................. PASS
Single high error ................................................. PASS
Low and high error ................................................ PASS
Non existing high error ........................................... PASS
Non existing low error ............................................ PASS
Non existing low and high error ................................... PASS

----------------------------------------------------------------------------

PASSED (6 / 6 tests (0 skipped))
```

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>