### PR TITLE
psa: Define mbedtls_ecc_group_to_psa() inline

### DIFF
--- a/ChangeLog.d/inline-mbedtls_gcc_group_to_psa.txt
+++ b/ChangeLog.d/inline-mbedtls_gcc_group_to_psa.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix potential linker errors on dual world platforms by inlining
+     mbedtls_gcc_group_to_psa(). This allows the pk.c module to link separately
+     from psa_crypto.c. Fixes #3300.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -578,8 +578,55 @@ psa_status_t psa_get_key_domain_parameters(
  *                      (`PSA_ECC_CURVE_xxx`).
  * \return              \c 0 on failure (\p grpid is not recognized).
  */
-psa_ecc_curve_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
-                                          size_t *bits );
+static inline psa_ecc_curve_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
+                                                        size_t *bits )
+{
+    switch( grpid )
+    {
+        case MBEDTLS_ECP_DP_SECP192R1:
+            *bits = 192;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP224R1:
+            *bits = 224;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP256R1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP384R1:
+            *bits = 384;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP521R1:
+            *bits = 521;
+            return( PSA_ECC_CURVE_SECP_R1 );
+        case MBEDTLS_ECP_DP_BP256R1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP384R1:
+            *bits = 384;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP512R1:
+            *bits = 512;
+            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_CURVE25519:
+            *bits = 255;
+            return( PSA_ECC_CURVE_MONTGOMERY );
+        case MBEDTLS_ECP_DP_SECP192K1:
+            *bits = 192;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP224K1:
+            *bits = 224;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP256K1:
+            *bits = 256;
+            return( PSA_ECC_CURVE_SECP_K1 );
+        case MBEDTLS_ECP_DP_CURVE448:
+            *bits = 448;
+            return( PSA_ECC_CURVE_MONTGOMERY );
+        default:
+            *bits = 0;
+            return( 0 );
+    }
+}
 
 /** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
  *

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -420,6 +420,7 @@ psa_ecc_curve_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
             *bits = 448;
             return( PSA_ECC_CURVE_MONTGOMERY );
         default:
+            *bits = 0;
             return( 0 );
     }
 }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -375,56 +375,6 @@ static inline int psa_key_slot_is_external( const psa_key_slot_t *slot )
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
 #if defined(MBEDTLS_ECP_C)
-psa_ecc_curve_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
-                                          size_t *bits )
-{
-    switch( grpid )
-    {
-        case MBEDTLS_ECP_DP_SECP192R1:
-            *bits = 192;
-            return( PSA_ECC_CURVE_SECP_R1 );
-        case MBEDTLS_ECP_DP_SECP224R1:
-            *bits = 224;
-            return( PSA_ECC_CURVE_SECP_R1 );
-        case MBEDTLS_ECP_DP_SECP256R1:
-            *bits = 256;
-            return( PSA_ECC_CURVE_SECP_R1 );
-        case MBEDTLS_ECP_DP_SECP384R1:
-            *bits = 384;
-            return( PSA_ECC_CURVE_SECP_R1 );
-        case MBEDTLS_ECP_DP_SECP521R1:
-            *bits = 521;
-            return( PSA_ECC_CURVE_SECP_R1 );
-        case MBEDTLS_ECP_DP_BP256R1:
-            *bits = 256;
-            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
-        case MBEDTLS_ECP_DP_BP384R1:
-            *bits = 384;
-            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
-        case MBEDTLS_ECP_DP_BP512R1:
-            *bits = 512;
-            return( PSA_ECC_CURVE_BRAINPOOL_P_R1 );
-        case MBEDTLS_ECP_DP_CURVE25519:
-            *bits = 255;
-            return( PSA_ECC_CURVE_MONTGOMERY );
-        case MBEDTLS_ECP_DP_SECP192K1:
-            *bits = 192;
-            return( PSA_ECC_CURVE_SECP_K1 );
-        case MBEDTLS_ECP_DP_SECP224K1:
-            *bits = 224;
-            return( PSA_ECC_CURVE_SECP_K1 );
-        case MBEDTLS_ECP_DP_SECP256K1:
-            *bits = 256;
-            return( PSA_ECC_CURVE_SECP_K1 );
-        case MBEDTLS_ECP_DP_CURVE448:
-            *bits = 448;
-            return( PSA_ECC_CURVE_MONTGOMERY );
-        default:
-            *bits = 0;
-            return( 0 );
-    }
-}
-
 mbedtls_ecp_group_id mbedtls_ecc_group_of_psa( psa_ecc_curve_t curve,
                                                size_t byte_length )
 {


### PR DESCRIPTION
On dual world platforms, we want to run the PK module (pk.c) on the NS
side so TLS can use PSA APIs via the PK interface. PK currently has a
hard dependency on mbedtls_ecc_group_to_psa() which is declared in
crypto_extra.h, but only defined in psa_crypto.c, which is only built
for the S side.

Without this change, dual world platforms get error messages like the
following.

    [Error] @0,0: L6218E: Undefined symbol mbedtls_ecc_group_to_psa (referred from BUILD/LPC55S69_NS/ARM/mbed-os/features/mbedtls/mbed-crypto/src/pk.o)

Make mbedtls_ecc_group_to_psa() inline within crypto_extra.h so that it
is available to both NS and S world code.

Fixes #3300

Signed-off-by: Darryl Green <darryl.green@arm.com>
Signed-off-by: Jaeden Amero <jaeden.amero@arm.com>


## Status
**READY**

## Requires Backporting
NO  - PSA related change, and no LTS branches contain PSA.

## Migrations
mbedtls_ecc_group_to_psa() is becoming inline. This will require a rebuild of code using this function.

## Todos
- [X] Tests - covered by Mbed OS CI on LPC55S69
- ~[ ] Documentation~
- [X] Changelog updated
- ~[ ] Backported~
