### PR TITLE
Backport 2.7: Rationalize Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ jobs:
       script:
         - tests/scripts/all.sh -k test_default_out_of_box
 
+    - name: Windows
+      os: windows
+      script:
+        - scripts/windows_msbuild.bat
+
 after_failure:
 - tests/scripts/travis-log-failure.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Windows
       os: windows
       script:
-        - scripts/windows_msbuild.bat
+        - scripts/windows_msbuild.bat v141 # Visual Studio 2017
 
 after_failure:
 - tests/scripts/travis-log-failure.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: ccache
 
 jobs:
   include:
-    - name: basic checks
+    - name: basic checks and reference configurations
       addons:
         apt:
           packages:
@@ -21,15 +21,15 @@ jobs:
       script:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
-        - tests/scripts/all.sh -k build_arm_none_eabi_gcc
+        - tests/scripts/test-ref-configs.pl
+        - tests/scripts/all.sh -k build_arm_none_eabi_gcc # baremetal
 
     - name: full configuration
       script:
         - tests/scripts/all.sh -k test_full_cmake_gcc_asan
 
-    - name: enumerated configurations
+    - name: check compilation guards
       script:
-        - tests/scripts/test-ref-configs.pl
         - tests/scripts/all.sh -k 'test_depends_*' 'build_key_exchanges'
 
     - name: macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,15 @@ jobs:
         - pip install pylint==2.4.4
       script:
         - tests/scripts/all.sh -k 'check_*'
+        - tests/scripts/all.sh -k test_default_out_of_box
 
-    - name: default configuration
+    - name: full configuration
       addons:
         apt:
           packages:
           - gnutls-bin
       script:
-        - tests/scripts/all.sh -k test_default_cmake_gcc_asan
+        - tests/scripts/all.sh -k test_full_cmake_gcc_asan
 
     - name: enumerated configurations
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ jobs:
         - tests/scripts/test-ref-configs.pl
         - tests/scripts/all.sh -k 'test_depends_*' 'build_key_exchanges'
 
+    - name: macOS
+      os: osx
+      compiler: clang
+      script:
+        - tests/scripts/all.sh -k test_default_out_of_box
+
 after_failure:
 - tests/scripts/travis-log-failure.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ jobs:
         - tests/scripts/all.sh -k 'check_*'
 
     - name: default configuration
+      addons:
+        apt:
+          packages:
+          - gnutls-bin
       script:
-        - cmake -D CMAKE_BUILD_TYPE:String="Check" .
-        - make
-        - make test
-        - programs/test/selftest
-        - OSSL_NO_DTLS=1 tests/compat.sh
-        - tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
+        - tests/scripts/all.sh -k test_default_cmake_gcc_asan
 
     - name: enumerated configurations
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,36 @@ language: c
 compiler: gcc
 sudo: false
 cache: ccache
-script:
-- tests/scripts/recursion.pl library/*.c
-- tests/scripts/check-generated-files.sh
-- tests/scripts/check-doxy-blocks.pl
-- tests/scripts/check-names.sh
-- tests/scripts/check-files.py
-- tests/scripts/doxygen.sh
-- cmake -D CMAKE_BUILD_TYPE:String="Check" .
-- make
-- make test
-- programs/test/selftest
-- OSSL_NO_DTLS=1 tests/compat.sh
-- tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
-- tests/scripts/test-ref-configs.pl
-- tests/scripts/curves.pl
-- tests/scripts/key-exchanges.pl
+
+jobs:
+  include:
+    - name: basic checks
+      script:
+        - tests/scripts/recursion.pl library/*.c
+        - tests/scripts/check-generated-files.sh
+        - tests/scripts/check-doxy-blocks.pl
+        - tests/scripts/check-names.sh
+        - tests/scripts/check-files.py
+        - tests/scripts/doxygen.sh
+
+    - name: default configuration
+      script:
+        - cmake -D CMAKE_BUILD_TYPE:String="Check" .
+        - make
+        - make test
+        - programs/test/selftest
+        - OSSL_NO_DTLS=1 tests/compat.sh
+        - tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
+
+    - name: enumerated configurations
+      script:
+        - tests/scripts/test-ref-configs.pl
+        - tests/scripts/curves.pl
+        - tests/scripts/key-exchanges.pl
+
 after_failure:
 - tests/scripts/travis-log-failure.sh
+
 env:
   global:
     - SEED=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
-compiler:
-- clang
-- gcc
+compiler: gcc
 sudo: false
 cache: ccache
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache: ccache
 jobs:
   include:
     - name: basic checks
+      addons:
+        apt:
+          packages:
+          - doxygen
+          - graphviz
       script:
         - tests/scripts/recursion.pl library/*.c
         - tests/scripts/check-generated-files.sh
@@ -38,10 +43,6 @@ env:
     - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
 
 addons:
-  apt:
-    packages:
-    - doxygen
-    - graphviz
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
         - tests/scripts/test-ref-configs.pl
-        - tests/scripts/all.sh -k build_arm_none_eabi_gcc # baremetal
+        - tests/scripts/all.sh -k build_arm_none_eabi_gcc_arm5vte build_arm_none_eabi_gcc_m0plus
 
     - name: full configuration
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ jobs:
           packages:
           - doxygen
           - graphviz
+      language: python # Needed to get pip for Python 3
+      python: 3.5 # version from Ubuntu 16.04
+      install:
+        - pip install pylint==2.4.4
       script:
         - tests/scripts/recursion.pl library/*.c
         - tests/scripts/check-generated-files.sh
@@ -18,6 +22,7 @@ jobs:
         - tests/scripts/check-names.sh
         - tests/scripts/check-files.py
         - tests/scripts/doxygen.sh
+        - tests/scripts/check-python-files.sh
 
     - name: default configuration
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ jobs:
     - name: enumerated configurations
       script:
         - tests/scripts/test-ref-configs.pl
-        - tests/scripts/curves.pl
-        - tests/scripts/key-exchanges.pl
+        - tests/scripts/all.sh -k 'test_depends_*' 'build_key_exchanges'
 
 after_failure:
 - tests/scripts/travis-log-failure.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"
-    notification_email: p.j.bakker@polarssl.org
+    notification_email: support-mbedtls@arm.com
     build_command_prepend:
     build_command: make
     branch_pattern: coverity_scan

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jobs:
           - gnutls-bin
           - doxygen
           - graphviz
+          - gcc-arm-none-eabi
+          - libnewlib-arm-none-eabi
       language: python # Needed to get pip for Python 3
       python: 3.5 # version from Ubuntu 16.04
       install:
@@ -19,6 +21,7 @@ jobs:
       script:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
+        - tests/scripts/all.sh -k build_arm_none_eabi_gcc
 
     - name: full configuration
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jobs:
       addons:
         apt:
           packages:
+          - gnutls-bin
           - doxygen
           - graphviz
       language: python # Needed to get pip for Python 3
@@ -20,10 +21,6 @@ jobs:
         - tests/scripts/all.sh -k test_default_out_of_box
 
     - name: full configuration
-      addons:
-        apt:
-          packages:
-          - gnutls-bin
       script:
         - tests/scripts/all.sh -k test_full_cmake_gcc_asan
 
@@ -42,6 +39,9 @@ env:
     - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
 
 addons:
+  apt:
+    packages:
+    - gnutls-bin
   coverity_scan:
     project:
       name: "ARMmbed/mbedtls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,7 @@ jobs:
       install:
         - pip install pylint==2.4.4
       script:
-        - tests/scripts/recursion.pl library/*.c
-        - tests/scripts/check-generated-files.sh
-        - tests/scripts/check-doxy-blocks.pl
-        - tests/scripts/check-names.sh
-        - tests/scripts/check-files.py
-        - tests/scripts/doxygen.sh
-        - tests/scripts/check-python-files.sh
+        - tests/scripts/all.sh -k 'check_*'
 
     - name: default configuration
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_failure:
 env:
   global:
     - SEED=1
-    - secure: "barHldniAfXyoWOD/vcO+E6/Xm4fmcaUoC9BeKW+LwsHqlDMLvugaJnmLXkSpkbYhVL61Hzf3bo0KPJn88AFc5Rkf8oYHPjH4adMnVXkf3B9ghHCgznqHsAH3choo6tnPxaFgOwOYmLGb382nQxfE5lUdvnM/W/psQjWt66A1+k="
+    - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
 
 addons:
   apt:

--- a/scripts/windows_msbuild.bat
+++ b/scripts/windows_msbuild.bat
@@ -1,0 +1,20 @@
+@rem Build and test Mbed TLS with Visual Studio using msbuild.
+@rem Usage: windows_msbuild [RETARGET]
+@rem   RETARGET: version of Visual Studio to emulate
+@rem             https://docs.microsoft.com/en-us/cpp/build/how-to-modify-the-target-framework-and-platform-toolset
+
+@rem These parameters are hard-coded for now.
+set "arch=x64" & @rem "x86" or "x64"
+set "cfg=Release" & @rem "Debug" or "Release"
+set "vcvarsall=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+
+if not "%~1"=="" set "retarget=,PlatformToolset=%1"
+
+@rem If the %USERPROFILE%\Source directory exists, then running
+@rem vcvarsall.bat will silently change the directory to that directory.
+@rem Setting the VSCMD_START_DIR environment variable causes it to change
+@rem to that directory instead.
+set "VSCMD_START_DIR=%~dp0\..\visualc\VS2010"
+
+"%vcvarsall%" x64 && ^
+msbuild /t:Rebuild /p:Configuration=%cfg%%retarget% /m mbedTLS.sln

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -281,9 +281,13 @@ armc6_build_test()
 {
     FLAGS="$1"
 
-    msg "build: ARM Compiler 6 ($FLAGS), make"
+    msg "build: ARM Compiler 6 ($FLAGS)"
     ARM_TOOL_VARIANT="ult" CC="$ARMC6_CC" AR="$ARMC6_AR" CFLAGS="$FLAGS" \
                     WARNING_CFLAGS='-xc -std=c99' make lib
+
+    msg "size: ARM Compiler 6 ($FLAGS)"
+    "$ARMC6_FROMELF" -z library/*.o
+
     make clean
 }
 
@@ -533,9 +537,12 @@ pre_check_tools () {
         *_armcc*|*_yotta*)
             ARMC5_CC="$ARMC5_BIN_DIR/armcc"
             ARMC5_AR="$ARMC5_BIN_DIR/armar"
+            ARMC5_FROMELF="$ARMC5_BIN_DIR/fromelf"
             ARMC6_CC="$ARMC6_BIN_DIR/armclang"
             ARMC6_AR="$ARMC6_BIN_DIR/armar"
-            check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC6_CC" "$ARMC6_AR";;
+            ARMC6_FROMELF="$ARMC6_BIN_DIR/fromelf"
+            check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC5_FROMELF" \
+                        "$ARMC6_CC" "$ARMC6_AR" "$ARMC6_FROMELF";;
     esac
 
     msg "info: output_env.sh"
@@ -1088,13 +1095,16 @@ component_test_have_int64 () {
 }
 
 component_build_arm_none_eabi_gcc () {
-    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1, make" # ~ 10s
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1" # ~ 10s
     scripts/config.pl baremetal
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra -O1' lib
+
+    msg "size: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1"
+    ${ARM_NONE_EABI_GCC_PREFIX}size library/*.o
 }
 
 component_build_arm_none_eabi_gcc_arm5vte () {
-    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -march=arm5vte, make" # ~ 10s
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -march=arm5vte" # ~ 10s
     scripts/config.pl baremetal
     # Build for a target platform that's close to what Debian uses
     # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
@@ -1102,12 +1112,18 @@ component_build_arm_none_eabi_gcc_arm5vte () {
     # It would be better to build with arm-linux-gnueabi-gcc but
     # we don't have that on our CI at this time.
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+
+    msg "size: ${ARM_NONE_EABI_GCC_PREFIX}gcc -march=armv5te -O1"
+    ${ARM_NONE_EABI_GCC_PREFIX}size library/*.o
 }
 
 component_build_arm_none_eabi_gcc_m0plus () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -mthumb -mcpu=cortex-m0plus" # ~ 10s
     scripts/config.pl baremetal
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra -mthumb -mcpu=cortex-m0plus -Os' lib
+
+    msg "size: ${ARM_NONE_EABI_GCC_PREFIX}gcc -mthumb -mcpu=cortex-m0plus -Os"
+    ${ARM_NONE_EABI_GCC_PREFIX}size library/*.o
 }
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
@@ -1120,10 +1136,13 @@ component_build_arm_none_eabi_gcc_no_udbl_division () {
 }
 
 component_build_armcc () {
-    msg "build: ARM Compiler 5, make"
+    msg "build: ARM Compiler 5"
     scripts/config.pl baremetal
-
     make CC="$ARMC5_CC" AR="$ARMC5_AR" WARNING_CFLAGS='--strict --c99' lib
+
+    msg "size: ARM Compiler 5"
+    "$ARMC5_FROMELF" -z library/*.o
+
     make clean
 
     # ARM Compiler 6 - Target ARMv7-A

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -131,7 +131,7 @@ pre_initialize_variables () {
     : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
     : ${ARMC5_BIN_DIR:=/usr/bin}
     : ${ARMC6_BIN_DIR:=/usr/bin}
-    : ${ARM_GCC_PREFIX:=arm-none-eabi-}
+    : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
 
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
     if [ -z "${MAKEFLAGS+set}" ]; then
@@ -193,8 +193,9 @@ General options:
   -f|--force            Force the tests to overwrite any modified files.
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
-     --arm-gcc-prefix=<string>  Prefix for gcc as a cross-compiler for arm
-                                (default: "${ARM_GCC_PREFIX}")
+     --arm-none-eabi-gcc-prefix=<string>
+                        Prefix for a cross-compiler for arm-none-eabi
+                        (default: "${ARM_NONE_EABI_GCC_PREFIX}")
      --armcc            Run ARM Compiler builds (on by default).
      --except           Exclude the COMPONENTs listed on the command line,
                         instead of running only those.
@@ -308,7 +309,7 @@ pre_parse_command_line () {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --arm-gcc-prefix) shift; ARM_GCC_PREFIX="$1";;
+            --arm-none-eabi-gcc-prefix) shift; ARM_NONE_EABI_GCC_PREFIX="$1";;
             --armcc) no_armcc=;;
             --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
             --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
@@ -521,7 +522,7 @@ pre_check_tools () {
     esac
 
     case " $RUN_COMPONENTS " in
-        *_arm_none_eabi_gcc[_\ ]*) check_tools "${ARM_GCC_PREFIX}gcc";;
+        *_arm_none_eabi_gcc[_\ ]*) check_tools "${ARM_NONE_EABI_GCC_PREFIX}gcc";;
     esac
 
     case " $RUN_COMPONENTS " in
@@ -1087,16 +1088,16 @@ component_test_have_int64 () {
 }
 
 component_build_arm_none_eabi_gcc () {
-    msg "build: ${ARM_GCC_PREFIX}, make" # ~ 10s
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}, make" # ~ 10s
     scripts/config.pl baremetal
-    make CC="${ARM_GCC_PREFIX}gcc" AR="${ARM_GCC_PREFIX}ar" LD="${ARM_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
+    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
 }
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
-    msg "build: ${ARM_GCC_PREFIX} -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX} -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal
     scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-    make CC="${ARM_GCC_PREFIX}gcc" AR="${ARM_GCC_PREFIX}ar" LD="${ARM_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
+    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
     echo "Checking that software 64-bit division is not required"
     if_build_succeeded not grep __aeabi_uldiv library/*.o
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -619,7 +619,7 @@ component_test_default_out_of_box () {
     make test
 
     msg "selftest: make, default config (out-of-box)" # ~10s
-    programs/test/selftest
+    if_build_succeeded programs/test/selftest
 }
 
 component_build_yotta () {
@@ -640,6 +640,9 @@ component_test_default_cmake_gcc_asan () {
     msg "test: main suites (inc. selftests) (ASan build)" # ~ 50s
     make test
 
+    msg "test: selftest (ASan build)" # ~ 10s
+    if_build_succeeded programs/test/selftest
+
     msg "test: ssl-opt.sh (ASan build)" # ~ 1 min
     if_build_succeeded tests/ssl-opt.sh
 
@@ -655,6 +658,9 @@ component_test_full_cmake_gcc_asan () {
 
     msg "test: main suites (inc. selftests) (full config, ASan build)"
     make test
+
+    msg "test: selftest (ASan build)" # ~ 10s
+    if_build_succeeded programs/test/selftest
 
     msg "test: ssl-opt.sh (full config, ASan build)"
     if_build_succeeded tests/ssl-opt.sh

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1088,9 +1088,9 @@ component_test_have_int64 () {
 }
 
 component_build_arm_none_eabi_gcc () {
-    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}, make" # ~ 10s
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1, make" # ~ 10s
     scripts/config.pl baremetal
-    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
+    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra -O1' lib
 }
 
 component_build_arm_none_eabi_gcc_arm5vte () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1104,6 +1104,12 @@ component_build_arm_none_eabi_gcc_arm5vte () {
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 }
 
+component_build_arm_none_eabi_gcc_m0plus () {
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -mthumb -mcpu=cortex-m0plus" # ~ 10s
+    scripts/config.pl baremetal
+    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra -mthumb -mcpu=cortex-m0plus -Os' lib
+}
+
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX} -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -131,6 +131,7 @@ pre_initialize_variables () {
     : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
     : ${ARMC5_BIN_DIR:=/usr/bin}
     : ${ARMC6_BIN_DIR:=/usr/bin}
+    : ${ARM_GCC_PREFIX:=arm-none-eabi-}
 
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
     if [ -z "${MAKEFLAGS+set}" ]; then
@@ -192,6 +193,8 @@ General options:
   -f|--force            Force the tests to overwrite any modified files.
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
+     --arm-gcc-prefix=<string>  Prefix for gcc as a cross-compiler for arm
+                                (default: "${ARM_GCC_PREFIX}")
      --armcc            Run ARM Compiler builds (on by default).
      --except           Exclude the COMPONENTs listed on the command line,
                         instead of running only those.
@@ -305,6 +308,7 @@ pre_parse_command_line () {
 
     while [ $# -gt 0 ]; do
         case "$1" in
+            --arm-gcc-prefix) shift; ARM_GCC_PREFIX="$1";;
             --armcc) no_armcc=;;
             --armc5-bin-dir) shift; ARMC5_BIN_DIR="$1";;
             --armc6-bin-dir) shift; ARMC6_BIN_DIR="$1";;
@@ -517,7 +521,7 @@ pre_check_tools () {
     esac
 
     case " $RUN_COMPONENTS " in
-        *_arm_none_eabi_gcc[_\ ]*) check_tools "arm-none-eabi-gcc";;
+        *_arm_none_eabi_gcc[_\ ]*) check_tools "${ARM_GCC_PREFIX}gcc";;
     esac
 
     case " $RUN_COMPONENTS " in
@@ -1083,16 +1087,16 @@ component_test_have_int64 () {
 }
 
 component_build_arm_none_eabi_gcc () {
-    msg "build: arm-none-eabi-gcc, make" # ~ 10s
+    msg "build: ${ARM_GCC_PREFIX}, make" # ~ 10s
     scripts/config.pl baremetal
-    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+    make CC="${ARM_GCC_PREFIX}gcc" AR="${ARM_GCC_PREFIX}ar" LD="${ARM_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
 }
 
 component_build_arm_none_eabi_gcc_no_udbl_division () {
-    msg "build: arm-none-eabi-gcc -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
+    msg "build: ${ARM_GCC_PREFIX} -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal
     scripts/config.pl set MBEDTLS_NO_UDBL_DIVISION
-    make CC=arm-none-eabi-gcc AR=arm-none-eabi-ar LD=arm-none-eabi-ld CFLAGS='-Werror -Wall -Wextra' lib
+    make CC="${ARM_GCC_PREFIX}gcc" AR="${ARM_GCC_PREFIX}ar" LD="${ARM_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
     echo "Checking that software 64-bit division is not required"
     if_build_succeeded not grep __aeabi_uldiv library/*.o
 }

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1093,6 +1093,17 @@ component_build_arm_none_eabi_gcc () {
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" LD="${ARM_NONE_EABI_GCC_PREFIX}ld" CFLAGS='-Werror -Wall -Wextra' lib
 }
 
+component_build_arm_none_eabi_gcc_arm5vte () {
+    msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -march=arm5vte, make" # ~ 10s
+    scripts/config.pl baremetal
+    # Build for a target platform that's close to what Debian uses
+    # for its "armel" distribution (https://wiki.debian.org/ArmEabiPort).
+    # See https://github.com/ARMmbed/mbedtls/pull/2169 and comments.
+    # It would be better to build with arm-linux-gnueabi-gcc but
+    # we don't have that on our CI at this time.
+    make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" CFLAGS='-Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
+}
+
 component_build_arm_none_eabi_gcc_no_udbl_division () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX} -DMBEDTLS_NO_UDBL_DIVISION, make" # ~ 10s
     scripts/config.pl baremetal

--- a/tests/scripts/check-files.py
+++ b/tests/scripts/check-files.py
@@ -103,7 +103,7 @@ class LineIssueTracker(FileIssueTracker):
 
 def is_windows_file(filepath):
     _root, ext = os.path.splitext(filepath)
-    return ext in ('.dsp', '.sln', '.vcxproj')
+    return ext in ('.bat', '.dsp', '.sln', '.vcxproj')
 
 
 class PermissionIssueTracker(FileIssueTracker):
@@ -223,6 +223,7 @@ class IntegrityChecker:
         self.logger = None
         self.setup_logger(log_file)
         self.extensions_to_check = (
+            ".bat",
             ".c",
             ".data",
             ".dsp",


### PR DESCRIPTION
Mostly straightforward backport of #3218. Differences:

* There's no `psa_constant_names` in 2.7, and so no need for Python on Windows.
* In `all.sh`, `build_arm_none_eabi_gcc_arm5vte` didn't exist in 2.7, so I added it.

Like in the 2.16 backport (#3247), first backport (the applicable part of) #2821 because it's easier to keep all LTS branches in synch.
