### PR TITLE
Remove hardcoded line number from the zeroize test

### DIFF
--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -4,12 +4,10 @@
  * This is a simple test application used for debugger-driven testing to check
  * whether calls to mbedtls_platform_zeroize() are being eliminated by compiler
  * optimizations. This application is used by the GDB script at
- * tests/scripts/test_zeroize.gdb under the assumption that the code does not
- * change often (as opposed to the library code) because the script sets a
- * breakpoint at the last return statement in the main() function of this
- * program. The debugger facilities are then used to manually inspect the
- * memory and verify that the call to mbedtls_platform_zeroize() was not
- * eliminated.
+ * tests/scripts/test_zeroize.gdb: the script sets a breakpoint at the last
+ * return statement in the main() function of this program. The debugger
+ * facilities are then used to manually inspect the memory and verify that the
+ * call to mbedtls_platform_zeroize() was not eliminated.
  *
  *  Copyright (C) 2018, Arm Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
@@ -98,5 +96,5 @@ int main( int argc, char** argv )
     fclose( fp );
     mbedtls_platform_zeroize( buf, sizeof( buf ) );
 
-    mbedtls_exit( exit_code );
+    mbedtls_exit( exit_code ); // GDB_BREAK_HERE -- don't remove this comment!
 }

--- a/tests/scripts/test_zeroize.gdb
+++ b/tests/scripts/test_zeroize.gdb
@@ -31,19 +31,13 @@
 # the compiler potentially has a bug.
 #
 # Note: This test requires that the test program is compiled with -g3.
-#
-# WARNING: There does not seem to be a mechanism in GDB scripts to set a
-# breakpoint at the end of a function (probably because there are a lot of
-# complications as function can have multiple exit points, etc). Therefore, it
-# was necessary to hard-code the line number of the breakpoint in the zeroize.c
-# test app. The assumption is that zeroize.c is a simple test app that does not
-# change often (as opposed to the actual library code), so the breakpoint line
-# number does not need to be updated often.
 
 set confirm off
 
 file ./programs/test/zeroize
-break zeroize.c:100
+
+search GDB_BREAK_HERE
+break $_
 
 set args ./programs/test/zeroize.c
 run


### PR DESCRIPTION
## Description
We can insert a comment in the line we want to break at, and let the gdb script search for it instead of using the hardcoded line number.

## Status
**READY**

## Requires Backporting
Yes
Which branch?
2.16: #3415

## Todos
- [x] Backported