### PR TITLE
Fix wrong modulo call in ecp_double_add_mxz

### DIFF
--- a/ChangeLog.d/fix-ecp_double_add_mxz.txt
+++ b/ChangeLog.d/fix-ecp_double_add_mxz.txt
@@ -1,0 +1,4 @@
+Changes
+   * Fix minor performance issue in operations on Curve25519 caused by using a
+     suboptimal modular reduction in one place. Found and fix contributed by
+     Aurelien Jarno in #3209.

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2332,7 +2332,7 @@ static int ecp_double_add_mxz( const mbedtls_ecp_group *grp,
     MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &D,    &Q->X,   &Q->Z ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &DA,   &D,      &A    ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &CB,   &C,      &B    ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &S->X, &DA,     &CB   ) ); MOD_MUL( S->X );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_add_mod( grp, &S->X, &DA,     &CB   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &S->X, &S->X,   &S->X ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &S->Z, &DA,     &CB   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &S->Z, &S->Z,   &S->Z ) );


### PR DESCRIPTION
## Description

ecp_double_add_mxz wrongly does an MPI addition followed by a call to
MOD_MUL instead of MOD_ADD. This is more visible since the
mbedtls_mpi_xxx_mod functions have been added in commit 3b3b34f60800
("Replace some macros by functions").

Fix that by using mbedtls_mpi_add_mod instead. The testsuite still
passes after that change.

## Status
READY

## Requires Backporting

I am not sure it requires backporting, I don't think it as any real impact.

## Migrations

NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported