### PR TITLE
Fix required symboles not defined when compile ecdh_curve25519.c exam…

### DIFF
--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -36,6 +36,8 @@
 #define MBEDTLS_EXIT_FAILURE    EXIT_FAILURE
 #endif /* MBEDTLS_PLATFORM_C */
 
+#include "mbedtls/ecdh.h"
+
 #if !defined(MBEDTLS_ECDH_C) || !defined(MBEDTLS_ECDH_LEGACY_CONTEXT) || \
     !defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) || \
     !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CTR_DRBG_C)
@@ -51,7 +53,6 @@ int main( void )
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/ecdh.h"
 
 
 int main( int argc, char *argv[] )


### PR DESCRIPTION
## Description
I built the example ecdh_curve25519.c with the accompanied include/mbedtls/config.h file. The build was successfully. However when I executed the example, it always displayed following error:

```
MBEDTLS_ECDH_C and/or MBEDTLS_ECDH_LEGACY_CONTEXT and/or
MBEDTLS_ECP_DP_CURVE25519_ENABLED and/or MBEDTLS_ENTROPY_C and/or
MBEDTLS_CTR_DRBG_C not defined
```

## Status
READY

## Requires Backporting
NO

Which branch?
Development

## Migrations
NO

## Steps to test or reproduce
Please refer [ecdh_curve25519.c example - always complains required symboles not defined](https://github.com/ARMmbed/mbedtls/issues/3191) for the discussion.
