### PR TITLE
BUILD: Update IAR support in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,10 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(CMAKE_COMPILER_IS_IAR)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts --warnings_are_errors -Ohz")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts")
+    set(CMAKE_C_FLAGS_RELEASE     "-Ohz")
+    set(CMAKE_C_FLAGS_DEBUG       "--debug -On")
+    set(CMAKE_C_FLAGS_CHECK       "--warnings_are_errors")
 endif(CMAKE_COMPILER_IS_IAR)
 
 if(CMAKE_COMPILER_IS_MSVC)


### PR DESCRIPTION
Applied the same change as in mbed-crypto for using this as a sub
project with the IAR toolchain.

Signed-off-by: TTornblom <thomas.tornblom@iar.com>


## Description
Split CMAKE_C_FLAGS settings for IAR to mimic the GCC and CLANG settings.
The old settings was causing issues with mbed-crypto when building TF-M with the IAR toolchain due to multiple settings of "-Ohz" when using it as a subproject.
This is a proactive fix for similar issues with mbedtls.

## Status
READY

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
