### PR TITLE
fix: Constant-time enhancements for bignum.c and ecdsa.c

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -124,6 +124,18 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_MPI_UINT_BITS)
+            #define MBEDTLS_MPI_UINT_BITS 64
+        #endif /* MBEDTLS_MPI_UINT_BITS */
+        #if !defined(MBEDTLS_MPI_HALF_MASK)
+            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
+        #endif /* MBEDTLS_MPI_HALF_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_BITS)
+            #define MBEDTLS_MPI_HALF_BITS 32
+        #endif /* MBEDTLS_MPI_HALF_BITS */
+        #if !defined(MBEDTLS_MPI_UINT_MASK)
+            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
+        #endif /* MBEDTLS_MPI_UINT_MASK */
     #elif defined(__GNUC__) && (                         \
         defined(__amd64__) || defined(__x86_64__)     || \
         defined(__ppc64__) || defined(__powerpc64__)  || \
@@ -131,11 +143,23 @@
         ( defined(__sparc__) && defined(__arch64__) ) || \
         defined(__s390x__) || defined(__mips64)       || \
         defined(__aarch64__) )
-        #if !defined(MBEDTLS_HAVE_INT64)
+    #if !defined(MBEDTLS_HAVE_INT64)
             #define MBEDTLS_HAVE_INT64
         #endif /* MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_MPI_UINT_BITS)
+            #define MBEDTLS_MPI_UINT_BITS 64
+        #endif /* MBEDTLS_MPI_UINT_BITS */
+        #if !defined(MBEDTLS_MPI_UINT_MASK)
+            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
+        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_MASK)
+            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
+        #endif /* MBEDTLS_MPI_HALF_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_BITS)
+            #define MBEDTLS_MPI_HALF_BITS 32
+        #endif /* MBEDTLS_MPI_HALF_BITS */
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
             /* mbedtls_t_udbl defined as 128-bit unsigned int */
             typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
@@ -151,6 +175,18 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_MPI_UINT_BITS)
+            #define MBEDTLS_MPI_UINT_BITS 64
+        #endif /* MBEDTLS_MPI_UINT_BITS */
+        #if !defined(MBEDTLS_MPI_UINT_MASK)
+            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
+        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_MASK)
+            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
+        #endif /* MBEDTLS_MPI_HALF_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_BITS)
+            #define MBEDTLS_MPI_HALF_BITS 32
+        #endif /* MBEDTLS_MPI_HALF_BITS */
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
             /* mbedtls_t_udbl defined as 128-bit unsigned int */
             typedef __uint128_t mbedtls_t_udbl;
@@ -160,6 +196,18 @@
         /* Force 64-bit integers with unknown compiler */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
+        #if !defined(MBEDTLS_MPI_UINT_BITS)
+            #define MBEDTLS_MPI_UINT_BITS 64
+        #endif /* MBEDTLS_MPI_UINT_BITS */
+        #if !defined(MBEDTLS_MPI_UINT_MASK)
+            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
+        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_MASK)
+            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
+        #endif /* MBEDTLS_MPI_HALF_MASK */
+        #if !defined(MBEDTLS_MPI_HALF_BITS)
+            #define MBEDTLS_MPI_HALF_BITS 32
+        #endif /* MBEDTLS_MPI_HALF_BITS */
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -170,6 +218,18 @@
     #endif /* !MBEDTLS_HAVE_INT32 */
     typedef  int32_t mbedtls_mpi_sint;
     typedef uint32_t mbedtls_mpi_uint;
+    #if !defined(MBEDTLS_MPI_UINT_BITS)
+        #define MBEDTLS_MPI_UINT_BITS 32
+    #endif /* MBEDTLS_MPI_UINT_BITS */
+    #if !defined(MBEDTLS_MPI_UINT_MASK)
+        #define MBEDTLS_MPI_UINT_MASK 0x7fffffff
+    #endif /* MBEDTLS_MPI_UINT_MASK */
+    #if !defined(MBEDTLS_MPI_HALF_MASK)
+        #define MBEDTLS_MPI_HALF_MASK 0xffff
+    #endif /* MBEDTLS_MPI_HALF_MASK */
+    #if !defined(MBEDTLS_MPI_HALF_BITS)
+        #define MBEDTLS_MPI_HALF_BITS 16
+    #endif /* MBEDTLS_MPI_HALF_BITS */
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
         typedef uint64_t mbedtls_t_udbl;
         #define MBEDTLS_HAVE_UDBL
@@ -547,6 +607,27 @@ int mbedtls_mpi_write_binary_le( const mbedtls_mpi *X,
                                  unsigned char *buf, size_t buflen );
 
 /**
+ * \brief          Return the index of the highest non-zero limb in X.
+ *
+ * \param out
+ * \param X        The MPI to analyze.
+ *                 This must point to an initialized MPI.
+ *
+ * \return         Index of the highest nonzero limb in X.
+ */
+int mbedtls_mpi_first_nonzero(size_t *out, const mbedtls_mpi *X);
+
+/**
+ * \brief          Is this equal to zero? (Constant-time)
+ *
+ * \param X        The MPI to analyze.
+ *                 This must point to an initialized MPI.
+ *
+ * \return         1 if all limbs in X == 0, 0 otherwise.
+ */
+int mbedtls_mpi_is_zero( mbedtls_mpi *X );
+
+/**
  * \brief          Perform a left-shift on an MPI: X <<= count
  *
  * \param X        The MPI to shift. This must point to an initialized MPI.
@@ -593,6 +674,30 @@ int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y );
  * \return         \c 0 if \p X is equal to \p Y.
  */
 int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+
+/**
+ * \brief          Compare two MPIs. Constant-time.
+ *
+ * \param X        The left-hand MPI. This must point to an initialized MPI.
+ * \param Y        The right-hand MPI. This must point to an initialized MPI.
+ *
+ * \return         \c 1 if \p X is greater than \p Y.
+ * \return         \c -1 if \p X is lesser than \p Y.
+ * \return         \c 0 if \p X is equal to \p Y.
+ */
+int mbedtls_mpi_cmp_mpi_ct( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+
+/**
+ * \brief          Compare an MPI with an integer. Constant-time.
+ *
+ * \param X        The left-hand MPI. This must point to an initialized MPI.
+ * \param z        The integer value to compare \p X to.
+ *
+ * \return         \c 1 if \p X is greater than \p z.
+ * \return         \c -1 if \p X is lesser than \p z.
+ * \return         \c 0 if \p X is equal to \p z.
+ */
+int mbedtls_mpi_cmp_int_ct( const mbedtls_mpi *X, mbedtls_mpi_sint z );
 
 /**
  * \brief          Check if an MPI is less than the other in constant time.

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -133,9 +133,9 @@
         #if !defined(MBEDTLS_MPI_HALF_BITS)
             #define MBEDTLS_MPI_HALF_BITS 32
         #endif /* MBEDTLS_MPI_HALF_BITS */
-        #if !defined(MBEDTLS_MPI_UINT_MASK)
-            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
-        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_INT_MASK)
+            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
+        #endif /* MBEDTLS_MPI_INT_MASK */
     #elif defined(__GNUC__) && (                         \
         defined(__amd64__) || defined(__x86_64__)     || \
         defined(__ppc64__) || defined(__powerpc64__)  || \
@@ -151,9 +151,9 @@
         #if !defined(MBEDTLS_MPI_UINT_BITS)
             #define MBEDTLS_MPI_UINT_BITS 64
         #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_UINT_MASK)
-            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
-        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_INT_MASK)
+            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
+        #endif /* MBEDTLS_MPI_INT_MASK */
         #if !defined(MBEDTLS_MPI_HALF_MASK)
             #define MBEDTLS_MPI_HALF_MASK 0xffffffff
         #endif /* MBEDTLS_MPI_HALF_MASK */
@@ -178,9 +178,9 @@
         #if !defined(MBEDTLS_MPI_UINT_BITS)
             #define MBEDTLS_MPI_UINT_BITS 64
         #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_UINT_MASK)
-            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
-        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_INT_MASK)
+            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
+        #endif /* MBEDTLS_MPI_INT_MASK */
         #if !defined(MBEDTLS_MPI_HALF_MASK)
             #define MBEDTLS_MPI_HALF_MASK 0xffffffff
         #endif /* MBEDTLS_MPI_HALF_MASK */
@@ -199,9 +199,9 @@
         #if !defined(MBEDTLS_MPI_UINT_BITS)
             #define MBEDTLS_MPI_UINT_BITS 64
         #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_UINT_MASK)
-            #define MBEDTLS_MPI_UINT_MASK 0x7fffffffffffffffLL
-        #endif /* MBEDTLS_MPI_UINT_MASK */
+        #if !defined(MBEDTLS_MPI_INT_MASK)
+            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
+        #endif /* MBEDTLS_MPI_INT_MASK */
         #if !defined(MBEDTLS_MPI_HALF_MASK)
             #define MBEDTLS_MPI_HALF_MASK 0xffffffff
         #endif /* MBEDTLS_MPI_HALF_MASK */
@@ -221,9 +221,9 @@
     #if !defined(MBEDTLS_MPI_UINT_BITS)
         #define MBEDTLS_MPI_UINT_BITS 32
     #endif /* MBEDTLS_MPI_UINT_BITS */
-    #if !defined(MBEDTLS_MPI_UINT_MASK)
-        #define MBEDTLS_MPI_UINT_MASK 0x7fffffff
-    #endif /* MBEDTLS_MPI_UINT_MASK */
+    #if !defined(MBEDTLS_MPI_INT_MASK)
+        #define MBEDTLS_MPI_INT_MASK 0xffffffff
+    #endif /* MBEDTLS_MPI_INT_MASK */
     #if !defined(MBEDTLS_MPI_HALF_MASK)
         #define MBEDTLS_MPI_HALF_MASK 0xffff
     #endif /* MBEDTLS_MPI_HALF_MASK */

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -143,7 +143,7 @@
         ( defined(__sparc__) && defined(__arch64__) ) || \
         defined(__s390x__) || defined(__mips64)       || \
         defined(__aarch64__) )
-    #if !defined(MBEDTLS_HAVE_INT64)
+        #if !defined(MBEDTLS_HAVE_INT64)
             #define MBEDTLS_HAVE_INT64
         #endif /* MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -124,18 +124,7 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        #if !defined(MBEDTLS_MPI_UINT_BITS)
-            #define MBEDTLS_MPI_UINT_BITS 64
-        #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_HALF_MASK)
-            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
-        #endif /* MBEDTLS_MPI_HALF_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_BITS)
-            #define MBEDTLS_MPI_HALF_BITS 32
-        #endif /* MBEDTLS_MPI_HALF_BITS */
-        #if !defined(MBEDTLS_MPI_INT_MASK)
-            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
-        #endif /* MBEDTLS_MPI_INT_MASK */
+        #define MBEDTLS_MPI_UINT_BITS 64
     #elif defined(__GNUC__) && (                         \
         defined(__amd64__) || defined(__x86_64__)     || \
         defined(__ppc64__) || defined(__powerpc64__)  || \
@@ -148,18 +137,7 @@
         #endif /* MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        #if !defined(MBEDTLS_MPI_UINT_BITS)
-            #define MBEDTLS_MPI_UINT_BITS 64
-        #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_INT_MASK)
-            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
-        #endif /* MBEDTLS_MPI_INT_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_MASK)
-            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
-        #endif /* MBEDTLS_MPI_HALF_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_BITS)
-            #define MBEDTLS_MPI_HALF_BITS 32
-        #endif /* MBEDTLS_MPI_HALF_BITS */
+        #define MBEDTLS_MPI_UINT_BITS 64
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
             /* mbedtls_t_udbl defined as 128-bit unsigned int */
             typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
@@ -175,18 +153,7 @@
         #endif /* !MBEDTLS_HAVE_INT64 */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        #if !defined(MBEDTLS_MPI_UINT_BITS)
-            #define MBEDTLS_MPI_UINT_BITS 64
-        #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_INT_MASK)
-            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
-        #endif /* MBEDTLS_MPI_INT_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_MASK)
-            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
-        #endif /* MBEDTLS_MPI_HALF_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_BITS)
-            #define MBEDTLS_MPI_HALF_BITS 32
-        #endif /* MBEDTLS_MPI_HALF_BITS */
+        #define MBEDTLS_MPI_UINT_BITS 64
         #if !defined(MBEDTLS_NO_UDBL_DIVISION)
             /* mbedtls_t_udbl defined as 128-bit unsigned int */
             typedef __uint128_t mbedtls_t_udbl;
@@ -196,18 +163,7 @@
         /* Force 64-bit integers with unknown compiler */
         typedef  int64_t mbedtls_mpi_sint;
         typedef uint64_t mbedtls_mpi_uint;
-        #if !defined(MBEDTLS_MPI_UINT_BITS)
-            #define MBEDTLS_MPI_UINT_BITS 64
-        #endif /* MBEDTLS_MPI_UINT_BITS */
-        #if !defined(MBEDTLS_MPI_INT_MASK)
-            #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
-        #endif /* MBEDTLS_MPI_INT_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_MASK)
-            #define MBEDTLS_MPI_HALF_MASK 0xffffffff
-        #endif /* MBEDTLS_MPI_HALF_MASK */
-        #if !defined(MBEDTLS_MPI_HALF_BITS)
-            #define MBEDTLS_MPI_HALF_BITS 32
-        #endif /* MBEDTLS_MPI_HALF_BITS */
+        #define MBEDTLS_MPI_UINT_BITS 64
     #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -221,20 +177,21 @@
     #if !defined(MBEDTLS_MPI_UINT_BITS)
         #define MBEDTLS_MPI_UINT_BITS 32
     #endif /* MBEDTLS_MPI_UINT_BITS */
-    #if !defined(MBEDTLS_MPI_INT_MASK)
-        #define MBEDTLS_MPI_INT_MASK 0xffffffff
-    #endif /* MBEDTLS_MPI_INT_MASK */
-    #if !defined(MBEDTLS_MPI_HALF_MASK)
-        #define MBEDTLS_MPI_HALF_MASK 0xffff
-    #endif /* MBEDTLS_MPI_HALF_MASK */
-    #if !defined(MBEDTLS_MPI_HALF_BITS)
-        #define MBEDTLS_MPI_HALF_BITS 16
-    #endif /* MBEDTLS_MPI_HALF_BITS */
     #if !defined(MBEDTLS_NO_UDBL_DIVISION)
         typedef uint64_t mbedtls_t_udbl;
         #define MBEDTLS_HAVE_UDBL
     #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
+
+#if MBEDTLS_MPI_UINT_BITS == 64
+    #define MBEDTLS_MPI_INT_MASK 0xffffffffffffffffLL
+    #define MBEDTLS_MPI_HALF_MASK 0xffffffff
+    #define MBEDTLS_MPI_HALF_BITS 32
+#elif MBEDTLS_MPI_UINT_BITS == 32
+    #define MBEDTLS_MPI_INT_MASK 0xffffffff
+    #define MBEDTLS_MPI_HALF_MASK 0xffff
+    #define MBEDTLS_MPI_HALF_BITS 16
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2663,7 +2663,6 @@ int mbedtls_mpi_inv_mod( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
         MBEDTLS_MPI_CHK( mbedtls_mpi_safe_cond_swap(&tmp, &V2, (comp & 1)) );
     }
     while ( !mbedtls_mpi_is_zero(&TU) );
-    // while( mbedtls_mpi_cmp_int_ct( &TU, 0 ) != 0 );
 
     while( mbedtls_mpi_cmp_int_ct( &V1, 0 ) < 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &V1, &V1, N ) );

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1042,9 +1042,11 @@ int mbedtls_mpi_first_nonzero(size_t *out, const mbedtls_mpi *X)
 
         /* if (X->p[iterator] == 0) imask = 1; */
         /* if (X->p[iterator] != 0) imask = 0; */
-        imask = (
+        imask = (mbedtls_mpi_sint) (
             (
-                ((mbedtls_mpi_sint) X->p[iterator]) ^ ((mbedtls_mpi_sint) X->p[iterator] - 1)
+                ((int64_t) X->p[iterator]) ^ (
+                    (int64_t) (X->p[iterator] - 1)
+                )
             ) >> (MBEDTLS_MPI_UINT_BITS - 1)
         ) & 1;
 

--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -239,7 +239,7 @@ static int derive_mpi( const mbedtls_ecp_group *grp, mbedtls_mpi *x,
         MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( x, use_size * 8 - grp->nbits ) );
 
     /* While at it, reduce modulo N */
-    if( mbedtls_mpi_cmp_mpi( x, &grp->N ) >= 0 )
+    if( mbedtls_mpi_cmp_mpi_ct( x, &grp->N ) >= 0 )
         MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mpi( x, x, &grp->N ) );
 
 cleanup:
@@ -270,7 +270,7 @@ static int ecdsa_sign_restartable( mbedtls_ecp_group *grp,
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     /* Make sure d is in range 1..n-1 */
-    if( mbedtls_mpi_cmp_int( d, 1 ) < 0 || mbedtls_mpi_cmp_mpi( d, &grp->N ) >= 0 )
+    if( mbedtls_mpi_cmp_int_ct( d, 1 ) < 0 || mbedtls_mpi_cmp_mpi_ct( d, &grp->N ) >= 0 )
         return( MBEDTLS_ERR_ECP_INVALID_KEY );
 
     mbedtls_ecp_point_init( &R );
@@ -331,7 +331,7 @@ mul:
                                                           ECDSA_RS_ECP ) );
             MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( pr, &R.X, &grp->N ) );
         }
-        while( mbedtls_mpi_cmp_int( pr, 0 ) == 0 );
+        while( mbedtls_mpi_is_zero( pr ) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
         if( rs_ctx != NULL && rs_ctx->sig != NULL )
@@ -369,7 +369,7 @@ modn:
         MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( s, s, &e ) );
         MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( s, s, &grp->N ) );
     }
-    while( mbedtls_mpi_cmp_int( s, 0 ) == 0 );
+    while( mbedtls_mpi_is_zero( s) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if( rs_ctx != NULL && rs_ctx->sig != NULL )


### PR DESCRIPTION
## Description

This change ensures many bignum operations critical to asymmetric cryptography (especially RSA and ECDSA signing, which relies on `mbedtls_mpi_inv_mod()`) are constant-time for a given fixed-size input.

## Status

**READY**

## Requires Backporting

Yes. 

This should be backported to any branches still in support. I can follow-up this PR with a backport pull request. At minimum, the 2.16 branch should receive a backport.

## Migrations

YES. Additional functions are *added* to bignum.h, but no backwards incompatible changes were introduced.

## Additional comments

N/A

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce

* Ensure unit tests pass.

There isn't really a reliable and trivial way to reproduce and measure a failing case (variable-time behavior).
