### PR TITLE
[Backport 2.16] Fix undeclared dependencies on CTR_DRBG (and add test)

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -787,6 +787,20 @@ component_test_rsa_no_crt () {
     if_build_succeeded tests/compat.sh -t RSA
 }
 
+component_test_no_ctr_drbg () {
+    msg "build: Full minus CTR_DRBG"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_CTR_DRBG_C
+
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: no CTR_DRBG"
+    make test
+
+    # no SSL tests as they all depend on CTR_DRBG so far
+}
+
 component_test_small_ssl_out_content_len () {
     msg "build: small SSL_OUT_CONTENT_LEN (ASan build)"
     scripts/config.pl set MBEDTLS_SSL_IN_CONTENT_LEN 16384

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -1506,7 +1506,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG:MBEDTLS_ENTROPY_C:MBEDTLS_CTR_DRBG_C */
 void mbedtls_rsa_validate_params( int radix_N, char *input_N,
                                   int radix_P, char *input_P,
                                   int radix_Q, char *input_Q,


### PR DESCRIPTION
This is the 2.16 backport of #3378. Differences from the main PR:

- first commit (test suites): the SSL test suite doesn't have the new stuff testing full handshakes, so nothing to change here
- second commit (programs/fuzz): skipped entirely as there is no `programs/fuzz` here
- third upstream commit (all.sh): apart form context conflicts, used `config.pl` instead of `config.py` which is not in 2.16.
