### PR TITLE
Backport 2.16: Fix failure detection in basic-build-test.sh

### DIFF
--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -220,3 +220,7 @@ make clean
 if [ -f "$CONFIG_BAK" ]; then
     mv "$CONFIG_BAK" "$CONFIG_H"
 fi
+
+if [ $TOTAL_FAIL -ne 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -100,7 +100,15 @@ echo
 
 # Step 3 - Process the coverage report
 cd ..
-make lcov |tee tests/cov-$TEST_OUTPUT
+{
+    make lcov
+    echo SUCCESS
+} | tee tests/cov-$TEST_OUTPUT
+
+if [ "$(tail -n1 tests/cov-$TEST_OUTPUT)" != "SUCCESS" ]; then
+    echo >&2 "Fatal: 'make lcov' failed"
+    exit 2
+fi
 
 
 # Step 4 - Summarise the test report

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -67,7 +67,6 @@ export CFLAGS=' --coverage -g3 -O0 '
 make clean
 cp "$CONFIG_H" "$CONFIG_BAK"
 scripts/config.pl full
-scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE
 make -j
 
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -75,6 +75,10 @@ make -j
 TEST_OUTPUT=out_${PPID}
 cd tests
 
+if [ ! -f "seedfile" ]; then
+    dd if=/dev/urandom of="seedfile" bs=64 count=1
+fi
+
 # Step 2a - Unit Tests (keep going even if some tests fail)
 perl scripts/run-test-suites.pl -v 2 |tee unit-test-$TEST_OUTPUT
 echo

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -75,15 +75,15 @@ make -j
 TEST_OUTPUT=out_${PPID}
 cd tests
 
-# Step 2a - Unit Tests
+# Step 2a - Unit Tests (keep going even if some tests fail)
 perl scripts/run-test-suites.pl -v 2 |tee unit-test-$TEST_OUTPUT
 echo
 
-# Step 2b - System Tests
+# Step 2b - System Tests (keep going even if some tests fail)
 sh ssl-opt.sh |tee sys-test-$TEST_OUTPUT
 echo
 
-# Step 2c - Compatibility tests
+# Step 2c - Compatibility tests (keep going even if some tests fail)
 sh compat.sh -m 'tls1 tls1_1 tls1_2 dtls1 dtls1_2' | \
     tee compat-test-$TEST_OUTPUT
 OPENSSL_CMD="$OPENSSL_LEGACY"                               \


### PR DESCRIPTION
This is a partial backport of https://github.com/ARMmbed/mbedtls/pull/3181 which we merged before it was backported because it was holding up the release on development only.

* Fix #3178: make basic-build-test.sh exit with a failure status if some test cases fail
* Minor log readability improvements
* Added: create a seedfile explicitly, to align with development.
* Omitted: config changes.

CI run: https://jenkins-internal.mbed.com/job/mbedtls-release-new/733/ → PASS
