### PR TITLE
2.16 only: cmake cleanups under programs/

### DIFF
--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
 add_executable(ssl_client2 ssl_client2.c)
-target_sources(ssl_client2 PUBLIC query_config.c)
+target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 target_link_libraries(ssl_client2 ${libs})
 
 add_executable(ssl_fork_server ssl_fork_server.c)
@@ -51,7 +51,7 @@ add_executable(ssl_server ssl_server.c)
 target_link_libraries(ssl_server ${libs})
 
 add_executable(ssl_server2 ssl_server2.c)
-target_sources(ssl_server2 PUBLIC query_config.c)
+target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -8,12 +8,12 @@ set(libs
 set(targets
     dtls_client
     dtls_server
+    mini_client
     ssl_client1
     ssl_client2
-    ssl_server
     ssl_fork_server
     ssl_mail_client
-    mini_client
+    ssl_server
 )
 
 if(USE_PKCS11_HELPER_LIBRARY)
@@ -30,6 +30,9 @@ target_link_libraries(dtls_client ${libs})
 add_executable(dtls_server dtls_server.c)
 target_link_libraries(dtls_server ${libs})
 
+add_executable(mini_client mini_client.c)
+target_link_libraries(mini_client ${libs})
+
 add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
@@ -37,21 +40,18 @@ add_executable(ssl_client2 ssl_client2.c)
 target_sources(ssl_client2 PUBLIC query_config.c)
 target_link_libraries(ssl_client2 ${libs})
 
-add_executable(ssl_server ssl_server.c)
-target_link_libraries(ssl_server ${libs})
-
-add_executable(ssl_server2 ssl_server2.c)
-target_sources(ssl_server2 PUBLIC query_config.c)
-target_link_libraries(ssl_server2 ${libs})
-
 add_executable(ssl_fork_server ssl_fork_server.c)
 target_link_libraries(ssl_fork_server ${libs})
 
 add_executable(ssl_mail_client ssl_mail_client.c)
 target_link_libraries(ssl_mail_client ${libs})
 
-add_executable(mini_client mini_client.c)
-target_link_libraries(mini_client ${libs})
+add_executable(ssl_server ssl_server.c)
+target_link_libraries(ssl_server ${libs})
+
+add_executable(ssl_server2 ssl_server2.c)
+target_sources(ssl_server2 PUBLIC query_config.c)
+target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)
     add_executable(ssl_pthread_server ssl_pthread_server.c)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(targets
     ssl_fork_server
     ssl_mail_client
     ssl_server
+    ssl_server2
 )
 
 if(USE_PKCS11_HELPER_LIBRARY)

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(zeroize zeroize.c)
 target_link_libraries(zeroize ${libs})
 
 add_executable(query_compile_time_config query_compile_time_config.c)
-target_sources(query_compile_time_config PUBLIC ../ssl/query_config.c)
+target_sources(query_compile_time_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../ssl/query_config.c)
 target_link_libraries(query_compile_time_config ${libs})
 
 install(TARGETS selftest benchmark udp_proxy query_compile_time_config


### PR DESCRIPTION
This is a partial backport of #3438, covering only the bug fixes in `programs/*/CmakeLists.txt`.

* “programs: ssl: cmake: Reorder declaration of executables” — not a bug fix, but harmless and facilitates maintenance (including applying the subsequent patches).
* “programs: ssl: cmake: Add missing executables” — adapted, only one executable is missing in 2.16.
* “programs: cmake: Fix relative path warnings”

Not backported:

* “programs: cmake: Use list of executables” — it would facilitate maintenance, but there are many merge conflicts because development links crypto programs with libmbedcrypto whereas 2.16 links everything with libmbedtls.
* “programs: psa: Link against mbedcrypto not mbedtls” — not applicable to 2.16.

Needs backport to 2.7.
