### PR TITLE
Remove Dangerous Parameter Passing

### DIFF
--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -270,7 +270,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
             else
             {
                 TEST_EQUAL( psa_export_key( handle,
-                                            reexported, sizeof( reexported ),
+                                            NULL, 0,
                                             &reexported_length ),
                             PSA_ERROR_NOT_PERMITTED );
             }


### PR DESCRIPTION
## Description

### Fix for coverity bug #350039

When the persistent slot lifecycle test discovers a key of the wrong type (not exportable), it still throws it through the export function in order to check that it too will detect this as a not permitted action. For the buffer and buffer length arguments it passes in a local pointer (which will most likely be NULL), and the sizeof that pointer, as it knows that they will never be used. Coverity rightly (imho) flagged this as suspicious - if we are going to pass in incorrect parameters, at least make them obviously incorrect, and ones that will not potentially cause errors if the code later changes. There is, for example safety checks for zero length buffer, but less protection for an insufficiently sized one.

## Status
**READY**

## Requires Backporting
NO  (Bug not present in other LTS branches)

## Migrations
NO

## Todos
- [ ] Tests
