### PR TITLE
Fix failure detection and failures in basic-build-test.sh with SSL3 in basic-build-test

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -68,6 +68,10 @@ export LDFLAGS=' --coverage'
 make clean
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.py full
+# Enable some deprecated or experimental features that are not in the
+# full config, but are compatible with it and have tests.
+scripts/config.py set MBEDTLS_SSL_PROTO_SSL3
+scripts/config.py set MBEDTLS_PSA_CRYPTO_SE_C
 make -j
 
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -68,7 +68,6 @@ export LDFLAGS=' --coverage'
 make clean
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.py full
-scripts/config.py unset MBEDTLS_MEMORY_BACKTRACE
 make -j
 
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -104,7 +104,15 @@ echo
 
 # Step 3 - Process the coverage report
 cd ..
-make lcov |tee tests/cov-$TEST_OUTPUT
+{
+    make lcov
+    echo SUCCESS
+} | tee tests/cov-$TEST_OUTPUT
+
+if [ "$(tail -n1 tests/cov-$TEST_OUTPUT)" != "SUCCESS" ]; then
+    echo >&2 "Fatal: 'make lcov' failed"
+    exit 2
+fi
 
 
 # Step 4 - Summarise the test report

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -79,15 +79,15 @@ if [ ! -f "seedfile" ]; then
     dd if=/dev/urandom of="seedfile" bs=32 count=1
 fi
 
-# Step 2a - Unit Tests
+# Step 2a - Unit Tests (keep going even if some tests fail)
 perl scripts/run-test-suites.pl -v 2 |tee unit-test-$TEST_OUTPUT
 echo
 
-# Step 2b - System Tests
+# Step 2b - System Tests (keep going even if some tests fail)
 sh ssl-opt.sh |tee sys-test-$TEST_OUTPUT
 echo
 
-# Step 2c - Compatibility tests
+# Step 2c - Compatibility tests (keep going even if some tests fail)
 sh compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2' | \
     tee compat-test-$TEST_OUTPUT
 OPENSSL_CMD="$OPENSSL_LEGACY"                               \

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -224,3 +224,7 @@ make clean
 if [ -f "$CONFIG_BAK" ]; then
     mv "$CONFIG_BAK" "$CONFIG_H"
 fi
+
+if [ $TOTAL_FAIL -ne 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -76,7 +76,7 @@ make -j
 TEST_OUTPUT=out_${PPID}
 cd tests
 if [ ! -f "seedfile" ]; then
-    dd if=/dev/urandom of="seedfile" bs=32 count=1
+    dd if=/dev/urandom of="seedfile" bs=64 count=1
 fi
 
 # Step 2a - Unit Tests (keep going even if some tests fail)


### PR DESCRIPTION
* Fix #3178: make basic-build-test.sh exit with a failure status if some test cases fail
* Minor log readability improvements
* Fix #3179: enable SSL3 in basic-build-test.sh

Needs partial backports. This PR is release-critical, but the backports aren't (we can check the logs manually to verify that there are no failures).

Alternative that does change the full config: https://github.com/ARMmbed/mbedtls/pull/3180
