### PR TITLE
Add comment for mbedtls_platform_random_delay() and returning an FAULT_DETECTED error on potential FI attack detection

### DIFF
--- a/library/pk.c
+++ b/library/pk.c
@@ -46,10 +46,9 @@
 #endif /* MBEDTLS_USE_TINYCRYPT */
 
 #include "mbedtls/platform_util.h"
-
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdlib.h>
 #define mbedtls_calloc    calloc
 #define mbedtls_free       free
@@ -1561,7 +1560,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
         }
         else
         {
-            verify_ret = MBEDTLS_ERR_PK_HW_ACCEL_FAILED;
+            verify_ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
         }
     }
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -190,6 +190,9 @@ void mbedtls_platform_random_delay( void )
     do
     {
         i++;
+        /* Dummy calculations to increase the time between iterations and
+         * make side channel attack more difficult by reducing predictability
+         * of its behaviour */
         shift = rn_2 & 0x07;
         if ( i % 2 )
             rn_2 = (uint32_t)( rn_2 >> shift | rn_2 << ( 32 - shift ) );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -27,9 +27,9 @@
 
 #if defined(MBEDTLS_SSL_CLI_C)
 
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdlib.h>
 #define mbedtls_calloc    calloc
 #define mbedtls_free      free
@@ -723,6 +723,10 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
         {
             ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
             return( 0 );
+        }
+        else
+        {
+            ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
         }
     }
 
@@ -2388,6 +2392,10 @@ static int ssl_rsa_generate_partial_pms( mbedtls_ssl_context *ssl,
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
             return( 0 );
         }
+        else
+        {
+            ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+        }
     }
 
     MBEDTLS_SSL_DEBUG_RET( 1, "f_rng", ret );
@@ -2459,6 +2467,12 @@ static int ssl_rsa_encrypt_partial_pms( mbedtls_ssl_context *ssl,
         if( ret == 0 )
         {
             ssl->handshake->premaster_generated = MBEDTLS_SSL_FI_FLAG_SET;
+        }
+        else
+        {
+            ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+            MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_rsa_pkcs1_encrypt", ret );
+            goto cleanup;
         }
     }
     else
@@ -3101,7 +3115,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
             }
             else
             {
-                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
+                return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
             }
         }
 #if defined(MBEDTLS_SSL__ECP_RESTARTABLE)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -27,9 +27,9 @@
 
 #if defined(MBEDTLS_SSL_SRV_C)
 
-#if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
-#else
+
+#if !defined(MBEDTLS_PLATFORM_C)
 #include <stdlib.h>
 #define mbedtls_calloc    calloc
 #define mbedtls_free      free
@@ -4658,6 +4658,10 @@ static int ssl_parse_certificate_verify( mbedtls_ssl_context *ssl )
 
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= parse certificate verify" ) );
             goto exit;
+        }
+        else
+        {
+            ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
         }
 
     }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2027,8 +2027,9 @@ int mbedtls_ssl_build_pms( mbedtls_ssl_context *ssl )
             }
             else
             {
-                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_dhm_calc_secret", ret );
-                return( ret );
+                MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_dhm_calc_secret",
+                                       MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
+                return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
             }
         }
         else

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2936,7 +2936,7 @@ static int x509_crt_check_parent( const mbedtls_x509_crt_sig_info *sig_info,
  *
  * Return value:
  *  - 0 on success
- *  - MBEDTLS_ERR_ECP_IN_PROGRESS otherwise
+ *  - MBEDTLS_ERR_ECP_IN_PROGRESS or MBEDTLS_ERR_PLATFORM_FAULT_DETECTED otherwise
  */
 static int x509_crt_find_parent_in(
                         mbedtls_x509_crt_sig_info const *child_sig,
@@ -3051,6 +3051,8 @@ check_signature:
             mbedtls_platform_random_delay();
             if( ret_fi == 0 )
                 signature_is_good = X509_SIGNATURE_IS_GOOD;
+            else
+                return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
         }
 
         if( top && ! signature_is_good )
@@ -3869,6 +3871,8 @@ exit:
         mbedtls_platform_random_delay();
         if( flags_fi == 0 )
             return( 0 );
+        else
+            return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
     }
 
     /* Preserve the API by removing internal extra bits - from now on the


### PR DESCRIPTION
Signed-off-by: Piotr Nowicki <piotr.nowicki@arm.com>

## Description
The calculations inside the mbedtls_platform_random_delay() function were not entirely clear. This PR add a comment explaining them.

Random delay is used to secure sensitive security operations against double synchronous FI attacks. When such an attack is detected, an appropriate error code should be returned. This PR adds returning MBEDTLS_ERR_PLATFORM_FAULT_DETECTED error code where it was missing..

## Status
**READY**