### PR TITLE
Remove unnecessary `& 0xFF`

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -77,12 +77,12 @@
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE(n,b,i)                          \
+{                                                     \
+    (b)[(i)    ] = (unsigned char) ( (n)       ) ;    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 ) ;    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 ) ;    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 ) ;    \
 }
 #endif
 

--- a/library/aria.c
+++ b/library/aria.c
@@ -75,12 +75,12 @@
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE( n, b, i )                                \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE( n, b, i )                     \
+{                                                    \
+    (b)[(i)    ] = (unsigned char) ( (n)       );    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 );    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 );    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 );    \
 }
 #endif
 

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -111,8 +111,8 @@ static const unsigned char FSb[256] =
 };
 
 #define SBOX1(n) FSb[(n)]
-#define SBOX2(n) (unsigned char)((FSb[(n)] >> 7 ^ FSb[(n)] << 1) & 0xff)
-#define SBOX3(n) (unsigned char)((FSb[(n)] >> 1 ^ FSb[(n)] << 7) & 0xff)
+#define SBOX2(n) (unsigned char)(FSb[(n)] >> 7 ^ FSb[(n)] << 1)
+#define SBOX3(n) (unsigned char)(FSb[(n)] >> 1 ^ FSb[(n)] << 7)
 #define SBOX4(n) FSb[((n) << 1 ^ (n) >> 7) &0xff]
 
 #else /* MBEDTLS_CAMELLIA_SMALL_MEMORY */

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -206,7 +206,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = (unsigned char)( len_left & 0xFF );
+        b[15-i] = (unsigned char)( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
@@ -227,8 +227,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
-        b[1] = (unsigned char)( ( add_len      ) & 0xFF );
+        b[0] = (unsigned char)( add_len >> 8 );
+        b[1] = (unsigned char)( add_len      );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -172,10 +172,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = (unsigned char)( ( len >> 24 ) & 0xFF );
-    (*p)[1] = (unsigned char)( ( len >> 16 ) & 0xFF );
-    (*p)[2] = (unsigned char)( ( len >>  8 ) & 0xFF );
-    (*p)[3] = (unsigned char)( ( len       ) & 0xFF );
+    (*p)[0] = (unsigned char)( len >> 24 );
+    (*p)[1] = (unsigned char)( len >> 16 );
+    (*p)[2] = (unsigned char)( len >>  8 );
+    (*p)[3] = (unsigned char)( len       );
 
     *p += 4 + len;
 
@@ -215,10 +215,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = (unsigned char)( ( id_len >> 24 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >> 16 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >>  8 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len       ) & 0xFF );
+    *p++ = (unsigned char)( id_len >> 24 );
+    *p++ = (unsigned char)( id_len >> 16 );
+    *p++ = (unsigned char)( id_len >>  8 );
+    *p++ = (unsigned char)( id_len       );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
@@ -358,7 +358,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = (unsigned char)( len & 0xFF );
+    *(*p)++ = (unsigned char)( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/md4.c
+++ b/library/md4.c
@@ -64,12 +64,12 @@
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE(n,b,i)                          \
+{                                                     \
+    (b)[(i)    ] = (unsigned char) ( (n)       ) ;    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 ) ;    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 ) ;    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 ) ;    \
 }
 #endif
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -63,12 +63,12 @@
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE(n,b,i)                         \
+{                                                    \
+    (b)[(i)    ] = (unsigned char) ( (n)       );    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 );    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 );    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 );    \
 }
 #endif
 

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -241,12 +241,12 @@ static psa_status_t psa_crypto_storage_get_data_length(
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE( n, b, i )                                \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE( n, b, i )                      \
+{                                                     \
+    (b)[(i)    ] = (unsigned char) ( (n)       ) ;    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 ) ;    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 ) ;    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 ) ;    \
 }
 #endif
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -64,12 +64,12 @@
 #endif
 
 #ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define PUT_UINT32_LE(n,b,i)                         \
+{                                                    \
+    (b)[(i)    ] = (unsigned char) ( (n)       );    \
+    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 );    \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 );    \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 );    \
 }
 #endif
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -142,18 +142,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SERVERNAME >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SERVERNAME      );
 
-    *p++ = (unsigned char)( ( (hostname_len + 5) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 5)      ) & 0xFF );
+    *p++ = (unsigned char)( (hostname_len + 5) >> 8 );
+    *p++ = (unsigned char)( (hostname_len + 5)      );
 
-    *p++ = (unsigned char)( ( (hostname_len + 3) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 3)      ) & 0xFF );
+    *p++ = (unsigned char)( (hostname_len + 3) >> 8 );
+    *p++ = (unsigned char)( (hostname_len + 3)      );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = (unsigned char)( hostname_len >> 8 );
+    *p++ = (unsigned char)( hostname_len      );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -187,10 +187,8 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      )
-                            & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      );
 
     *p++ = 0x00;
     *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
@@ -289,14 +287,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SIG_ALG >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SIG_ALG      );
 
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 )      ) & 0xFF );
+    *p++ = (unsigned char)( ( sig_alg_len + 2 ) >> 8 );
+    *p++ = (unsigned char)( ( sig_alg_len + 2 )      );
 
-    *p++ = (unsigned char)( ( sig_alg_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( sig_alg_len      ) & 0xFF );
+    *p++ = (unsigned char)( sig_alg_len >> 8 );
+    *p++ = (unsigned char)( sig_alg_len      );
 
     *olen = 6 + sig_alg_len;
 
@@ -364,16 +362,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES      )
-                            & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES      );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 )      ) & 0xFF );
+    *p++ = (unsigned char)( ( elliptic_curve_len + 2 ) >> 8 );
+    *p++ = (unsigned char)( ( elliptic_curve_len + 2 )      );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     )      ) & 0xFF );
+    *p++ = (unsigned char)( ( elliptic_curve_len     ) >> 8 );
+    *p++ = (unsigned char)( ( elliptic_curve_len     )      );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -394,10 +390,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      )
-                            & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -433,8 +427,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -476,8 +470,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = (unsigned char)( kkpp_len >> 8 );
+    *p++ = (unsigned char)( kkpp_len      );
 
     *olen = kkpp_len + 4;
 
@@ -516,11 +510,11 @@ static int ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, (unsigned)( ssl->own_cid_len + 5 ) );
 
     /* Add extension ID + size */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_CID >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_CID      );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+    *p++ = (unsigned char)( ext_len >> 8 );
+    *p++ = (unsigned char)( ext_len      );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -549,10 +543,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      )
-                            & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -583,8 +575,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -614,8 +606,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -645,10 +637,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      )
-                            & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -679,11 +669,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SESSION_TICKET      );
 
-    *p++ = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( tlen      ) & 0xFF );
+    *p++ = (unsigned char)( tlen >> 8 );
+    *p++ = (unsigned char)( tlen      );
 
     *olen = 4;
 
@@ -723,8 +713,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ALPN >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ALPN      );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -751,12 +741,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = (unsigned char)( ( *olen - 6 ) >> 8 );
+    buf[5] = (unsigned char)( ( *olen - 6 )      );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = (unsigned char)( ( *olen - 4 ) >> 8 );
+    buf[3] = (unsigned char)( ( *olen - 4 )      );
 
     return( 0 );
 }
@@ -1303,8 +1293,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = (unsigned char)( ext_len >> 8 );
+        *p++ = (unsigned char)( ext_len      );
         p += ext_len;
     }
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1207,8 +1207,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     for( i = 0, p = buf + 6; i < ciph_len; i += 3, p += 3 )
     {
         if( p[0] == 0 &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[2] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+            p[1] == (unsigned char)( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) &&
+            p[2] == (unsigned char)( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
@@ -1970,8 +1970,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
     for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
-        if( p[0] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+        if( p[0] == (unsigned char)( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) &&
+            p[1] == (unsigned char)( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 
@@ -2174,8 +2174,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2219,11 +2219,11 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
      *   } ConnectionId;
     */
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_CID >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_CID      );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+    *p++ = (unsigned char)( ext_len >> 8 );
+    *p++ = (unsigned char)( ext_len      );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -2265,8 +2265,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2292,8 +2292,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2317,8 +2317,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SESSION_TICKET      );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2341,8 +2341,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2382,8 +2382,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2412,8 +2412,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2450,8 +2450,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 );
+    *p++ = (unsigned char)( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2462,8 +2462,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = (unsigned char)( kkpp_len >> 8 );
+    *p++ = (unsigned char)( kkpp_len      );
 
     *olen = kkpp_len + 4;
 }
@@ -2488,18 +2488,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    buf[1] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    buf[0] = (unsigned char)( MBEDTLS_TLS_EXT_ALPN >> 8 );
+    buf[1] = (unsigned char)( MBEDTLS_TLS_EXT_ALPN      );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = (unsigned char)( ( *olen - 4 ) >> 8 );
+    buf[3] = (unsigned char)( ( *olen - 4 )      );
 
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = (unsigned char)( ( *olen - 6 ) >> 8 );
+    buf[5] = (unsigned char)( ( *olen - 6 )      );
 
-    buf[6] = (unsigned char)( ( ( *olen - 7 )      ) & 0xFF );
+    buf[6] = (unsigned char)( ( *olen - 7 )      );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2797,8 +2797,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = (unsigned char)( ext_len >> 8 );
+        *p++ = (unsigned char)( ext_len      );
         p += ext_len;
     }
 
@@ -4422,8 +4422,8 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
     ssl->out_msg[6] = ( lifetime >>  8 ) & 0xFF;
     ssl->out_msg[7] = ( lifetime       ) & 0xFF;
 
-    ssl->out_msg[8] = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    ssl->out_msg[9] = (unsigned char)( ( tlen      ) & 0xFF );
+    ssl->out_msg[8] = (unsigned char)( tlen >> 8 );
+    ssl->out_msg[9] = (unsigned char)( tlen      );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5256,14 +5256,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     {
         start = (uint64_t) session->start;
 
-        *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( start       ) & 0xFF );
+        *p++ = (unsigned char)( start >> 56 ) ;
+        *p++ = (unsigned char)( start >> 48 ) ;
+        *p++ = (unsigned char)( start >> 40 ) ;
+        *p++ = (unsigned char)( start >> 32 ) ;
+        *p++ = (unsigned char)( start >> 24 ) ;
+        *p++ = (unsigned char)( start >> 16 ) ;
+        *p++ = (unsigned char)( start >>  8 ) ;
+        *p++ = (unsigned char)( start       ) ;
     }
 #endif /* MBEDTLS_HAVE_TIME */
 
@@ -5279,22 +5279,22 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session->ciphersuite >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ciphersuite      ) & 0xFF );
+        *p++ = (unsigned char)( session->ciphersuite >> 8 );
+        *p++ = (unsigned char)( session->ciphersuite      );
 
-        *p++ = (unsigned char)( session->compression & 0xFF );
+        *p++ = (unsigned char)( session->compression );
 
-        *p++ = (unsigned char)( session->id_len & 0xFF );
+        *p++ = (unsigned char)( session->id_len );
         memcpy( p, session->id, 32 );
         p += 32;
 
         memcpy( p, session->master, 48 );
         p += 48;
 
-        *p++ = (unsigned char)( ( session->verify_result >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result       ) & 0xFF );
+        *p++ = (unsigned char)( session->verify_result >> 24 );
+        *p++ = (unsigned char)( session->verify_result >> 16 );
+        *p++ = (unsigned char)( session->verify_result >>  8 );
+        *p++ = (unsigned char)( session->verify_result       );
     }
 
     /*
@@ -5311,9 +5311,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( cert_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( cert_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( cert_len       ) & 0xFF );
+        *p++ = (unsigned char)( cert_len >> 16 );
+        *p++ = (unsigned char)( cert_len >>  8 );
+        *p++ = (unsigned char)( cert_len       );
 
         if( session->peer_cert != NULL )
         {
@@ -5354,9 +5354,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session->ticket_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len       ) & 0xFF );
+        *p++ = (unsigned char)( session->ticket_len >> 16 );
+        *p++ = (unsigned char)( session->ticket_len >>  8 );
+        *p++ = (unsigned char)( session->ticket_len       );
 
         if( session->ticket != NULL )
         {
@@ -5364,10 +5364,10 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
             p += session->ticket_len;
         }
 
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime       ) & 0xFF );
+        *p++ = (unsigned char)( session->ticket_lifetime >> 24 );
+        *p++ = (unsigned char)( session->ticket_lifetime >> 16 );
+        *p++ = (unsigned char)( session->ticket_lifetime >>  8 );
+        *p++ = (unsigned char)( session->ticket_lifetime       );
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
@@ -5385,14 +5385,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     used += 1;
 
     if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->trunc_hmac ) & 0xFF );
+        *p++ = (unsigned char)( session->trunc_hmac );
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     used += 1;
 
     if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->encrypt_then_mac ) & 0xFF );
+        *p++ = (unsigned char)( session->encrypt_then_mac );
 #endif
 
     /* Done */
@@ -6235,10 +6235,10 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4 + session_len;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session_len >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len       ) & 0xFF );
+        *p++ = (unsigned char)( session_len >> 24 );
+        *p++ = (unsigned char)( session_len >> 16 );
+        *p++ = (unsigned char)( session_len >>  8 );
+        *p++ = (unsigned char)( session_len       );
 
         ret = ssl_session_save( ssl->session, 1,
                                 p, session_len, &session_len );
@@ -6280,10 +6280,10 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( ssl->badmac_seen >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen       ) & 0xFF );
+        *p++ = (unsigned char)( ssl->badmac_seen >> 24 );
+        *p++ = (unsigned char)( ssl->badmac_seen >> 16 );
+        *p++ = (unsigned char)( ssl->badmac_seen >>  8 );
+        *p++ = (unsigned char)( ssl->badmac_seen       );
     }
 #endif /* MBEDTLS_SSL_DTLS_BADMAC_LIMIT */
 
@@ -6291,23 +6291,23 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 16;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top       ) & 0xFF );
+        *p++ = (unsigned char)( ssl->in_window_top >> 56 );
+        *p++ = (unsigned char)( ssl->in_window_top >> 48 );
+        *p++ = (unsigned char)( ssl->in_window_top >> 40 );
+        *p++ = (unsigned char)( ssl->in_window_top >> 32 );
+        *p++ = (unsigned char)( ssl->in_window_top >> 24 );
+        *p++ = (unsigned char)( ssl->in_window_top >> 16 );
+        *p++ = (unsigned char)( ssl->in_window_top >>  8 );
+        *p++ = (unsigned char)( ssl->in_window_top       );
 
-        *p++ = (unsigned char)( ( ssl->in_window >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window       ) & 0xFF );
+        *p++ = (unsigned char)( ssl->in_window >> 56 );
+        *p++ = (unsigned char)( ssl->in_window >> 48 );
+        *p++ = (unsigned char)( ssl->in_window >> 40 );
+        *p++ = (unsigned char)( ssl->in_window >> 32 );
+        *p++ = (unsigned char)( ssl->in_window >> 24 );
+        *p++ = (unsigned char)( ssl->in_window >> 16 );
+        *p++ = (unsigned char)( ssl->in_window >>  8 );
+        *p++ = (unsigned char)( ssl->in_window       );
     }
 #endif /* MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 
@@ -6330,8 +6330,8 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 2;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( ssl->mtu >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->mtu       ) & 0xFF );
+        *p++ = (unsigned char)( ssl->mtu >>  8 );
+        *p++ = (unsigned char)( ssl->mtu       );
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -540,16 +540,16 @@ int main( void )
 #define ALPN_LIST_SIZE  10
 #define CURVE_LIST_SIZE 20
 
-#define PUT_UINT64_BE(out_be,in_le,i)                                   \
-{                                                                       \
-    (out_be)[(i) + 0] = (unsigned char)( ( (in_le) >> 56 ) & 0xFF );    \
-    (out_be)[(i) + 1] = (unsigned char)( ( (in_le) >> 48 ) & 0xFF );    \
-    (out_be)[(i) + 2] = (unsigned char)( ( (in_le) >> 40 ) & 0xFF );    \
-    (out_be)[(i) + 3] = (unsigned char)( ( (in_le) >> 32 ) & 0xFF );    \
-    (out_be)[(i) + 4] = (unsigned char)( ( (in_le) >> 24 ) & 0xFF );    \
-    (out_be)[(i) + 5] = (unsigned char)( ( (in_le) >> 16 ) & 0xFF );    \
-    (out_be)[(i) + 6] = (unsigned char)( ( (in_le) >> 8  ) & 0xFF );    \
-    (out_be)[(i) + 7] = (unsigned char)( ( (in_le) >> 0  ) & 0xFF );    \
+#define PUT_UINT64_BE(out_be,in_le,i)                        \
+{                                                            \
+    (out_be)[(i) + 0] = (unsigned char)( (in_le) >> 56 );    \
+    (out_be)[(i) + 1] = (unsigned char)( (in_le) >> 48 );    \
+    (out_be)[(i) + 2] = (unsigned char)( (in_le) >> 40 );    \
+    (out_be)[(i) + 3] = (unsigned char)( (in_le) >> 32 );    \
+    (out_be)[(i) + 4] = (unsigned char)( (in_le) >> 24 );    \
+    (out_be)[(i) + 5] = (unsigned char)( (in_le) >> 16 );    \
+    (out_be)[(i) + 6] = (unsigned char)( (in_le) >> 8  );    \
+    (out_be)[(i) + 7] = (unsigned char)( (in_le) >> 0  );    \
 }
 
 


### PR DESCRIPTION
## Description

When casting to an unsigned char an integer it is unnecessary to bitwise-and it with 0xFF before.
The project enforces that unsigned chars are 8 bits long. This was pointed at by @mpg during the code review of #873: https://github.com/ARMmbed/mbedtls/pull/873#discussion_r437241777.

## Status
CI TESTING

## Requires Backporting
 NO  

