### PR TITLE
Remove a secret-dependent branch in Montgomery multiplication

### DIFF
--- a/ChangeLog.d/montmul-cmp-branch.txt
+++ b/ChangeLog.d/montmul-cmp-branch.txt
@@ -1,0 +1,6 @@
+Security
+   * Fix a side channel vulnerability in modular exponentiation that could
+     reveal an RSA private key used in a secure enclave. Noticed by Sangho Lee,
+     Ming-Wei Shih, Prasun Gera, Taesoo Kim and Hyesoon Kim (Georgia Institute
+     of Technology); and Marcus Peinado (Microsoft Research). Reported by Raoul
+     Strackx (Fortanix) in #3394.

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1347,8 +1347,8 @@ cleanup:
  * d -= s where d and s have the same size and d >= s.
  */
 static void mpi_sub_hlp( size_t n,
-                         const mbedtls_mpi_uint *s,
-                         mbedtls_mpi_uint *d )
+                         mbedtls_mpi_uint *d,
+                         const mbedtls_mpi_uint *s )
 {
     size_t i;
     mbedtls_mpi_uint c, z;
@@ -1403,7 +1403,7 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
         if( B->p[n - 1] != 0 )
             break;
 
-    mpi_sub_hlp( n, B->p, X->p );
+    mpi_sub_hlp( n, X->p, B->p );
 
 cleanup:
 
@@ -2047,7 +2047,7 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
      * timing attacks. */
     /* Set d to A + (2^biL)^n - N. */
     d[n] += 1;
-    mpi_sub_hlp( n, N->p, d );
+    mpi_sub_hlp( n, d, N->p );
     /* Now d - (2^biL)^n = A - N so d >= (2^biL)^n iff A >= N.
      * So we want to copy the result of the subtraction iff d->p[n] != 0.
      * Note that d->p[n] is either 0 or 1 since A - N <= N <= (2^biL)^n. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1330,7 +1330,9 @@ cleanup:
 /*
  * Helper for mbedtls_mpi subtraction
  */
-static void mpi_sub_hlp( size_t n, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d )
+static void mpi_sub_hlp( size_t n,
+                         const mbedtls_mpi_uint *s,
+                         mbedtls_mpi_uint *d )
 {
     size_t i;
     mbedtls_mpi_uint c, z;

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1342,7 +1342,7 @@ cleanup:
     return( ret );
 }
 
-/*
+/**
  * Helper for mbedtls_mpi subtraction.
  *
  * Calculate d - s where d and s have the same size.
@@ -1352,7 +1352,7 @@ cleanup:
  * \param n             Number of limbs of \p d and \p s.
  * \param[in,out] d     On input, the left operand.
  *                      On output, the result of the subtraction:
- * \param[s]            The right operand.
+ * \param[in] s         The right operand.
  *
  * \return              1 if `d < s`.
  *                      0 if `d >= s`.
@@ -1385,9 +1385,6 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
-
-    /* if( mbedtls_mpi_cmp_abs( A, B ) < 0 ) */
-    /*     return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE ); */
 
     mbedtls_mpi_init( &TB );
 
@@ -2067,7 +2064,7 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
     /* Copy the n least significant limbs of d to A, so that
      * A = d if d < N (recall that N has n limbs). */
     memcpy( A->p, d, n * ciL );
-    /* If d >= N then we want to set A to N - d. To prevent timing attacks,
+    /* If d >= N then we want to set A to d - N. To prevent timing attacks,
      * do the calculation without using conditional tests. */
     /* Set d to d0 + (2^biL)^n - N where d0 is the current value of d. */
     d[n] += 1;

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1343,12 +1343,23 @@ cleanup:
 }
 
 /*
- * Helper for mbedtls_mpi subtraction:
- * d -= s where d and s have the same size and d >= s.
+ * Helper for mbedtls_mpi subtraction.
+ *
+ * Calculate d - s where d and s have the same size.
+ * This function operates modulo (2^ciL)^n and returns the carry
+ * (1 if there was a wraparound, i.e. if `d < s`, and 0 otherwise).
+ *
+ * \param n             Number of limbs of \p d and \p s.
+ * \param[in,out] d     On input, the left operand.
+ *                      On output, the result of the subtraction:
+ * \param[s]            The right operand.
+ *
+ * \return              1 if `d < s`.
+ *                      0 if `d >= s`.
  */
-static void mpi_sub_hlp( size_t n,
-                         mbedtls_mpi_uint *d,
-                         const mbedtls_mpi_uint *s )
+static mbedtls_mpi_uint mpi_sub_hlp( size_t n,
+                                     mbedtls_mpi_uint *d,
+                                     const mbedtls_mpi_uint *s )
 {
     size_t i;
     mbedtls_mpi_uint c, z;
@@ -1359,11 +1370,7 @@ static void mpi_sub_hlp( size_t n,
         c = ( *d < *s ) + z; *d -= *s;
     }
 
-    while( c != 0 )
-    {
-        z = ( *d < c ); *d -= c;
-        c = z; d++;
-    }
+    return( c );
 }
 
 /*
@@ -1374,6 +1381,7 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     mbedtls_mpi TB;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
+    mbedtls_mpi_uint c, z;
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
@@ -1403,7 +1411,12 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
         if( B->p[n - 1] != 0 )
             break;
 
-    mpi_sub_hlp( n, X->p, B->p );
+    c = mpi_sub_hlp( n, X->p, B->p );
+    while( c != 0 )
+    {
+        z = ( X->p[n] < c ); X->p[n] -= c;
+        c = z; n++;
+    }
 
 cleanup:
 
@@ -2047,7 +2060,7 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
      * timing attacks. */
     /* Set d to A + (2^biL)^n - N. */
     d[n] += 1;
-    mpi_sub_hlp( n, d, N->p );
+    d[n] -= mpi_sub_hlp( n, d, N->p );
     /* Now d - (2^biL)^n = A - N so d >= (2^biL)^n iff A >= N.
      * So we want to copy the result of the subtraction iff d->p[n] != 0.
      * Note that d->p[n] is either 0 or 1 since A - N <= N <= (2^biL)^n. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1328,7 +1328,8 @@ cleanup:
 }
 
 /*
- * Helper for mbedtls_mpi subtraction
+ * Helper for mbedtls_mpi subtraction:
+ * d -= s where d and s have the same size and d >= s.
  */
 static void mpi_sub_hlp( size_t n,
                          const mbedtls_mpi_uint *s,
@@ -1977,8 +1978,27 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
     *mm = ~x + 1;
 }
 
-/*
- * Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
+/** Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
+ *
+ * \param[in,out]   A   One of the numbers to multiply.
+ *                      It must have at least one more limb than N
+ *                      (A->n >= N->n + 1).
+ *                      On successful completion, A contains the result of
+ *                      the multiplication A * B * R^-1 mod N where
+ *                      R = (2^ciL)^n.
+ * \param[in]       B   One of the numbers to multiply.
+ *                      It must be nonzero and must not have more limbs than N
+ *                      (B->n <= N->n).
+ * \param[in]       N   The modulo. N must be odd.
+ * \param           mm  The value calculated by `mpi_montg_init(&mm, N)`.
+ *                      This is -N^-1 mod 2^ciL.
+ * \param[in,out]   T   A bignum for temporary storage.
+ *                      It must be at least twice the limb size of N plus 2
+ *                      (T->n >= 2 * (N->n + 1)).
+ *                      Its initial content is unused and
+ *                      its final content is indeterminate.
+ *                      Note that unlike the usual convention in the library
+ *                      for `const mbedtls_mpi*`, the content of T can change.
  */
 static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi *N, mbedtls_mpi_uint mm,
                          const mbedtls_mpi *T )
@@ -2008,6 +2028,8 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
 
     memcpy( A->p, d, ( n + 1 ) * ciL );
 
+    /* If A >= N then A -= N. Do the subtraction unconditionally to prevent
+     * timing attacks. Modify T as a side effect. */
     if( mbedtls_mpi_cmp_abs( A, N ) >= 0 )
         mpi_sub_hlp( n, N->p, A->p );
     else
@@ -2017,6 +2039,8 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
 
 /*
  * Montgomery reduction: A = A * R^-1 mod N
+ *
+ * See mpi_montmul() regarding constraints and guarantees on the parameters.
  */
 static void mpi_montred( mbedtls_mpi *A, const mbedtls_mpi *N,
                          mbedtls_mpi_uint mm, const mbedtls_mpi *T )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2051,7 +2051,7 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
     /* Now d - (2^biL)^n = A - N so d >= (2^biL)^n iff A >= N.
      * So we want to copy the result of the subtraction iff d->p[n] != 0.
      * Note that d->p[n] is either 0 or 1 since A - N <= N <= (2^biL)^n. */
-    mpi_safe_cond_assign( n + 1, A->p, d, d[n] );
+    mpi_safe_cond_assign( n + 1, A->p, d, (unsigned char) d[n] );
     A->p[n] = 0;
 }
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2044,12 +2044,15 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
     memcpy( A->p, d, ( n + 1 ) * ciL );
 
     /* If A >= N then A -= N. Do the subtraction unconditionally to prevent
-     * timing attacks. Modify T as a side effect. */
-    if( mbedtls_mpi_cmp_abs( A, N ) >= 0 )
-        mpi_sub_hlp( n, N->p, A->p );
-    else
-        /* prevent timing attacks */
-        mpi_sub_hlp( n, A->p, T->p );
+     * timing attacks. */
+    /* Set d to A + (2^biL)^n - N. */
+    d[n] += 1;
+    mpi_sub_hlp( n, N->p, d );
+    /* Now d - (2^biL)^n = A - N so d >= (2^biL)^n iff A >= N.
+     * So we want to copy the result of the subtraction iff d->p[n] != 0.
+     * Note that d->p[n] is either 0 or 1 since A - N <= N <= (2^biL)^n. */
+    mpi_safe_cond_assign( n + 1, A->p, d, d[n] );
+    A->p[n] = 0;
 }
 
 /*

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2009,8 +2009,8 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
 /** Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
  *
  * \param[in,out]   A   One of the numbers to multiply.
- *                      It must have at least one more limb than N
- *                      (A->n >= N->n + 1).
+ *                      It must have at least as many limbs as N
+ *                      (A->n >= N->n), and any limbs beyond n are ignored.
  *                      On successful completion, A contains the result of
  *                      the multiplication A * B * R^-1 mod N where
  *                      R = (2^ciL)^n.
@@ -2054,18 +2054,25 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
         *d++ = u0; d[n + 1] = 0;
     }
 
-    memcpy( A->p, d, ( n + 1 ) * ciL );
+    /* At this point, d is either the desired result or the desired result
+     * plus N. We now potentially subtract N, avoiding leaking whether the
+     * subtraction is performed through side channels. */
 
-    /* If A >= N then A -= N. Do the subtraction unconditionally to prevent
-     * timing attacks. */
-    /* Set d to A + (2^biL)^n - N. */
+    /* Copy the n least significant limbs of d to A, so that
+     * A = d if d < N (recall that N has n limbs). */
+    memcpy( A->p, d, n * ciL );
+    /* If d >= N then we want to set A to N - d. To prevent timing attacks,
+     * do the calculation without using conditional tests. */
+    /* Set d to d0 + (2^biL)^n - N where d0 is the current value of d. */
     d[n] += 1;
     d[n] -= mpi_sub_hlp( n, d, N->p );
-    /* Now d - (2^biL)^n = A - N so d >= (2^biL)^n iff A >= N.
-     * So we want to copy the result of the subtraction iff d->p[n] != 0.
-     * Note that d->p[n] is either 0 or 1 since A - N <= N <= (2^biL)^n. */
-    mpi_safe_cond_assign( n + 1, A->p, d, (unsigned char) d[n] );
-    A->p[n] = 0;
+    /* If d0 < N then d < (2^biL)^n
+     * so d[n] == 0 and we want to keep A as it is.
+     * If d0 >= N then d >= (2^biL)^n, and d <= (2^biL)^n + N < 2 * (2^biL)^n
+     * so d[n] == 1 and we want to set A to the result of the subtraction
+     * which is d - (2^biL)^n, i.e. the n least significant limbs of d.
+     * This exactly corresponds to a conditional assignment. */
+    mpi_safe_cond_assign( n, A->p, d, (unsigned char) d[n] );
 }
 
 /*

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1374,20 +1374,20 @@ static mbedtls_mpi_uint mpi_sub_hlp( size_t n,
 }
 
 /*
- * Unsigned subtraction: X = |A| - |B|  (HAC 14.9)
+ * Unsigned subtraction: X = |A| - |B|  (HAC 14.9, 14.10)
  */
 int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     mbedtls_mpi TB;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
-    mbedtls_mpi_uint c, z;
+    mbedtls_mpi_uint carry;
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
 
-    if( mbedtls_mpi_cmp_abs( A, B ) < 0 )
-        return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE );
+    /* if( mbedtls_mpi_cmp_abs( A, B ) < 0 ) */
+    /*     return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE ); */
 
     mbedtls_mpi_init( &TB );
 
@@ -1411,11 +1411,17 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
         if( B->p[n - 1] != 0 )
             break;
 
-    c = mpi_sub_hlp( n, X->p, B->p );
-    while( c != 0 )
+    carry = mpi_sub_hlp( n, X->p, B->p );
+    if( carry != 0 )
     {
-        z = ( X->p[n] < c ); X->p[n] -= c;
-        c = z; n++;
+        /* Propagate the carry to the first nonzero limb of X. */
+        for( ; n < X->n && X->p[n] == 0; n++ )
+            --X->p[n];
+        /* If we ran out of space for the carry, it means that the result
+         * is negative. */
+        if( n == X->n )
+            return( MBEDTLS_ERR_MPI_NEGATIVE_VALUE );
+        --X->p[n];
     }
 
 cleanup:


### PR DESCRIPTION
Remove a secret-dependent branch in Montgomery multiplication that could expose some bits of a private RSA key.

The potential leak was documented in https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-lee-sangho.pdf and again in https://arxiv.org/pdf/2005.11516.pdf and reported in https://github.com/ARMmbed/mbedtls/issues/3394.

Fix #3394.

In this pull request, I reverted commit 2cc69fffcf431085f18f4e59c3c5188297f97b87 from https://github.com/ARMmbed/mbedtls/pull/457, partly because the only real value of the check it added was to silence a false positive from clang-analyzer, and partly because half of the check was wrong anyway. I think this reversal should be backported with the rest, because it has the benefit that it more than compensates the additional code size from this security fix, and the risk of removing a redundant check is minimal.

Needs backports to all supported branches.
