### PR TITLE
[Backport 2.16] Fix undeclared dependencies on HMAC_DRBG

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -798,7 +798,23 @@ component_test_no_ctr_drbg () {
     msg "test: no CTR_DRBG"
     make test
 
-    # no SSL tests as they all depend on CTR_DRBG so far
+    # no ssl-opt.sh/compat.sh as they all depend on CTR_DRBG so far
+}
+
+component_test_no_hmac_drbg () {
+    msg "build: Full minus HMAC_DRBG"
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_HMAC_DRBG_C
+    scripts/config.pl unset MBEDTLS_ECDSA_DETERMINISTIC # requires HMAC_DRBG
+
+    CC=gcc cmake -D CMAKE_BUILD_TYPE:String=Asan .
+    make
+
+    msg "test: no HMAC_DRBG"
+    make test
+
+    # No ssl-opt.sh/compat.sh as they never use HMAC_DRBG so far,
+    # so there's little value in running those lengthy tests here.
 }
 
 component_test_small_ssl_out_content_len () {


### PR DESCRIPTION
This is the 2.16 backport of #3400. Compared to the original, only the test is backported, as the issue fixed was the PSA test suite, and `config.py` is changed to `config.pl`.
