### PR TITLE
[Backport 2.7] Fix undeclared dependencies on CTR_DRBG (and add test)

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -784,6 +784,20 @@ component_test_rsa_no_crt () {
     if_build_succeeded tests/compat.sh -t RSA
 }
 
+component_test_no_ctr_drbg () {
+    msg "build: Full minus CTR_DRBG"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_CTR_DRBG_C
+
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: no CTR_DRBG"
+    make test
+
+    # no SSL tests as they all depend on CTR_DRBG so far
+}
+
 component_test_full_cmake_clang () {
     msg "build: cmake, full config, clang" # ~ 50s
     scripts/config.pl full

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -1124,7 +1124,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG */
+/* BEGIN_CASE depends_on:MBEDTLS_ENTROPY_C:ENTROPY_HAVE_STRONG:MBEDTLS_ENTROPY_C:MBEDTLS_CTR_DRBG_C */
 void mbedtls_rsa_validate_params( int radix_N, char *input_N,
                                   int radix_P, char *input_P,
                                   int radix_Q, char *input_Q,


### PR DESCRIPTION
This is the 2.7 backport of #3378, actually based on the 2.16 backport #3384 - it has the same diff except for a difference of context in `all.sh`.
