### PR TITLE
PSA: Fix copypasta and align terminology about asymmetric encryption

### DIFF
--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -450,9 +450,9 @@
 
 /** Sufficient output buffer size for psa_asymmetric_decrypt().
  *
- * This macro returns a sufficient buffer size for a ciphertext produced using
+ * This macro returns a sufficient buffer size for a plaintext produced using
  * a key of the specified type and size, with the specified algorithm.
- * Note that the actual size of the ciphertext may be smaller, depending
+ * Note that the actual size of the plaintext may be smaller, depending
  * on the algorithm.
  *
  * \warning This function may call its arguments multiple times or

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -431,7 +431,7 @@
  * \param key_type  An asymmetric key type (this may indifferently be a
  *                  key pair type or a public key type).
  * \param key_bits  The size of the key in bits.
- * \param alg       The signature algorithm.
+ * \param alg       The asymmetric encryption algorithm.
  *
  * \return If the parameters are valid and supported, return
  *         a buffer size in bytes that guarantees that
@@ -462,7 +462,7 @@
  * \param key_type  An asymmetric key type (this may indifferently be a
  *                  key pair type or a public key type).
  * \param key_bits  The size of the key in bits.
- * \param alg       The signature algorithm.
+ * \param alg       The asymmetric encryption algorithm.
  *
  * \return If the parameters are valid and supported, return
  *         a buffer size in bytes that guarantees that

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -672,22 +672,24 @@
 #define PSA_ALG_IS_AEAD(alg)                                            \
     (((alg) & PSA_ALG_CATEGORY_MASK) == PSA_ALG_CATEGORY_AEAD)
 
-/** Whether the specified algorithm is a public-key signature algorithm.
+/** Whether the specified algorithm is a asymmetric signature algorithm,
+ * also known as public-key signature algorithm.
  *
  * \param alg An algorithm identifier (value of type #psa_algorithm_t).
  *
- * \return 1 if \p alg is a public-key signature algorithm, 0 otherwise.
+ * \return 1 if \p alg is an asymmetric signature algorithm, 0 otherwise.
  *         This macro may return either 0 or 1 if \p alg is not a supported
  *         algorithm identifier.
  */
 #define PSA_ALG_IS_SIGN(alg)                                            \
     (((alg) & PSA_ALG_CATEGORY_MASK) == PSA_ALG_CATEGORY_SIGN)
 
-/** Whether the specified algorithm is a public-key encryption algorithm.
+/** Whether the specified algorithm is an asymmetric encryption algorithm,
+ * also known as public-key encryption algorithm.
  *
  * \param alg An algorithm identifier (value of type #psa_algorithm_t).
  *
- * \return 1 if \p alg is a public-key encryption algorithm, 0 otherwise.
+ * \return 1 if \p alg is an asymmetric encryption algorithm, 0 otherwise.
  *         This macro may return either 0 or 1 if \p alg is not a supported
  *         algorithm identifier.
  */
@@ -1205,9 +1207,9 @@
 
 /** Whether the specified algorithm is a hash-and-sign algorithm.
  *
- * Hash-and-sign algorithms are public-key signature algorithms structured
- * in two parts: first the calculation of a hash in a way that does not
- * depend on the key, then the calculation of a signature from the
+ * Hash-and-sign algorithms are asymmetric (public-key) signature algorithms
+ * structured in two parts: first the calculation of a hash in a way that
+ * does not depend on the key, then the calculation of a signature from the
  * hash value and the key.
  *
  * \param alg An algorithm identifier (value of type #psa_algorithm_t).

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -672,7 +672,7 @@
 #define PSA_ALG_IS_AEAD(alg)                                            \
     (((alg) & PSA_ALG_CATEGORY_MASK) == PSA_ALG_CATEGORY_AEAD)
 
-/** Whether the specified algorithm is a asymmetric signature algorithm,
+/** Whether the specified algorithm is an asymmetric signature algorithm,
  * also known as public-key signature algorithm.
  *
  * \param alg An algorithm identifier (value of type #psa_algorithm_t).

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1259,7 +1259,7 @@
  *                      #PSA_ALG_IS_HASH(\p hash_alg) is true) to use
  *                      for MGF1.
  *
- * \return              The corresponding RSA OAEP signature algorithm.
+ * \return              The corresponding RSA OAEP encryption algorithm.
  * \return              Unspecified if \p hash_alg is not a supported
  *                      hash algorithm.
  */


### PR DESCRIPTION
* Fix some copypasta (PSA Crypto API bug: private link: https://github.com/ARMmbed/psa-crypto-api/issues/404).
* Both “asymmetric signature/encryption” and “public key signature/encryption” were used indifferently. Prefer “asymmetric”, but mention “public-key” as a synonym.
