### PR TITLE
Define _POSIX_C_SOURCE to be 200112L, as a minimum for C99.

### DIFF
--- a/ChangeLog.d/bugfix_PR3421.txt
+++ b/ChangeLog.d/bugfix_PR3421.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Set _POSIX_C_SOURCE to at least 200112L in C99 code. Reported in #3420 and fix submitted in #3421 by Nia Alarie.

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -22,7 +22,7 @@
 /* Enable definition of fileno() even when compiling with -std=c99. Must be
  * set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 200112L
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -23,7 +23,7 @@
 /* Enable definition of fileno() even when compiling with -std=c99. Must be
  * set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 200112L
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -21,7 +21,7 @@
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #if !defined(_POSIX_C_SOURCE)
-#define _POSIX_C_SOURCE 1 // for fileno() from <stdio.h>
+#define _POSIX_C_SOURCE 200112L // for fileno() from <stdio.h>
 #endif
 #endif
 


### PR DESCRIPTION
Fixes #3420