### PR TITLE
Renamed mbedtls_platform_memcmp() to mbedtls_platform_memequal()

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -130,11 +130,11 @@
  */
 #define MBEDTLS_OID_CMP(oid_str, oid_buf)                                   \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf)->len ) ||                \
-          mbedtls_platform_memcmp( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
+          mbedtls_platform_memequal( (oid_str), (oid_buf)->p, (oid_buf)->len) != 0 )
 
 #define MBEDTLS_OID_CMP_RAW(oid_str, oid_buf, oid_buf_len)                  \
         ( ( MBEDTLS_OID_SIZE(oid_str) != (oid_buf_len) ) ||                 \
-          mbedtls_platform_memcmp( (oid_str), (oid_buf), (oid_buf_len) ) != 0 )
+          mbedtls_platform_memequal( (oid_str), (oid_buf), (oid_buf_len) ) != 0 )
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/compat-1.3.h
+++ b/include/mbedtls/compat-1.3.h
@@ -2231,7 +2231,7 @@
 #define rsa_rsassa_pss_verify_ext mbedtls_rsa_rsassa_pss_verify_ext
 #define rsa_self_test mbedtls_rsa_self_test
 #define rsa_set_padding mbedtls_rsa_set_padding
-#define safer_memcmp mbedtls_platform_memcmp
+#define safer_memcmp mbedtls_platform_memequal
 #define set_alarm mbedtls_set_alarm
 #define sha1 mbedtls_sha1
 #define sha1_context mbedtls_sha1_context

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -215,12 +215,12 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 int mbedtls_platform_memmove( void *dst, const void *src, size_t num );
 
 /**
- * \brief       Secure memcmp
+ * \brief       Secure check if the buffers have the same data.
  *
- *              This is a constant-time version of memcmp(). If
- *              MBEDTLS_ENTROPY_HARDWARE_ALT is defined, the order is also
- *              randomised using the hardware RNG in order to further harden
- *              against side-channel attacks.
+ *              This is a constant-time version of memcmp(), but without checking
+ *              if the bytes are greater or lower. If MBEDTLS_ENTROPY_HARDWARE_ALT
+ *              is defined, the order is also randomised using the hardware RNG in
+ *              order to further harden against side-channel attacks.
  *
  * \param buf1  First buffer to compare.
  * \param buf2  Second buffer to compare against.
@@ -229,7 +229,7 @@ int mbedtls_platform_memmove( void *dst, const void *src, size_t num );
  * \return      0 if the buffers were equal or an unspecified non-zero value
  *              otherwise.
  */
-int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
+int mbedtls_platform_memequal( const void *buf1, const void *buf2, size_t num );
 
 /**
  * \brief       RNG-function for getting a random 32-bit integer.

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -431,7 +431,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *
     while( list != NULL )
     {
         if( list->oid.len == len &&
-            mbedtls_platform_memcmp( list->oid.p, oid, len ) == 0 )
+            mbedtls_platform_memequal( list->oid.p, oid, len ) == 0 )
         {
             break;
         }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -348,7 +348,7 @@ static mbedtls_asn1_named_data *asn1_find_named_data(
     while( list != NULL )
     {
         if( list->oid.len == len &&
-            mbedtls_platform_memcmp( list->oid.p, oid, len ) == 0 )
+            mbedtls_platform_memequal( list->oid.p, oid, len ) == 0 )
         {
             break;
         }

--- a/library/des.c
+++ b/library/des.c
@@ -417,7 +417,7 @@ int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] )
     int i;
 
     for( i = 0; i < WEAK_KEY_COUNT; i++ )
-        if( mbedtls_platform_memcmp( weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0 )
+        if( mbedtls_platform_memequal( weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0 )
             return( 1 );
 
     return( 0 );

--- a/library/oid.c
+++ b/library/oid.c
@@ -75,7 +75,7 @@
         if( p == NULL || oid == NULL ) return( NULL );                  \
         while( cur->asn1 != NULL ) {                                    \
             if( cur->asn1_len == oid->len &&                            \
-                mbedtls_platform_memcmp( cur->asn1, oid->p, oid->len ) == 0 ) {          \
+                mbedtls_platform_memequal( cur->asn1, oid->p, oid->len ) == 0 ) {          \
                 return( p );                                            \
             }                                                           \
             p++;                                                        \

--- a/library/pem.c
+++ b/library/pem.c
@@ -273,7 +273,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
     enc = 0;
 
-    if( s2 - s1 >= 22 && mbedtls_platform_memcmp( s1, "Proc-Type: 4,ENCRYPTED", 22 ) == 0 )
+    if( s2 - s1 >= 22 && mbedtls_platform_memequal( s1, "Proc-Type: 4,ENCRYPTED", 22 ) == 0 )
     {
 #if defined(MBEDTLS_MD5_C) && defined(MBEDTLS_CIPHER_MODE_CBC) &&         \
     ( defined(MBEDTLS_DES_C) || defined(MBEDTLS_AES_C) )
@@ -286,7 +286,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
 
 #if defined(MBEDTLS_DES_C)
-        if( s2 - s1 >= 23 && mbedtls_platform_memcmp( s1, "DEK-Info: DES-EDE3-CBC,", 23 ) == 0 )
+        if( s2 - s1 >= 23 && mbedtls_platform_memequal( s1, "DEK-Info: DES-EDE3-CBC,", 23 ) == 0 )
         {
             enc_alg = MBEDTLS_CIPHER_DES_EDE3_CBC;
 
@@ -296,7 +296,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 
             s1 += 16;
         }
-        else if( s2 - s1 >= 18 && mbedtls_platform_memcmp( s1, "DEK-Info: DES-CBC,", 18 ) == 0 )
+        else if( s2 - s1 >= 18 && mbedtls_platform_memequal( s1, "DEK-Info: DES-CBC,", 18 ) == 0 )
         {
             enc_alg = MBEDTLS_CIPHER_DES_CBC;
 
@@ -309,15 +309,15 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
 #endif /* MBEDTLS_DES_C */
 
 #if defined(MBEDTLS_AES_C)
-        if( s2 - s1 >= 14 && mbedtls_platform_memcmp( s1, "DEK-Info: AES-", 14 ) == 0 )
+        if( s2 - s1 >= 14 && mbedtls_platform_memequal( s1, "DEK-Info: AES-", 14 ) == 0 )
         {
             if( s2 - s1 < 22 )
                 return( MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG );
-            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-128-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memequal( s1, "DEK-Info: AES-128-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_128_CBC;
-            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-192-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memequal( s1, "DEK-Info: AES-192-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_192_CBC;
-            else if( mbedtls_platform_memcmp( s1, "DEK-Info: AES-256-CBC,", 22 ) == 0 )
+            else if( mbedtls_platform_memequal( s1, "DEK-Info: AES-256-CBC,", 22 ) == 0 )
                 enc_alg = MBEDTLS_CIPHER_AES_256_CBC;
             else
                 return( MBEDTLS_ERR_PEM_UNKNOWN_ENC_ALG );

--- a/library/pk.c
+++ b/library/pk.c
@@ -556,7 +556,7 @@ static int uecc_eckey_check_pair( const void *pub, const void *prv )
     const mbedtls_uecc_keypair *uecc_prv =
         (const mbedtls_uecc_keypair *) prv;
 
-    if( mbedtls_platform_memcmp( uecc_pub->public_key,
+    if( mbedtls_platform_memequal( uecc_pub->public_key,
                 uecc_prv->public_key,
                 2 * NUM_ECC_BYTES ) == 0 )
     {

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -309,7 +309,7 @@ static int pk_group_from_specified( const mbedtls_asn1_buf *params, mbedtls_ecp_
         return( ret );
 
     if( len != MBEDTLS_OID_SIZE( MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD ) ||
-        mbedtls_platform_memcmp( p, MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD, len ) != 0 )
+        mbedtls_platform_memequal( p, MBEDTLS_OID_ANSI_X9_62_PRIME_FIELD, len ) != 0 )
     {
         return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
     }

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -144,7 +144,7 @@ int mbedtls_platform_memmove( void *dst, const void *src, size_t num )
     return MBEDTLS_ERR_PLATFORM_ALLOC_FAILED;
 }
 
-int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
+int mbedtls_platform_memequal( const void *buf1, const void *buf2, size_t num )
 {
     volatile const unsigned char *A = (volatile const unsigned char *) buf1;
     volatile const unsigned char *B = (volatile const unsigned char *) buf2;

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2275,7 +2275,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     if ( ret != 0 )
         goto exit;
 
-    if( mbedtls_platform_memcmp( hash_start, result, hlen ) != 0 )
+    if( mbedtls_platform_memequal( hash_start, result, hlen ) != 0 )
     {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto exit;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -94,7 +94,7 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
             continue;
         }
 
-        if( mbedtls_platform_memcmp( session->id, entry->session.id,
+        if( mbedtls_platform_memequal( session->id, entry->session.id,
                     entry->session.id_len ) != 0 )
             continue;
 
@@ -180,7 +180,7 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
         }
 #endif
 
-        if( mbedtls_platform_memcmp( session->id, cur->session.id, cur->session.id_len ) == 0 )
+        if( mbedtls_platform_memequal( session->id, cur->session.id, cur->session.id_len ) == 0 )
             break; /* client reconnected, keep timestamp for session id */
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1164,9 +1164,9 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len * 2 ||
             buf[0] !=     ssl->verify_data_len * 2 ||
-            mbedtls_platform_memcmp( buf + 1,
+            mbedtls_platform_memequal( buf + 1,
                           ssl->own_verify_data, ssl->verify_data_len ) != 0 ||
-            mbedtls_platform_memcmp( buf + 1 + ssl->verify_data_len,
+            mbedtls_platform_memequal( buf + 1 + ssl->verify_data_len,
                           ssl->peer_verify_data, ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );
@@ -1495,7 +1495,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
     for( p = ssl->conf->alpn_list; *p != NULL; p++ )
     {
         if( name_len == strlen( *p ) &&
-            mbedtls_platform_memcmp( buf + 3, *p, name_len ) == 0 )
+            mbedtls_platform_memequal( buf + 3, *p, name_len ) == 0 )
         {
             ssl->alpn_chosen = *p;
             return( 0 );
@@ -1746,7 +1746,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
 
     mbedtls_platform_memcpy( ssl->handshake->randbytes + 32, buf + 2, 32 );
 
-    if( mbedtls_platform_memcmp( ssl->handshake->randbytes + 32, buf + 2, 32 ) == 0 )
+    if( mbedtls_platform_memequal( ssl->handshake->randbytes + 32, buf + 2, 32 ) == 0 )
     {
         ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
     }
@@ -1847,7 +1847,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
         mbedtls_ssl_session_get_ciphersuite( ssl->session_negotiate ) != i ||
         mbedtls_ssl_session_get_compression( ssl->session_negotiate ) != comp ||
         ssl->session_negotiate->id_len != n ||
-        mbedtls_platform_memcmp( ssl->session_negotiate->id, buf + 35, n ) != 0 )
+        mbedtls_platform_memequal( ssl->session_negotiate->id, buf + 35, n ) != 0 )
     {
         ssl->handshake->resume = MBEDTLS_SSL_FI_FLAG_UNSET;
     }
@@ -2876,7 +2876,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );
         }
 
-        if( mbedtls_platform_memcmp( p, ecdh_group, sizeof( ecdh_group ) ) != 0 )
+        if( mbedtls_platform_memequal( p, ecdh_group, sizeof( ecdh_group ) ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "Bad server key exchange (unexpected header)" ) );
             return( MBEDTLS_ERR_SSL_HW_ACCEL_FAILED );

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -229,7 +229,7 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
     if( ret != 0 )
         return( ret );
 
-    if( mbedtls_platform_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
+    if( mbedtls_platform_memequal( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
         return( -1 );
 
 #if defined(MBEDTLS_HAVE_TIME)

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -162,7 +162,7 @@ static int ssl_parse_renegotiation_info( mbedtls_ssl_context *ssl,
         /* Check verify-data in constant-time. The length OTOH is no secret */
         if( len    != 1 + ssl->verify_data_len ||
             buf[0] !=     ssl->verify_data_len ||
-            mbedtls_platform_memcmp( buf + 1, ssl->peer_verify_data,
+            mbedtls_platform_memequal( buf + 1, ssl->peer_verify_data,
                           ssl->verify_data_len ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "non-matching renegotiation info" ) );
@@ -711,7 +711,7 @@ static int ssl_parse_alpn_ext( mbedtls_ssl_context *ssl,
             cur_len = *theirs++;
 
             if( cur_len == ours_len &&
-                mbedtls_platform_memcmp( theirs, *ours, cur_len ) == 0 )
+                mbedtls_platform_memequal( theirs, *ours, cur_len ) == 0 )
             {
                 ssl->alpn_chosen = *ours;
                 return( 0 );
@@ -1228,7 +1228,7 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_UNSET;
     memset( ssl->handshake->randbytes, 0, 64 );
     mbedtls_platform_memcpy( ssl->handshake->randbytes + 32 - chal_len, p, chal_len );
-    if( mbedtls_platform_memcmp( ssl->handshake->randbytes + 32 - chal_len, p, chal_len ) == 0 )
+    if( mbedtls_platform_memequal( ssl->handshake->randbytes + 32 - chal_len, p, chal_len ) == 0 )
     {
         ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
     }
@@ -1628,7 +1628,7 @@ read_record_header:
          * fragment_offset == 0 and fragment_length == length
          */
         if( ssl->in_msg[6] != 0 || ssl->in_msg[7] != 0 || ssl->in_msg[8] != 0 ||
-            mbedtls_platform_memcmp( ssl->in_msg + 1, ssl->in_msg + 9, 3 ) != 0 )
+            mbedtls_platform_memequal( ssl->in_msg + 1, ssl->in_msg + 9, 3 ) != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "ClientHello fragmentation not supported" ) );
             return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
@@ -1728,7 +1728,7 @@ read_record_header:
     MBEDTLS_SSL_DEBUG_BUF( 3, "client hello, random bytes", buf + 2, 32 );
 
     mbedtls_platform_memcpy( ssl->handshake->randbytes, buf + 2, 32 );
-    if( mbedtls_platform_memcmp( ssl->handshake->randbytes, buf + 2, 32 ) == 0 )
+    if( mbedtls_platform_memequal( ssl->handshake->randbytes, buf + 2, 32 ) == 0 )
     {
         ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
     }
@@ -2827,7 +2827,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     p += 28;
     ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_UNSET;
     mbedtls_platform_memcpy( ssl->handshake->randbytes + 32, buf + 6, 32 );
-    if( mbedtls_platform_memcmp( ssl->handshake->randbytes + 32, buf + 6, 32 ) == 0 )
+    if( mbedtls_platform_memequal( ssl->handshake->randbytes + 32, buf + 6, 32 ) == 0 )
     {
         ssl->handshake->hello_random_set = MBEDTLS_SSL_FI_FLAG_SET;
     }
@@ -4119,7 +4119,7 @@ static int ssl_parse_client_psk_identity( mbedtls_ssl_context *ssl, unsigned cha
         /* Identity is not a big secret since clients send it in the clear,
          * but treat it carefully anyway, just in case */
         if( n != ssl->conf->psk_identity_len ||
-            mbedtls_platform_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
+            mbedtls_platform_memequal( ssl->conf->psk_identity, *p, n ) != 0 )
         {
             ret = MBEDTLS_ERR_SSL_UNKNOWN_IDENTITY;
         }

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -259,7 +259,7 @@ static mbedtls_ssl_ticket_key *ssl_ticket_select_key(
     unsigned char i;
 
     for( i = 0; i < sizeof( ctx->keys ) / sizeof( *ctx->keys ); i++ )
-        if( mbedtls_platform_memcmp( name, ctx->keys[i].name, 4 ) == 0 )
+        if( mbedtls_platform_memequal( name, ctx->keys[i].name, 4 ) == 0 )
             return( &ctx->keys[i] );
 
     return( NULL );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3164,7 +3164,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
              *
              * Afterwards, we know that data + data_len is followed by at
              * least maclen Bytes, which justifies the call to
-             * mbedtls_platform_memcmp() below.
+             * mbedtls_platform_memequal() below.
              *
              * Further, we still know that data_len > minlen */
             rec->data_len -= transform->maclen;
@@ -3186,8 +3186,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
                                    transform->maclen );
 
             /* Compare expected MAC with MAC at the end of the record. */
-            if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
-                                          transform->maclen ) != 0 )
+            if( mbedtls_platform_memequal( data + rec->data_len, mac_expect,
+                                           transform->maclen ) != 0 )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1, ( "message mac does not match" ) );
                 return( MBEDTLS_ERR_SSL_INVALID_MAC );
@@ -3525,8 +3525,8 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         MBEDTLS_SSL_DEBUG_BUF( 4, "message  mac", data + rec->data_len, transform->maclen );
 #endif
 
-        if( mbedtls_platform_memcmp( data + rec->data_len, mac_expect,
-                                      transform->maclen ) != 0 )
+        if( mbedtls_platform_memequal( data + rec->data_len, mac_expect,
+                                       transform->maclen ) != 0 )
         {
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "message mac does not match" ) );
@@ -4734,8 +4734,8 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
 static int ssl_hs_is_proper_fragment( mbedtls_ssl_context *ssl )
 {
     if( ssl->in_msglen < ssl->in_hslen ||
-        mbedtls_platform_memcmp( ssl->in_msg + 6, "\0\0\0",        3 ) != 0 ||
-        mbedtls_platform_memcmp( ssl->in_msg + 9, ssl->in_msg + 1, 3 ) != 0 )
+        mbedtls_platform_memequal( ssl->in_msg + 6, "\0\0\0",        3 ) != 0 ||
+        mbedtls_platform_memequal( ssl->in_msg + 9, ssl->in_msg + 1, 3 ) != 0 )
     {
         return( PROPER_HS_FRAGMENT );
     }
@@ -7070,7 +7070,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( peer_crt->raw.len != crt_buf_len )
         return( PEER_CRT_CHANGED );
 
-    return( mbedtls_platform_memcmp( peer_crt->raw.p, crt_buf, crt_buf_len ) );
+    return( mbedtls_platform_memequal( peer_crt->raw.p, crt_buf, crt_buf_len ) );
 }
 #elif defined(MBEDTLS_SSL_RENEGOTIATION)
 #define PEER_CRT_CHANGED 0x75555555
@@ -7102,7 +7102,7 @@ static int ssl_check_peer_crt_unchanged( mbedtls_ssl_context *ssl,
     if( ret != 0 )
         return( PEER_CRT_CHANGED );
 
-    return( mbedtls_platform_memcmp( tmp_digest, peer_cert_digest, digest_len ) );
+    return( mbedtls_platform_memequal( tmp_digest, peer_cert_digest, digest_len ) );
 }
 #endif /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE && MBEDTLS_SSL_RENEGOTIATION */
 #endif /* MBEDTLS_SSL_RENEGOTIATION && MBEDTLS_SSL_CLI_C */
@@ -8350,8 +8350,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         return( MBEDTLS_ERR_SSL_BAD_HS_FINISHED );
     }
 
-    if( mbedtls_platform_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
-                      buf, hash_len ) != 0 )
+    if( mbedtls_platform_memequal( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
+                                   buf, hash_len ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
         mbedtls_ssl_pend_fatal_alert( ssl,
@@ -12125,7 +12125,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
             for( cur = ssl->conf->alpn_list; *cur != NULL; cur++ )
             {
                 if( strlen( *cur ) == alpn_len &&
-                    mbedtls_platform_memcmp( p, cur, alpn_len ) == 0 )
+                    mbedtls_platform_memequal( p, cur, alpn_len ) == 0 )
                 {
                     ssl->alpn_chosen = *cur;
                     break;

--- a/library/x509.c
+++ b/library/x509.c
@@ -516,7 +516,7 @@ static int x509_string_cmp( const mbedtls_x509_buf *a,
 {
     if( a->tag == b->tag &&
         a->len == b->len &&
-        mbedtls_platform_memcmp( a->p, b->p, b->len ) == 0 )
+        mbedtls_platform_memequal( a->p, b->p, b->len ) == 0 )
     {
         return( 0 );
     }
@@ -605,7 +605,7 @@ static int mbedtls_x509_name_cmp_raw( mbedtls_x509_buf_raw const *a,
             goto exit;
 
         if( oid[0].len != oid[1].len ||
-            mbedtls_platform_memcmp( oid[0].p, oid[1].p, oid[1].len ) != 0 )
+            mbedtls_platform_memequal( oid[0].p, oid[1].p, oid[1].len ) != 0 )
         {
             return( 1 );
         }

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -511,10 +511,10 @@ int mbedtls_x509_crl_parse_der( mbedtls_x509_crl *chain,
     }
 
     if( crl->sig_oid.len != sig_oid2.len ||
-        mbedtls_platform_memcmp( crl->sig_oid.p, sig_oid2.p, crl->sig_oid.len ) != 0 ||
+        mbedtls_platform_memequal( crl->sig_oid.p, sig_oid2.p, crl->sig_oid.len ) != 0 ||
         sig_params1.len != sig_params2.len ||
         ( sig_params1.len != 0 &&
-          mbedtls_platform_memcmp( sig_params1.p, sig_params2.p, sig_params1.len ) != 0 ) )
+          mbedtls_platform_memequal( sig_params1.p, sig_params2.p, sig_params1.len ) != 0 ) )
     {
         mbedtls_x509_crl_free( crl );
         return( MBEDTLS_ERR_X509_SIG_MISMATCH );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1322,7 +1322,7 @@ static int x509_crt_parse_frame( unsigned char *start,
      *    signature field in the sequence tbsCertificate (Section 4.1.2.3).
      */
     if( outer_sig_alg.len != inner_sig_alg_len ||
-        mbedtls_platform_memcmp( outer_sig_alg.p, inner_sig_alg_start, inner_sig_alg_len ) != 0 )
+        mbedtls_platform_memequal( outer_sig_alg.p, inner_sig_alg_start, inner_sig_alg_len ) != 0 )
     {
         return( MBEDTLS_ERR_X509_SIG_MISMATCH );
     }
@@ -2594,7 +2594,7 @@ static int x509_crt_check_ext_key_usage_cb( void *ctx,
         return( 1 );
     }
 
-    if( data_len == cb_ctx->oid_len && mbedtls_platform_memcmp( data, cb_ctx->oid,
+    if( data_len == cb_ctx->oid_len && mbedtls_platform_memequal( data, cb_ctx->oid,
                                                data_len ) == 0 )
     {
         return( 1 );
@@ -2652,7 +2652,7 @@ static int x509_serial_is_revoked( unsigned char const *serial,
     while( cur != NULL && cur->serial.len != 0 )
     {
         if( serial_len == cur->serial.len &&
-            mbedtls_platform_memcmp( serial, cur->serial.p, serial_len ) == 0 )
+            mbedtls_platform_memequal( serial, cur->serial.p, serial_len ) == 0 )
         {
             if( mbedtls_x509_time_is_past( &cur->revocation_date ) )
                 return( 1 );
@@ -3191,7 +3191,7 @@ static int x509_crt_check_ee_locally_trusted(
     for( cur = trust_ca; cur != NULL; cur = cur->next )
     {
         if( crt->raw.len == cur->raw.len &&
-            mbedtls_platform_memcmp( crt->raw.p, cur->raw.p, crt->raw.len ) == 0 )
+            mbedtls_platform_memequal( crt->raw.p, cur->raw.p, crt->raw.len ) == 0 )
         {
             return( 0 );
         }


### PR DESCRIPTION
## Description
This PR contains minor refactoring changes like:
* Renamed `mbedtls_platform_memcmp()` to `mbedtls_platform_memequal()`
* A few smaller changes


## Status
**READY**
