### PR TITLE
Rfc3161 convenience functions

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -277,6 +277,31 @@ int mbedtls_asn1_get_int( unsigned char **p,
                           int *val );
 
 /**
+ * \brief       Retrieve an integer ASN.1 tag and its value as an
+ *              unsigned 64 bit integer. 
+ *     
+ *              Updates the pointer to immediately behind the full tag.
+ *
+ * \param p     On entry, \c *p points to the start of the ASN.1 element.
+ *              On successful completion, \c *p points to the first byte
+ *              beyond the ASN.1 element.
+ *              On error, the value of \c *p is undefined.
+ * \param end   End of data.
+ * \param val   On success, the parsed value.
+ *
+ * \return      0 if successful.
+ * \return      An ASN.1 error code if the input does not start with
+ *              a valid ASN.1 INTEGER.
+ * \return      #MBEDTLS_ERR_ASN1_INVALID_LENGTH if the parsed value does
+ *              not fit in an \c int. 
+ *              #MBEDTLS_ERR_ASN1_INVALID_DATA is returned if the parsed
+ *              value is negative.
+ */
+int mbedtls_asn1_get_uint64( unsigned char **p,
+                                    const unsigned char *end,
+                                    uint64_t *val );
+
+/**
  * \brief       Retrieve an enumerated ASN.1 tag and its value.
  *              Updates the pointer to immediately behind the full tag.
  *
@@ -569,6 +594,41 @@ int mbedtls_asn1_get_alg( unsigned char **p,
 int mbedtls_asn1_get_alg_null( unsigned char **p,
                        const unsigned char *end,
                        mbedtls_asn1_buf *alg );
+
+/**
+ * \brief       Retrieve an ASN1_INTEGER of arbitrary size as often used
+ *              for (certificate) serial numbers as a bitstring (which
+ *              commonly run to 130-160 bits).
+ *
+ * \param p     On entry, \c *p points to the start of the ASN.1 element.
+ *              On successful completion, \c *p points to the first byte
+ *              beyond the AlgorithmIdentifier element.
+ *              On error, the value of \c *p is undefined.
+ * \param end   End of data.
+ * \param alg   The buffer to receive the bitstring.
+ *
+ * \return      0 if successful or a specific ASN.1 or MPI error code.
+ */
+int mbedtls_asn1_get_serial_bitstring( unsigned char **p,
+    const unsigned char *end,
+    mbedtls_asn1_bitstring *val );
+
+/**
+ * \brief       Retrieve an ASN1_INTEGER of arbitrary size as often used
+ *              for (certificate) serial numbers as a a bignum.
+ *
+ * \param p     On entry, \c *p points to the start of the ASN.1 element.
+ *              On successful completion, \c *p points to the first byte
+ *              beyond the AlgorithmIdentifier element.
+ *              On error, the value of \c *p is undefined.
+ * \param end   End of data.
+ * \param alg   The buffer to receive the bitstring.
+ *
+ * \return      0 if successful or a specific ASN.1 or MPI error code.
+ */
+int mbedtls_asn1_get_serial_mpi( unsigned char **p,
+                                        const unsigned char *end,
+                                        mbedtls_mpi *val );
 
 /**
  * \brief       Find a specific named_data entry in a sequence or list based on

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -276,6 +276,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
                           const unsigned char *end,
                           int *val );
 
+#ifdef MBEDTLS_HAVE_INT64
 /**
  * \brief       Retrieve an integer ASN.1 tag and its value as an
  *              unsigned 64 bit integer. 
@@ -300,6 +301,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
 int mbedtls_asn1_get_uint64( unsigned char **p,
                                     const unsigned char *end,
                                     uint64_t *val );
+#endif
 
 /**
  * \brief       Retrieve an enumerated ASN.1 tag and its value.

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -310,6 +310,8 @@ int mbedtls_x509_self_test( int verbose );
  */
 int mbedtls_x509_get_name( unsigned char **p, const unsigned char *end,
                    mbedtls_x509_name *cur );
+int mbedtls_x509_get_names( unsigned char **p, const unsigned char *end,
+                            mbedtls_x509_name *cur );
 int mbedtls_x509_get_alg_null( unsigned char **p, const unsigned char *end,
                        mbedtls_x509_buf *alg );
 int mbedtls_x509_get_alg( unsigned char **p, const unsigned char *end,

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -511,6 +511,7 @@ int mbedtls_asn1_get_serial_bitstring( unsigned char **p,
     return ( 0 );
 }
 
+#ifdef MBEDTLS_HAVE_INT64
 int mbedtls_asn1_get_uint64( unsigned char **p,
                                     const unsigned char *end,
                                     uint64_t *val )
@@ -540,6 +541,7 @@ int mbedtls_asn1_get_uint64( unsigned char **p,
 
   return ( 0 );
 }
+#endif
 
 void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *cur )
 {

--- a/library/x509.c
+++ b/library/x509.c
@@ -802,6 +802,22 @@ int mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *dn )
     return( (int) ( size - n ) );
 }
 
+int mbedtls_x509_get_names( unsigned char **p, const unsigned char *end,
+                            mbedtls_x509_name *cur )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t set_len = 0;
+
+    if (0 != (ret = mbedtls_asn1_get_tag(p, end, &set_len,
+                                         MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)))
+         return ( ret );
+
+    if (0 != (ret = mbedtls_x509_get_name(p, *p + set_len, cur)))
+         return ( ret );
+
+    return ( 0 );
+};
+
 /*
  * Store the serial in printable form into buf; no more
  * than size characters will be written


### PR DESCRIPTION
We created a RFC 3161 Digital signature time stamp validation (inserted into the firmware OTA updating process). During implementation we found that a few convenience functions would be nice to have in the API.

## Status
**IN DEVELOPMENT**

## Requires Backporting
NO

## Migrations
NO (just additions)

## Additional comments

Just testing the waters if it makes sense to spend the time to integrate this here; or that it is easier to package this up in the OTA firmware handler (of the ESP32/Arduino OTA).

## Todos
- [X ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

Signed-off-by: dirkx