### PR TITLE
2.16 only: Add missing changelog entry for PRs since 2.16.6

### DIFF
--- a/ChangeLog.d/max_pathlen.txt
+++ b/ChangeLog.d/max_pathlen.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix undefined behavior in X.509 certificate parsing if the
+     pathLenConstraint basic constraint value is equal to INT_MAX.
+     The actual effect with almost every compiler is the intended
+     behavior, so this is unlikely to be exploitable anywhere. #3197


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3216. In 2.16 there has only been one PR that's missing a changelog entry, which is a backport of a PR that was missing a changelog entry in development too.
