### PR TITLE
[backport 2.7] Use all.sh in pre-push hook

### DIFF
--- a/tests/git-scripts/pre-push.sh
+++ b/tests/git-scripts/pre-push.sh
@@ -72,18 +72,4 @@ echo "URL is $URL"
 
 set -eu
 
-run_test()
-{
-    TEST=$1
-    echo "running '$TEST'"
-    if ! `$TEST > /dev/null 2>&1`; then
-        echo "test '$TEST' failed"
-        return 1
-    fi
-}
-
-run_test ./tests/scripts/check-doxy-blocks.pl
-run_test ./tests/scripts/check-names.sh
-run_test ./tests/scripts/check-generated-files.sh
-run_test ./tests/scripts/check-files.py
-run_test ./tests/scripts/doxygen.sh
+tests/scripts/all.sh -q -k 'check_*'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1424,7 +1424,7 @@ run_component () {
 
     # Restore the build tree to a clean state.
     cleanup
-    current_component=""
+    unset current_component
 }
 
 # Preliminary setup


### PR DESCRIPTION
This is the 2.7 backport of #2639, based on the 2.16 backport in #3446. Compared to the 2.16 backports, differences are:

- yotta option still present in 2.7 (context change only)
- `component_check_generate_test_code` not present in 2.7 (skipped 1 commit)

