### PR TITLE
Add support to build and link test common code in programs 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,15 @@ list(APPEND libs ${thirdparty_lib})
 
 add_subdirectory(library)
 
+if(ENABLE_TESTING OR ENABLE_PROGRAMS)
+    file(GLOB MBEDTLS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/*.c)
+    add_library(mbedtls_test OBJECT ${MBEDTLS_TEST_FILES})
+    target_include_directories(mbedtls_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/library)
+endif()
+
 if(ENABLE_PROGRAMS)
     add_subdirectory(programs)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,20 @@ list(APPEND libs ${thirdparty_lib})
 
 add_subdirectory(library)
 
+#
+# The C files in tests/src directory contain test code shared among test suites
+# and programs. This shared test code is compiled and linked to test suites and
+# programs objects as a set of compiled objects. The compiled objects are NOT
+# built into a library that the test suite and program objects would link
+# against as they link against the mbedcrypto, mbedx509 and mbedtls libraries.
+# The reason is that such library is expected to have mutual dependencies with
+# the aforementioned libraries and that there is as of today no portable way of
+# handling such dependencies (only toolchain specific solutions).
+#
+# Thus the below definition of the `mbedtls_test` CMake library of objects
+# target. This library of objects is used by tests and programs CMake files
+# to define the test executables.
+#
 if(ENABLE_TESTING OR ENABLE_PROGRAMS)
     file(GLOB MBEDTLS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/*.c)
     add_library(mbedtls_test OBJECT ${MBEDTLS_TEST_FILES})

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,17 @@ all: programs tests
 
 no_test: programs
 
-programs: lib
+programs: lib mbedtls_test
 	$(MAKE) -C programs
 
 lib:
 	$(MAKE) -C library
 
-tests: lib
+tests: lib mbedtls_test
 	$(MAKE) -C tests
+
+mbedtls_test:
+	$(MAKE) -C tests mbedtls_test
 
 ifndef WINDOWS
 install: no_test

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -7,9 +7,13 @@ WARNING_CFLAGS ?= -Wall -Wextra
 WARNING_CXXFLAGS ?= -Wall -Wextra
 LDFLAGS ?=
 
-LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
+MBEDTLS_TEST_PATH:=../tests/src
+MBEDTLS_TEST_OBJS:=$(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/*.c))
+
+LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../tests/include -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_CXXFLAGS = $(WARNING_CXXFLAGS) -I../include -D_FILE_OFFSET_BITS=64
-LOCAL_LDFLAGS = -L../library 			\
+LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS} 		\
+		-L../library 			\
 		-lmbedtls$(SHARED_SUFFIX)	\
 		-lmbedx509$(SHARED_SUFFIX)	\
 		-lmbedcrypto$(SHARED_SUFFIX)
@@ -18,10 +22,11 @@ include ../3rdparty/Makefile.inc
 LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)
 
 ifndef SHARED
-DEP=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
+MBEDLIBS=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
 else
-DEP=../library/libmbedcrypto.$(DLEXT) ../library/libmbedx509.$(DLEXT) ../library/libmbedtls.$(DLEXT)
+MBEDLIBS=../library/libmbedcrypto.$(DLEXT) ../library/libmbedx509.$(DLEXT) ../library/libmbedtls.$(DLEXT)
 endif
+DEP=${MBEDLIBS} ${MBEDTLS_TEST_OBJS}
 
 ifdef DEBUG
 LOCAL_CFLAGS += -g3
@@ -127,11 +132,14 @@ ifndef WINDOWS
 all: fuzz
 endif
 
-fuzz:
+fuzz: ${MBEDTLS_TEST_OBJS}
 	$(MAKE) -C fuzz THIRDPARTY_INCLUDES=$(THIRDPARTY_INCLUDES)
 
-$(DEP):
+$(MBEDLIBS):
 	$(MAKE) -C ../library
+
+${MBEDTLS_TEST_OBJS}:
+	$(MAKE) -C ../tests mbedtls_test
 
 ifdef WINDOWS
 EXTRA_GENERATED += psa\psa_constant_names_generated.c

--- a/programs/aes/CMakeLists.txt
+++ b/programs/aes/CMakeLists.txt
@@ -1,9 +1,13 @@
-add_executable(aescrypt2 aescrypt2.c)
-target_link_libraries(aescrypt2 mbedcrypto)
+set(executables
+    aescrypt2
+    crypt_and_hash
+)
 
-add_executable(crypt_and_hash crypt_and_hash.c)
-target_link_libraries(crypt_and_hash mbedcrypto)
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedcrypto)
+endforeach()
 
-install(TARGETS aescrypt2 crypt_and_hash
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/aes/CMakeLists.txt
+++ b/programs/aes/CMakeLists.txt
@@ -4,7 +4,7 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedcrypto)
 endforeach()
 

--- a/programs/fuzz/CMakeLists.txt
+++ b/programs/fuzz/CMakeLists.txt
@@ -11,70 +11,41 @@ if(ENABLE_ZLIB_SUPPORT)
 endif(ENABLE_ZLIB_SUPPORT)
 
 find_library(FUZZINGENGINE_LIB FuzzingEngine)
-
-if(NOT FUZZINGENGINE_LIB)
-    add_executable(fuzz_x509csr fuzz_x509csr.c onefile.c)
-    target_link_libraries(fuzz_x509csr ${libs})
-
-    add_executable(fuzz_x509crl fuzz_x509crl.c onefile.c)
-    target_link_libraries(fuzz_x509crl ${libs})
-
-    add_executable(fuzz_x509crt fuzz_x509crt.c onefile.c)
-    target_link_libraries(fuzz_x509crt ${libs})
-
-    add_executable(fuzz_privkey fuzz_privkey.c onefile.c)
-    target_link_libraries(fuzz_privkey ${libs})
-
-    add_executable(fuzz_pubkey fuzz_pubkey.c onefile.c)
-    target_link_libraries(fuzz_pubkey ${libs})
-
-    add_executable(fuzz_client fuzz_client.c common.c onefile.c)
-    target_link_libraries(fuzz_client ${libs})
-
-    add_executable(fuzz_server fuzz_server.c common.c onefile.c)
-    target_link_libraries(fuzz_server ${libs})
-
-    add_executable(fuzz_dtlsclient fuzz_dtlsclient.c common.c onefile.c)
-    target_link_libraries(fuzz_dtlsclient ${libs})
-
-    add_executable(fuzz_dtlsserver fuzz_dtlsserver.c common.c onefile.c)
-    target_link_libraries(fuzz_dtlsserver ${libs})
-else()
+if(FUZZINGENGINE_LIB)
     project(fuzz CXX)
-
-    add_executable(fuzz_x509csr fuzz_x509csr.c)
-    target_link_libraries(fuzz_x509csr ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_x509csr PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_x509crl fuzz_x509crl.c)
-    target_link_libraries(fuzz_x509crl ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_x509crl PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_x509crt fuzz_x509crt.c)
-    target_link_libraries(fuzz_x509crt ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_x509crt PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_privkey fuzz_privkey.c)
-    target_link_libraries(fuzz_privkey ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_privkey PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_pubkey fuzz_pubkey.c)
-    target_link_libraries(fuzz_pubkey ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_pubkey PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_client fuzz_client.c common.c)
-    target_link_libraries(fuzz_client ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_client PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_server fuzz_server.c common.c)
-    target_link_libraries(fuzz_server ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_server PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_dtlsclient fuzz_dtlsclient.c common.c)
-    target_link_libraries(fuzz_dtlsclient ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_dtlsclient PROPERTIES LINKER_LANGUAGE CXX)
-
-    add_executable(fuzz_dtlsserver fuzz_dtlsserver.c common.c)
-    target_link_libraries(fuzz_dtlsserver ${libs} FuzzingEngine)
-    SET_TARGET_PROPERTIES(fuzz_dtlsserver PROPERTIES LINKER_LANGUAGE CXX)
 endif()
+
+set(executables_no_common_c
+    fuzz_privkey
+    fuzz_pubkey
+    fuzz_x509crl
+    fuzz_x509crt
+    fuzz_x509csr
+)
+
+set(executables_with_common_c
+    fuzz_client
+    fuzz_dtlsclient
+    fuzz_dtlsserver
+    fuzz_server
+)
+
+foreach(exe IN LISTS executables_no_common_c executables_with_common_c)
+
+    add_executable(${exe} ${exe}.c)
+
+    if (NOT FUZZINGENGINE_LIB)
+        target_link_libraries(${exe} ${libs})
+        target_sources(${exe} PRIVATE onefile.c)
+    else()
+        target_link_libraries(${exe} ${libs} FuzzingEngine)
+        SET_TARGET_PROPERTIES(${exe} PROPERTIES LINKER_LANGUAGE CXX)
+    endif()
+
+    # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
+    list(FIND executables_with_common_c ${exe} exe_index)
+    if (${exe_index} GREATER -1)
+        target_sources(${exe} PRIVATE common.c)
+    endif()
+
+endforeach()

--- a/programs/fuzz/CMakeLists.txt
+++ b/programs/fuzz/CMakeLists.txt
@@ -32,7 +32,7 @@ set(executables_with_common_c
 
 foreach(exe IN LISTS executables_no_common_c executables_with_common_c)
 
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
 
     if (NOT FUZZINGENGINE_LIB)
         target_link_libraries(${exe} ${libs})

--- a/programs/fuzz/Makefile
+++ b/programs/fuzz/Makefile
@@ -1,6 +1,9 @@
+MBEDTLS_TEST_PATH:=../../tests/src
+MBEDTLS_TEST_OBJS:=$(patsubst %.c,%.o,$(wildcard ${MBEDTLS_TEST_PATH}/*.c))
 
-LOCAL_CFLAGS = -I../../include -D_FILE_OFFSET_BITS=64
-LOCAL_LDFLAGS = -L../../library			\
+LOCAL_CFLAGS = -I../../tests/include -I../../include -D_FILE_OFFSET_BITS=64
+LOCAL_LDFLAGS = ${MBEDTLS_TEST_OBJS}		\
+		-L../../library			\
 		-lmbedtls$(SHARED_SUFFIX)	\
 		-lmbedx509$(SHARED_SUFFIX)	\
 		-lmbedcrypto$(SHARED_SUFFIX)

--- a/programs/hash/CMakeLists.txt
+++ b/programs/hash/CMakeLists.txt
@@ -1,9 +1,13 @@
-add_executable(hello hello.c)
-target_link_libraries(hello mbedcrypto)
+set(executables
+    generic_sum
+    hello
+)
 
-add_executable(generic_sum generic_sum.c)
-target_link_libraries(generic_sum mbedcrypto)
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedcrypto)
+endforeach()
 
-install(TARGETS hello generic_sum
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/hash/CMakeLists.txt
+++ b/programs/hash/CMakeLists.txt
@@ -4,7 +4,7 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedcrypto)
 endforeach()
 

--- a/programs/pkey/CMakeLists.txt
+++ b/programs/pkey/CMakeLists.txt
@@ -1,63 +1,39 @@
-add_executable(dh_client dh_client.c)
-target_link_libraries(dh_client mbedtls)
+set(executables_mbedtls
+    dh_client
+    dh_server
+)
 
-add_executable(dh_genprime dh_genprime.c)
-target_link_libraries(dh_genprime mbedcrypto)
+foreach(exe IN LISTS executables_mbedtls)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedtls)
+endforeach()
 
-add_executable(dh_server dh_server.c)
-target_link_libraries(dh_server mbedtls)
+set(executables_mbedcrypto
+    dh_genprime
+    ecdh_curve25519
+    ecdsa
+    gen_key
+    key_app
+    key_app_writer
+    mpi_demo
+    pk_encrypt
+    pk_decrypt
+    pk_sign
+    pk_verify
+    rsa_decrypt
+    rsa_encrypt
+    rsa_genkey
+    rsa_sign
+    rsa_sign_pss
+    rsa_verify
+    rsa_verify_pss
+)
 
-add_executable(ecdh_curve25519 ecdh_curve25519.c)
-target_link_libraries(ecdh_curve25519 mbedcrypto)
+foreach(exe IN LISTS executables_mbedcrypto)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedcrypto)
+endforeach()
 
-add_executable(ecdsa ecdsa.c)
-target_link_libraries(ecdsa mbedcrypto)
-
-add_executable(gen_key gen_key.c)
-target_link_libraries(gen_key mbedcrypto)
-
-add_executable(key_app key_app.c)
-target_link_libraries(key_app mbedcrypto)
-
-add_executable(key_app_writer key_app_writer.c)
-target_link_libraries(key_app_writer mbedcrypto)
-
-add_executable(mpi_demo mpi_demo.c)
-target_link_libraries(mpi_demo mbedcrypto)
-
-add_executable(rsa_genkey rsa_genkey.c)
-target_link_libraries(rsa_genkey mbedcrypto)
-
-add_executable(rsa_sign rsa_sign.c)
-target_link_libraries(rsa_sign mbedcrypto)
-
-add_executable(rsa_verify rsa_verify.c)
-target_link_libraries(rsa_verify mbedcrypto)
-
-add_executable(rsa_sign_pss rsa_sign_pss.c)
-target_link_libraries(rsa_sign_pss mbedcrypto)
-
-add_executable(rsa_verify_pss rsa_verify_pss.c)
-target_link_libraries(rsa_verify_pss mbedcrypto)
-
-add_executable(rsa_encrypt rsa_encrypt.c)
-target_link_libraries(rsa_encrypt mbedcrypto)
-
-add_executable(rsa_decrypt rsa_decrypt.c)
-target_link_libraries(rsa_decrypt mbedcrypto)
-
-add_executable(pk_sign pk_sign.c)
-target_link_libraries(pk_sign mbedcrypto)
-
-add_executable(pk_verify pk_verify.c)
-target_link_libraries(pk_verify mbedcrypto)
-
-add_executable(pk_encrypt pk_encrypt.c)
-target_link_libraries(pk_encrypt mbedcrypto)
-
-add_executable(pk_decrypt pk_decrypt.c)
-target_link_libraries(pk_decrypt mbedcrypto)
-
-install(TARGETS dh_client dh_genprime dh_server key_app mpi_demo rsa_genkey rsa_sign rsa_verify rsa_encrypt rsa_decrypt pk_encrypt pk_decrypt pk_sign pk_verify gen_key
+install(TARGETS ${executables_mbedtls} ${executables_mbedcrypto}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/pkey/CMakeLists.txt
+++ b/programs/pkey/CMakeLists.txt
@@ -4,7 +4,7 @@ set(executables_mbedtls
 )
 
 foreach(exe IN LISTS executables_mbedtls)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedtls)
 endforeach()
 
@@ -30,7 +30,7 @@ set(executables_mbedcrypto
 )
 
 foreach(exe IN LISTS executables_mbedcrypto)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedcrypto)
 endforeach()
 

--- a/programs/psa/CMakeLists.txt
+++ b/programs/psa/CMakeLists.txt
@@ -5,8 +5,9 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedtls)
+    target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
 endforeach()
 
 target_include_directories(psa_constant_names PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/programs/psa/CMakeLists.txt
+++ b/programs/psa/CMakeLists.txt
@@ -1,12 +1,15 @@
-add_executable(crypto_examples crypto_examples.c)
-target_link_libraries(crypto_examples mbedtls)
+set(executables
+    crypto_examples
+    key_ladder_demo
+    psa_constant_names
+)
 
-add_executable(key_ladder_demo key_ladder_demo.c)
-target_link_libraries(key_ladder_demo mbedtls)
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedtls)
+endforeach()
 
-add_executable(psa_constant_names psa_constant_names.c)
 target_include_directories(psa_constant_names PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(psa_constant_names mbedtls)
 
 add_custom_target(
     psa_constant_names_generated
@@ -15,10 +18,7 @@ add_custom_target(
 )
 add_dependencies(psa_constant_names psa_constant_names_generated)
 
-install(TARGETS
-            crypto_examples
-            key_ladder_demo
-            psa_constant_names
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 

--- a/programs/psa/CMakeLists.txt
+++ b/programs/psa/CMakeLists.txt
@@ -6,7 +6,7 @@ set(executables
 
 foreach(exe IN LISTS executables)
     add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
-    target_link_libraries(${exe} mbedtls)
+    target_link_libraries(${exe} mbedcrypto)
     target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
 endforeach()
 

--- a/programs/random/CMakeLists.txt
+++ b/programs/random/CMakeLists.txt
@@ -5,7 +5,7 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} mbedcrypto)
 endforeach()
 

--- a/programs/random/CMakeLists.txt
+++ b/programs/random/CMakeLists.txt
@@ -1,12 +1,14 @@
-add_executable(gen_random_havege gen_random_havege.c)
-target_link_libraries(gen_random_havege mbedcrypto)
+set(executables
+    gen_entropy
+    gen_random_ctr_drbg
+    gen_random_havege
+)
 
-add_executable(gen_random_ctr_drbg gen_random_ctr_drbg.c)
-target_link_libraries(gen_random_ctr_drbg mbedcrypto)
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} mbedcrypto)
+endforeach()
 
-add_executable(gen_entropy gen_entropy.c)
-target_link_libraries(gen_entropy mbedcrypto)
-
-install(TARGETS gen_random_havege gen_random_ctr_drbg gen_entropy
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -39,7 +39,7 @@ add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
 add_executable(ssl_client2 ssl_client2.c)
-target_sources(ssl_client2 PUBLIC ../test/query_config.c)
+target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
 target_link_libraries(ssl_client2 ${libs})
 
 add_executable(ssl_context_info ssl_context_info.c)
@@ -55,7 +55,7 @@ add_executable(ssl_server ssl_server.c)
 target_link_libraries(ssl_server ${libs})
 
 add_executable(ssl_server2 ssl_server2.c)
-target_sources(ssl_server2 PUBLIC ../test/query_config.c)
+target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
 target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -27,15 +27,16 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} ${libs})
+    target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
 endforeach()
 
 target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
 target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
 
 if(THREADS_FOUND)
-    add_executable(ssl_pthread_server ssl_pthread_server.c)
+    add_executable(ssl_pthread_server ssl_pthread_server.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(ssl_pthread_server ${libs} ${CMAKE_THREAD_LIBS_INIT})
     list(APPEND executables ssl_pthread_server)
 endif(THREADS_FOUND)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -11,9 +11,11 @@ set(targets
     mini_client
     ssl_client1
     ssl_client2
+    ssl_context_info
     ssl_fork_server
     ssl_mail_client
     ssl_server
+    ssl_server2
 )
 
 if(USE_PKCS11_HELPER_LIBRARY)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -5,7 +5,15 @@ set(libs
     mbedtls
 )
 
-set(targets
+if(USE_PKCS11_HELPER_LIBRARY)
+    set(libs ${libs} pkcs11-helper)
+endif(USE_PKCS11_HELPER_LIBRARY)
+
+if(ENABLE_ZLIB_SUPPORT)
+    set(libs ${libs} ${ZLIB_LIBRARIES})
+endif(ENABLE_ZLIB_SUPPORT)
+
+set(executables
     dtls_client
     dtls_server
     mini_client
@@ -18,52 +26,20 @@ set(targets
     ssl_server2
 )
 
-if(USE_PKCS11_HELPER_LIBRARY)
-    set(libs ${libs} pkcs11-helper)
-endif(USE_PKCS11_HELPER_LIBRARY)
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} ${libs})
+endforeach()
 
-if(ENABLE_ZLIB_SUPPORT)
-    set(libs ${libs} ${ZLIB_LIBRARIES})
-endif(ENABLE_ZLIB_SUPPORT)
-
-add_executable(dtls_client dtls_client.c)
-target_link_libraries(dtls_client ${libs})
-
-add_executable(dtls_server dtls_server.c)
-target_link_libraries(dtls_server ${libs})
-
-add_executable(mini_client mini_client.c)
-target_link_libraries(mini_client ${libs})
-
-add_executable(ssl_client1 ssl_client1.c)
-target_link_libraries(ssl_client1 ${libs})
-
-add_executable(ssl_client2 ssl_client2.c)
 target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
-target_link_libraries(ssl_client2 ${libs})
-
-add_executable(ssl_context_info ssl_context_info.c)
-target_link_libraries(ssl_context_info ${libs})
-
-add_executable(ssl_fork_server ssl_fork_server.c)
-target_link_libraries(ssl_fork_server ${libs})
-
-add_executable(ssl_mail_client ssl_mail_client.c)
-target_link_libraries(ssl_mail_client ${libs})
-
-add_executable(ssl_server ssl_server.c)
-target_link_libraries(ssl_server ${libs})
-
-add_executable(ssl_server2 ssl_server2.c)
 target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
-target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)
     add_executable(ssl_pthread_server ssl_pthread_server.c)
     target_link_libraries(ssl_pthread_server ${libs} ${CMAKE_THREAD_LIBS_INIT})
-    set(targets ${targets} ssl_pthread_server)
+    list(APPEND executables ssl_pthread_server)
 endif(THREADS_FOUND)
 
-install(TARGETS ${targets}
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -30,19 +30,15 @@ target_link_libraries(dtls_client ${libs})
 add_executable(dtls_server dtls_server.c)
 target_link_libraries(dtls_server ${libs})
 
+add_executable(mini_client mini_client.c)
+target_link_libraries(mini_client ${libs})
+
 add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
 add_executable(ssl_client2 ssl_client2.c)
 target_sources(ssl_client2 PUBLIC ../test/query_config.c)
 target_link_libraries(ssl_client2 ${libs})
-
-add_executable(ssl_server ssl_server.c)
-target_link_libraries(ssl_server ${libs})
-
-add_executable(ssl_server2 ssl_server2.c)
-target_sources(ssl_server2 PUBLIC ../test/query_config.c)
-target_link_libraries(ssl_server2 ${libs})
 
 add_executable(ssl_context_info ssl_context_info.c)
 target_link_libraries(ssl_context_info ${libs})
@@ -53,8 +49,12 @@ target_link_libraries(ssl_fork_server ${libs})
 add_executable(ssl_mail_client ssl_mail_client.c)
 target_link_libraries(ssl_mail_client ${libs})
 
-add_executable(mini_client mini_client.c)
-target_link_libraries(mini_client ${libs})
+add_executable(ssl_server ssl_server.c)
+target_link_libraries(ssl_server ${libs})
+
+add_executable(ssl_server2 ssl_server2.c)
+target_sources(ssl_server2 PUBLIC ../test/query_config.c)
+target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)
     add_executable(ssl_pthread_server ssl_pthread_server.c)

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -74,6 +74,8 @@ int main( void )
 #include "mbedtls/psa_util.h"
 #endif
 
+#include <test/helpers.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1016,45 +1018,6 @@ int idle( mbedtls_net_context *fd,
     return( 0 );
 }
 
-/* Unhexify `hex` into `dst`. `dst` must have
- * size at least `strlen( hex ) / 2`. */
-int unhexify( char const *hex, unsigned char *dst )
-{
-    unsigned char c;
-    size_t j;
-    size_t len = strlen( hex );
-
-    if( len % 2 != 0 )
-        return( -1 );
-
-    for( j = 0; j < len; j += 2 )
-    {
-        c = hex[j];
-        if( c >= '0' && c <= '9' )
-            c -= '0';
-        else if( c >= 'a' && c <= 'f' )
-            c -= 'a' - 10;
-        else if( c >= 'A' && c <= 'F' )
-            c -= 'A' - 10;
-        else
-            return( -1 );
-        dst[ j / 2 ] = c << 4;
-
-        c = hex[j + 1];
-        if( c >= '0' && c <= '9' )
-            c -= '0';
-        else if( c >= 'a' && c <= 'f' )
-            c -= 'a' - 10;
-        else if( c >= 'A' && c <= 'F' )
-            c -= 'A' - 10;
-        else
-            return( -1 );
-        dst[ j / 2 ] |= c;
-    }
-
-    return( 0 );
-}
-
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 int report_cid_usage( mbedtls_ssl_context *ssl,
                       const char *additional_description )
@@ -1785,16 +1748,10 @@ int main( int argc, char *argv[] )
      */
     if( strlen( opt.psk ) )
     {
-        psk_len = strlen( opt.psk ) / 2;
-        if( psk_len > sizeof( psk ) )
+        if( mbedtls_test_unhexify( psk, sizeof( psk ),
+                                   opt.psk, &psk_len ) != 0 )
         {
-            mbedtls_printf( "pre-shared key too long\n" );
-            goto exit;
-        }
-
-        if( unhexify( opt.psk, psk ) != 0 )
-        {
-            mbedtls_printf( "pre-shared key not valid hex\n" );
+            mbedtls_printf( "pre-shared key not valid\n" );
             goto exit;
         }
     }
@@ -1896,16 +1853,10 @@ int main( int argc, char *argv[] )
     }
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-    cid_len = strlen( opt.cid_val ) / 2;
-    if( cid_len > sizeof( cid ) )
+    if( mbedtls_test_unhexify( cid, sizeof( cid ),
+                               opt.cid_val, &cid_len ) != 0 )
     {
-        mbedtls_printf( "CID too long\n" );
-        goto exit;
-    }
-
-    if( unhexify( opt.cid_val, cid ) != 0 )
-    {
-        mbedtls_printf( "CID not valid hex\n" );
+        mbedtls_printf( "CID not valid\n" );
         goto exit;
     }
 
@@ -1916,16 +1867,10 @@ int main( int argc, char *argv[] )
     if( opt.cid_val_renego == DFL_CID_VALUE_RENEGO )
         opt.cid_val_renego = opt.cid_val;
 
-    cid_renego_len = strlen( opt.cid_val_renego ) / 2;
-    if( cid_renego_len > sizeof( cid_renego ) )
+    if( mbedtls_test_unhexify( cid_renego, sizeof( cid_renego ),
+                               opt.cid_val_renego, &cid_renego_len ) != 0 )
     {
-        mbedtls_printf( "CID too long\n" );
-        goto exit;
-    }
-
-    if( unhexify( opt.cid_val_renego, cid_renego ) != 0 )
-    {
-        mbedtls_printf( "CID not valid hex\n" );
+        mbedtls_printf( "CID not valid\n" );
         goto exit;
     }
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -70,6 +70,8 @@ int main( void )
 #include "mbedtls/psa_util.h"
 #endif
 
+#include <test/helpers.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1202,52 +1204,6 @@ int sni_callback( void *p_info, mbedtls_ssl_context *ssl,
 
 #endif /* SNI_OPTION */
 
-#if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED) || \
-    defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-
-#define HEX2NUM( c )                        \
-    do                                      \
-    {                                       \
-        if( (c) >= '0' && (c) <= '9' )      \
-            (c) -= '0';                     \
-        else if( (c) >= 'a' && (c) <= 'f' ) \
-            (c) -= 'a' - 10;                \
-        else if( (c) >= 'A' && (c) <= 'F' ) \
-            (c) -= 'A' - 10;                \
-        else                                \
-            return( -1 );                   \
-    } while( 0 )
-
-/*
- * Convert a hex string to bytes.
- * Return 0 on success, -1 on error.
- */
-int unhexify( unsigned char *output, const char *input, size_t *olen )
-{
-    unsigned char c;
-    size_t j;
-
-    *olen = strlen( input );
-    if( *olen % 2 != 0 || *olen / 2 > MBEDTLS_PSK_MAX_LEN )
-        return( -1 );
-    *olen /= 2;
-
-    for( j = 0; j < *olen * 2; j += 2 )
-    {
-        c = input[j];
-        HEX2NUM( c );
-        output[ j / 2 ] = c << 4;
-
-        c = input[j + 1];
-        HEX2NUM( c );
-        output[ j / 2 ] |= c;
-    }
-
-    return( 0 );
-}
-
-#endif
-
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
 
 typedef struct _psk_entry psk_entry;
@@ -1319,7 +1275,8 @@ psk_entry *psk_parse( char *psk_string )
         GET_ITEM( new->name );
         GET_ITEM( key_hex );
 
-        if( unhexify( new->key, key_hex, &new->key_len ) != 0 )
+        if( mbedtls_test_unhexify( new->key, MBEDTLS_PSK_MAX_LEN,
+                                   key_hex, &new->key_len ) != 0 )
             goto error;
 
         new->next = cur;
@@ -2632,7 +2589,8 @@ int main( int argc, char *argv[] )
     }
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-    if( unhexify( cid, opt.cid_val, &cid_len ) != 0 )
+    if( mbedtls_test_unhexify( cid, sizeof( cid ),
+                               opt.cid_val, &cid_len ) != 0 )
     {
         mbedtls_printf( "CID not valid hex\n" );
         goto exit;
@@ -2645,7 +2603,8 @@ int main( int argc, char *argv[] )
     if( opt.cid_val_renego == DFL_CID_VALUE_RENEGO )
         opt.cid_val_renego = opt.cid_val;
 
-    if( unhexify( cid_renego, opt.cid_val_renego, &cid_renego_len ) != 0 )
+    if( mbedtls_test_unhexify( cid_renego, sizeof( cid_renego ),
+                               opt.cid_val_renego, &cid_renego_len ) != 0 )
     {
         mbedtls_printf( "CID not valid hex\n" );
         goto exit;
@@ -2656,7 +2615,8 @@ int main( int argc, char *argv[] )
     /*
      * Unhexify the pre-shared key and parse the list if any given
      */
-    if( unhexify( psk, opt.psk, &psk_len ) != 0 )
+    if( mbedtls_test_unhexify( psk, sizeof( psk ),
+                               opt.psk, &psk_len ) != 0 )
     {
         mbedtls_printf( "pre-shared key not valid hex\n" );
         goto exit;

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(zeroize zeroize.c)
 target_link_libraries(zeroize mbedcrypto)
 
 add_executable(query_compile_time_config query_compile_time_config.c)
-target_sources(query_compile_time_config PUBLIC query_config.c)
+target_sources(query_compile_time_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 target_link_libraries(query_compile_time_config mbedcrypto)
 
 install(TARGETS selftest benchmark udp_proxy query_compile_time_config

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -10,27 +10,35 @@ if(ENABLE_ZLIB_SUPPORT)
     set(libs ${libs} ${ZLIB_LIBRARIES})
 endif(ENABLE_ZLIB_SUPPORT)
 
-add_executable(selftest selftest.c)
-target_link_libraries(selftest ${libs})
+set(executables_libs
+    selftest
+    udp_proxy
+)
 
-add_executable(benchmark benchmark.c)
-target_link_libraries(benchmark mbedcrypto)
+set(executables_mbedcrypto
+    benchmark
+    query_compile_time_config
+    zeroize
+)
 
 if(TEST_CPP)
-    add_executable(cpp_dummy_build cpp_dummy_build.cpp)
-    target_link_libraries(cpp_dummy_build mbedcrypto)
+    list(APPEND executables_mbedcrypto cpp_dummy_build)
 endif()
 
-add_executable(udp_proxy udp_proxy.c)
-target_link_libraries(udp_proxy ${libs})
+foreach(exe IN LISTS executables_libs executables_mbedcrypto)
+    add_executable(${exe} ${exe}.c)
 
-add_executable(zeroize zeroize.c)
-target_link_libraries(zeroize mbedcrypto)
+    # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
+    list(FIND executables_libs ${exe} exe_index)
+    if (${exe_index} GREATER -1)
+        target_link_libraries(${exe} ${libs})
+    else()
+        target_link_libraries(${exe} mbedcrypto)
+    endif()
+endforeach()
 
-add_executable(query_compile_time_config query_compile_time_config.c)
 target_sources(query_compile_time_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
-target_link_libraries(query_compile_time_config mbedcrypto)
 
-install(TARGETS selftest benchmark udp_proxy query_compile_time_config
+install(TARGETS ${executables_libs} ${executables_mbedcrypto}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -26,7 +26,7 @@ if(TEST_CPP)
 endif()
 
 foreach(exe IN LISTS executables_libs executables_mbedcrypto)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
 
     # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
     list(FIND executables_libs ${exe} exe_index)

--- a/programs/util/CMakeLists.txt
+++ b/programs/util/CMakeLists.txt
@@ -2,12 +2,16 @@ set(libs
     mbedcrypto
 )
 
-add_executable(strerror strerror.c)
-target_link_libraries(strerror ${libs})
+set(executables
+    pem2der
+    strerror
+)
 
-add_executable(pem2der pem2der.c)
-target_link_libraries(pem2der ${libs})
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} ${libs})
+endforeach()
 
-install(TARGETS strerror pem2der
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/util/CMakeLists.txt
+++ b/programs/util/CMakeLists.txt
@@ -8,7 +8,7 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} ${libs})
 endforeach()
 

--- a/programs/x509/CMakeLists.txt
+++ b/programs/x509/CMakeLists.txt
@@ -10,21 +10,21 @@ if(ENABLE_ZLIB_SUPPORT)
     set(libs ${libs} ${ZLIB_LIBRARIES})
 endif(ENABLE_ZLIB_SUPPORT)
 
-add_executable(cert_app cert_app.c)
-target_link_libraries(cert_app ${libs} mbedtls)
+set(executables
+    cert_app
+    cert_req
+    cert_write
+    crl_app
+    req_app
+)
 
-add_executable(crl_app crl_app.c)
-target_link_libraries(crl_app ${libs})
+foreach(exe IN LISTS executables)
+    add_executable(${exe} ${exe}.c)
+    target_link_libraries(${exe} ${libs})
+endforeach()
 
-add_executable(req_app req_app.c)
-target_link_libraries(req_app ${libs})
+target_link_libraries(cert_app mbedtls)
 
-add_executable(cert_req cert_req.c)
-target_link_libraries(cert_req ${libs})
-
-add_executable(cert_write cert_write.c)
-target_link_libraries(cert_write ${libs})
-
-install(TARGETS cert_app crl_app req_app cert_req cert_write
+install(TARGETS ${executables}
         DESTINATION "bin"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/programs/x509/CMakeLists.txt
+++ b/programs/x509/CMakeLists.txt
@@ -19,7 +19,7 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c)
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(${exe} ${libs})
 endforeach()
 

--- a/scripts/generate_visualc_files.pl
+++ b/scripts/generate_visualc_files.pl
@@ -39,6 +39,8 @@ my $programs_dir = 'programs';
 my $mbedtls_header_dir = 'include/mbedtls';
 my $psa_header_dir = 'include/psa';
 my $source_dir = 'library';
+my $test_source_dir = 'tests/src';
+my $test_header_dir = 'tests/include/test';
 
 my @thirdparty_header_dirs = qw(
     3rdparty/everest/include/everest
@@ -58,6 +60,7 @@ my @include_directories = qw(
     3rdparty/everest/include/everest
     3rdparty/everest/include/everest/vs2010
     3rdparty/everest/include/everest/kremlib
+    tests/include
 );
 my $include_directories = join(';', map {"../../$_"} @include_directories);
 
@@ -104,6 +107,8 @@ sub check_dirs {
         && -d $mbedtls_header_dir
         && -d $psa_header_dir
         && -d $source_dir
+        && -d $test_source_dir
+        && -d $test_header_dir
         && -d $programs_dir;
 }
 
@@ -249,12 +254,14 @@ sub main {
     my @header_dirs = (
                        $mbedtls_header_dir,
                        $psa_header_dir,
+                       $test_header_dir,
                        $source_dir,
                        @thirdparty_header_dirs,
                       );
     my @headers = (map { <$_/*.h> } @header_dirs);
     my @source_dirs = (
                        $source_dir,
+                       $test_source_dir,
                        @thirdparty_source_dirs,
                       );
     my @sources = (map { <$_/*.c> } @source_dirs);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ function(add_test_suite suite_name)
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_test_code.py mbedtls ${CMAKE_CURRENT_SOURCE_DIR}/suites/helpers.function ${CMAKE_CURRENT_SOURCE_DIR}/suites/main_test.function ${CMAKE_CURRENT_SOURCE_DIR}/suites/host_test.function ${CMAKE_CURRENT_SOURCE_DIR}/suites/test_suite_${suite_name}.function ${CMAKE_CURRENT_SOURCE_DIR}/suites/test_suite_${data_name}.data
     )
 
-    add_executable(test_suite_${data_name} test_suite_${data_name}.c $<TARGET_OBJECTS:mbedtests>)
+    add_executable(test_suite_${data_name} test_suite_${data_name}.c $<TARGET_OBJECTS:mbedtls_test>)
     target_link_libraries(test_suite_${data_name} ${libs})
     target_include_directories(test_suite_${data_name}
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -69,9 +69,9 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX-")
 endif(MSVC)
 
-file(GLOB MBEDTESTS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
-add_library(mbedtests OBJECT ${MBEDTESTS_FILES})
-target_include_directories(mbedtests
+file(GLOB MBEDTLS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
+add_library(mbedtls_test OBJECT ${MBEDTLS_TEST_FILES})
+target_include_directories(mbedtls_test
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../library)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,13 +69,6 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX-")
 endif(MSVC)
 
-file(GLOB MBEDTLS_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
-add_library(mbedtls_test OBJECT ${MBEDTLS_TEST_FILES})
-target_include_directories(mbedtls_test
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../library)
-
 add_test_suite(aes aes.cbc)
 add_test_suite(aes aes.cfb)
 add_test_suite(aes aes.ecb)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -77,7 +77,7 @@ all: $(BINARIES)
 $(MBEDLIBS):
 	$(MAKE) -C ../library
 
-MBEDTESTS_OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c))
+MBEDTLS_TEST_OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c))
 
 # Rule to compile common test C files in src folder
 src/%.o : src/%.c
@@ -112,9 +112,9 @@ C_FILES := $(addsuffix .c,$(APPS))
 		-o .
 
 
-$(BINARIES): %$(EXEXT): %.c $(MBEDLIBS) $(MBEDTESTS_OBJS)
+$(BINARIES): %$(EXEXT): %.c $(MBEDLIBS) $(MBEDTLS_TEST_OBJS)
 	echo "  CC    $<"
-	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $< $(MBEDTESTS_OBJS) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
+	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $< $(MBEDTLS_TEST_OBJS) $(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 # Some test suites require additional header files.
 $(filter test_suite_psa_crypto%, $(BINARIES)): include/test/psa_crypto_helpers.h

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,6 +79,8 @@ $(MBEDLIBS):
 
 MBEDTLS_TEST_OBJS=$(patsubst %.c,%.o,$(wildcard src/*.c))
 
+mbedtls_test: $(MBEDTLS_TEST_OBJS)
+
 # Rule to compile common test C files in src folder
 src/%.o : src/%.c
 	echo "  CC    $<"

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -54,7 +54,29 @@
 int mbedtls_test_platform_setup( void );
 void mbedtls_test_platform_teardown( void );
 
-int mbedtls_test_unhexify( unsigned char *obuf, const char *ibuf );
+/**
+ * \brief          This function translates an ASCII string encoding an
+ *                 hexadecimal number into the encoded hexadecimal number. The
+ *                 hexadecimal number is represented as an array of
+ *                 unsigned char.
+ *
+ * \note           The output buffer can be the same as the input buffer. For
+ *                 any other overlapping of the input and output buffers, the
+ *                 behavior is undefined.
+ *
+ * \param obuf     Output buffer.
+ * \param obufmax  Size in number of bytes of \p obuf.
+ * \param ibuf     Input buffer.
+ * \param len      The number of unsigned char written in \p obuf. This must
+ *                 not be \c NULL.
+ *
+ * \return         \c 0 on success.
+ * \return         \c -1 if the output buffer is too small or the input string
+ *                 is not a valid ASCII encoding of an hexadecimal number.
+ */
+int mbedtls_test_unhexify( unsigned char *obuf, size_t obufmax,
+                           const char *ibuf, size_t *len );
+
 void mbedtls_test_hexify( unsigned char *obuf,
                           const unsigned char *ibuf,
                           int len );

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -277,8 +277,13 @@ static int convert_params( size_t cnt , char ** params , int * int_params_store 
         {
             if ( verify_string( &val ) == 0 )
             {
-                *int_params_store = mbedtls_test_unhexify(
-                                        (unsigned char *) val, val );
+                size_t len;
+
+                TEST_HELPER_ASSERT(
+                  mbedtls_test_unhexify( (unsigned char *) val, strlen( val ),
+                                         val, &len ) == 0 );
+
+                *int_params_store = len;
                 *out++ = val;
                 *out++ = (char *)(int_params_store++);
             }

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -70,12 +70,16 @@ uint8_t receive_byte()
 {
     uint8_t byte;
     uint8_t c[3];
-    char *endptr;
+    size_t len;
+
     c[0] = greentea_getc();
     c[1] = greentea_getc();
     c[2] = '\0';
 
-    TEST_HELPER_ASSERT( mbedtls_test_unhexify( &byte, c ) != 2 );
+    TEST_HELPER_ASSERT( mbedtls_test_unhexify( &byte, sizeof( byte ),
+                                               c, &len ) == 0 );
+    TEST_HELPER_ASSERT( len != 2 );
+
     return( byte );
 }
 
@@ -90,6 +94,7 @@ uint8_t receive_byte()
 uint32_t receive_uint32()
 {
     uint32_t value;
+    size_t len;
     const uint8_t c_be[8] = { greentea_getc(),
                               greentea_getc(),
                               greentea_getc(),
@@ -101,7 +106,11 @@ uint32_t receive_uint32()
                              };
     const uint8_t c[9] = { c_be[6], c_be[7], c_be[4], c_be[5], c_be[2],
                            c_be[3], c_be[0], c_be[1], '\0' };
-    TEST_HELPER_ASSERT( mbedtls_test_unhexify( (uint8_t*)&value, c ) != 8 );
+
+    TEST_HELPER_ASSERT( mbedtls_test_unhexify( (uint8_t*)&value, sizeof( value ),
+                                               c, &len ) == 0 );
+    TEST_HELPER_ASSERT( len != 8 );
+
     return( value );
 }
 

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -329,13 +329,13 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_OFB */
 void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
                       char *hex_iv_string, char *hex_src_string,
-                      char *hex_dst_string )
+                      char *hex_expected_output_string )
 {
     unsigned char key_str[32];
     unsigned char iv_str[16];
     unsigned char src_str[64];
-    unsigned char dst_str[64];
     unsigned char output[32];
+    unsigned char output_string[65];
     mbedtls_aes_context ctx;
     size_t iv_offset = 0;
     int in_buffer_len;
@@ -345,14 +345,15 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
+    memset( output_string, 0x00, sizeof( output_string ) );
     mbedtls_aes_init( &ctx );
 
+    TEST_ASSERT( (size_t)fragment_size < sizeof( output ) );
     TEST_ASSERT( strlen( hex_key_string ) <= ( 32 * 2 ) );
     TEST_ASSERT( strlen( hex_iv_string ) <= ( 16 * 2 ) );
     TEST_ASSERT( strlen( hex_src_string ) <= ( 64 * 2 ) );
-    TEST_ASSERT( strlen( hex_dst_string ) <= ( 64 * 2 ) );
+    TEST_ASSERT( strlen( hex_expected_output_string ) <= ( 64 * 2 ) );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
@@ -366,12 +367,12 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
                                             iv_str, src_str_next, output ) == 0 );
 
-        mbedtls_test_hexify( dst_str, output, fragment_size );
-        TEST_ASSERT( strncmp( (char *) dst_str, hex_dst_string,
+        mbedtls_test_hexify( output_string, output, fragment_size );
+        TEST_ASSERT( strncmp( (char *) output_string, hex_expected_output_string,
                               ( 2 * fragment_size ) ) == 0 );
 
         in_buffer_len -= fragment_size;
-        hex_dst_string += ( fragment_size * 2 );
+        hex_expected_output_string += ( fragment_size * 2 );
         src_str_next += fragment_size;
 
         if( in_buffer_len < fragment_size )

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -327,52 +327,39 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_OFB */
-void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
-                      char *hex_iv_string, char *hex_src_string,
-                      char *hex_expected_output_string )
+void aes_encrypt_ofb( int fragment_size, data_t *key_str,
+                      data_t *iv_str, data_t *src_str,
+                      char *expected_output_string)
 {
-    unsigned char key_str[32];
-    unsigned char iv_str[16];
-    unsigned char src_str[64];
     unsigned char output[32];
     unsigned char output_string[65];
     mbedtls_aes_context ctx;
     size_t iv_offset = 0;
     int in_buffer_len;
     unsigned char* src_str_next;
-    int key_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( output, 0x00, sizeof( output ) );
     memset( output_string, 0x00, sizeof( output_string ) );
     mbedtls_aes_init( &ctx );
 
     TEST_ASSERT( (size_t)fragment_size < sizeof( output ) );
-    TEST_ASSERT( strlen( hex_key_string ) <= ( 32 * 2 ) );
-    TEST_ASSERT( strlen( hex_iv_string ) <= ( 16 * 2 ) );
-    TEST_ASSERT( strlen( hex_src_string ) <= ( 64 * 2 ) );
-    TEST_ASSERT( strlen( hex_expected_output_string ) <= ( 64 * 2 ) );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    in_buffer_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aes_setkey_enc( &ctx, key_str, key_len * 8 ) == 0 );
-    src_str_next = src_str;
+    TEST_ASSERT( mbedtls_aes_setkey_enc( &ctx, key_str->x,
+                                         key_str->len * 8 ) == 0 );
+    in_buffer_len = src_str->len;
+    src_str_next = src_str->x;
 
     while( in_buffer_len > 0 )
     {
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
-                                            iv_str, src_str_next, output ) == 0 );
+                                            iv_str->x, src_str_next, output ) == 0 );
 
         mbedtls_test_hexify( output_string, output, fragment_size );
-        TEST_ASSERT( strncmp( (char *) output_string, hex_expected_output_string,
+        TEST_ASSERT( strncmp( (char *) output_string, expected_output_string,
                               ( 2 * fragment_size ) ) == 0 );
 
         in_buffer_len -= fragment_size;
-        hex_expected_output_string += ( fragment_size * 2 );
+        expected_output_string += ( fragment_size * 2 );
         src_str_next += fragment_size;
 
         if( in_buffer_len < fragment_size )

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -214,7 +214,7 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len, i;
+    size_t key_len, src_str_len, i;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
@@ -223,18 +223,18 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     mbedtls_aria_init( &ctx );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                                                  == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -253,7 +253,7 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len, i;
+    size_t key_len, src_str_len, i;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
@@ -262,18 +262,18 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     mbedtls_aria_init( &ctx );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                          == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -294,7 +294,7 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -305,15 +305,15 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, data_len,
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, src_str_len,
                                          iv_str, src_str, output )
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -334,7 +334,7 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -345,15 +345,15 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, data_len,
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, src_str_len,
                                          iv_str, src_str, output )
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -375,7 +375,7 @@ void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -386,14 +386,14 @@ void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT,
-                                            data_len, &iv_offset, iv_str,
+                                            src_str_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -414,7 +414,7 @@ void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -425,14 +425,14 @@ void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT,
-                                            data_len, &iv_offset, iv_str,
+                                            src_str_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -454,7 +454,7 @@ void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -465,13 +465,13 @@ void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -493,7 +493,7 @@ void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -504,13 +504,13 @@ void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -206,35 +206,28 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
+void aria_encrypt_ecb( data_t *key_str, data_t *src_str,
                        char *hex_dst_string, int setkey_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len, i;
+    size_t i;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 )
+    TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str->len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
-                                                 == 0 );
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
+                                                 output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -245,35 +238,28 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
+void aria_decrypt_ecb( data_t *key_str, data_t *src_str,
                        char *hex_dst_string, int setkey_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len, i;
+    size_t i;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 )
+    TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str->x, key_str->len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str->len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
-                         == 0 );
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
+                                                 output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -284,36 +270,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
-void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_cbc( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int cbc_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, src_str_len,
-                                         iv_str, src_str, output )
-                 == cbc_result );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT,
+                                         src_str->len, iv_str->x, src_str->x,
+                                         output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -324,36 +299,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
-void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_cbc( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int cbc_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, src_str_len,
-                                         iv_str, src_str, output )
-                 == cbc_result );
+    mbedtls_aria_setkey_dec( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT,
+                                         src_str->len, iv_str->x, src_str->x,
+                                         output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -364,36 +328,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
-void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
-                          char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_cfb128( data_t *key_str, data_t *iv_str,
+                          data_t *src_str, char *hex_dst_string,
                           int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT,
-                                            src_str_len, &iv_offset, iv_str,
-                                            src_str, output )
+                                            src_str->len, &iv_offset,
+                                            iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -403,36 +356,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
-void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
-                          char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_cfb128( data_t *key_str, data_t *iv_str,
+                          data_t *src_str, char *hex_dst_string,
                           int result  )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT,
-                                            src_str_len, &iv_offset, iv_str,
-                                            src_str, output )
+                                            src_str->len, &iv_offset,
+                                            iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -442,36 +384,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
-void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_ctr( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
-                                         blk, src_str, output )
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
+                                         iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -481,36 +412,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
-void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_ctr( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
-                                         blk, src_str, output )
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
+                                         iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -192,69 +192,51 @@ exit:
 
 /* BEGIN_CASE */
 void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
-                            char *key_hex, char *msg_hex,
-                            char *source_address_hex, char *frame_counter_hex,
-                            int sec_level, char *add_hex,
-                            char *expected_result_hex, int output_ret )
+                            data_t *key, data_t *msg,
+                            data_t *source_address, data_t *frame_counter,
+                            int sec_level, data_t *add,
+                            data_t *expected_result, int output_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[50];
     unsigned char iv[13];
-    unsigned char add[32];
     unsigned char result[50];
-    unsigned char expected_result[50];
-    unsigned char source_address[8];
-    unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, expected_result_len, source_address_len, frame_counter_len, tag_len;
+    size_t i, iv_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
-    memset( add, 0x00, sizeof( add ) );
     memset( result, 0x00, sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
-    memset( source_address, 0x00, sizeof( source_address ) );
-    memset( frame_counter, 0x00, sizeof( frame_counter ) );
-
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    add_len = mbedtls_test_unhexify( add, add_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address,
-                                                source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter,
-                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
     else
         tag_len = 1 << ( sec_level % 4 + 1);
 
-    for( i = 0; i < source_address_len; i++ )
-        iv[i] = source_address[i];
+    for( i = 0; i < source_address->len; i++ )
+        iv[i] = source_address->x[i];
 
-    for( i = 0; i < frame_counter_len; i++ )
-        iv[source_address_len + i] = frame_counter[i];
+    for( i = 0; i < frame_counter->len; i++ )
+        iv[source_address->len + i] = frame_counter->x[i];
 
-    iv[source_address_len + frame_counter_len] = sec_level;
+    iv[source_address->len + frame_counter->len] = sec_level;
     iv_len = sizeof( iv );
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id,
+                                     key->x, key->len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, result, result + msg_len, tag_len );
+    ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg->len, iv, iv_len,
+                                            add->x, add->len, msg->x,
+                                            result, result + msg->len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( result,
+                         expected_result->x, expected_result->len ) == 0 );
 
     /* Check we didn't write past the end */
-    TEST_ASSERT( result[expected_result_len] == 0 &&
-                 result[expected_result_len + 1] == 0 );
+    TEST_ASSERT( result[expected_result->len] == 0 &&
+                 result[expected_result->len + 1] == 0 );
 
 exit:
     mbedtls_ccm_free( &ctx );
@@ -263,70 +245,51 @@ exit:
 
 /* BEGIN_CASE */
 void mbedtls_ccm_star_auth_decrypt( int cipher_id,
-                            char *key_hex, char *msg_hex,
-                            char *source_address_hex, char *frame_counter_hex,
-                            int sec_level, char *add_hex,
-                            char *expected_result_hex, int output_ret )
+                            data_t *key, data_t *msg,
+                            data_t *source_address, data_t *frame_counter,
+                            int sec_level, data_t *add,
+                            data_t *expected_result, int output_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[50];
     unsigned char iv[13];
-    unsigned char add[32];
     unsigned char result[50];
-    unsigned char expected_result[50];
-    unsigned char source_address[8];
-    unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, tag_len, expected_result_len, source_address_len, frame_counter_len;
+    size_t i, iv_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
-    memset( add, 0x00, sizeof( add ) );
     memset( result, '+', sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
-    memset( source_address, 0x00, sizeof( source_address ) );
-    memset( frame_counter, 0x00, sizeof( frame_counter ) );
-
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    add_len = mbedtls_test_unhexify( add, add_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address,
-                                                source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter,
-                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
     else
         tag_len = 1 << ( sec_level % 4 + 1);
 
-    for( i = 0; i < source_address_len; i++ )
-        iv[i] = source_address[i];
+    for( i = 0; i < source_address->len; i++ )
+        iv[i] = source_address->x[i];
 
-    for( i = 0; i < frame_counter_len; i++ )
-        iv[source_address_len + i] = frame_counter[i];
+    for( i = 0; i < frame_counter->len; i++ )
+        iv[source_address->len + i] = frame_counter->x[i];
 
-    iv[source_address_len + frame_counter_len] = sec_level;
+    iv[source_address->len + frame_counter->len] = sec_level;
     iv_len = sizeof( iv );
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key->x, key->len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len - tag_len, iv, iv_len,
-                 add, add_len, msg, result, msg + msg_len - tag_len, tag_len );
+    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg->len - tag_len, iv, iv_len,
+                                         add->x, add->len, msg->x, result,
+                                         msg->x + msg->len - tag_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result->x,
+                                 expected_result->len ) == 0 );
 
     /* Check we didn't write past the end (where the original tag is) */
-    TEST_ASSERT( ( msg_len + 2 ) <= sizeof( result ) );
-    TEST_EQUAL( result[msg_len], '+' );
-    TEST_EQUAL( result[msg_len + 1], '+' );
+    TEST_ASSERT( ( msg->len + 2 ) <= sizeof( result ) );
+    TEST_EQUAL( result[msg->len], '+' );
+    TEST_EQUAL( result[msg->len + 1], '+' );
 
 exit:
     mbedtls_ccm_free( &ctx );

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -195,17 +195,18 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
                             char *key_hex, char *msg_hex,
                             char *source_address_hex, char *frame_counter_hex,
                             int sec_level, char *add_hex,
-                            char *result_hex, int output_ret )
+                            char *expected_result_hex, int output_ret )
 {
     unsigned char key[32];
     unsigned char msg[50];
     unsigned char iv[13];
     unsigned char add[32];
     unsigned char result[50];
+    unsigned char expected_result[50];
     unsigned char source_address[8];
     unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, result_len, source_address_len, frame_counter_len, tag_len;
+    size_t i, key_len, msg_len, iv_len, add_len, expected_result_len, source_address_len, frame_counter_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
@@ -215,13 +216,14 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     memset( iv, 0x00, sizeof( iv ) );
     memset( add, 0x00, sizeof( add ) );
     memset( result, 0x00, sizeof( result ) );
+    memset( expected_result, 0x00, sizeof( expected_result ) );
     memset( source_address, 0x00, sizeof( source_address ) );
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
-    result_len = mbedtls_test_unhexify( result, result_hex );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
     source_address_len = mbedtls_test_unhexify( source_address,
                                                 source_address_hex );
     frame_counter_len = mbedtls_test_unhexify( frame_counter,
@@ -244,14 +246,15 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
 
     ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, msg, msg + msg_len, tag_len );
+                 add, add_len, msg, result, result + msg_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( msg, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
 
     /* Check we didn't write past the end */
-    TEST_ASSERT( msg[result_len] == 0 && msg[result_len + 1] == 0 );
+    TEST_ASSERT( result[expected_result_len] == 0 &&
+                 result[expected_result_len + 1] == 0 );
 
 exit:
     mbedtls_ccm_free( &ctx );
@@ -263,18 +266,18 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
                             char *key_hex, char *msg_hex,
                             char *source_address_hex, char *frame_counter_hex,
                             int sec_level, char *add_hex,
-                            char *result_hex, int output_ret )
+                            char *expected_result_hex, int output_ret )
 {
     unsigned char key[32];
     unsigned char msg[50];
     unsigned char iv[13];
     unsigned char add[32];
-    unsigned char tag[16];
     unsigned char result[50];
+    unsigned char expected_result[50];
     unsigned char source_address[8];
     unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, tag_len, result_len, source_address_len, frame_counter_len;
+    size_t i, key_len, msg_len, iv_len, add_len, tag_len, expected_result_len, source_address_len, frame_counter_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
@@ -283,15 +286,15 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
     memset( add, 0x00, sizeof( add ) );
-    memset( result, 0x00, sizeof( result ) );
+    memset( result, '+', sizeof( result ) );
+    memset( expected_result, 0x00, sizeof( expected_result ) );
     memset( source_address, 0x00, sizeof( source_address ) );
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
-    memset( tag, 0x00, sizeof( tag ) );
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
-    result_len = mbedtls_test_unhexify( result, result_hex );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
     source_address_len = mbedtls_test_unhexify( source_address,
                                                 source_address_hex );
     frame_counter_len = mbedtls_test_unhexify( frame_counter,
@@ -311,20 +314,19 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     iv[source_address_len + frame_counter_len] = sec_level;
     iv_len = sizeof( iv );
 
-    msg_len -= tag_len;
-    memcpy( tag, msg + msg_len, tag_len );
-
     TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, msg, msg + msg_len, tag_len );
+    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len - tag_len, iv, iv_len,
+                 add, add_len, msg, result, msg + msg_len - tag_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( msg, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
 
     /* Check we didn't write past the end (where the original tag is) */
-    TEST_ASSERT( memcmp( msg + msg_len, tag, tag_len ) == 0 );
+    TEST_ASSERT( ( msg_len + 2 ) <= sizeof( result ) );
+    TEST_EQUAL( result[msg_len], '+' );
+    TEST_EQUAL( result[msg_len + 1], '+' );
 
 exit:
     mbedtls_ccm_free( &ctx );

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -12,31 +12,33 @@ void chacha20_crypt( char *hex_key_string,
                      char *hex_nonce_string,
                      int counter,
                      char *hex_src_string,
-                     char *hex_dst_string )
+                     char *hex_expected_output_string )
 {
     unsigned char key_str[32]; /* size set by the standard */
     unsigned char nonce_str[12]; /* size set by the standard */
     unsigned char src_str[375]; /* max size of binary input */
-    unsigned char dst_str[751]; /* hex expansion of the above */
-    unsigned char output[751];
+    unsigned char expected_output_str[375];
+    unsigned char output[375];
+    unsigned char output_string[751]; /* ASCII string representation of output */
     size_t key_len;
     size_t nonce_len;
     size_t src_len;
-    size_t dst_len;
+    size_t expected_output_len;
     mbedtls_chacha20_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( src_str,    0x00, sizeof( src_str ) );
-    memset( dst_str,    0x00, sizeof( dst_str ) );
-    memset( output,     0x00, sizeof( output ) );
+    memset( key_str,       0x00, sizeof( key_str ) );
+    memset( nonce_str,     0x00, sizeof( nonce_str ) );
+    memset( src_str,       0x00, sizeof( src_str ) );
+    memset( output,        0x00, sizeof( output ) );
+    memset( output_string, 0x00, sizeof( output_string ) );
 
     key_len   = mbedtls_test_unhexify( key_str, hex_key_string );
     nonce_len = mbedtls_test_unhexify( nonce_str, hex_nonce_string );
     src_len   = mbedtls_test_unhexify( src_str, hex_src_string );
-    dst_len   = mbedtls_test_unhexify( dst_str, hex_dst_string );
+    expected_output_len = mbedtls_test_unhexify( expected_output_str,
+                                                 hex_expected_output_string );
 
-    TEST_ASSERT( src_len   == dst_len );
+    TEST_ASSERT( src_len   == expected_output_len );
     TEST_ASSERT( key_len   == 32U );
     TEST_ASSERT( nonce_len == 12U );
 
@@ -45,8 +47,8 @@ void chacha20_crypt( char *hex_key_string,
      */
     TEST_ASSERT( mbedtls_chacha20_crypt( key_str, nonce_str, counter, src_len, src_str, output ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string, hex_expected_output_string ) == 0 );
 
     /*
      * Test the streaming API
@@ -60,8 +62,9 @@ void chacha20_crypt( char *hex_key_string,
     memset( output, 0x00, sizeof( output ) );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len, src_str, output ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string,
+                         hex_expected_output_string ) == 0 );
 
     /*
      * Test the streaming API again, piecewise
@@ -75,8 +78,9 @@ void chacha20_crypt( char *hex_key_string,
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str, output ) == 0 );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len - 1, src_str + 1, output + 1 ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string,
+                         hex_expected_output_string ) == 0 );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -8,63 +8,55 @@
  */
 
 /* BEGIN_CASE */
-void chacha20_crypt( char *hex_key_string,
-                     char *hex_nonce_string,
+void chacha20_crypt( data_t *key_str,
+                     data_t *nonce_str,
                      int counter,
-                     char *hex_src_string,
-                     char *hex_expected_output_string )
+                     data_t *src_str,
+                     data_t *expected_output_str )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char src_str[375]; /* max size of binary input */
-    unsigned char expected_output_str[375];
     unsigned char output[375];
-    unsigned char output_string[751]; /* ASCII string representation of output */
-    size_t key_len;
-    size_t nonce_len;
-    size_t src_len;
-    size_t expected_output_len;
     mbedtls_chacha20_context ctx;
 
-    memset( key_str,       0x00, sizeof( key_str ) );
-    memset( nonce_str,     0x00, sizeof( nonce_str ) );
-    memset( src_str,       0x00, sizeof( src_str ) );
-    memset( output,        0x00, sizeof( output ) );
-    memset( output_string, 0x00, sizeof( output_string ) );
+    /*
+     * Buffers to store the ASCII string representation of output and
+     * expected_output_str.
+     */
+    unsigned char output_string[751] = { '\0' };
+    unsigned char expected_output_string[751] = { '\0' };
 
-    key_len   = mbedtls_test_unhexify( key_str, hex_key_string );
-    nonce_len = mbedtls_test_unhexify( nonce_str, hex_nonce_string );
-    src_len   = mbedtls_test_unhexify( src_str, hex_src_string );
-    expected_output_len = mbedtls_test_unhexify( expected_output_str,
-                                                 hex_expected_output_string );
+    memset( output, 0x00, sizeof( output ) );
 
-    TEST_ASSERT( src_len   == expected_output_len );
-    TEST_ASSERT( key_len   == 32U );
-    TEST_ASSERT( nonce_len == 12U );
+    TEST_ASSERT( src_str->len   == expected_output_str->len );
+    TEST_ASSERT( key_str->len   == 32U );
+    TEST_ASSERT( nonce_str->len == 12U );
 
     /*
      * Test the integrated API
      */
-    TEST_ASSERT( mbedtls_chacha20_crypt( key_str, nonce_str, counter, src_len, src_str, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_crypt( key_str->x, nonce_str->x, counter, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string, hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( expected_output_string,
+                         expected_output_str->x,
+                         expected_output_str->len);
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     /*
      * Test the streaming API
      */
     mbedtls_chacha20_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chacha20_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_setkey( &ctx, key_str->x ) == 0 );
 
-    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str, counter ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str->x, counter ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len, src_str, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string,
-                         hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     /*
      * Test the streaming API again, piecewise
@@ -72,15 +64,16 @@ void chacha20_crypt( char *hex_key_string,
 
     /* Don't free/init the context nor set the key again,
      * in order to test that starts() does the right thing. */
-    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str, counter ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str->x, counter ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str, output ) == 0 );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len - 1, src_str + 1, output + 1 ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str->x, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len - 1,
+                                          src_str->x + 1, output + 1 ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string,
-                         hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_chachapoly.function
+++ b/tests/suites/test_suite_chachapoly.function
@@ -8,53 +8,27 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_chachapoly_enc( char *hex_key_string, char *hex_nonce_string, char *hex_aad_string, char *hex_input_string, char *hex_output_string, char *hex_mac_string )
+void mbedtls_chachapoly_enc( data_t *key_str, data_t *nonce_str, data_t *aad_str, data_t *input_str, data_t *output_str, data_t *mac_str )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char aad_str[12]; /* max size of test data so far */
-    unsigned char input_str[265]; /* max size of binary input/output so far */
-    unsigned char output_str[265];
     unsigned char output[265];
-    unsigned char mac_str[16]; /* size set by the standard */
     unsigned char mac[16]; /* size set by the standard */
-    size_t input_len;
-    size_t output_len;
-    size_t aad_len;
-    size_t key_len;
-    size_t nonce_len;
-    size_t mac_len;
     mbedtls_chachapoly_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( aad_str,    0x00, sizeof( aad_str ) );
-    memset( input_str,  0x00, sizeof( input_str ) );
-    memset( output_str, 0x00, sizeof( output_str ) );
-    memset( mac_str,    0x00, sizeof( mac_str ) );
-
-    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
-    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
-    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
-    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
-    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
-
-    TEST_ASSERT( key_len   == 32 );
-    TEST_ASSERT( nonce_len == 12 );
-    TEST_ASSERT( mac_len   == 16 );
+    TEST_ASSERT( key_str->len   == 32 );
+    TEST_ASSERT( nonce_str->len == 12 );
+    TEST_ASSERT( mac_str->len   == 16 );
 
     mbedtls_chachapoly_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str->x ) == 0 );
 
     TEST_ASSERT( mbedtls_chachapoly_encrypt_and_tag( &ctx,
-                                      input_len, nonce_str,
-                                      aad_str, aad_len,
-                                      input_str, output, mac ) == 0 );
+                                      input_str->len, nonce_str->x,
+                                      aad_str->x, aad_str->len,
+                                      input_str->x, output, mac ) == 0 );
 
-    TEST_ASSERT( memcmp( output_str, output, output_len ) == 0 );
-    TEST_ASSERT( memcmp( mac_str, mac, 16U ) == 0 );
+    TEST_ASSERT( memcmp( output_str->x, output, output_str->len ) == 0 );
+    TEST_ASSERT( memcmp( mac_str->x, mac, 16U ) == 0 );
 
 exit:
     mbedtls_chachapoly_free( &ctx );
@@ -62,55 +36,29 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_chachapoly_dec( char *hex_key_string, char *hex_nonce_string, char *hex_aad_string, char *hex_input_string, char *hex_output_string, char *hex_mac_string, int ret_exp )
+void mbedtls_chachapoly_dec( data_t *key_str, data_t *nonce_str, data_t *aad_str, data_t *input_str, data_t *output_str, data_t *mac_str, int ret_exp )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char aad_str[12]; /* max size of test data so far */
-    unsigned char input_str[265]; /* max size of binary input/output so far */
-    unsigned char output_str[265];
     unsigned char output[265];
-    unsigned char mac_str[16]; /* size set by the standard */
-    size_t input_len;
-    size_t output_len;
-    size_t aad_len;
-    size_t key_len;
-    size_t nonce_len;
-    size_t mac_len;
     int ret;
     mbedtls_chachapoly_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( aad_str,    0x00, sizeof( aad_str ) );
-    memset( input_str,  0x00, sizeof( input_str ) );
-    memset( output_str, 0x00, sizeof( output_str ) );
-    memset( mac_str,    0x00, sizeof( mac_str ) );
-
-    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
-    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
-    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
-    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
-    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
-
-    TEST_ASSERT( key_len   == 32 );
-    TEST_ASSERT( nonce_len == 12 );
-    TEST_ASSERT( mac_len   == 16 );
+    TEST_ASSERT( key_str->len   == 32 );
+    TEST_ASSERT( nonce_str->len == 12 );
+    TEST_ASSERT( mac_str->len   == 16 );
 
     mbedtls_chachapoly_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str->x ) == 0 );
 
     ret = mbedtls_chachapoly_auth_decrypt( &ctx,
-                                           input_len, nonce_str,
-                                           aad_str, aad_len,
-                                           mac_str, input_str, output );
+                                           input_str->len, nonce_str->x,
+                                           aad_str->x, aad_str->len,
+                                           mac_str->x, input_str->x, output );
 
     TEST_ASSERT( ret == ret_exp );
     if( ret_exp == 0 )
     {
-        TEST_ASSERT( memcmp( output_str, output, output_len ) == 0 );
+        TEST_ASSERT( memcmp( output_str->x, output, output_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1125,26 +1125,17 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_WITH_PADDING */
-void test_vec_crypt( int cipher_id, int operation, char *hex_key,
-                     char *hex_iv, char *hex_input, char *hex_result,
+void test_vec_crypt( int cipher_id, int operation, data_t *key,
+                     data_t *iv, data_t *input, data_t *result,
                      int finish_result, int use_psa )
 {
-    unsigned char key[50];
-    unsigned char input[16];
-    unsigned char result[16];
-    unsigned char iv[16];
-    size_t key_len, iv_len, inputlen, resultlen;
     mbedtls_cipher_context_t ctx;
     unsigned char output[32];
     size_t outlen;
 
     mbedtls_cipher_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( input, 0x00, sizeof( input ) );
-    memset( result, 0x00, sizeof( result ) );
     memset( output, 0x00, sizeof( output ) );
-    memset( iv, 0x00, sizeof( iv ) );
 
     /* Prepare context */
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -1161,23 +1152,17 @@ void test_vec_crypt( int cipher_id, int operation, char *hex_key,
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
                               mbedtls_cipher_info_from_type( cipher_id ) ) );
 
-    key_len = mbedtls_test_unhexify( key, hex_key );
-    inputlen =  mbedtls_test_unhexify( input, hex_input );
-    resultlen = mbedtls_test_unhexify( result, hex_result );
-
-    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, operation ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len, operation ) );
     if( MBEDTLS_MODE_CBC == ctx.cipher_info->mode )
         TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, MBEDTLS_PADDING_NONE ) );
 
-    iv_len = mbedtls_test_unhexify( iv, hex_iv );
-
-    TEST_ASSERT( finish_result == mbedtls_cipher_crypt( &ctx, iv_len ? iv : NULL,
-                                                        iv_len, input, inputlen,
+    TEST_ASSERT( finish_result == mbedtls_cipher_crypt( &ctx, iv->len ? iv->x : NULL,
+                                                        iv->len, input->x, input->len,
                                                         output, &outlen ) );
-    TEST_ASSERT( resultlen == outlen );
+    TEST_ASSERT( result->len == outlen );
     /* check plaintext only if everything went fine */
     if( 0 == finish_result )
-        TEST_ASSERT( 0 == memcmp( output, result, outlen ) );
+        TEST_ASSERT( 0 == memcmp( output, result->x, outlen ) );
 
 exit:
     mbedtls_cipher_free( &ctx );

--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -346,7 +346,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE */
-void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
+void ecdh_restart( int id, data_t *dA, data_t *dB, data_t *z,
                    int enable, int max_ops, int min_restart, int max_restart )
 {
     int ret;
@@ -354,10 +354,6 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     unsigned char buf[1000];
     const unsigned char *vbuf;
     size_t len;
-    unsigned char z[MBEDTLS_ECP_MAX_BYTES];
-    size_t z_len;
-    unsigned char rnd_buf_A[MBEDTLS_ECP_MAX_BYTES];
-    unsigned char rnd_buf_B[MBEDTLS_ECP_MAX_BYTES];
     mbedtls_test_rnd_buf_info rnd_info_A, rnd_info_B;
     int cnt_restart;
     mbedtls_ecp_group grp;
@@ -366,13 +362,11 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     mbedtls_ecdh_init( &srv );
     mbedtls_ecdh_init( &cli );
 
-    z_len = mbedtls_test_unhexify( z, z_str );
+    rnd_info_A.buf = dA->x;
+    rnd_info_A.length = dA->len;
 
-    rnd_info_A.buf = rnd_buf_A;
-    rnd_info_A.length = mbedtls_test_unhexify( rnd_buf_A, dA_str );
-
-    rnd_info_B.buf = rnd_buf_B;
-    rnd_info_B.length = mbedtls_test_unhexify( rnd_buf_B, dB_str );
+    rnd_info_B.buf = dB->x;
+    rnd_info_B.length = dB->len;
 
     /* The ECDH context is not guaranteed ot have an mbedtls_ecp_group structure
      * in every configuration, therefore we load it separately. */
@@ -444,8 +438,8 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );
 
-    TEST_ASSERT( len == z_len );
-    TEST_ASSERT( memcmp( buf, z, len ) == 0 );
+    TEST_ASSERT( len == z->len );
+    TEST_ASSERT( memcmp( buf, z->x, len ) == 0 );
 
     /* client computes shared secret */
     memset( buf, 0, sizeof( buf ) );
@@ -461,8 +455,8 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );
 
-    TEST_ASSERT( len == z_len );
-    TEST_ASSERT( memcmp( buf, z, len ) == 0 );
+    TEST_ASSERT( len == z->len );
+    TEST_ASSERT( memcmp( buf, z->x, len ) == 0 );
 
 exit:
     mbedtls_ecp_group_free( &grp );

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -411,33 +411,26 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE */
-void ecdsa_read_restart( int id, char *k_str, char *h_str, char *s_str,
+void ecdsa_read_restart( int id, data_t *pk, data_t *hash, data_t *sig,
                          int max_ops, int min_restart, int max_restart )
 {
     mbedtls_ecdsa_context ctx;
     mbedtls_ecdsa_restart_ctx rs_ctx;
-    unsigned char hash[64];
-    unsigned char sig[200];
-    unsigned char pk[65];
-    size_t sig_len, hash_len, pk_len;
     int ret, cnt_restart;
 
     mbedtls_ecdsa_init( &ctx );
     mbedtls_ecdsa_restart_init( &rs_ctx );
 
-    hash_len = mbedtls_test_unhexify(hash, h_str);
-    sig_len = mbedtls_test_unhexify(sig, s_str);
-    pk_len = mbedtls_test_unhexify(pk, k_str);
-
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
-    TEST_ASSERT( mbedtls_ecp_point_read_binary( &ctx.grp, &ctx.Q, pk, pk_len ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_point_read_binary( &ctx.grp, &ctx.Q,
+                                                pk->x, pk->len ) == 0 );
 
     mbedtls_ecp_set_max_ops( max_ops );
 
     cnt_restart = 0;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
@@ -445,29 +438,31 @@ void ecdsa_read_restart( int id, char *k_str, char *h_str, char *s_str,
     TEST_ASSERT( cnt_restart <= max_restart );
 
     /* try modifying r */
-    sig[10]++;
+
+    TEST_ASSERT( sig->len > 10 );
+    sig->x[10]++;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     TEST_ASSERT( ret == MBEDTLS_ERR_ECP_VERIFY_FAILED );
-    sig[10]--;
+    sig->x[10]--;
 
     /* try modifying s */
-    sig[sig_len - 1]++;
+    sig->x[sig->len - 1]++;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     TEST_ASSERT( ret == MBEDTLS_ERR_ECP_VERIFY_FAILED );
-    sig[sig_len - 1]--;
+    sig->x[sig->len - 1]--;
 
     /* Do we leak memory when aborting an operation?
      * This test only makes sense when we actually restart */
     if( min_restart > 0 )
     {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
         TEST_ASSERT( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     }
 
@@ -479,7 +474,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:MBEDTLS_ECDSA_DETERMINISTIC */
 void ecdsa_write_restart( int id, char *d_str, int md_alg,
-                          char *msg, char *sig_str,
+                          char *msg, data_t *sig_check,
                           int max_ops, int min_restart, int max_restart )
 {
     int ret, cnt_restart;
@@ -487,19 +482,16 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
     mbedtls_ecdsa_context ctx;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
-    unsigned char sig_check[MBEDTLS_ECDSA_MAX_LEN];
-    size_t hlen, slen, slen_check;
+    size_t hlen, slen;
     const mbedtls_md_info_t *md_info;
 
     mbedtls_ecdsa_restart_init( &rs_ctx );
     mbedtls_ecdsa_init( &ctx );
     memset( hash, 0, sizeof( hash ) );
     memset( sig, 0, sizeof( sig ) );
-    memset( sig_check, 0, sizeof( sig_check ) );
 
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &ctx.d, 16, d_str ) == 0 );
-    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
@@ -519,8 +511,8 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
-    TEST_ASSERT( slen == slen_check );
-    TEST_ASSERT( memcmp( sig, sig_check, slen ) == 0 );
+    TEST_ASSERT( slen == sig_check->len );
+    TEST_ASSERT( memcmp( sig, sig_check->x, slen ) == 0 );
 
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -10,20 +10,20 @@
 
 /* BEGIN_CASE */
 void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
-                char *hex_info_string, char *hex_okm_string )
+                char *hex_info_string, char *hex_expected_okm_string )
 {
     int ret;
-    size_t ikm_len, salt_len, info_len, okm_len;
+    size_t ikm_len, salt_len, info_len, expected_okm_len;
     unsigned char ikm[128] = { '\0' };
     unsigned char salt[128] = { '\0' };
     unsigned char info[128] = { '\0' };
     unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
     /*
-     * okm_hex is the string representation of okm,
+     * okm_string is the ASCII string representation of okm,
      * so its size is twice the size of okm, and an extra null-termination.
      */
-    unsigned char okm_hex[257] = { '\0' };
+    unsigned char okm_string[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
@@ -31,18 +31,21 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     ikm_len = mbedtls_test_unhexify( ikm, hex_ikm_string );
     salt_len = mbedtls_test_unhexify( salt, hex_salt_string );
     info_len = mbedtls_test_unhexify( info, hex_info_string );
-    okm_len = mbedtls_test_unhexify( expected_okm, hex_okm_string );
+    expected_okm_len = mbedtls_test_unhexify( expected_okm,
+                                              hex_expected_okm_string );
+
+    TEST_ASSERT( expected_okm_len <= sizeof( okm ) );
 
     ret = mbedtls_hkdf( md, salt, salt_len, ikm, ikm_len, info, info_len, okm,
-                        okm_len);
+                        expected_okm_len);
     TEST_ASSERT( ret == 0 );
 
     /*
      * Run mbedtls_test_hexify on it so that it looks nicer if the assertion
      * fails.
      */
-    mbedtls_test_hexify( okm_hex, okm, okm_len );
-    TEST_ASSERT( !strcmp( (char *)okm_hex, hex_okm_string ) );
+    mbedtls_test_hexify( okm_string, okm, expected_okm_len );
+    TEST_ASSERT( !strcmp( (char *)okm_string, hex_expected_okm_string ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -9,43 +9,36 @@
  */
 
 /* BEGIN_CASE */
-void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
-                char *hex_info_string, char *hex_expected_okm_string )
+void test_hkdf( int md_alg, data_t *ikm, data_t *salt, data_t *info,
+                data_t *expected_okm )
 {
     int ret;
-    size_t ikm_len, salt_len, info_len, expected_okm_len;
-    unsigned char ikm[128] = { '\0' };
-    unsigned char salt[128] = { '\0' };
-    unsigned char info[128] = { '\0' };
-    unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
     /*
-     * okm_string is the ASCII string representation of okm,
-     * so its size is twice the size of okm, and an extra null-termination.
+     * okm_string and expected_okm_string are the ASCII string representations
+     * of km and expected_okm, so their size should be twice the size of
+     * okm and expected_okm, and an extra null-termination.
      */
     unsigned char okm_string[257] = { '\0' };
+    unsigned char expected_okm_string[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
 
-    ikm_len = mbedtls_test_unhexify( ikm, hex_ikm_string );
-    salt_len = mbedtls_test_unhexify( salt, hex_salt_string );
-    info_len = mbedtls_test_unhexify( info, hex_info_string );
-    expected_okm_len = mbedtls_test_unhexify( expected_okm,
-                                              hex_expected_okm_string );
+    TEST_ASSERT( expected_okm->len <= sizeof( okm ) );
 
-    TEST_ASSERT( expected_okm_len <= sizeof( okm ) );
-
-    ret = mbedtls_hkdf( md, salt, salt_len, ikm, ikm_len, info, info_len, okm,
-                        expected_okm_len);
+    ret = mbedtls_hkdf( md, salt->x, salt->len, ikm->x, ikm->len,
+                        info->x, info->len, okm, expected_okm->len );
     TEST_ASSERT( ret == 0 );
 
     /*
-     * Run mbedtls_test_hexify on it so that it looks nicer if the assertion
-     * fails.
+     * Run mbedtls_test_hexify on okm and expected_okm so that it looks nicer
+     * if the assertion fails.
      */
-    mbedtls_test_hexify( okm_string, okm, expected_okm_len );
-    TEST_ASSERT( !strcmp( (char *)okm_string, hex_expected_okm_string ) );
+    mbedtls_test_hexify( okm_string, okm, expected_okm->len );
+    mbedtls_test_hexify( expected_okm_string,
+                         expected_okm->x, expected_okm->len );
+    TEST_ASSERT( !strcmp( (char *)okm_string, (char *)expected_okm_string ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -244,14 +244,14 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_nist_kw_wrap( int cipher_id, int mode,
                            char *key_hex, char *msg_hex,
-                           char *result_hex )
+                           char *expected_result_hex )
 {
     unsigned char key[32];
     unsigned char msg[512];
     unsigned char result[528];
     unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, output_len, result_len, i, padlen;
+    size_t key_len, msg_len, result_len, expected_result_len, i, padlen;
 
     mbedtls_nist_kw_init( &ctx );
 
@@ -261,19 +261,19 @@ void mbedtls_nist_kw_wrap( int cipher_id, int mode,
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    result_len = mbedtls_test_unhexify( expected_result, result_hex );
-    output_len = sizeof( result );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
+    result_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 1 )
                  == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg, msg_len,
-                 result, &output_len, sizeof( result ) ) == 0 );
+                 result, &result_len, sizeof( result ) ) == 0 );
 
-    TEST_ASSERT( output_len == result_len );
+    TEST_ASSERT( result_len == expected_result_len );
 
-    TEST_ASSERT( memcmp( expected_result, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
 
     padlen = ( msg_len % 8 != 0 ) ? 8 - (msg_len % 8 ) : 0;
     /* Check that the function didn't write beyond the end of the buffer. */
@@ -290,14 +290,14 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
                              char *key_hex, char *msg_hex,
-                             char *result_hex, int expected_ret )
+                             char *expected_result_hex, int expected_ret )
 {
     unsigned char key[32];
     unsigned char msg[528];
     unsigned char result[528];
     unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, output_len, result_len, i;
+    size_t key_len, msg_len, result_len, expected_result_len, i;
 
     mbedtls_nist_kw_init( &ctx );
 
@@ -308,23 +308,23 @@ void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    result_len = mbedtls_test_unhexify( expected_result, result_hex );
-    output_len = sizeof( result );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
+    result_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 0 )
                  == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg, msg_len,
-                 result, &output_len, sizeof( result ) ) == expected_ret );
+                 result, &result_len, sizeof( result ) ) == expected_ret );
     if( expected_ret == 0 )
     {
-        TEST_ASSERT( output_len == result_len );
-        TEST_ASSERT( memcmp( expected_result, result, result_len ) == 0 );
+        TEST_ASSERT( result_len == expected_result_len );
+        TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
     }
     else
     {
-        TEST_ASSERT( output_len == 0 );
+        TEST_ASSERT( result_len == 0 );
     }
 
     /* Check that the function didn't write beyond the end of the buffer. */

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -242,42 +242,31 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_nist_kw_wrap( int cipher_id, int mode,
-                           char *key_hex, char *msg_hex,
-                           char *expected_result_hex )
+void mbedtls_nist_kw_wrap( int cipher_id, int mode, data_t *key, data_t *msg,
+                           data_t *expected_result )
 {
-    unsigned char key[32];
-    unsigned char msg[512];
     unsigned char result[528];
-    unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, result_len, expected_result_len, i, padlen;
+    size_t result_len, i, padlen;
 
     mbedtls_nist_kw_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( result, '+', sizeof( result ) );
 
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    result_len = sizeof( result );
-
-    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 1 )
-                 == 0 );
+    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id,
+                                         key->x, key->len * 8, 1 ) == 0 );
 
     /* Test with input == output */
-    TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg, msg_len,
+    TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg->x, msg->len,
                  result, &result_len, sizeof( result ) ) == 0 );
 
-    TEST_ASSERT( result_len == expected_result_len );
+    TEST_ASSERT( result_len == expected_result->len );
 
-    TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( expected_result->x, result, result_len ) == 0 );
 
-    padlen = ( msg_len % 8 != 0 ) ? 8 - (msg_len % 8 ) : 0;
+    padlen = ( msg->len % 8 != 0 ) ? 8 - (msg->len % 8 ) : 0;
     /* Check that the function didn't write beyond the end of the buffer. */
-    for( i = msg_len + 8 + padlen; i < sizeof( result ); i++ )
+    for( i = msg->len + 8 + padlen; i < sizeof( result ); i++ )
     {
         TEST_ASSERT( result[i] == '+' );
     }
@@ -288,39 +277,27 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
-                             char *key_hex, char *msg_hex,
-                             char *expected_result_hex, int expected_ret )
+void mbedtls_nist_kw_unwrap( int cipher_id, int mode, data_t *key, data_t *msg,
+                             data_t *expected_result, int expected_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[528];
     unsigned char result[528];
-    unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, result_len, expected_result_len, i;
+    size_t result_len, i;
 
     mbedtls_nist_kw_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( result, '+', sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
 
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    result_len = sizeof( result );
-
-    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 0 )
-                 == 0 );
+    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id,
+                                         key->x, key->len * 8, 0 ) == 0 );
 
     /* Test with input == output */
-    TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg, msg_len,
+    TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg->x, msg->len,
                  result, &result_len, sizeof( result ) ) == expected_ret );
     if( expected_ret == 0 )
     {
-        TEST_ASSERT( result_len == expected_result_len );
-        TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
+        TEST_ASSERT( result_len == expected_result->len );
+        TEST_ASSERT( memcmp( expected_result->x, result, result_len ) == 0 );
     }
     else
     {
@@ -328,7 +305,7 @@ void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
     }
 
     /* Check that the function didn't write beyond the end of the buffer. */
-    for( i = msg_len - 8; i < sizeof( result ); i++ )
+    for( i = msg->len - 8; i < sizeof( result ); i++ )
     {
         TEST_ASSERT( result[i] == '+' );
     }

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -788,7 +788,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:MBEDTLS_ECDSA_C:MBEDTLS_ECDSA_DETERMINISTIC */
 void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
                               char *QX_str, char *QY_str,
-                              int md_alg, char *msg, char *sig_str,
+                              int md_alg, char *msg, data_t *sig_check,
                               int max_ops, int min_restart, int max_restart )
 {
     int ret, cnt_restart;
@@ -796,8 +796,7 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     mbedtls_pk_context prv, pub;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
-    unsigned char sig_check[MBEDTLS_ECDSA_MAX_LEN];
-    size_t hlen, slen, slen_check;
+    size_t hlen, slen;
     const mbedtls_md_info_t *md_info;
 
     mbedtls_pk_restart_init( &rs_ctx );
@@ -805,7 +804,6 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     mbedtls_pk_init( &pub );
     memset( hash, 0, sizeof( hash ) );
     memset( sig, 0, sizeof( sig ) );
-    memset( sig_check, 0, sizeof( sig_check ) );
 
     TEST_ASSERT( mbedtls_pk_setup( &prv, mbedtls_pk_info_from_type( pk_type ) ) == 0 );
     TEST_ASSERT( mbedtls_ecp_group_load( &mbedtls_pk_ec( prv )->grp, grp_id ) == 0 );
@@ -814,8 +812,6 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     TEST_ASSERT( mbedtls_pk_setup( &pub, mbedtls_pk_info_from_type( pk_type ) ) == 0 );
     TEST_ASSERT( mbedtls_ecp_group_load( &mbedtls_pk_ec( pub )->grp, grp_id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &mbedtls_pk_ec( pub )->Q, 16, QX_str, QY_str ) == 0 );
-
-    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
@@ -835,8 +831,8 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
-    TEST_ASSERT( slen == slen_check );
-    TEST_ASSERT( memcmp( sig, sig_check, slen ) == 0 );
+    TEST_ASSERT( slen == sig_check->len );
+    TEST_ASSERT( memcmp( sig, sig_check->x, slen ) == 0 );
 
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -9,27 +9,20 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src_string  )
+void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
 {
-    unsigned char src_str[375]; /* max size of binary input */
-    unsigned char key[32]; /* size set by the standard */
     unsigned char mac[16]; /* size set by the standard */
     unsigned char mac_str[33]; /* hex expansion of the above */
-    size_t src_len;
     mbedtls_poly1305_context ctx;
 
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( mac_str, 0x00, sizeof( mac_str ) );
-    memset( key,     0x00, sizeof( key ) );
     memset( mac,     0x00, sizeof( mac ) );
-
-    src_len = mbedtls_test_unhexify( src_str, hex_src_string );
-    mbedtls_test_unhexify( key, hex_key_string );
 
     /*
      * Test the integrated API
      */
-    TEST_ASSERT( mbedtls_poly1305_mac( key, src_str, src_len, mac ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_mac( key->x, src_str->x,
+                                       src_str->len, mac ) == 0 );
 
     mbedtls_test_hexify( mac_str, mac, 16 );
     TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
@@ -39,9 +32,9 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
      */
     mbedtls_poly1305_init( &ctx );
 
-    TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-    TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, src_len ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, src_str->len ) == 0 );
 
     TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
@@ -54,12 +47,12 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
 
     /* Don't free/init the context, in order to test that starts() does the
      * right thing. */
-    if( src_len >= 1 )
+    if( src_str->len >= 1 )
     {
-        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 1, src_len - 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 1, src_str->len - 1 ) == 0 );
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
@@ -70,13 +63,13 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
     /*
      * Again with more pieces
      */
-    if( src_len >= 2 )
+    if( src_str->len >= 2 )
     {
-        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 1, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 2, src_len - 2 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 1, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 2, src_str->len - 2 ) == 0 );
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 

--- a/visualc/VS2010/aescrypt2.vcxproj
+++ b/visualc/VS2010/aescrypt2.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/benchmark.vcxproj
+++ b/visualc/VS2010/benchmark.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/cert_app.vcxproj
+++ b/visualc/VS2010/cert_app.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/cert_req.vcxproj
+++ b/visualc/VS2010/cert_req.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/cert_write.vcxproj
+++ b/visualc/VS2010/cert_write.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/crl_app.vcxproj
+++ b/visualc/VS2010/crl_app.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/crypt_and_hash.vcxproj
+++ b/visualc/VS2010/crypt_and_hash.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/crypto_examples.vcxproj
+++ b/visualc/VS2010/crypto_examples.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/dh_client.vcxproj
+++ b/visualc/VS2010/dh_client.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/dh_genprime.vcxproj
+++ b/visualc/VS2010/dh_genprime.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/dh_server.vcxproj
+++ b/visualc/VS2010/dh_server.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/dtls_client.vcxproj
+++ b/visualc/VS2010/dtls_client.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/dtls_server.vcxproj
+++ b/visualc/VS2010/dtls_server.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ecdh_curve25519.vcxproj
+++ b/visualc/VS2010/ecdh_curve25519.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ecdsa.vcxproj
+++ b/visualc/VS2010/ecdsa.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/gen_entropy.vcxproj
+++ b/visualc/VS2010/gen_entropy.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/gen_key.vcxproj
+++ b/visualc/VS2010/gen_key.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/gen_random_ctr_drbg.vcxproj
+++ b/visualc/VS2010/gen_random_ctr_drbg.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/gen_random_havege.vcxproj
+++ b/visualc/VS2010/gen_random_havege.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/generic_sum.vcxproj
+++ b/visualc/VS2010/generic_sum.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/hello.vcxproj
+++ b/visualc/VS2010/hello.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/key_app.vcxproj
+++ b/visualc/VS2010/key_app.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/key_app_writer.vcxproj
+++ b/visualc/VS2010/key_app_writer.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/key_ladder_demo.vcxproj
+++ b/visualc/VS2010/key_ladder_demo.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -84,7 +84,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_USRDLL;MBEDTLS_EXPORTS;KRML_VERIFIED_UINT128;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
     <Link>
@@ -98,7 +98,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_USRDLL;MBEDTLS_EXPORTS;KRML_VERIFIED_UINT128;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
     <Link>
@@ -114,7 +114,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;MBEDTLS_EXPORTS;KRML_VERIFIED_UINT128;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN64;NDEBUG;_WINDOWS;_USRDLL;MBEDTLS_EXPORTS;KRML_VERIFIED_UINT128;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -232,6 +232,11 @@
     <ClInclude Include="..\..\include\psa\crypto_struct.h" />
     <ClInclude Include="..\..\include\psa\crypto_types.h" />
     <ClInclude Include="..\..\include\psa\crypto_values.h" />
+    <ClInclude Include="..\..\tests\include\test\helpers.h" />
+    <ClInclude Include="..\..\tests\include\test\macros.h" />
+    <ClInclude Include="..\..\tests\include\test\psa_crypto_helpers.h" />
+    <ClInclude Include="..\..\tests\include\test\psa_helpers.h" />
+    <ClInclude Include="..\..\tests\include\test\random.h" />
     <ClInclude Include="..\..\library\common.h" />
     <ClInclude Include="..\..\library\psa_crypto_core.h" />
     <ClInclude Include="..\..\library\psa_crypto_invasive.h" />
@@ -330,6 +335,8 @@
     <ClCompile Include="..\..\library\x509write_crt.c" />
     <ClCompile Include="..\..\library\x509write_csr.c" />
     <ClCompile Include="..\..\library\xtea.c" />
+    <ClCompile Include="..\..\tests\src\helpers.c" />
+    <ClCompile Include="..\..\tests\src\random.c" />
     <ClCompile Include="..\..\3rdparty\everest\library\everest.c" />
     <ClCompile Include="..\..\3rdparty\everest\library\Hacl_Curve25519_joined.c" />
     <ClCompile Include="..\..\3rdparty\everest\library\x25519.c" />

--- a/visualc/VS2010/mini_client.vcxproj
+++ b/visualc/VS2010/mini_client.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/mpi_demo.vcxproj
+++ b/visualc/VS2010/mpi_demo.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/pem2der.vcxproj
+++ b/visualc/VS2010/pem2der.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/pk_decrypt.vcxproj
+++ b/visualc/VS2010/pk_decrypt.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/pk_encrypt.vcxproj
+++ b/visualc/VS2010/pk_encrypt.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/pk_sign.vcxproj
+++ b/visualc/VS2010/pk_sign.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/pk_verify.vcxproj
+++ b/visualc/VS2010/pk_verify.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/psa_constant_names.vcxproj
+++ b/visualc/VS2010/psa_constant_names.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/query_compile_time_config.vcxproj
+++ b/visualc/VS2010/query_compile_time_config.vcxproj
@@ -94,7 +94,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,7 +112,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -132,7 +132,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,7 +151,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/req_app.vcxproj
+++ b/visualc/VS2010/req_app.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_decrypt.vcxproj
+++ b/visualc/VS2010/rsa_decrypt.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_encrypt.vcxproj
+++ b/visualc/VS2010/rsa_encrypt.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_genkey.vcxproj
+++ b/visualc/VS2010/rsa_genkey.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_sign.vcxproj
+++ b/visualc/VS2010/rsa_sign.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_sign_pss.vcxproj
+++ b/visualc/VS2010/rsa_sign_pss.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_verify.vcxproj
+++ b/visualc/VS2010/rsa_verify.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/rsa_verify_pss.vcxproj
+++ b/visualc/VS2010/rsa_verify_pss.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/selftest.vcxproj
+++ b/visualc/VS2010/selftest.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_client1.vcxproj
+++ b/visualc/VS2010/ssl_client1.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_client2.vcxproj
+++ b/visualc/VS2010/ssl_client2.vcxproj
@@ -94,7 +94,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,7 +112,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -132,7 +132,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,7 +151,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_context_info.vcxproj
+++ b/visualc/VS2010/ssl_context_info.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_fork_server.vcxproj
+++ b/visualc/VS2010/ssl_fork_server.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_mail_client.vcxproj
+++ b/visualc/VS2010/ssl_mail_client.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_server.vcxproj
+++ b/visualc/VS2010/ssl_server.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/ssl_server2.vcxproj
+++ b/visualc/VS2010/ssl_server2.vcxproj
@@ -94,7 +94,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,7 +112,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -132,7 +132,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,7 +151,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/strerror.vcxproj
+++ b/visualc/VS2010/strerror.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/udp_proxy.vcxproj
+++ b/visualc/VS2010/udp_proxy.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/visualc/VS2010/zeroize.vcxproj
+++ b/visualc/VS2010/zeroize.vcxproj
@@ -93,7 +93,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,7 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib      </AdditionalIncludeDirectories>
+../../include;../../3rdparty/everest/include/;../../3rdparty/everest/include/everest;../../3rdparty/everest/include/everest/vs2010;../../3rdparty/everest/include/everest/kremlib;../../tests/include      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Description
Add support to build and link test common code to test programs.
Demonstrate the support by using mbedtls_test_unhexify() in programs.

This is a follow-up of #3387.
This implements #3325.

## Status
READY

## Requires Backporting
Partial:
- [x] #3461  
- [x] #3460 