### PR TITLE
Fix arithmetic overflow in benchmark

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -150,6 +150,16 @@ do {                                                                    \
 
 #if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C) && defined(MBEDTLS_MEMORY_DEBUG)
 
+/* How much space to reserve for the title when printing heap usage results.
+ * Updated manually as the output of the following command:
+ *
+ *  sed -n 's/.*[T]IME_PUBLIC.*"\(.*\)",/\1/p' programs/test/benchmark.c |
+ *      awk '{print length+2}' | sort -rn | head -n1
+ *
+ * This computes the maximum length of a title +2 (because we appends "/s").
+ * (If the value is too small, the only consequence is poor alignement.) */
+#define TITLE_SPACE 16
+
 #define MEMORY_MEASURE_INIT                                             \
     size_t max_used, max_blocks, max_bytes;                             \
     size_t prv_used, prv_blocks;                                        \
@@ -158,8 +168,8 @@ do {                                                                    \
 
 #define MEMORY_MEASURE_PRINT( title_len )                               \
     mbedtls_memory_buffer_alloc_max_get( &max_used, &max_blocks );      \
-    for( ii = 12 > (title_len) ? 12 - (title_len) : 1; ii !=0; ii--)    \
-        mbedtls_printf( " " );                                          \
+    ii = TITLE_SPACE > (title_len) ? TITLE_SPACE - (title_len) : 1;     \
+    while( ii-- ) mbedtls_printf( " " );                                \
     max_used -= prv_used;                                               \
     max_blocks -= prv_blocks;                                           \
     max_bytes = max_used + MEM_BLOCK_OVERHEAD * max_blocks;             \

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -158,7 +158,8 @@ do {                                                                    \
 
 #define MEMORY_MEASURE_PRINT( title_len )                               \
     mbedtls_memory_buffer_alloc_max_get( &max_used, &max_blocks );      \
-    for( ii = 12 - (title_len); ii != 0; ii-- ) mbedtls_printf( " " );  \
+    for( ii = 12 > (title_len) ? 12 - (title_len) : 1; ii !=0; ii--)    \
+        mbedtls_printf( " " );                                          \
     max_used -= prv_used;                                               \
     max_blocks -= prv_blocks;                                           \
     max_bytes = max_used + MEM_BLOCK_OVERHEAD * max_blocks;             \


### PR DESCRIPTION
## Description

When building with MBEDTLS_MEMORY_DEBUG enabled, and running the ecdh part, the benchmark program would start writing a very large number of space characters on stdout, and would have to be killed because it never seemed to terminate.

This was due to an integer overflow in computing how many space to leave after the title in order to get memory measurements aligned, which resulted in close to SIZE_MAX spaces being printed.

## Status
**READY**

(No ChangeLog entry as the bug is only in one of the example programs in a non-default config.)

## Requires Backporting

Yes - I'll create backport once this PR has receive some review.

- [x] 2.16 - #3198
- [x] 2.7 - #3199 

## Steps to test or reproduce

I used the following script:

```sh
#!/bin/sh

# this is necessary for the bug to be present
scripts/config.py set MBEDTLS_PLATFORM_MEMORY
scripts/config.py set MBEDTLS_MEMORY_BUFFER_ALLOC_C
scripts/config.py set MBEDTLS_MEMORY_DEBUG

# this just saves time
scripts/config.py unset MBEDTLS_ECP_DP_SECP192R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP224R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP384R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP521R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP192K1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP224K1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_SECP256K1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_BP256R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_BP384R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_BP512R1_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_CURVE25519_ENABLED
scripts/config.py unset MBEDTLS_ECP_DP_CURVE448_ENABLED

# build with the current config
make clean
make -C programs test/benchmark

# be ready to press ctrl-c...
programs/test/benchmark ecdh

# you'll need to to this manually after pressing ctrl-c
git checkout -- include/mbedtls/config.h
```

- Run it in the development branch and be ready to press ctrl-c when your screen get flooded with spaces (then restore `config.h`) ;
- run it after the first commit, and notice that the program now terminates without flooding your screen but the end of the last line isn't quite aligned ;
- run it after the second commit and notice how the program still terminates and the output is now aligned too!