### PR TITLE
Make basic-build-test.sh more deterministic

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -123,7 +123,11 @@ pre_initialize_variables () {
     KEEP_GOING=0
 
     # Seed value used with the --release-test option.
-    # !!! Keep this in sync with SEED in basic-build-test.sh !!!
+    #
+    # See also RELEASE_SEED in basic-build-test.sh. Debugging is easier if
+    # both values are kept in sync. If you change the value here because it
+    # breaks some tests, you'll definitely want to change it in
+    # basic-build-test.sh as well.
     RELEASE_SEED=1
 
     : ${MBEDTLS_TEST_OUTCOME_FILE=}

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -122,6 +122,10 @@ pre_initialize_variables () {
     FORCE=0
     KEEP_GOING=0
 
+    # Seed value used with the --release-test option.
+    # !!! Keep this in sync with SEED in basic-build-test.sh !!!
+    RELEASE_SEED=1
+
     : ${MBEDTLS_TEST_OUTCOME_FILE=}
     : ${MBEDTLS_TEST_PLATFORM="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
     export MBEDTLS_TEST_OUTCOME_FILE
@@ -219,7 +223,7 @@ General options:
      --outcome-file=<path>  File where test outcomes are written (not done if
                             empty; default: \$MBEDTLS_TEST_OUTCOME_FILE).
      --random-seed      Use a random seed value for randomized tests (default).
-  -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
+  -r|--release-test     Run this script in release mode. This fixes the seed value to ${RELEASE_SEED}.
   -s|--seed             Integer seed value to use for this test run.
 
 Tool path options:
@@ -369,7 +373,7 @@ pre_parse_command_line () {
             --outcome-file) shift; MBEDTLS_TEST_OUTCOME_FILE="$1";;
             --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
             --random-seed) unset SEED;;
-            --release-test|-r) SEED=1;;
+            --release-test|-r) SEED=$RELEASE_SEED;;
             --seed|-s) shift; SEED="$1";;
             -*)
                 echo >&2 "Unknown option: $1"

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -44,7 +44,10 @@ fi
 : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
 
 # Used to make ssl-opt.sh deterministic.
-# !!! Keep this in sync with RELEASE_SEED in all.sh !!!
+#
+# See also RELEASE_SEED in all.sh. Debugging is easier if both values are kept
+# in sync. If you change the value here because it breaks some tests, you'll
+# definitely want to change it in all.sh as well.
 : ${SEED:=1}
 export SEED
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -43,6 +43,11 @@ fi
 : ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
 : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
 
+# Used to make ssl-opt.sh deterministic.
+# !!! Keep this in sync with RELEASE_SEED in all.sh !!!
+: ${SEED:=1}
+export SEED
+
 # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
 # we just export the variables they require
 export OPENSSL_CMD="$OPENSSL"


### PR DESCRIPTION

## Description

This PR makes the invocations of `ssl-opt.sh` in `basic-build-test.sh` more deterministic by fixing the seed used by the proxy. The motivations for this include:

- avoid random failures in CI runs due to unlucky seeds that cause the proxy to drop too aggressively, resulting in timeouts
- avoid random variations in coverage stats

I think that was the only part of `basic-build-test.sh` that was non-deterministic in ways that could cause such variations. (Of course SSL tests all use entropy, but neither the result of the tests nor the coverage data should depend on the random values used here.)

## Status
**READY**

## Requires Backporting

Yes 

- [x] 2.16 - #3442 
- [x] 2.7 - #3443 

