### PR TITLE
Fix typo in program benchmark.

### DIFF
--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -101,7 +101,7 @@ int main( void )
 #define OPTIONS                                                         \
     "md4, md5, ripemd160, sha1, sha256, sha512,\n"                      \
     "arc4, des3, des, camellia, blowfish, chacha20,\n"                  \
-    "aes_cbc, aes_gcm, aes_ccm, aes_ctx, chachapoly,\n"                 \
+    "aes_cbc, aes_gcm, aes_ccm, aes_xts, chachapoly,\n"                 \
     "aes_cmac, des3_cmac, poly1305\n"                                   \
     "havege, ctr_drbg, hmac_drbg\n"                                     \
     "rsa, dhm, ecdsa, ecdh.\n"


### PR DESCRIPTION
## Description
A typo in program benchmark. AES-XTS test should be called aes_xts not aes_ctx


## Status
**READY**

