### PR TITLE
Add the ability to build the libraries with a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
-if(TEST_CPP)
+if(TEST_CPP OR BUILD_LIBS_AS_CPP)
     project("mbed TLS" C CXX)
 else()
     project("mbed TLS" C)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -77,6 +77,9 @@ set(src_crypto
     version_features.c
     xtea.c
 )
+if(BUILD_LIBS_AS_CPP)
+    set_source_files_properties(${src_crypto} PROPERTIES LANGUAGE CXX)
+endif()
 
 list(APPEND src_crypto ${thirdparty_src})
 
@@ -91,6 +94,9 @@ set(src_x509
     x509write_crt.c
     x509write_csr.c
 )
+if(BUILD_LIBS_AS_CPP)
+    set_source_files_properties(${src_x509} PROPERTIES LANGUAGE CXX)
+endif()
 
 set(src_tls
     debug.c
@@ -104,6 +110,9 @@ set(src_tls
     ssl_ticket.c
     ssl_tls.c
 )
+if(BUILD_LIBS_AS_CPP)
+    set_source_files_properties(${src_tls} PROPERTIES LANGUAGE CXX)
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes")
@@ -161,16 +170,25 @@ endif()
 if(USE_STATIC_MBEDTLS_LIBRARY)
     add_library(${mbedcrypto_static_target} STATIC ${src_crypto})
     set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(${mbedcrypto_static_target} PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(${mbedcrypto_static_target} ${libs})
     target_include_directories(${mbedcrypto_static_target}
         PUBLIC ${MBEDTLS_DIR}/include/)
 
     add_library(${mbedx509_static_target} STATIC ${src_x509})
     set_target_properties(${mbedx509_static_target} PROPERTIES OUTPUT_NAME mbedx509)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(${mbedx509_static_target} PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(${mbedx509_static_target} ${libs} ${mbedcrypto_static_target})
 
     add_library(${mbedtls_static_target} STATIC ${src_tls})
     set_target_properties(${mbedtls_static_target} PROPERTIES OUTPUT_NAME mbedtls)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(${mbedtls_static_target} PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
 
     install(TARGETS ${mbedtls_static_target} ${mbedx509_static_target} ${mbedcrypto_static_target}
@@ -182,18 +200,27 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
 
     add_library(mbedcrypto SHARED ${src_crypto})
     set_target_properties(mbedcrypto PROPERTIES VERSION 2.22.0 SOVERSION 4)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(mbedcrypto PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(mbedcrypto ${libs})
     target_include_directories(mbedcrypto
         PUBLIC ${MBEDTLS_DIR}/include/)
 
     add_library(mbedx509 SHARED ${src_x509})
     set_target_properties(mbedx509 PROPERTIES VERSION 2.22.0 SOVERSION 1)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(mbedx509 PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(mbedx509 ${libs} mbedcrypto)
     target_include_directories(mbedx509
         PUBLIC ${MBEDTLS_DIR}/include/)
 
     add_library(mbedtls SHARED ${src_tls})
     set_target_properties(mbedtls PROPERTIES VERSION 2.22.0 SOVERSION 13)
+    if(BUILD_LIBS_AS_CPP)
+        set_target_properties(mbedtls PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
     target_link_libraries(mbedtls ${libs} mbedx509)
     target_include_directories(mbedtls
         PUBLIC ${MBEDTLS_DIR}/include/)

--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -141,4 +141,8 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* PSA_CRYPTO_ITS_H */


### PR DESCRIPTION
## Description
This PR adds an option to produce a build using the platform's C++ compiler.  It is not enabled by default and must be explicitly enabled by the user.  I am aware that the library itself can be linked to from C++ code, but in my specific use-case I have to include C++ headers from another project in config.h to define e.g. MBEDTLS_PLATFORM_SNPRINTF_MACRO, MBEDTLS_PLATFORM_CALLOC_MACRO, etc using prototypes from them.

The mbedcrypto library mostly builds successfully, except for the blowfish and PSA code (which have to be disabled currently).  The problem in the blowfish code is that C++ does not allow forward declarations of static arrays:

https://stackoverflow.com/questions/936446/is-it-possible-to-forward-declare-a-static-array

Currently the Blowfish S-box has a C-compatible forward declaration which looks like this:
```
/* declarations of data at the end of this file */
static const uint32_t S[4][256];
```
and the real definition is at the end of the file.  This could be fixed by moving the large S-box above where it is used, but since I don't need this Blowfish implemention I've just disabled it via config.h.

There is a missing ifdef at the end of library/psa_crypto_its.h which I've added here as well.

## Status
READY

## Requires Backporting
NO

## Repro
Run the following:
```
./scripts/config.pl unset MBEDTLS_BLOWFISH_C
./scripts/config.pl unset MBEDTLS_PSA_CRYPTO_C
./scripts/config.pl unset MBEDTLS_PSA_CRYPTO_STORAGE_C
mkdir build && cd build
cmake -DBUILD_LIBS_AS_CPP=ON -DCMAKE_CXX_FLAGS=-fpermissive ..
make mbedcrypto VERBOSE=1
```