### PR TITLE
[backport 2.16] Use all.sh in pre-push hook

### DIFF
--- a/tests/git-scripts/pre-push.sh
+++ b/tests/git-scripts/pre-push.sh
@@ -72,18 +72,4 @@ echo "URL is $URL"
 
 set -eu
 
-run_test()
-{
-    TEST=$1
-    echo "running '$TEST'"
-    if ! `$TEST > /dev/null 2>&1`; then
-        echo "test '$TEST' failed"
-        return 1
-    fi
-}
-
-run_test ./tests/scripts/check-doxy-blocks.pl
-run_test ./tests/scripts/check-names.sh
-run_test ./tests/scripts/check-generated-files.sh
-run_test ./tests/scripts/check-files.py
-run_test ./tests/scripts/doxygen.sh
+tests/scripts/all.sh -q -k 'check_*'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1585,7 +1585,10 @@ component_check_python_files () {
 
 component_check_generate_test_code () {
     msg "uint test: generate_test_code.py"
-    record_status ./tests/scripts/test_generate_test_code.py
+    # unittest writes out mundane stuff like number or tests run on stderr.
+    # Our convention is to reserve stderr for actual errors, and write
+    # harmless info on stdout so it can be suppress with --quiet.
+    record_status ./tests/scripts/test_generate_test_code.py 2>&1
 }
 
 ################################################################

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1624,7 +1624,7 @@ run_component () {
 
     # Restore the build tree to a clean state.
     cleanup
-    current_component=""
+    unset current_component
 }
 
 # Preliminary setup

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -158,6 +158,7 @@ pre_initialize_variables () {
 
     MEMORY=0
     FORCE=0
+    QUIET=0
     KEEP_GOING=0
 
     # Seed value used with the --release-test option.
@@ -238,6 +239,7 @@ Special options:
   --list-components     List components supported on this platform and exit.
 
 General options:
+  -q|--quiet            Only output component names, and errors if any.
   -f|--force            Force the tests to overwrite any modified files.
   -k|--keep-going       Run all tests and report errors at the end.
   -m|--memory           Additional optional memory tests.
@@ -251,6 +253,7 @@ General options:
      --no-force         Refuse to overwrite modified files (default).
      --no-keep-going    Stop at the first error (default).
      --no-memory        No additional memory tests (default).
+     --no-quiet         Print full ouput from components.
      --out-of-source-dir=<path>  Directory used for CMake out-of-source build tests.
      --random-seed      Use a random seed value for randomized tests (default).
   -r|--release-test     Run this script in release mode. This fixes the seed value to ${RELEASE_SEED}.
@@ -317,6 +320,11 @@ msg()
     else
         current_section="$1"
     fi
+
+    if [ $QUIET -eq 1 ]; then
+        return
+    fi
+
     echo ""
     echo "******************************************************************"
     echo "* $current_section "
@@ -387,10 +395,12 @@ pre_parse_command_line () {
             --no-force) FORCE=0;;
             --no-keep-going) KEEP_GOING=0;;
             --no-memory) MEMORY=0;;
+            --no-quiet) QUIET=0;;
             --openssl) shift; OPENSSL="$1";;
             --openssl-legacy) shift; OPENSSL_LEGACY="$1";;
             --openssl-next) shift; OPENSSL_NEXT="$1";;
             --out-of-source-dir) shift; OUT_OF_SOURCE_DIR="$1";;
+            --quiet|-q) QUIET=1;;
             --random-seed) unset SEED;;
             --release-test|-r) SEED=$RELEASE_SEED;;
             --seed|-s) shift; SEED="$1";;
@@ -472,7 +482,7 @@ pre_setup_keep_going () {
             failure_summary="$failure_summary
 $text"
             failure_count=$((failure_count + 1))
-            echo "${start_red}^^^^$text^^^^${end_color}"
+            echo "${start_red}^^^^$text^^^^${end_color}" >&2
         fi
     }
     make () {
@@ -518,7 +528,23 @@ not() {
     ! "$@"
 }
 
+pre_setup_quiet_redirect () {
+    if [ $QUIET -ne 1 ]; then
+        redirect_out () {
+            "$@"
+        }
+    else
+        redirect_out () {
+            "$@" >/dev/null
+        }
+    fi
+}
+
 pre_print_configuration () {
+    if [ $QUIET -eq 1 ]; then
+        return
+    fi
+
     msg "info: $0 configuration"
     echo "MEMORY: $MEMORY"
     echo "FORCE: $FORCE"
@@ -590,6 +616,11 @@ pre_check_tools () {
             check_tools "$ARMC5_CC" "$ARMC5_AR" "$ARMC5_FROMELF" \
                         "$ARMC6_CC" "$ARMC6_AR" "$ARMC6_FROMELF";;
     esac
+
+    # past this point, no call to check_tool, only printing output
+    if [ $QUIET -eq 1 ]; then
+        return
+    fi
 
     msg "info: output_env.sh"
     case $RUN_COMPONENTS in
@@ -1580,8 +1611,17 @@ run_component () {
     # The cleanup function will restore it.
     cp -p "$CONFIG_H" "$CONFIG_BAK"
     current_component="$1"
-    "$@"
+
+    # Run the component code.
+    if [ $QUIET -eq 1 ]; then
+        # msg() is silenced, so just print the component name here
+        echo "${current_component#component_}"
+    fi
+    redirect_out "$@"
+
+    # Restore the build tree to a clean state.
     cleanup
+    current_component=""
 }
 
 # Preliminary setup
@@ -1598,6 +1638,7 @@ else
         "$@"
     }
 fi
+pre_setup_quiet_redirect
 pre_print_configuration
 pre_check_tools
 cleanup


### PR DESCRIPTION
This is the 2.16 backport of #2639. It's mostly straighforward except for the following differences:

- invocation of dd not present in 2.16 (skipped 2 commits)
- `component_check_test_cases` not present in 2.16 (skipped 1 commit)
- `OUTCOME_FILE` not present in 2.16 (context only)
