### PR TITLE
Don't force MBEDTLS_PLATFORM_SNPRINTF_ALT on Windows in check_config.h

### DIFF
--- a/ChangeLog.d/win32-snprintf-alt.txt
+++ b/ChangeLog.d/win32-snprintf-alt.txt
@@ -1,0 +1,6 @@
+Changes
+   * The symbols MBEDTLS_PLATFORM_VSNPRINTF_ALT and
+     MBEDTLS_PLATFORM_SNPRINTF_ALT are no longer forced to be defined on
+     Windows. The library still uses its (v)snprintf wrappers on older
+     Windows runtimes where they are needed, so this only affects applications
+     that test MBEDTLS_PLATFORM_{V,}SNPRINTF_ALT in their own code.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -39,24 +39,6 @@
 #error "mbed TLS requires a platform with 8-bit chars"
 #endif
 
-#if defined(_WIN32)
-#if !defined(MBEDTLS_PLATFORM_C)
-#error "MBEDTLS_PLATFORM_C is required on Windows"
-#endif
-
-/* Fix the config here. Not convenient to put an #ifdef _WIN32 in config.h as
- * it would confuse config.py. */
-#if !defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) && \
-    !defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
-#define MBEDTLS_PLATFORM_SNPRINTF_ALT
-#endif
-
-#if !defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT) && \
-    !defined(MBEDTLS_PLATFORM_VSNPRINTF_MACRO)
-#define MBEDTLS_PLATFORM_VSNPRINTF_ALT
-#endif
-#endif /* _WIN32 */
-
 #if defined(TARGET_LIKE_MBED) && \
     ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
 #error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -65,6 +65,9 @@ extern "C" {
 #if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER <= 1900)
 #define MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF
 #define MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF
+#if !defined(MBEDTLS_PLATFORM_C)
+#error "MBEDTLS_PLATFORM_C is required on older Windows runtimes with a non-conforming snprintf"
+#endif
 #endif
 
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)


### PR DESCRIPTION
`check_config.h` forces `MBEDTLS_PLATFORM_SNPRINTF_ALT` and `MBEDTLS_PLATFORM_VSNPRINTF_ALT` to be defined on Windows. The reason for this is that the native (v)snprintf on older Windows runtimes (up to Visual Studio 2015: `_MSVC_VER <= 1900`) does not correctly zero-terminate the buffer. This is documented in `platform.h` and tested in `selftest.c`. To work around this bug, the library defines wrappers mbedtls_platform_win32_snprintf` and `mbedtls_platform_win32_vsnprintf` in `platform.c` and uses them as the value of `mbedtls_snprintf` and `mbedtls_vsnprintf`.

Even if `MBEDTLS_PLATFORM_{V,}SNPRINTF_ALT` is not defined, the macro `mbedtls_{v,}snprintf` expands to the corresponding wrapper function on platforms where it is necessary. Therefore modifying the configuration to set the `xxxSNPRINTF_ALT` symbols is not actually necessary. Don't do it.

With this change, `check_config.h` is truly a configuration _check_, as the name implies, and does not modify the configuration.

Here's a CI run with an additional patch that removes the wrapper altogether, to validate that the wrapper is getting used in this pull request: https://jenkins-internal.mbed.com/job/mbedtls-release-new/740/
* VS 2015 and VS 2017 builds pass.
* The mingw tests fail as expected because the test suite contains a test for snprintf as well.
* I expected the selftest on VS 2013 to fail, but that actually doesn't build because VS 2013 (at least the way we set it up) doesn't have enough C99 to declare `snprintf` (only `vsnprintf`). Never mind, the failure of snprintf on mingw shows that we do have a test that would catch the absence of the wrapper if it was necessary.

I don't see a need to backport this. The only reason I want to make this change is as a precursor to changing the way `check_config.h` is included, as done in #1999. That would be too disruptive for LTS branches.
