### PR TITLE
Add missing changelog entries for PRs since 2.22.0

### DIFF
--- a/ChangeLog.d/error_const.txt
+++ b/ChangeLog.d/error_const.txt
@@ -1,6 +1,6 @@
 Features
    * New functions in the error module return constant strings for
-     high- and low-level error codes, complementing mbedtls_strerror
+     high- and low-level error codes, complementing mbedtls_strerror()
      which constructs a string for any error code, including compound
      ones, but requires a writable buffer. Contributed by Gaurav Aggarwal
      in #3176.

--- a/ChangeLog.d/error_const.txt
+++ b/ChangeLog.d/error_const.txt
@@ -1,0 +1,6 @@
+Features
+   * New functions in the error module return constant strings for
+     high- and low-level error codes, complementing mbedtls_strerror
+     which constructs a string for any error code, including compound
+     ones, but requires a writable buffer. Contributed by Gaurav Aggarwal
+     in #3176.

--- a/ChangeLog.d/max_pathlen.txt
+++ b/ChangeLog.d/max_pathlen.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix undefined behavior in X.509 certificate parsing if the
+     pathLenConstraint basic constraint value is equal to INT_MAX.
+     The actual effect with almost every compiler is the intended
+     behavior, so this is unlikely to be exploitable anywhere. #3192

--- a/ChangeLog.d/md_switch.txt
+++ b/ChangeLog.d/md_switch.txt
@@ -1,0 +1,3 @@
+Changes
+   * Combine identical cases in switch statements in md.c. Contributed
+     by irwir in #3208.

--- a/ChangeLog.d/ssl_context_info.txt
+++ b/ChangeLog.d/ssl_context_info.txt
@@ -1,0 +1,3 @@
+Features
+   * The new utility programs/ssl/ssl_context_info prints a human-readable
+     dump of an SSL context saved with mbedtls_ssl_context_save().

--- a/ChangeLog.d/ssl_write_certificate_request.txt
+++ b/ChangeLog.d/ssl_write_certificate_request.txt
@@ -1,0 +1,3 @@
+Changes
+   * Simplify a bounds check in ssl_write_certificate_request(). Contributed
+     by irwir in #3150.


### PR DESCRIPTION
Some pull requests merged since the 2.22.0 release were missing changelog entries.

* :heavy_plus_sign: #3127: new utility program. Entry in this PR.
* :heavy_plus_sign: #3192: product bug fix. Entry in this PR.
* :heavy_minus_sign: #3155: bug fix in tests. No entry needed.
* :heavy_minus_sign: #3118: maintenance improvement. No entry needed.
* :heavy_minus_sign: #3162: maintenance improvement. No entry needed.
* :heavy_minus_sign: #3177: bug fix in sample program in an exotic configuration. No entry needed.
* :heavy_minus_sign: #3120: maintenance improvement. No entry needed.
* :heavy_minus_sign: #2840: bug fix in tests. No entry needed.
* :heavy_minus_sign: #3194: test program improvement. No entry needed.
* :heavy_minus_sign: #3210: maintenance fix. No entry needed.
* :heavy_plus_sign: #3176: external contribution. Entry in this PR.
* :heavy_plus_sign: #3208: external contribution. Entry in this PR.
* :heavy_plus_sign: #3150: external contribution. Entry in this PR.

Needs backports for the backport of #3192: #3283, #3284.