### PR TITLE
Duplicate sensitive buffer and buffer length information

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -686,6 +686,8 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
     unsigned int flow_ctrl = 0;
     volatile unsigned int i = 0;
     volatile int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+    volatile const unsigned char *key_dup = key;
+    volatile unsigned int keybits_dup = keybits;
     uint32_t *RK;
     uint32_t offset = 0;
 
@@ -814,7 +816,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 #endif
     ) )
     {
-        return ret;
+        if( keybits_dup == keybits && key_dup == key )
+        {
+            return ret;
+        }
     }
 
     return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
@@ -1063,6 +1068,8 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     aes_r_data_t *aes_data_table[2];    // pointers to real and fake data
     int round_ctrl_table_len = ctx->nr + 2 + AES_SCA_CM_ROUNDS;
     volatile int flow_control;
+    volatile const unsigned char *input_dup = input;
+    volatile unsigned char *output_dup = output;
     // control bytes for AES calculation rounds,
     // reserve based on max rounds + dummy rounds + 2 (for initial key addition)
     uint8_t round_ctrl_table[( 14 + AES_SCA_CM_ROUNDS + 2 )];
@@ -1163,7 +1170,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     if( flow_control == tindex + dummy_rounds + 8 )
     {
         /* Validate control path due possible fault injection */
-        return 0;
+        if( output_dup == output && input_dup == input )
+        {
+            return 0;
+        }
     }
 
     return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
@@ -1342,6 +1352,8 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
     aes_r_data_t *aes_data_table[2];    // pointers to real and fake data
     int round_ctrl_table_len = ctx->nr + 2 + AES_SCA_CM_ROUNDS;
     volatile int flow_control;
+    volatile const unsigned char *input_dup = input;
+    volatile unsigned char *output_dup = output;
     // control bytes for AES calculation rounds,
     // reserve based on max rounds + dummy rounds + 2 (for initial key addition)
     uint8_t round_ctrl_table[( 14 + AES_SCA_CM_ROUNDS + 2 )];
@@ -1442,7 +1454,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
     if( flow_control == tindex + dummy_rounds + 8 )
     {
         /* Validate control path due possible fault injection */
-        return 0;
+        if( output_dup == output && input_dup == input )
+        {
+            return 0;
+        }
     }
 
     return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -77,6 +77,8 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
 {
     int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
     const mbedtls_cipher_info_t *cipher_info;
+    volatile const unsigned char *key_dup = key;
+    volatile unsigned int keybits_dup = keybits;
 
     CCM_VALIDATE_RET( ctx != NULL );
     CCM_VALIDATE_RET( key != NULL );
@@ -97,6 +99,11 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
                                MBEDTLS_ENCRYPT ) ) != 0 )
     {
         return( ret );
+    }
+
+    if( keybits_dup != keybits || key_dup != key )
+    {
+        return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
     }
 
     return( ret );
@@ -165,6 +172,15 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     unsigned char ctr[16];
     const unsigned char *src;
     unsigned char *dst;
+    volatile size_t length_dup = length;
+    volatile const unsigned char *iv_dup = iv;
+    volatile size_t iv_len_dup = iv_len;
+    volatile const unsigned char *add_dup = add;
+    volatile size_t add_len_dup = add_len;
+    volatile const unsigned char *input_dup = input;
+    volatile unsigned char *output_dup = output;
+    volatile unsigned char *tag_dup = tag;
+    volatile size_t tag_len_dup = tag_len;
 
     /*
      * Check length requirements: SP800-38C A.1
@@ -316,6 +332,13 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     CTR_CRYPT( y, y, 16 );
     mbedtls_platform_memcpy( tag, y, tag_len );
 
+    if( length_dup != length || iv_dup != iv || iv_len_dup != iv_len ||
+        add_dup != add || add_len_dup != add_len || input_dup != input ||
+        output_dup != output || tag_dup != tag || tag_len_dup != tag_len)
+    {
+        return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+    }
+
     return( ret );
 }
 
@@ -370,6 +393,15 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
     unsigned char check_tag[16];
     unsigned char i;
     int diff;
+    volatile size_t length_dup = length;
+    volatile const unsigned char *iv_dup = iv;
+    volatile size_t iv_len_dup = iv_len;
+    volatile const unsigned char *add_dup = add;
+    volatile size_t add_len_dup = add_len;
+    volatile const unsigned char *input_dup = input;
+    volatile unsigned char *output_dup = output;
+    volatile const unsigned char *tag_dup = tag;
+    volatile size_t tag_len_dup = tag_len;
 
     CCM_VALIDATE_RET( ctx != NULL );
     CCM_VALIDATE_RET( iv != NULL );
@@ -393,6 +425,13 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
     {
         mbedtls_platform_zeroize( output, length );
         return( MBEDTLS_ERR_CCM_AUTH_FAILED );
+    }
+
+    if( length_dup != length || iv_dup != iv || iv_len_dup != iv_len ||
+        add_dup != add || add_len_dup != add_len || input_dup != input ||
+        output_dup != output || tag_dup != tag || tag_len_dup != tag_len)
+    {
+        return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
     }
 
     return( ret );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1158,6 +1158,8 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
                                          const unsigned char *buf,
                                          size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
     {
@@ -1189,7 +1191,12 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         ssl->secure_renegotiation = MBEDTLS_SSL_SECURE_RENEGOTIATION;
     }
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
@@ -1197,6 +1204,8 @@ static int ssl_parse_max_fragment_length_ext( mbedtls_ssl_context *ssl,
                                               const unsigned char *buf,
                                               size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
     /*
      * server should use the extension only if we did,
      * and if so the server's value should match ours (and len is always 1)
@@ -1211,7 +1220,12 @@ static int ssl_parse_max_fragment_length_ext( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
     }
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
@@ -1220,6 +1234,9 @@ static int ssl_parse_truncated_hmac_ext( mbedtls_ssl_context *ssl,
                                          const unsigned char *buf,
                                          size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
+
     if( ssl->conf->trunc_hmac == MBEDTLS_SSL_TRUNC_HMAC_DISABLED ||
         len != 0 )
     {
@@ -1233,7 +1250,12 @@ static int ssl_parse_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     ssl->session_negotiate->trunc_hmac = MBEDTLS_SSL_TRUNC_HMAC_ENABLED;
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_TRUNCATED_HMAC */
 
@@ -1243,6 +1265,8 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
                               size_t len )
 {
     size_t peer_cid_len;
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
 
     if( /* CID extension only makes sense in DTLS */
         MBEDTLS_SSL_TRANSPORT_IS_TLS( ssl->conf->transport ) ||
@@ -1290,7 +1314,12 @@ static int ssl_parse_cid_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "Use of CID extension negotiated" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "Server CID", buf, peer_cid_len );
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( ( buf_dup + 1 ) == buf && ( len_dup - 1 ) == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
@@ -1299,6 +1328,9 @@ static int ssl_parse_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
                                          const unsigned char *buf,
                                          size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
+
     if( ssl->conf->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED ||
         mbedtls_ssl_get_minor_ver( ssl ) == MBEDTLS_SSL_MINOR_VERSION_0 ||
         len != 0 )
@@ -1313,7 +1345,12 @@ static int ssl_parse_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     ssl->session_negotiate->encrypt_then_mac = MBEDTLS_SSL_ETM_ENABLED;
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_ENCRYPT_THEN_MAC */
 
@@ -1322,6 +1359,8 @@ static int ssl_parse_extended_ms_ext( mbedtls_ssl_context *ssl,
                                          const unsigned char *buf,
                                          size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
     if( mbedtls_ssl_conf_get_ems( ssl->conf ) ==
           MBEDTLS_SSL_EXTENDED_MS_DISABLED ||
         mbedtls_ssl_get_minor_ver( ssl ) == MBEDTLS_SSL_MINOR_VERSION_0 ||
@@ -1334,7 +1373,12 @@ static int ssl_parse_extended_ms_ext( mbedtls_ssl_context *ssl,
     }
 
     ((void) buf);
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_EXTENDED_MASTER_SECRET */
 
@@ -1343,6 +1387,9 @@ static int ssl_parse_session_ticket_ext( mbedtls_ssl_context *ssl,
                                          const unsigned char *buf,
                                          size_t len )
 {
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
+
     if( ssl->conf->session_tickets == MBEDTLS_SSL_SESSION_TICKETS_DISABLED ||
         len != 0 )
     {
@@ -1356,7 +1403,12 @@ static int ssl_parse_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     ssl->handshake->new_session_ticket = 1;
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS */
 
@@ -1370,6 +1422,8 @@ static int ssl_parse_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 {
     size_t list_size;
     const unsigned char *p;
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
 
     if( len == 0 || (size_t)( buf[0] + 1 ) != len )
     {
@@ -1393,7 +1447,12 @@ static int ssl_parse_supported_point_formats_ext( mbedtls_ssl_context *ssl,
             ssl->handshake->ecjpake_ctx.point_format = p[0];
 #endif
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "point format selected: %d", p[0] ) );
-            return( 0 );
+            /* Secure against buffer substitution */
+            if( buf_dup == buf && len_dup == len )
+            {
+                return( 0 );
+            }
+            return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
         }
 
         list_size--;
@@ -1414,6 +1473,8 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
                                    size_t len )
 {
     int ret;
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
 
     if( mbedtls_ssl_suite_get_key_exchange(
             mbedtls_ssl_handshake_get_ciphersuite( ssl->handshake ) )
@@ -1437,7 +1498,12 @@ static int ssl_parse_ecjpake_kkpp( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && len_dup == len )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 
@@ -1447,6 +1513,8 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
 {
     size_t list_len, name_len;
     const char **p;
+    volatile const unsigned char *buf_dup = buf;
+    volatile size_t len_dup = len;
 
     /* If we didn't send it, the server shouldn't send it */
     if( ssl->conf->alpn_list == NULL )
@@ -1498,7 +1566,12 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
             mbedtls_platform_memcmp( buf + 3, *p, name_len ) == 0 )
         {
             ssl->alpn_chosen = *p;
-            return( 0 );
+            /* Secure against buffer substitution */
+            if( buf_dup == buf && len_dup == len )
+            {
+                return( 0 );
+            }
+            return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
         }
     }
 
@@ -2191,7 +2264,8 @@ static int ssl_parse_server_dh_params( mbedtls_ssl_context *ssl, unsigned char *
                                        unsigned char *end )
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-
+    unsigned char ** volatile p_dup = p;
+    volatile unsigned char *end_dup = end;
     /*
      * Ephemeral DH parameters:
      *
@@ -2218,8 +2292,12 @@ static int ssl_parse_server_dh_params( mbedtls_ssl_context *ssl, unsigned char *
     MBEDTLS_SSL_DEBUG_MPI( 3, "DHM: P ", &ssl->handshake->dhm_ctx.P  );
     MBEDTLS_SSL_DEBUG_MPI( 3, "DHM: G ", &ssl->handshake->dhm_ctx.G  );
     MBEDTLS_SSL_DEBUG_MPI( 3, "DHM: GY", &ssl->handshake->dhm_ctx.GY );
-
-    return( ret );
+    /* Secure against buffer substitution */
+    if( p_dup == p && end_dup == end )
+    {
+        return( ret );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED ||
           MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED */
@@ -2278,7 +2356,8 @@ static int ssl_parse_server_ecdh_params( mbedtls_ssl_context *ssl,
                                          unsigned char *end )
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
-
+    unsigned char ** volatile p_dup = p;
+    volatile unsigned char *end_dup = end;
     /*
      * Ephemeral ECDH parameters:
      *
@@ -2300,7 +2379,12 @@ static int ssl_parse_server_ecdh_params( mbedtls_ssl_context *ssl,
         return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
     }
 
-    return( ret );
+    /* Secure against buffer substitution */
+    if( p_dup == p && end_dup == end )
+    {
+        return( ret );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_ECDH_C &&
           ( MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED   ||
@@ -2314,6 +2398,8 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
     size_t  len;
+    unsigned char ** volatile p_dup = p;
+    volatile unsigned char *end_dup = end;
     ((void) ssl);
 
     /*
@@ -2345,7 +2431,12 @@ static int ssl_parse_server_psk_hint( mbedtls_ssl_context *ssl,
     *p += len;
     ret = 0;
 
-    return( ret );
+    /* Secure against buffer substitution */
+    if( p_dup == p && end_dup == end )
+    {
+        return( ret );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
 
@@ -2522,6 +2613,8 @@ static int ssl_parse_signature_algorithm( mbedtls_ssl_context *ssl,
                                           mbedtls_md_type_t *md_alg,
                                           mbedtls_pk_type_t *pk_alg )
 {
+    unsigned char ** volatile p_dup = p;
+    volatile unsigned char *end_dup = end;
     ((void) ssl);
     *md_alg = MBEDTLS_MD_NONE;
     *pk_alg = MBEDTLS_PK_NONE;
@@ -2569,7 +2662,12 @@ static int ssl_parse_signature_algorithm( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "Server used HashAlgorithm %d", (*p)[0] ) );
     *p += 2;
 
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( p_dup == p && end_dup == end )
+    {
+        return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 #endif /* MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED ||
           MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
@@ -3594,7 +3692,10 @@ static int ssl_out_client_key_exchange_write( mbedtls_ssl_context *ssl,
 {
     int ret;
     unsigned char *p, *end;
+    volatile unsigned char *buf_dup = buf;
+    volatile size_t buflen_dup = buflen;
     size_t n;
+
     mbedtls_ssl_ciphersuite_handle_t ciphersuite_info =
         mbedtls_ssl_handshake_get_ciphersuite( ssl->handshake );
 
@@ -3877,7 +3978,12 @@ static int ssl_out_client_key_exchange_write( mbedtls_ssl_context *ssl,
     }
 
     *olen = p - buf;
-    return( 0 );
+    /* Secure against buffer substitution */
+    if( buf_dup == buf && buflen_dup == buflen )
+    {
+       return( 0 );
+    }
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 
 static int ssl_out_client_key_exchange_postprocess( mbedtls_ssl_context *ssl )

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3286,6 +3286,7 @@ static int ssl_resume_server_key_exchange( mbedtls_ssl_context *ssl,
 static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
                                             size_t *signature_len )
 {
+    volatile size_t *signature_len_dup = signature_len;
     mbedtls_ssl_ciphersuite_handle_t ciphersuite_info =
         mbedtls_ssl_handshake_get_ciphersuite( ssl->handshake );
 
@@ -3673,7 +3674,11 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
     }
 #endif /* MBEDTLS_KEY_EXCHANGE__WITH_SERVER_SIGNATURE__ENABLED */
 
-    return( 0 );
+    if( signature_len_dup == signature_len )
+    {
+        return( 0 );
+    }
+    return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
 }
 
 /* Prepare the ServerKeyExchange message and send it. For ciphersuites
@@ -4218,6 +4223,8 @@ static int ssl_in_client_key_exchange_parse( mbedtls_ssl_context *ssl,
     mbedtls_ssl_ciphersuite_handle_t ciphersuite_info =
         mbedtls_ssl_handshake_get_ciphersuite( ssl->handshake );
     unsigned char *p, *end;
+    volatile unsigned char *buf_dup = buf;
+    volatile size_t buflen_dup = buflen;
 
     p = buf + mbedtls_ssl_hs_hdr_len( ssl );
     end = buf + buflen;
@@ -4412,8 +4419,11 @@ static int ssl_in_client_key_exchange_parse( mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
         return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
     }
-
-    return( ret );
+    if( buf_dup == buf && buflen_dup == buflen )
+    {
+        return( ret );
+    }
+    return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
 }
 
 /* Update the handshake state */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -177,6 +177,8 @@ int mbedtls_ssl_check_record( mbedtls_ssl_context const *ssl,
                               size_t buflen )
 {
     int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+    volatile unsigned char *buf_dup = buf;
+    volatile size_t buflen_dup = buflen;
     mbedtls_record rec;
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "=> mbedtls_ssl_check_record" ) );
     MBEDTLS_SSL_DEBUG_BUF( 3, "record buffer", buf, buflen );
@@ -228,6 +230,10 @@ exit:
         ret = MBEDTLS_ERR_SSL_UNEXPECTED_RECORD;
     }
 
+    if( buf_dup != buf || buflen_dup != buflen )
+    {
+        return MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+    }
     MBEDTLS_SSL_DEBUG_MSG( 1, ( "<= mbedtls_ssl_check_record" ) );
     return( ret );
 }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2486,7 +2486,6 @@ static int ssl_cid_build_inner_plaintext( unsigned char *content,
     volatile size_t *content_size_dup = content_size;
     volatile size_t remaining_dup = remaining;
 
-
     /* Write real content type */
     if( remaining == 0 )
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
@@ -4910,6 +4909,7 @@ static void ssl_bitmask_set( unsigned char *mask, size_t offset, size_t len )
     memset( mask + offset / 8, 0xFF, len / 8 );
 }
 
+#define BITMASK_CHECK_FAILED 0x75555555
 /*
  * Check that bitmask is full
  */
@@ -4921,11 +4921,11 @@ static int ssl_bitmask_check( unsigned char *mask, size_t len )
 
     for( i = 0; i < len / 8; i++ )
         if( mask[i] != 0xFF )
-            return( 0x75555555 );
+            return( BITMASK_CHECK_FAILED );
 
     for( i = 0; i < len % 8; i++ )
         if( ( mask[len / 8] & ( 1 << ( 7 - i ) ) ) == 0 )
-            return( 0x75555555 );
+            return( BITMASK_CHECK_FAILED );
 
     /* Secure against buffer substitution */
     if( mask_dup == mask && len_dup == len )
@@ -7183,6 +7183,7 @@ write_msg:
 #if defined(MBEDTLS_SSL_RENEGOTIATION) && defined(MBEDTLS_SSL_CLI_C)
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
+#define PEER_CRT_CHANGED 0x75555555
 static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
                                          unsigned char *crt_buf,
                                          size_t crt_buf_len )
@@ -7190,14 +7191,15 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     mbedtls_x509_crt const * const peer_crt = ssl->session->peer_cert;
 
     if( peer_crt == NULL )
-        return( 0x75555555 );
+        return( PEER_CRT_CHANGED );
 
     if( peer_crt->raw.len != crt_buf_len )
-        return( 0x75555555 );
+        return( PEER_CRT_CHANGED );
 
     return( mbedtls_platform_memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
 }
 #elif defined(MBEDTLS_SSL_RENEGOTIATION)
+#define PEER_CRT_CHANGED 0x75555555
 static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
                                          unsigned char *crt_buf,
                                          size_t crt_buf_len )
@@ -7215,7 +7217,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( peer_cert_digest == NULL ||
         digest_info == MBEDTLS_MD_INVALID_HANDLE )
     {
-        return( 0x75555555 );
+        return( PEER_CRT_CHANGED );
     }
 
     digest_len = mbedtls_md_get_size( digest_info );
@@ -7224,7 +7226,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
 
     ret = mbedtls_md( digest_info, crt_buf, crt_buf_len, tmp_digest );
     if( ret != 0 )
-        return( 0x75555555 );
+        return( PEER_CRT_CHANGED );
 
     return( mbedtls_platform_memcmp( tmp_digest, peer_cert_digest, digest_len ) );
 }

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -33,16 +33,16 @@
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *
- *    - Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
+ *	- Redistributions of source code must retain the above copyright notice,
+ *	 this list of conditions and the following disclaimer.
  *
- *    - Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *	- Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
  *
- *    - Neither the name of Intel Corporation nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *	- Neither the name of Intel Corporation nor the names of its contributors
+ *	may be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -99,7 +99,7 @@ const uECC_word_t curve_b[NUM_ECC_WORDS] = {
 };
 
 static int uECC_update_param_sha256(mbedtls_sha256_context *ctx,
-				    const uECC_word_t val[NUM_ECC_WORDS])
+					const uECC_word_t val[NUM_ECC_WORDS])
 {
 	uint8_t bytes[NUM_ECC_BYTES];
 
@@ -119,10 +119,10 @@ static int uECC_compute_param_sha256(unsigned char output[32])
 	}
 
 	if (uECC_update_param_sha256(&ctx, curve_p) != 0 ||
-	    uECC_update_param_sha256(&ctx, curve_n) != 0 ||
-	    uECC_update_param_sha256(&ctx, curve_G) != 0 ||
-	    uECC_update_param_sha256(&ctx, curve_G + NUM_ECC_WORDS) != 0 ||
-	    uECC_update_param_sha256(&ctx, curve_b) != 0)
+		uECC_update_param_sha256(&ctx, curve_n) != 0 ||
+		uECC_update_param_sha256(&ctx, curve_G) != 0 ||
+		uECC_update_param_sha256(&ctx, curve_G + NUM_ECC_WORDS) != 0 ||
+		uECC_update_param_sha256(&ctx, curve_b) != 0)
 	{
 		goto exit;
 	}
@@ -449,7 +449,7 @@ void ecc_wait_state_reset(ecc_wait_state_t *ws)
  * know it's always 8. This saves a bit of code size and execution speed.
  */
 static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
-			      const uECC_word_t *right, ecc_wait_state_t *s)
+				  const uECC_word_t *right, ecc_wait_state_t *s)
 {
 
 	uECC_word_t r0 = 0;
@@ -546,7 +546,7 @@ static void uECC_vli_mult_rnd(uECC_word_t *result, const uECC_word_t *left,
 }
 
 void uECC_vli_modAdd(uECC_word_t *result, const uECC_word_t *left,
-		     const uECC_word_t *right, const uECC_word_t *mod)
+			 const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t carry = uECC_vli_add(result, left, right);
 	if (carry || uECC_vli_cmp_unsafe(mod, result) != 1) {
@@ -557,7 +557,7 @@ void uECC_vli_modAdd(uECC_word_t *result, const uECC_word_t *left,
 }
 
 void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
-		     const uECC_word_t *right, const uECC_word_t *mod)
+			 const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t l_borrow = uECC_vli_sub(result, left, right);
 	if (l_borrow) {
@@ -570,7 +570,7 @@ void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
 /* Computes result = product % mod, where product is 2N words long. */
 /* Currently only designed to work for curve_p or curve_n. */
 void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
-    		   const uECC_word_t *mod)
+			   const uECC_word_t *mod)
 {
 	uECC_word_t mod_multiple[2 * NUM_ECC_WORDS];
 	uECC_word_t tmp[2 * NUM_ECC_WORDS];
@@ -608,14 +608,14 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 		index = !(index ^ borrow);
 		uECC_vli_rshift1(mod_multiple);
 		mod_multiple[num_words - 1] |= mod_multiple[num_words] <<
-					       (uECC_WORD_BITS - 1);
+						   (uECC_WORD_BITS - 1);
 		uECC_vli_rshift1(mod_multiple + num_words);
 	}
 	uECC_vli_set(result, v[index]);
 }
 
 void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
-		      const uECC_word_t *right, const uECC_word_t *mod)
+			  const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t product[2 * NUM_ECC_WORDS];
 	uECC_vli_mult_rnd(product, left, right, NULL);
@@ -640,7 +640,7 @@ void uECC_vli_modMult_fast(uECC_word_t *result, const uECC_word_t *left,
 #define EVEN(vli) (!(vli[0] & 1))
 
 static void vli_modInv_update(uECC_word_t *uv,
-			      const uECC_word_t *mod)
+				  const uECC_word_t *mod)
 {
 
 	uECC_word_t carry = 0;
@@ -655,7 +655,7 @@ static void vli_modInv_update(uECC_word_t *uv,
 }
 
 void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
-		     const uECC_word_t *mod)
+			 const uECC_word_t *mod)
 {
 	uECC_word_t a[NUM_ECC_WORDS], b[NUM_ECC_WORDS];
 	uECC_word_t u[NUM_ECC_WORDS], v[NUM_ECC_WORDS];
@@ -674,27 +674,27 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 	while ((cmpResult = uECC_vli_cmp_unsafe(a, b)) != 0) {
 		if (EVEN(a)) {
 			uECC_vli_rshift1(a);
-      			vli_modInv_update(u, mod);
-    		} else if (EVEN(b)) {
+	  			vli_modInv_update(u, mod);
+			} else if (EVEN(b)) {
 			uECC_vli_rshift1(b);
 			vli_modInv_update(v, mod);
 		} else if (cmpResult > 0) {
 			uECC_vli_sub(a, a, b);
 			uECC_vli_rshift1(a);
 			if (uECC_vli_cmp_unsafe(u, v) < 0) {
-        			uECC_vli_add(u, u, mod);
-      			}
-      			uECC_vli_sub(u, u, v);
-      			vli_modInv_update(u, mod);
-    		} else {
-      			uECC_vli_sub(b, b, a);
-      			uECC_vli_rshift1(b);
-      			if (uECC_vli_cmp_unsafe(v, u) < 0) {
-        			uECC_vli_add(v, v, mod);
-      			}
-      			uECC_vli_sub(v, v, u);
-      			vli_modInv_update(v, mod);
-    		}
+					uECC_vli_add(u, u, mod);
+	  			}
+	  			uECC_vli_sub(u, u, v);
+	  			vli_modInv_update(u, mod);
+			} else {
+	  			uECC_vli_sub(b, b, a);
+	  			uECC_vli_rshift1(b);
+	  			if (uECC_vli_cmp_unsafe(v, u) < 0) {
+					uECC_vli_add(v, v, mod);
+	  			}
+	  			uECC_vli_sub(v, v, u);
+	  			vli_modInv_update(v, mod);
+			}
   	}
   	uECC_vli_set(result, u);
 }
@@ -702,7 +702,7 @@ void uECC_vli_modInv(uECC_word_t *result, const uECC_word_t *input,
 /* ------ Point operations ------ */
 
 void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
-			     uECC_word_t * Z1)
+				 uECC_word_t * Z1)
 {
 	/* t1 = X, t2 = Y, t3 = Z */
 	uECC_word_t t4[NUM_ECC_WORDS];
@@ -755,7 +755,7 @@ void double_jacobian_default(uECC_word_t * X1, uECC_word_t * Y1,
  * @param curve IN -- elliptic curve
  */
 static void x_side_default(uECC_word_t *result,
-		    const uECC_word_t *x)
+			const uECC_word_t *x)
 {
 	uECC_word_t _3[NUM_ECC_WORDS] = {3}; /* -a = 3 */
 
@@ -861,7 +861,7 @@ void vli_mmod_fast_secp256r1(unsigned int *result, unsigned int*product)
 		while (carry < 0);
 	} else  {
 		while (carry ||
-		       uECC_vli_cmp_unsafe(curve_p, result) != 1) {
+			   uECC_vli_cmp_unsafe(curve_p, result) != 1) {
 			carry -= uECC_vli_sub(result, result, curve_p);
 		}
 	}
@@ -876,7 +876,7 @@ void apply_z(uECC_word_t * X1, uECC_word_t * Y1, const uECC_word_t * const Z)
 {
 	uECC_word_t t1[NUM_ECC_WORDS];
 
-	uECC_vli_modMult_fast(t1, Z, Z);    /* z^2 */
+	uECC_vli_modMult_fast(t1, Z, Z);	/* z^2 */
 	uECC_vli_modMult_fast(X1, X1, t1); /* x1 * z^2 */
 	uECC_vli_modMult_fast(t1, t1, Z);  /* z^3 */
 	uECC_vli_modMult_fast(Y1, Y1, t1); /* y1 * z^3 */
@@ -929,7 +929,7 @@ static void XYcZ_add_rnd(uECC_word_t * X1, uECC_word_t * Y1,
 }
 
 void XYcZ_add(uECC_word_t * X1, uECC_word_t * Y1,
-	      uECC_word_t * X2, uECC_word_t * Y2)
+		  uECC_word_t * X2, uECC_word_t * Y2)
 {
 	XYcZ_add_rnd(X1, Y1, X2, Y2, NULL);
 }
@@ -1030,7 +1030,7 @@ static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 	bitcount_t num_n_bits = NUM_ECC_BITS;
 
 	uECC_word_t carry = uECC_vli_add(k0, k, curve_n) ||
-			     uECC_vli_testBit(k0, num_n_bits);
+				 uECC_vli_testBit(k0, num_n_bits);
 
 	uECC_vli_add(k1, k0, curve_n);
 
@@ -1081,7 +1081,7 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 	carry = regularize_k(scalar, tmp, s);
 
 	/* If an RNG function was specified, get a random initial Z value to
-         * protect against side-channel attacks such as Template SPA */
+		 * protect against side-channel attacks such as Template SPA */
 	if (g_rng_function) {
 		if (uECC_generate_random_int(k2[carry], curve_p, num_words) != UECC_SUCCESS) {
 			r = UECC_FAILURE;
@@ -1121,8 +1121,8 @@ int EccPoint_mult_safer(uECC_word_t * result, const uECC_word_t * point,
 
 	r = UECC_SUCCESS;
 
-	if(result_dup != result || point_dup != point || scalar_dup != scalar){
-	    r = UECC_FAULT_DETECTED;
+	if (result_dup != result || point_dup != point || scalar_dup != scalar){
+		r = UECC_FAULT_DETECTED;
 	}
 clear_and_out:
 	/* erasing temporary buffer used to store secret: */
@@ -1141,7 +1141,7 @@ uECC_word_t EccPoint_compute_public_key(uECC_word_t *result,
 
 /* Converts an integer in uECC native format to big-endian bytes. */
 void uECC_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
-			    const unsigned int *native)
+				const unsigned int *native)
 {
 	wordcount_t i;
 	for (i = 0; i < num_bytes; ++i) {
@@ -1152,7 +1152,7 @@ void uECC_vli_nativeToBytes(uint8_t *bytes, int num_bytes,
 
 /* Converts big-endian bytes to an integer in uECC native format. */
 void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
-			    int num_bytes)
+				int num_bytes)
 {
 	wordcount_t i;
 	uECC_vli_clear(native);
@@ -1164,7 +1164,7 @@ void uECC_vli_bytesToNative(unsigned int *native, const uint8_t *bytes,
 }
 
 int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
-			     wordcount_t num_words)
+				 wordcount_t num_words)
 {
 	uECC_word_t mask = (uECC_word_t)-1;
 	uECC_word_t tries;
@@ -1176,10 +1176,10 @@ int uECC_generate_random_int(uECC_word_t *random, const uECC_word_t *top,
 
 	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
 		if (g_rng_function((uint8_t *)random, num_words * uECC_WORD_SIZE) != num_words * uECC_WORD_SIZE) {
-      			return UECC_FAILURE;
-    		}
+	  			return UECC_FAILURE;
+			}
 		random[num_words - 1] &=
-        		mask >> ((bitcount_t)(num_words * uECC_WORD_SIZE * 8 - num_bits));
+				mask >> ((bitcount_t)(num_words * uECC_WORD_SIZE * 8 - num_bits));
 		if (!uECC_vli_isZero(random) &&
 			uECC_vli_cmp(top, random) == 1) {
 			return UECC_SUCCESS;
@@ -1213,7 +1213,7 @@ int uECC_valid_point(const uECC_word_t *point)
 	/* Make sure that y^2 == x^3 + ax + b */
 	diff = uECC_vli_equal(tmp1, tmp2);
 	if (diff == 0) {
-	    mbedtls_platform_random_delay();
+		mbedtls_platform_random_delay();
 		if (diff == 0) {
 			return 0;
 		}
@@ -1240,13 +1240,13 @@ int uECC_valid_public_key(const uint8_t *public_key)
 	return uECC_valid_point(_public);
 }
 
-int uECC_compute_public_key(const uint8_t * private_key, uint8_t * public_key)
+int uECC_compute_public_key(const uint8_t *private_key, uint8_t *public_key)
 {
 	int ret = UECC_FAULT_DETECTED;
 	uECC_word_t _private[NUM_ECC_WORDS];
 	uECC_word_t _public[NUM_ECC_WORDS * 2];
-	volatile const uint8_t * private_key_dup = private_key;
-	volatile const uint8_t * public_key_dup = public_key;
+	volatile const uint8_t *private_key_dup = private_key;
+	volatile const uint8_t *public_key_dup = public_key;
 
 	uECC_vli_bytesToNative(
 	_private,
@@ -1272,8 +1272,8 @@ int uECC_compute_public_key(const uint8_t * private_key, uint8_t * public_key)
 	uECC_vli_nativeToBytes(
 	public_key +
 	NUM_ECC_BYTES, NUM_ECC_BYTES, _public + NUM_ECC_WORDS);
-	if(private_key_dup != private_key || public_key_dup != public_key){
-	    return UECC_FAULT_DETECTED;
+	if (private_key_dup != private_key || public_key_dup != public_key){
+		return UECC_FAULT_DETECTED;
 	}
 	return ret;
 }

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -12,10 +12,10 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *	this list of conditions and the following disclaimer.
  *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -36,16 +36,16 @@
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *
- *    - Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
+ *	- Redistributions of source code must retain the above copyright notice,
+ *	 this list of conditions and the following disclaimer.
  *
- *    - Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *	- Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
  *
- *    - Neither the name of Intel Corporation nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *	- Neither the name of Intel Corporation nor the names of its contributors
+ *	may be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -91,14 +91,14 @@ int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 
 	/* Converting buffers to correct bit order: */
 	uECC_vli_nativeToBytes(private_key,
-			       BITS_TO_BYTES(NUM_ECC_BITS),
-			       _private);
+				   BITS_TO_BYTES(NUM_ECC_BITS),
+				   _private);
 	uECC_vli_nativeToBytes(public_key,
-			       NUM_ECC_BYTES,
-			       _public);
+				   NUM_ECC_BYTES,
+				   _public);
 	uECC_vli_nativeToBytes(public_key + NUM_ECC_BYTES,
-			       NUM_ECC_BYTES,
-			       _public + NUM_ECC_WORDS);
+				   NUM_ECC_BYTES,
+				   _public + NUM_ECC_WORDS);
 
 exit:
 	/* erasing temporary buffer used to store secret: */
@@ -122,7 +122,7 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key)
 		uECC_RNG_Function rng_function = uECC_get_rng();
 		if (!rng_function ||
 			rng_function((uint8_t *)_random, 2 * NUM_ECC_WORDS*uECC_WORD_SIZE) != 2 * NUM_ECC_WORDS*uECC_WORD_SIZE) {
-        		return UECC_FAILURE;
+				return UECC_FAILURE;
 		}
 
 		/* computing modular reduction of _random (see FIPS 186.4 B.4.1): */
@@ -138,30 +138,29 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key)
 
 			/* Converting buffers to correct bit order: */
 			uECC_vli_nativeToBytes(private_key,
-					       BITS_TO_BYTES(NUM_ECC_BITS),
-					       _private);
+						   BITS_TO_BYTES(NUM_ECC_BITS),
+						   _private);
 			uECC_vli_nativeToBytes(public_key,
-					       NUM_ECC_BYTES,
-					       _public);
+						   NUM_ECC_BYTES,
+						   _public);
 			uECC_vli_nativeToBytes(public_key + NUM_ECC_BYTES,
- 					       NUM_ECC_BYTES,
-					       _public + NUM_ECC_WORDS);
+ 						   NUM_ECC_BYTES,
+						   _public + NUM_ECC_WORDS);
 
 			/* erasing temporary buffer that stored secret: */
 			mbedtls_platform_memset(_private, 0, NUM_ECC_BYTES);
 
-			if(private_key == private_key_dup &&
-               public_key == public_key_dup){
-			    return UECC_SUCCESS;
+			if (private_key == private_key_dup && public_key == public_key_dup) {
+				return UECC_SUCCESS;
 			}
 			return UECC_FAULT_DETECTED;
-    	}
+		}
   	}
 	return UECC_FAILURE;
 }
 
 int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
-		       uint8_t *secret)
+			   uint8_t *secret)
 {
 
 	uECC_word_t _public[NUM_ECC_WORDS * 2];
@@ -173,27 +172,25 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 	volatile const uint8_t *private_key_dup = private_key;
 	volatile const uint8_t *secret_dup = secret;
 
-
 	/* Converting buffers to correct bit order: */
 	uECC_vli_bytesToNative(_private,
-      			       private_key,
-			       BITS_TO_BYTES(NUM_ECC_BITS));
+	  				   private_key,
+				   BITS_TO_BYTES(NUM_ECC_BITS));
 	uECC_vli_bytesToNative(_public,
-      			       public_key,
-			       num_bytes);
+	  				   public_key,
+				   num_bytes);
 	uECC_vli_bytesToNative(_public + num_words,
-			       public_key + num_bytes,
-			       num_bytes);
+				   public_key + num_bytes,
+				   num_bytes);
 
 	r = EccPoint_mult_safer(_public, _public, _private);
 	uECC_vli_nativeToBytes(secret, num_bytes, _public);
 
 	/* erasing temporary buffer used to store secret: */
 	mbedtls_platform_zeroize(_private, sizeof(_private));
-	if(public_key_dup != public_key || private_key_dup != private_key ||
-	   secret_dup != secret){
-	    return UECC_FAULT_DETECTED;
-	 }
+	if (public_key_dup != public_key || private_key_dup != private_key || secret_dup != secret) {
+		return UECC_FAULT_DETECTED;
+	}
 
 	return r;
 }

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -90,7 +90,11 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_word_t p[NUM_ECC_WORDS * 2];
 	wordcount_t num_n_words = BITS_TO_WORDS(NUM_ECC_BITS);
 	int r = UECC_FAILURE;
-
+	volatile const uint8_t *private_key_dup = private_key;
+	volatile const uint8_t *message_hash_dup = message_hash;
+	volatile unsigned hash_size_dup = hash_size;
+	volatile uECC_word_t *k_dup = k;
+	volatile uint8_t *signature_dup = signature;
 
 	/* Make sure 0 < k < curve_n */
   	if (uECC_vli_isZero(k) ||
@@ -136,6 +140,10 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	}
 
 	uECC_vli_nativeToBytes(signature + NUM_ECC_BYTES, NUM_ECC_BYTES, s);
+	if(private_key_dup != private_key || message_hash_dup != message_hash ||
+       hash_size_dup != hash_size || k_dup != k || signature_dup != signature){
+	    return UECC_FAULT_DETECTED;
+	}
 	return r;
 }
 
@@ -146,6 +154,10 @@ int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_word_t _random[2*NUM_ECC_WORDS];
 	uECC_word_t k[NUM_ECC_WORDS];
 	uECC_word_t tries;
+	volatile const uint8_t *private_key_dup = private_key;
+	volatile const uint8_t *message_hash_dup = message_hash;
+    volatile unsigned hash_size_dup = hash_size;
+    volatile uint8_t *signature_dup = signature;
 
 	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
 		/* Generating _random uniformly at random: */
@@ -164,6 +176,10 @@ int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
 			return r;
 		}
 		if (r == UECC_SUCCESS) {
+		    if(private_key_dup != private_key || message_hash_dup != message_hash ||
+               hash_size_dup != hash_size || signature_dup != signature){
+		        return UECC_FAULT_DETECTED;
+		    }
 			return UECC_SUCCESS;
 		}
 		/* else keep trying */
@@ -194,6 +210,11 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	bitcount_t i;
 	bitcount_t flow_control;
 	volatile uECC_word_t diff;
+    volatile const uint8_t *public_key_dup = public_key;
+    volatile const uint8_t *message_hash_dup = message_hash;
+    volatile unsigned hash_size_dup = hash_size;
+    volatile const uint8_t *signature_dup = signature;
+
 
 	uECC_word_t _public[NUM_ECC_WORDS * 2];
 	uECC_word_t r[NUM_ECC_WORDS], s[NUM_ECC_WORDS];
@@ -295,6 +316,10 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	     * 1 (base value) + num_bits - 1 (from the loop) + 5 incrementations.
 	     */
 		if (diff == 0 && flow_control == (num_bits + 5)) {
+		    if(public_key_dup != public_key || message_hash_dup != message_hash ||
+		       hash_size_dup != hash_size || signature_dup != signature){
+                return UECC_FAULT_DETECTED;
+            }
 			return UECC_SUCCESS;
 		}
 		else {

--- a/tinycrypt/ecc_dsa.c
+++ b/tinycrypt/ecc_dsa.c
@@ -11,10 +11,10 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
+ *	this list of conditions and the following disclaimer.
  *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ *	this list of conditions and the following disclaimer in the documentation
+ *	and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -34,16 +34,16 @@
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
  *
- *    - Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
+ *	- Redistributions of source code must retain the above copyright notice,
+ *	 this list of conditions and the following disclaimer.
  *
- *    - Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *	- Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
  *
- *    - Neither the name of Intel Corporation nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *	- Neither the name of Intel Corporation nor the names of its contributors
+ *	may be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
  *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -69,7 +69,7 @@
 #include "mbedtls/platform_util.h"
 
 static void bits2int(uECC_word_t *native, const uint8_t *bits,
-		     unsigned bits_size)
+			 unsigned bits_size)
 {
 	unsigned num_n_bytes = BITS_TO_BYTES(NUM_ECC_BITS);
 
@@ -82,7 +82,7 @@ static void bits2int(uECC_word_t *native, const uint8_t *bits,
 }
 
 int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
-		     unsigned hash_size, uECC_word_t *k, uint8_t *signature)
+			 unsigned hash_size, uECC_word_t *k, uint8_t *signature)
 {
 
 	uECC_word_t tmp[NUM_ECC_WORDS];
@@ -98,12 +98,12 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* Make sure 0 < k < curve_n */
   	if (uECC_vli_isZero(k) ||
-	    uECC_vli_cmp(curve_n, k) != 1) {
+		uECC_vli_cmp(curve_n, k) != 1) {
 		return UECC_FAILURE;
 	}
 
 	r = EccPoint_mult_safer(p, curve_G, k);
-        if (r != UECC_SUCCESS) {
+		if (r != UECC_SUCCESS) {
 		return r;
 	}
 
@@ -120,7 +120,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	/* Prevent side channel analysis of uECC_vli_modInv() to determine
 	bits of k / the private key by premultiplying by a random number */
 	uECC_vli_modMult(k, k, tmp, curve_n); /* k' = rand * k */
-	uECC_vli_modInv(k, k, curve_n);       /* k = 1 / k' */
+	uECC_vli_modInv(k, k, curve_n);	   /* k = 1 / k' */
 	uECC_vli_modMult(k, k, tmp, curve_n); /* k = 1 / k */
 
 	uECC_vli_nativeToBytes(signature, NUM_ECC_BYTES, p); /* store r */
@@ -140,15 +140,15 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 	}
 
 	uECC_vli_nativeToBytes(signature + NUM_ECC_BYTES, NUM_ECC_BYTES, s);
-	if(private_key_dup != private_key || message_hash_dup != message_hash ||
-       hash_size_dup != hash_size || k_dup != k || signature_dup != signature){
-	    return UECC_FAULT_DETECTED;
+	if (private_key_dup != private_key || message_hash_dup != message_hash ||
+		hash_size_dup != hash_size || k_dup != k || signature_dup != signature) {
+		return UECC_FAULT_DETECTED;
 	}
 	return r;
 }
 
 int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
-	      unsigned hash_size, uint8_t *signature)
+		  unsigned hash_size, uint8_t *signature)
 {
 	int r;
 	uECC_word_t _random[2*NUM_ECC_WORDS];
@@ -156,14 +156,14 @@ int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
 	uECC_word_t tries;
 	volatile const uint8_t *private_key_dup = private_key;
 	volatile const uint8_t *message_hash_dup = message_hash;
-    volatile unsigned hash_size_dup = hash_size;
-    volatile uint8_t *signature_dup = signature;
+	volatile unsigned hash_size_dup = hash_size;
+	volatile uint8_t *signature_dup = signature;
 
 	for (tries = 0; tries < uECC_RNG_MAX_TRIES; ++tries) {
 		/* Generating _random uniformly at random: */
 		uECC_RNG_Function rng_function = uECC_get_rng();
 		if (!rng_function ||
-		    rng_function((uint8_t *)_random, 2*NUM_ECC_WORDS*uECC_WORD_SIZE) != 2*NUM_ECC_WORDS*uECC_WORD_SIZE) {
+			rng_function((uint8_t *)_random, 2*NUM_ECC_WORDS*uECC_WORD_SIZE) != 2*NUM_ECC_WORDS*uECC_WORD_SIZE) {
 			return UECC_FAILURE;
 		}
 
@@ -176,10 +176,10 @@ int uECC_sign(const uint8_t *private_key, const uint8_t *message_hash,
 			return r;
 		}
 		if (r == UECC_SUCCESS) {
-		    if(private_key_dup != private_key || message_hash_dup != message_hash ||
-               hash_size_dup != hash_size || signature_dup != signature){
-		        return UECC_FAULT_DETECTED;
-		    }
+			if (private_key_dup != private_key || message_hash_dup != message_hash ||
+				hash_size_dup != hash_size || signature_dup != signature) {
+				return UECC_FAULT_DETECTED;
+			}
 			return UECC_SUCCESS;
 		}
 		/* else keep trying */
@@ -210,10 +210,10 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	bitcount_t i;
 	bitcount_t flow_control;
 	volatile uECC_word_t diff;
-    volatile const uint8_t *public_key_dup = public_key;
-    volatile const uint8_t *message_hash_dup = message_hash;
-    volatile unsigned hash_size_dup = hash_size;
-    volatile const uint8_t *signature_dup = signature;
+	volatile const uint8_t *public_key_dup = public_key;
+	volatile const uint8_t *message_hash_dup = message_hash;
+	volatile unsigned hash_size_dup = hash_size;
+	volatile const uint8_t *signature_dup = signature;
 
 
 	uECC_word_t _public[NUM_ECC_WORDS * 2];
@@ -228,7 +228,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 
 	uECC_vli_bytesToNative(_public, public_key, NUM_ECC_BYTES);
 	uECC_vli_bytesToNative(_public + num_words, public_key + NUM_ECC_BYTES,
-			       NUM_ECC_BYTES);
+				   NUM_ECC_BYTES);
 	uECC_vli_bytesToNative(r, signature, NUM_ECC_BYTES);
 	uECC_vli_bytesToNative(s, signature + NUM_ECC_BYTES, NUM_ECC_BYTES);
 
@@ -239,7 +239,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 
 	/* r, s must be < n. */
 	if (uECC_vli_cmp_unsafe(curve_n, r) != 1 ||
-	    uECC_vli_cmp_unsafe(curve_n, s) != 1) {
+		uECC_vli_cmp_unsafe(curve_n, s) != 1) {
 		return UECC_FAILURE;
 	}
 
@@ -273,7 +273,7 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	uECC_vli_numBits(u2));
 
 	point = points[(!!uECC_vli_testBit(u1, num_bits - 1)) |
-                       ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
+					   ((!!uECC_vli_testBit(u2, num_bits - 1)) << 1)];
 	uECC_vli_set(rx, point);
 	uECC_vli_set(ry, point + num_words);
 	uECC_vli_clear(z);
@@ -309,17 +309,17 @@ int uECC_verify(const uint8_t *public_key, const uint8_t *message_hash,
 	/* Accept only if v == r. */
 	diff = uECC_vli_equal(rx, r);
 	if (diff == 0) {
-	    flow_control++;
-	    mbedtls_platform_random_delay();
-	    
-	    /* Re-check the condition and test if the control flow is as expected. 
-	     * 1 (base value) + num_bits - 1 (from the loop) + 5 incrementations.
-	     */
+		flow_control++;
+		mbedtls_platform_random_delay();
+
+		/* Re-check the condition and test if the control flow is as expected.
+		 * 1 (base value) + num_bits - 1 (from the loop) + 5 incrementations.
+		 */
 		if (diff == 0 && flow_control == (num_bits + 5)) {
-		    if(public_key_dup != public_key || message_hash_dup != message_hash ||
-		       hash_size_dup != hash_size || signature_dup != signature){
-                return UECC_FAULT_DETECTED;
-            }
+			if (public_key_dup != public_key || message_hash_dup != message_hash ||
+				hash_size_dup != hash_size || signature_dup != signature) {
+				return UECC_FAULT_DETECTED;
+			}
 			return UECC_SUCCESS;
 		}
 		else {


### PR DESCRIPTION
This PR adds protection against FI attacks based on buffer pointer substitution or buffer length manipulations.
Based on https://github.com/ARMmbed/mbedtls/pull/3395.
Please only review commit 738d8e5.