### PR TITLE
Include asn1.h in error.c

### DIFF
--- a/ChangeLog.d/error-asn1.txt
+++ b/ChangeLog.d/error-asn1.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Include asn1.h in error.c. Fixes #3328 reported by David Hu.

--- a/library/error.c
+++ b/library/error.c
@@ -52,6 +52,10 @@
 #include "mbedtls/aria.h"
 #endif
 
+#if defined(MBEDTLS_ASN1_PARSE_C)
+#include "mbedtls/asn1.h"
+#endif
+
 #if defined(MBEDTLS_BASE64_C)
 #include "mbedtls/base64.h"
 #endif

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -101,7 +101,6 @@ foreach my $line (@matches)
 
     my $include_name = $module_name;
     $include_name =~ tr/A-Z/a-z/;
-    $include_name = "" if ($include_name eq "asn1");
 
     # Fix faulty ones
     $include_name = "net_sockets" if ($module_name eq "NET");

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -48,12 +48,16 @@ close(FORMAT_FILE);
 $/ = $line_separator;
 
 my @files = <$include_dir/*.h>;
+my @necessary_include_files;
 my @matches;
 foreach my $file (@files) {
     open(FILE, "$file");
     my @grep_res = grep(/^\s*#define\s+MBEDTLS_ERR_\w+\s+\-0x[0-9A-Fa-f]+/, <FILE>);
     push(@matches, @grep_res);
     close FILE;
+    my $include_name = $file;
+    $include_name =~ s!.*/!!;
+    push @necessary_include_files, $include_name if @grep_res;
 }
 
 my $ll_old_define = "";
@@ -63,9 +67,9 @@ my $ll_code_check = "";
 my $hl_code_check = "";
 
 my $headers = "";
+my %included_headers;
 
 my %error_codes_seen;
-
 
 foreach my $line (@matches)
 {
@@ -101,6 +105,8 @@ foreach my $line (@matches)
 
     # Fix faulty ones
     $include_name = "net_sockets" if ($module_name eq "NET");
+
+    $included_headers{"${include_name}.h"} = $module_name;
 
     my $found_ll = grep $_ eq $module_name, @low_level_modules;
     my $found_hl = grep $_ eq $module_name, @high_level_modules;
@@ -194,3 +200,15 @@ $error_format =~ s/HIGH_LEVEL_CODE_CHECKS\n/$hl_code_check/g;
 open(ERROR_FILE, ">$error_file") or die "Opening destination file '$error_file': $!";
 print ERROR_FILE $error_format;
 close(ERROR_FILE);
+
+my $errors = 0;
+for my $include_name (@necessary_include_files)
+{
+    if (not $included_headers{$include_name})
+    {
+        print STDERR "The header file \"$include_name\" defines error codes but has not been included!\n";
+        ++$errors;
+    }
+}
+
+exit !!$errors;


### PR DESCRIPTION
Fix #3328. Add a check in `generate_errors.pl` that serves as a non-regression test.
