### PR TITLE
Backport 2.16: Add output of make, cmake and python3 versions

### DIFF
--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -112,6 +112,9 @@ echo
 print_version "python" "--version" "" "head -n 1"
 echo
 
+print_version "python3" "--version" "" "head -n 1"
+echo
+
 # Find the installed version of Pylint. Installed as a distro package this can
 # be pylint3 and as a PEP egg, pylint. In test scripts We prefer pylint over
 # pylint3

--- a/scripts/output_env.sh
+++ b/scripts/output_env.sh
@@ -13,6 +13,7 @@
 # This includes:
 #   - architecture of the system
 #   - type and version of the operating system
+#   - version of make and cmake
 #   - version of armcc, clang, gcc-arm and gcc compilers
 #   - version of libc, clang, asan and valgrind if installed
 #   - version of gnuTLS and OpenSSL
@@ -69,6 +70,12 @@ print_version "uname" "-a" ""
 echo
 echo
 echo "** Tool Versions:"
+echo
+
+print_version "make" "--version" "" "head -n 1"
+echo
+
+print_version "cmake" "--version" "" "head -n 1"
 echo
 
 if [ "${RUN_ARMCC:-1}" -ne 0 ]; then


### PR DESCRIPTION
Backport to 2.16 of #3351