### PR TITLE
Add variable initialization to large SSL TLS function

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -863,7 +863,7 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     unsigned char *key2;
     unsigned char *mac_enc;
     unsigned char *mac_dec;
-    size_t mac_key_len;
+    size_t mac_key_len = 0;
     size_t iv_copy_len;
     unsigned keylen;
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info;


### PR DESCRIPTION
Signed-off-by: sander-visser <github@visser.se>

## Description
Added variable initialization for maintainability. Reported as false positive by cpp-check 1.89


## Status
**READY**

## Requires Backporting
No

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
