### PR TITLE
entropy: Add support for BSD sysctl(KERN_ARND)

### DIFF
--- a/ChangeLog.d/sysctl-arnd-support.txt
+++ b/ChangeLog.d/sysctl-arnd-support.txt
@@ -1,0 +1,2 @@
+Features
+   * Added support to entropy_poll for the kern.arandom syscall supported on some BSD systems. Contributed by Nia Alarie in #3423.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -129,9 +129,8 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
 #if defined(KERN_ARND)
 #define HAVE_SYSCTL_ARND
 
-static int sysctl_arnd_wrapper( void *buf, size_t buflen )
+static int sysctl_arnd_wrapper( unsigned char *buf, size_t buflen )
 {
-    unsigned char *output = buf;
     int name[2];
     size_t len;
 
@@ -141,10 +140,10 @@ static int sysctl_arnd_wrapper( void *buf, size_t buflen )
     while( buflen > 0 )
     {
         len = buflen > 256 ? 256 : buflen;
-        if( sysctl(name, 2, output, &len, NULL, 0) == -1 )
+        if( sysctl(name, 2, buf, &len, NULL, 0) == -1 )
             return( -1 );
         buflen -= len;
-        output += len;
+        buf += len;
     }
     return( 0 );
 }

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -115,6 +115,41 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
 #endif /* SYS_getrandom */
 #endif /* __linux__ || __midipix__ */
 
+/*
+ * Some BSD systems provide KERN_ARND.
+ * This is equivalent to reading from /dev/urandom, only it doesn't require an
+ * open file descriptor, and provides up to 256 bytes per call (basically the
+ * same as getentropy(), but with a longer history).
+ *
+ * Documentation: https://netbsd.gw.com/cgi-bin/man-cgi?sysctl+7
+ */
+#if (defined(__FreeBSD__) || defined(__NetBSD__)) && !defined(HAVE_GETRANDOM)
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#if defined(KERN_ARND)
+#define HAVE_SYSCTL_ARND
+
+static int sysctl_wrapper ( void *buf, size_t buflen )
+{
+    int name[2];
+    size_t len;
+
+    name[0] = CTL_KERN;
+    name[1] = KERN_ARND;
+
+    while( buflen > 0 )
+    {
+        len = buflen > 256 ? 256 : buflen;
+        if( sysctl(name, 2, buf, &len, NULL, 0) == -1 )
+            return( -1 );
+        buflen -= len;
+        buf += len;
+    }
+    return( 0 );
+}
+#endif /* KERN_ARND */
+#endif /* __FreeBSD__ || __NetBSD__ */
+
 #include <stdio.h>
 
 int mbedtls_platform_entropy_poll( void *data,
@@ -139,6 +174,15 @@ int mbedtls_platform_entropy_poll( void *data,
     ((void) ret);
 #endif /* HAVE_GETRANDOM */
 
+#if defined(HAVE_SYSCTL_ARND)
+    ((void) file);
+    ((void) read_len);
+    if( sysctl_wrapper( output, len ) == -1 )
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+    *olen = len;
+    return( 0 );
+#else
+
     *olen = 0;
 
     file = fopen( "/dev/urandom", "rb" );
@@ -156,6 +200,7 @@ int mbedtls_platform_entropy_poll( void *data,
     *olen = len;
 
     return( 0 );
+#endif /* HAVE_SYSCTL_ARND */
 }
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 #endif /* !MBEDTLS_NO_PLATFORM_ENTROPY */

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -129,7 +129,7 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
 #if defined(KERN_ARND)
 #define HAVE_SYSCTL_ARND
 
-static int sysctl_wrapper ( void *buf, size_t buflen )
+static int sysctl_arnd_wrapper( void *buf, size_t buflen )
 {
     int name[2];
     size_t len;
@@ -177,7 +177,7 @@ int mbedtls_platform_entropy_poll( void *data,
 #if defined(HAVE_SYSCTL_ARND)
     ((void) file);
     ((void) read_len);
-    if( sysctl_wrapper( output, len ) == -1 )
+    if( sysctl_arnd_wrapper( output, len ) == -1 )
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     *olen = len;
     return( 0 );

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -131,6 +131,7 @@ static int getrandom_wrapper( void *buf, size_t buflen, unsigned int flags )
 
 static int sysctl_arnd_wrapper( void *buf, size_t buflen )
 {
+    unsigned char *output = buf;
     int name[2];
     size_t len;
 
@@ -140,10 +141,10 @@ static int sysctl_arnd_wrapper( void *buf, size_t buflen )
     while( buflen > 0 )
     {
         len = buflen > 256 ? 256 : buflen;
-        if( sysctl(name, 2, buf, &len, NULL, 0) == -1 )
+        if( sysctl(name, 2, output, &len, NULL, 0) == -1 )
             return( -1 );
         buflen -= len;
-        buf += len;
+        output += len;
     }
     return( 0 );
 }


### PR DESCRIPTION
This is basically the same as reading from `/dev/urandom` on supported systems, only it has a limit of 256 bytes per call (just to stop programs from spending too much time in the kernel), and does not require an open file descriptor (so it can be used in chroots, when resource limits are in place, or are otherwise exhausted).

It's functionally equivalent to the comparable function `getentropy`, but has been around for longer. It's actually used to implement `getentropy` in FreeBSD's libc. Discussions about adding `getrandom` or `getentropy` to NetBSD are still ongoing.

Note: this is also *much* faster than reading from `/dev/urandom` on NetBSD-current (the performance increase may not be as significant on other platforms). `time(1)` reports unpatched mbedTLS `gen_entropy` as spending 2-3 seconds in the kernel. With this patch applied, that number is 0. The overhead of reopening `/dev/urandom` 768 times in the process of generating 48K bytes is removed, and the overhead of libc stdio buffering for `fread` is removed -- libc is not optimized for repeated short reads on short lived files, so reads far more than necessary and stores it in a buffer.

* `KERN_ARND` is present and works as described in all supported versions of FreeBSD and NetBSD, going back 10 years.
* It's not present in DragonFly or OpenBSD.
* [Documentation](https://netbsd.gw.com/cgi-bin/man-cgi?sysctl+7) (NetBSD manual page)
* [Comparable code in OpenSSL](
https://github.com/openssl/openssl/blob/ddec332f329a432a45c0131d83f3bfb46114532b/crypto/rand/rand_unix.c#L208)