### PR TITLE
NetBSD 9.0 build fixes

### DIFF
--- a/ChangeLog.d/bugfix_PR3422.txt
+++ b/ChangeLog.d/bugfix_PR3422.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix building library/net_sockets.c and the ssl_mail_client program on NetBSD. Contributed by Nia Alarie in #3422.

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -23,6 +23,7 @@
  * be set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
+#define _XOPEN_SOURCE 600 /* sockaddr_storage */
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
@@ -322,7 +323,8 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
     struct sockaddr_storage client_addr;
 
 #if defined(__socklen_t_defined) || defined(_SOCKLEN_T) ||  \
-    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t)
+    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t) || \
+    defined(socklen_t)
     socklen_t n = (socklen_t) sizeof( client_addr );
     socklen_t type_len = (socklen_t) sizeof( type );
 #else

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -23,6 +23,7 @@
  * be set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
+#define _XOPEN_SOURCE 600
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"


### PR DESCRIPTION
- Define `_XOPEN_SOURCE` in specific files to get definitions of `gethostname` and `sockaddr_storage`
- Add another check for `socklen_t`'s definition. I'm not really happy adding to this since it's quite hacky/messy, but it seems like the least intrusive change I can make for now. (I'm not sure which platforms without socklen_t need special-casing).

Fixes #2310