### PR TITLE
add support for win2k

### DIFF
--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -54,8 +54,7 @@
 
 #define IS_EINTR( ret ) ( ( ret ) == WSAEINTR )
 
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0501)
-#undef _WIN32_WINNT
+#if !defined(_WIN32_WINNT)
 /* Enables getaddrinfo() & Co */
 #define _WIN32_WINNT 0x0501
 #endif
@@ -64,6 +63,9 @@
 
 #include <winsock2.h>
 #include <windows.h>
+#if (_WIN32_WINNT < 0x0501)
+#include <wspiapi.h>
+#endif
 
 #if defined(_MSC_VER)
 #if defined(_WIN32_WCE)


### PR DESCRIPTION
## Description
getaddrinfo() is not available on win2k. By including wspiapi.h (if _WIN32_WINNT is defined as value < 0x0501) then a compatibility layer will be used when running on win2k. For more details, refer to [Microsoft docs for getaddrinfo()](https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo).

## Status
READY

## Requires Backporting
NO

## Migrations
NO

## Steps to test or reproduce
Define _WIN32_WINNT as 0x0500, build, run on win2k VM. If you are cross compiling from linux to windows here's a sequence of commands to do this:

    sudo apt-get install mingw-w64
    CC=i686-w64-mingw32-gcc AR=i686-w64-mingw32-ar CFLAGS="-D_WIN32_WINNT=0x0500" LDFLAGS="-lws2_32" make
