### PR TITLE
[Backport 2.7] Make basic-build-test.sh more deterministic

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -162,7 +162,11 @@ pre_initialize_variables () {
     YOTTA=1
 
     # Seed value used with the --release-test option.
-    # !!! Keep this in sync with SEED in basic-build-test.sh !!!
+    #
+    # See also RELEASE_SEED in basic-build-test.sh. Debugging is easier if
+    # both values are kept in sync. If you change the value here because it
+    # breaks some tests, you'll definitely want to change it in
+    # basic-build-test.sh as well.
     RELEASE_SEED=1
 
     # Default commands, can be overridden by the environment

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -161,6 +161,10 @@ pre_initialize_variables () {
     KEEP_GOING=0
     YOTTA=1
 
+    # Seed value used with the --release-test option.
+    # !!! Keep this in sync with SEED in basic-build-test.sh !!!
+    RELEASE_SEED=1
+
     # Default commands, can be overridden by the environment
     : ${OPENSSL:="openssl"}
     : ${OPENSSL_LEGACY:="$OPENSSL"}
@@ -246,7 +250,7 @@ General options:
      --no-yotta         Skip yotta module build.
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
      --random-seed      Use a random seed value for randomized tests (default).
-  -r|--release-test     Run this script in release mode. This fixes the seed value to 1.
+  -r|--release-test     Run this script in release mode. This fixes the seed value to ${RELEASE_SEED}.
   -s|--seed             Integer seed value to use for this test run.
      --yotta            Build yotta module (on by default).
 
@@ -377,7 +381,7 @@ pre_parse_command_line () {
             --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
             --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
             --random-seed) unset SEED;;
-            --release-test|-r) SEED=1;;
+            --release-test|-r) SEED=$RELEASE_SEED;;
             --seed|-s) shift; SEED="$1";;
             --yotta) YOTTA=1;;
             -*)

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -84,7 +84,10 @@ fi
 : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
 
 # Used to make ssl-opt.sh deterministic.
-# !!! Keep this in sync with RELEASE_SEED in all.sh !!!
+#
+# See also RELEASE_SEED in all.sh. Debugging is easier if both values are kept
+# in sync. If you change the value here because it breaks some tests, you'll
+# definitely want to change it in all.sh as well.
 : ${SEED:=1}
 export SEED
 

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -83,6 +83,11 @@ fi
 : ${GNUTLS_LEGACY_CLI:="$GNUTLS_CLI"}
 : ${GNUTLS_LEGACY_SERV:="$GNUTLS_SERV"}
 
+# Used to make ssl-opt.sh deterministic.
+# !!! Keep this in sync with RELEASE_SEED in all.sh !!!
+: ${SEED:=1}
+export SEED
+
 # To avoid setting OpenSSL and GnuTLS for each call to compat.sh and ssl-opt.sh
 # we just export the variables they require
 export OPENSSL_CMD="$OPENSSL"


### PR DESCRIPTION
This is the straightforward 2.7 backport of #3410.
