### PR TITLE
[Backport 2.16] Get rid of mbedtls_test_unhexify() in unit test code

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -433,7 +433,7 @@ static void close_output( FILE* out_stream )
 }
 #endif /* __unix__ || __APPLE__ __MACH__ */
 
-int unhexify( unsigned char *obuf, const char *ibuf )
+int mbedtls_test_unhexify( unsigned char *obuf, const char *ibuf )
 {
     unsigned char c, c2;
     int len = strlen( ibuf ) / 2;
@@ -467,7 +467,7 @@ int unhexify( unsigned char *obuf, const char *ibuf )
     return len;
 }
 
-void hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
+void mbedtls_test_hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
 {
     unsigned char l, h;
 
@@ -533,7 +533,7 @@ unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
     obuf = mbedtls_calloc( 1, *olen );
     TEST_HELPER_ASSERT( obuf != NULL );
 
-    (void) unhexify( obuf, ibuf );
+    (void) mbedtls_test_unhexify( obuf, ibuf );
 
     return( obuf );
 }

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -277,7 +277,8 @@ static int convert_params( size_t cnt , char ** params , int * int_params_store 
         {
             if ( verify_string( &val ) == 0 )
             {
-                *int_params_store = mbedtls_test_unhexify( (unsigned char *) val, val );
+                *int_params_store = mbedtls_test_unhexify(
+                                        (unsigned char *) val, val );
                 *out++ = val;
                 *out++ = (char *)(int_params_store++);
             }

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -277,7 +277,7 @@ static int convert_params( size_t cnt , char ** params , int * int_params_store 
         {
             if ( verify_string( &val ) == 0 )
             {
-                *int_params_store = unhexify( (unsigned char *) val, val );
+                *int_params_store = mbedtls_test_unhexify( (unsigned char *) val, val );
                 *out++ = val;
                 *out++ = (char *)(int_params_store++);
             }

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -75,7 +75,7 @@ uint8_t receive_byte()
     c[1] = greentea_getc();
     c[2] = '\0';
 
-    TEST_HELPER_ASSERT( unhexify( &byte, c ) != 2 );
+    TEST_HELPER_ASSERT( mbedtls_test_unhexify( &byte, c ) != 2 );
     return( byte );
 }
 
@@ -101,7 +101,7 @@ uint32_t receive_uint32()
                              };
     const uint8_t c[9] = { c_be[6], c_be[7], c_be[4], c_be[5], c_be[2],
                            c_be[3], c_be[0], c_be[1], '\0' };
-    TEST_HELPER_ASSERT( unhexify( (uint8_t*)&value, c ) != 8 );
+    TEST_HELPER_ASSERT( mbedtls_test_unhexify( (uint8_t*)&value, c ) != 8 );
     return( value );
 }
 

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -340,9 +340,9 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
     TEST_ASSERT( strlen( hex_src_string ) <= ( 64 * 2 ) );
     TEST_ASSERT( strlen( hex_dst_string ) <= ( 64 * 2 ) );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    in_buffer_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    in_buffer_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aes_setkey_enc( &ctx, key_str, key_len * 8 ) == 0 );
     src_str_next = src_str;
@@ -352,7 +352,7 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
                                             iv_str, src_str_next, output ) == 0 );
 
-        hexify( dst_str, output, fragment_size );
+        mbedtls_test_hexify( dst_str, output, fragment_size );
         TEST_ASSERT( strncmp( (char *) dst_str, hex_dst_string,
                               ( 2 * fragment_size ) ) == 0 );
 

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -315,13 +315,13 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_OFB */
 void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
                       char *hex_iv_string, char *hex_src_string,
-                      char *hex_dst_string )
+                      char *hex_expected_output_string )
 {
     unsigned char key_str[32];
     unsigned char iv_str[16];
     unsigned char src_str[64];
-    unsigned char dst_str[64];
     unsigned char output[32];
+    unsigned char output_string[65];
     mbedtls_aes_context ctx;
     size_t iv_offset = 0;
     int in_buffer_len;
@@ -331,14 +331,15 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
+    memset( output_string, 0x00, sizeof( output_string ) );
     mbedtls_aes_init( &ctx );
 
+    TEST_ASSERT( (size_t)fragment_size < sizeof( output ) );
     TEST_ASSERT( strlen( hex_key_string ) <= ( 32 * 2 ) );
     TEST_ASSERT( strlen( hex_iv_string ) <= ( 16 * 2 ) );
     TEST_ASSERT( strlen( hex_src_string ) <= ( 64 * 2 ) );
-    TEST_ASSERT( strlen( hex_dst_string ) <= ( 64 * 2 ) );
+    TEST_ASSERT( strlen( hex_expected_output_string ) <= ( 64 * 2 ) );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
@@ -352,12 +353,12 @@ void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
                                             iv_str, src_str_next, output ) == 0 );
 
-        mbedtls_test_hexify( dst_str, output, fragment_size );
-        TEST_ASSERT( strncmp( (char *) dst_str, hex_dst_string,
+        mbedtls_test_hexify( output_string, output, fragment_size );
+        TEST_ASSERT( strncmp( (char *) output_string, hex_expected_output_string,
                               ( 2 * fragment_size ) ) == 0 );
 
         in_buffer_len -= fragment_size;
-        hex_dst_string += ( fragment_size * 2 );
+        hex_expected_output_string += ( fragment_size * 2 );
         src_str_next += fragment_size;
 
         if( in_buffer_len < fragment_size )

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -313,52 +313,39 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_OFB */
-void aes_encrypt_ofb( int fragment_size, char *hex_key_string,
-                      char *hex_iv_string, char *hex_src_string,
-                      char *hex_expected_output_string )
+void aes_encrypt_ofb( int fragment_size, data_t *key_str,
+                      data_t *iv_str, data_t *src_str,
+                      char *expected_output_string)
 {
-    unsigned char key_str[32];
-    unsigned char iv_str[16];
-    unsigned char src_str[64];
     unsigned char output[32];
     unsigned char output_string[65];
     mbedtls_aes_context ctx;
     size_t iv_offset = 0;
     int in_buffer_len;
     unsigned char* src_str_next;
-    int key_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( output, 0x00, sizeof( output ) );
     memset( output_string, 0x00, sizeof( output_string ) );
     mbedtls_aes_init( &ctx );
 
     TEST_ASSERT( (size_t)fragment_size < sizeof( output ) );
-    TEST_ASSERT( strlen( hex_key_string ) <= ( 32 * 2 ) );
-    TEST_ASSERT( strlen( hex_iv_string ) <= ( 16 * 2 ) );
-    TEST_ASSERT( strlen( hex_src_string ) <= ( 64 * 2 ) );
-    TEST_ASSERT( strlen( hex_expected_output_string ) <= ( 64 * 2 ) );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    in_buffer_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aes_setkey_enc( &ctx, key_str, key_len * 8 ) == 0 );
-    src_str_next = src_str;
+    TEST_ASSERT( mbedtls_aes_setkey_enc( &ctx, key_str->x,
+                                         key_str->len * 8 ) == 0 );
+    in_buffer_len = src_str->len;
+    src_str_next = src_str->x;
 
     while( in_buffer_len > 0 )
     {
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
-                                            iv_str, src_str_next, output ) == 0 );
+                                            iv_str->x, src_str_next, output ) == 0 );
 
         mbedtls_test_hexify( output_string, output, fragment_size );
-        TEST_ASSERT( strncmp( (char *) output_string, hex_expected_output_string,
+        TEST_ASSERT( strncmp( (char *) output_string, expected_output_string,
                               ( 2 * fragment_size ) ) == 0 );
 
         in_buffer_len -= fragment_size;
-        hex_expected_output_string += ( fragment_size * 2 );
+        expected_output_string += ( fragment_size * 2 );
         src_str_next += fragment_size;
 
         if( in_buffer_len < fragment_size )

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -222,8 +222,8 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 )
                  == setkey_result );
@@ -234,7 +234,7 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                                                  == 0 );
         }
-        hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, data_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -261,8 +261,8 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 )
                  == setkey_result );
@@ -273,7 +273,7 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                          == 0 );
         }
-        hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, data_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -303,9 +303,9 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, data_len,
@@ -313,7 +313,7 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, data_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -343,9 +343,9 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, data_len,
@@ -353,7 +353,7 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, data_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -384,16 +384,16 @@ void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT,
                                             data_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, data_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -423,16 +423,16 @@ void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT,
                                             data_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, data_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -463,15 +463,15 @@ void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, data_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -502,15 +502,15 @@ void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = unhexify( key_str, hex_key_string );
-    unhexify( iv_str, hex_iv_string );
-    data_len = unhexify( src_str, hex_src_string );
+    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
+    mbedtls_test_unhexify( iv_str, hex_iv_string );
+    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, data_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -214,7 +214,7 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len, i;
+    size_t key_len, src_str_len, i;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
@@ -223,18 +223,18 @@ void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
     mbedtls_aria_init( &ctx );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                                                  == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -253,7 +253,7 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len, i;
+    size_t key_len, src_str_len, i;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( src_str, 0x00, sizeof( src_str ) );
@@ -262,18 +262,18 @@ void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
     mbedtls_aria_init( &ctx );
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < data_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
                          == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -294,7 +294,7 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -305,15 +305,15 @@ void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, data_len,
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, src_str_len,
                                          iv_str, src_str, output )
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -334,7 +334,7 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -345,15 +345,15 @@ void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, data_len,
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, src_str_len,
                                          iv_str, src_str, output )
                  == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, data_len );
+        mbedtls_test_hexify( dst_str, output, src_str_len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -375,7 +375,7 @@ void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -386,14 +386,14 @@ void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT,
-                                            data_len, &iv_offset, iv_str,
+                                            src_str_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -414,7 +414,7 @@ void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -425,14 +425,14 @@ void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT,
-                                            data_len, &iv_offset, iv_str,
+                                            src_str_len, &iv_offset, iv_str,
                                             src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -454,7 +454,7 @@ void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -465,13 +465,13 @@ void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -493,7 +493,7 @@ void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    int key_len, data_len;
+    size_t key_len, src_str_len;
 
     memset( key_str, 0x00, sizeof( key_str ) );
     memset( iv_str, 0x00, sizeof( iv_str ) );
@@ -504,13 +504,13 @@ void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
 
     key_len = mbedtls_test_unhexify( key_str, hex_key_string );
     mbedtls_test_unhexify( iv_str, hex_iv_string );
-    data_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
 
     mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, data_len, &iv_offset, iv_str,
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
                                          blk, src_str, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, data_len );
+    mbedtls_test_hexify( dst_str, output, src_str_len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -206,35 +206,28 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void aria_encrypt_ecb( char *hex_key_string, char *hex_src_string,
+void aria_encrypt_ecb( data_t *key_str, data_t *src_str,
                        char *hex_dst_string, int setkey_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len, i;
+    size_t i;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 )
+    TEST_ASSERT( mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str->len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
-                                                 == 0 );
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
+                                                 output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -245,35 +238,28 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void aria_decrypt_ecb( char *hex_key_string, char *hex_src_string,
+void aria_decrypt_ecb( data_t *key_str, data_t *src_str,
                        char *hex_dst_string, int setkey_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len, i;
+    size_t i;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 )
+    TEST_ASSERT( mbedtls_aria_setkey_dec( &ctx, key_str->x, key_str->len * 8 )
                  == setkey_result );
     if( setkey_result == 0 )
     {
-        for( i = 0; i < src_str_len; i += MBEDTLS_ARIA_BLOCKSIZE )
+        for( i = 0; i < src_str->len; i += MBEDTLS_ARIA_BLOCKSIZE )
         {
-            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str + i, output + i )
-                         == 0 );
+            TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
+                                                 output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -284,36 +270,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
-void aria_encrypt_cbc( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_cbc( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int cbc_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT, src_str_len,
-                                         iv_str, src_str, output )
-                 == cbc_result );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_ENCRYPT,
+                                         src_str->len, iv_str->x, src_str->x,
+                                         output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -324,36 +299,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
-void aria_decrypt_cbc( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_cbc( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int cbc_result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_dec( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT, src_str_len,
-                                         iv_str, src_str, output )
-                 == cbc_result );
+    mbedtls_aria_setkey_dec( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_cbc( &ctx, MBEDTLS_ARIA_DECRYPT,
+                                         src_str->len, iv_str->x, src_str->x,
+                                         output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str_len );
+        mbedtls_test_hexify( dst_str, output, src_str->len );
 
         TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
     }
@@ -364,36 +328,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
-void aria_encrypt_cfb128( char *hex_key_string, char *hex_iv_string,
-                          char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_cfb128( data_t *key_str, data_t *iv_str,
+                          data_t *src_str, char *hex_dst_string,
                           int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_ENCRYPT,
-                                            src_str_len, &iv_offset, iv_str,
-                                            src_str, output )
+                                            src_str->len, &iv_offset,
+                                            iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -403,36 +356,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
-void aria_decrypt_cfb128( char *hex_key_string, char *hex_iv_string,
-                          char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_cfb128( data_t *key_str, data_t *iv_str,
+                          data_t *src_str, char *hex_dst_string,
                           int result  )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aria_crypt_cfb128( &ctx, MBEDTLS_ARIA_DECRYPT,
-                                            src_str_len, &iv_offset, iv_str,
-                                            src_str, output )
+                                            src_str->len, &iv_offset,
+                                            iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -442,36 +384,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
-void aria_encrypt_ctr( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_encrypt_ctr( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
-                                         blk, src_str, output )
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
+                                         iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 
@@ -481,36 +412,25 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
-void aria_decrypt_ctr( char *hex_key_string, char *hex_iv_string,
-                       char *hex_src_string, char *hex_dst_string,
+void aria_decrypt_ctr( data_t *key_str, data_t *iv_str,
+                       data_t *src_str, char *hex_dst_string,
                        int result )
 {
-    unsigned char key_str[ARIA_MAX_KEY_STR];
-    unsigned char iv_str[ARIA_BLOCK_STR];
-    unsigned char src_str[ARIA_MAX_DATA_STR];
     unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
-    size_t key_len, src_str_len;
 
-    memset( key_str, 0x00, sizeof( key_str ) );
-    memset( iv_str, 0x00, sizeof( iv_str ) );
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
-    key_len = mbedtls_test_unhexify( key_str, hex_key_string );
-    mbedtls_test_unhexify( iv_str, hex_iv_string );
-    src_str_len = mbedtls_test_unhexify( src_str, hex_src_string );
-
-    mbedtls_aria_setkey_enc( &ctx, key_str, key_len * 8 );
-    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str_len, &iv_offset, iv_str,
-                                         blk, src_str, output )
+    mbedtls_aria_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
+    TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
+                                         iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str_len );
+    mbedtls_test_hexify( dst_str, output, src_str->len );
 
     TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
 

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -195,17 +195,18 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
                             char *key_hex, char *msg_hex,
                             char *source_address_hex, char *frame_counter_hex,
                             int sec_level, char *add_hex,
-                            char *result_hex, int output_ret )
+                            char *expected_result_hex, int output_ret )
 {
     unsigned char key[32];
     unsigned char msg[50];
     unsigned char iv[13];
     unsigned char add[32];
     unsigned char result[50];
+    unsigned char expected_result[50];
     unsigned char source_address[8];
     unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, result_len, source_address_len, frame_counter_len, tag_len;
+    size_t i, key_len, msg_len, iv_len, add_len, expected_result_len, source_address_len, frame_counter_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
@@ -215,13 +216,14 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     memset( iv, 0x00, sizeof( iv ) );
     memset( add, 0x00, sizeof( add ) );
     memset( result, 0x00, sizeof( result ) );
+    memset( expected_result, 0x00, sizeof( expected_result ) );
     memset( source_address, 0x00, sizeof( source_address ) );
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
-    result_len = mbedtls_test_unhexify( result, result_hex );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
     source_address_len = mbedtls_test_unhexify( source_address,
                                                 source_address_hex );
     frame_counter_len = mbedtls_test_unhexify( frame_counter,
@@ -244,14 +246,15 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
 
     ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, msg, msg + msg_len, tag_len );
+                 add, add_len, msg, result, result + msg_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( msg, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
 
     /* Check we didn't write past the end */
-    TEST_ASSERT( msg[result_len] == 0 && msg[result_len + 1] == 0 );
+    TEST_ASSERT( result[expected_result_len] == 0 &&
+                 result[expected_result_len + 1] == 0 );
 
 exit:
     mbedtls_ccm_free( &ctx );
@@ -263,18 +266,18 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
                             char *key_hex, char *msg_hex,
                             char *source_address_hex, char *frame_counter_hex,
                             int sec_level, char *add_hex,
-                            char *result_hex, int output_ret )
+                            char *expected_result_hex, int output_ret )
 {
     unsigned char key[32];
     unsigned char msg[50];
     unsigned char iv[13];
     unsigned char add[32];
-    unsigned char tag[16];
     unsigned char result[50];
+    unsigned char expected_result[50];
     unsigned char source_address[8];
     unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, tag_len, result_len, source_address_len, frame_counter_len;
+    size_t i, key_len, msg_len, iv_len, add_len, tag_len, expected_result_len, source_address_len, frame_counter_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
@@ -283,15 +286,15 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
     memset( add, 0x00, sizeof( add ) );
-    memset( result, 0x00, sizeof( result ) );
+    memset( result, '+', sizeof( result ) );
+    memset( expected_result, 0x00, sizeof( expected_result ) );
     memset( source_address, 0x00, sizeof( source_address ) );
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
-    memset( tag, 0x00, sizeof( tag ) );
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
-    result_len = mbedtls_test_unhexify( result, result_hex );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
     source_address_len = mbedtls_test_unhexify( source_address,
                                                 source_address_hex );
     frame_counter_len = mbedtls_test_unhexify( frame_counter,
@@ -311,20 +314,19 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     iv[source_address_len + frame_counter_len] = sec_level;
     iv_len = sizeof( iv );
 
-    msg_len -= tag_len;
-    memcpy( tag, msg + msg_len, tag_len );
-
     TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, msg, msg + msg_len, tag_len );
+    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len - tag_len, iv, iv_len,
+                 add, add_len, msg, result, msg + msg_len - tag_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( msg, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
 
     /* Check we didn't write past the end (where the original tag is) */
-    TEST_ASSERT( memcmp( msg + msg_len, tag, tag_len ) == 0 );
+    TEST_ASSERT( ( msg_len + 2 ) <= sizeof( result ) );
+    TEST_ASSERT( result[msg_len] == '+' );
+    TEST_ASSERT( result[msg_len + 1] == '+' );
 
 exit:
     mbedtls_ccm_free( &ctx );

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -222,8 +222,10 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
     result_len = mbedtls_test_unhexify( result, result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address, source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter, frame_counter_hex );
+    source_address_len = mbedtls_test_unhexify( source_address,
+                                                source_address_hex );
+    frame_counter_len = mbedtls_test_unhexify( frame_counter,
+                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
@@ -290,8 +292,10 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
     add_len = mbedtls_test_unhexify( add, add_hex );
     result_len = mbedtls_test_unhexify( result, result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address, source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter, frame_counter_hex );
+    source_address_len = mbedtls_test_unhexify( source_address,
+                                                source_address_hex );
+    frame_counter_len = mbedtls_test_unhexify( frame_counter,
+                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -192,69 +192,51 @@ exit:
 
 /* BEGIN_CASE */
 void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
-                            char *key_hex, char *msg_hex,
-                            char *source_address_hex, char *frame_counter_hex,
-                            int sec_level, char *add_hex,
-                            char *expected_result_hex, int output_ret )
+                            data_t *key, data_t *msg,
+                            data_t *source_address, data_t *frame_counter,
+                            int sec_level, data_t *add,
+                            data_t *expected_result, int output_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[50];
     unsigned char iv[13];
-    unsigned char add[32];
     unsigned char result[50];
-    unsigned char expected_result[50];
-    unsigned char source_address[8];
-    unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, expected_result_len, source_address_len, frame_counter_len, tag_len;
+    size_t i, iv_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
-    memset( add, 0x00, sizeof( add ) );
     memset( result, 0x00, sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
-    memset( source_address, 0x00, sizeof( source_address ) );
-    memset( frame_counter, 0x00, sizeof( frame_counter ) );
-
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    add_len = mbedtls_test_unhexify( add, add_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address,
-                                                source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter,
-                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
     else
         tag_len = 1 << ( sec_level % 4 + 1);
 
-    for( i = 0; i < source_address_len; i++ )
-        iv[i] = source_address[i];
+    for( i = 0; i < source_address->len; i++ )
+        iv[i] = source_address->x[i];
 
-    for( i = 0; i < frame_counter_len; i++ )
-        iv[source_address_len + i] = frame_counter[i];
+    for( i = 0; i < frame_counter->len; i++ )
+        iv[source_address->len + i] = frame_counter->x[i];
 
-    iv[source_address_len + frame_counter_len] = sec_level;
+    iv[source_address->len + frame_counter->len] = sec_level;
     iv_len = sizeof( iv );
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id,
+                                     key->x, key->len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg_len, iv, iv_len,
-                 add, add_len, msg, result, result + msg_len, tag_len );
+    ret = mbedtls_ccm_star_encrypt_and_tag( &ctx, msg->len, iv, iv_len,
+                                            add->x, add->len, msg->x,
+                                            result, result + msg->len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( result,
+                         expected_result->x, expected_result->len ) == 0 );
 
     /* Check we didn't write past the end */
-    TEST_ASSERT( result[expected_result_len] == 0 &&
-                 result[expected_result_len + 1] == 0 );
+    TEST_ASSERT( result[expected_result->len] == 0 &&
+                 result[expected_result->len + 1] == 0 );
 
 exit:
     mbedtls_ccm_free( &ctx );
@@ -263,70 +245,51 @@ exit:
 
 /* BEGIN_CASE */
 void mbedtls_ccm_star_auth_decrypt( int cipher_id,
-                            char *key_hex, char *msg_hex,
-                            char *source_address_hex, char *frame_counter_hex,
-                            int sec_level, char *add_hex,
-                            char *expected_result_hex, int output_ret )
+                            data_t *key, data_t *msg,
+                            data_t *source_address, data_t *frame_counter,
+                            int sec_level, data_t *add,
+                            data_t *expected_result, int output_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[50];
     unsigned char iv[13];
-    unsigned char add[32];
     unsigned char result[50];
-    unsigned char expected_result[50];
-    unsigned char source_address[8];
-    unsigned char frame_counter[4];
     mbedtls_ccm_context ctx;
-    size_t i, key_len, msg_len, iv_len, add_len, tag_len, expected_result_len, source_address_len, frame_counter_len;
+    size_t i, iv_len, tag_len;
     int ret;
 
     mbedtls_ccm_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( iv, 0x00, sizeof( iv ) );
-    memset( add, 0x00, sizeof( add ) );
     memset( result, '+', sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
-    memset( source_address, 0x00, sizeof( source_address ) );
-    memset( frame_counter, 0x00, sizeof( frame_counter ) );
-
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    add_len = mbedtls_test_unhexify( add, add_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    source_address_len = mbedtls_test_unhexify( source_address,
-                                                source_address_hex );
-    frame_counter_len = mbedtls_test_unhexify( frame_counter,
-                                               frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
     else
         tag_len = 1 << ( sec_level % 4 + 1);
 
-    for( i = 0; i < source_address_len; i++ )
-        iv[i] = source_address[i];
+    for( i = 0; i < source_address->len; i++ )
+        iv[i] = source_address->x[i];
 
-    for( i = 0; i < frame_counter_len; i++ )
-        iv[source_address_len + i] = frame_counter[i];
+    for( i = 0; i < frame_counter->len; i++ )
+        iv[source_address->len + i] = frame_counter->x[i];
 
-    iv[source_address_len + frame_counter_len] = sec_level;
+    iv[source_address->len + frame_counter->len] = sec_level;
     iv_len = sizeof( iv );
 
-    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key, key_len * 8 ) == 0 );
+    TEST_ASSERT( mbedtls_ccm_setkey( &ctx, cipher_id, key->x, key->len * 8 ) == 0 );
 
-    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg_len - tag_len, iv, iv_len,
-                 add, add_len, msg, result, msg + msg_len - tag_len, tag_len );
+    ret = mbedtls_ccm_star_auth_decrypt( &ctx, msg->len - tag_len, iv, iv_len,
+                                         add->x, add->len, msg->x, result,
+                                         msg->x + msg->len - tag_len, tag_len );
 
     TEST_ASSERT( ret == output_ret );
 
-    TEST_ASSERT( memcmp( result, expected_result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( result, expected_result->x,
+                                 expected_result->len ) == 0 );
 
     /* Check we didn't write past the end (where the original tag is) */
-    TEST_ASSERT( ( msg_len + 2 ) <= sizeof( result ) );
-    TEST_ASSERT( result[msg_len] == '+' );
-    TEST_ASSERT( result[msg_len + 1] == '+' );
+    TEST_ASSERT( ( msg->len + 2 ) <= sizeof( result ) );
+    TEST_ASSERT( result[msg->len] == '+' );
+    TEST_ASSERT( result[msg->len + 1] == '+' );
 
 exit:
     mbedtls_ccm_free( &ctx );

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -218,12 +218,12 @@ void mbedtls_ccm_star_encrypt_and_tag( int cipher_id,
     memset( source_address, 0x00, sizeof( source_address ) );
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
 
-    key_len = unhexify( key, key_hex );
-    msg_len = unhexify( msg, msg_hex );
-    add_len = unhexify( add, add_hex );
-    result_len = unhexify( result, result_hex );
-    source_address_len = unhexify( source_address, source_address_hex );
-    frame_counter_len = unhexify( frame_counter, frame_counter_hex );
+    key_len = mbedtls_test_unhexify( key, key_hex );
+    msg_len = mbedtls_test_unhexify( msg, msg_hex );
+    add_len = mbedtls_test_unhexify( add, add_hex );
+    result_len = mbedtls_test_unhexify( result, result_hex );
+    source_address_len = mbedtls_test_unhexify( source_address, source_address_hex );
+    frame_counter_len = mbedtls_test_unhexify( frame_counter, frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;
@@ -286,12 +286,12 @@ void mbedtls_ccm_star_auth_decrypt( int cipher_id,
     memset( frame_counter, 0x00, sizeof( frame_counter ) );
     memset( tag, 0x00, sizeof( tag ) );
 
-    key_len = unhexify( key, key_hex );
-    msg_len = unhexify( msg, msg_hex );
-    add_len = unhexify( add, add_hex );
-    result_len = unhexify( result, result_hex );
-    source_address_len = unhexify( source_address, source_address_hex );
-    frame_counter_len = unhexify( frame_counter, frame_counter_hex );
+    key_len = mbedtls_test_unhexify( key, key_hex );
+    msg_len = mbedtls_test_unhexify( msg, msg_hex );
+    add_len = mbedtls_test_unhexify( add, add_hex );
+    result_len = mbedtls_test_unhexify( result, result_hex );
+    source_address_len = mbedtls_test_unhexify( source_address, source_address_hex );
+    frame_counter_len = mbedtls_test_unhexify( frame_counter, frame_counter_hex );
 
     if( sec_level % 4 == 0)
         tag_len = 0;

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -31,10 +31,10 @@ void chacha20_crypt( char *hex_key_string,
     memset( dst_str,    0x00, sizeof( dst_str ) );
     memset( output,     0x00, sizeof( output ) );
 
-    key_len   = unhexify( key_str, hex_key_string );
-    nonce_len = unhexify( nonce_str, hex_nonce_string );
-    src_len   = unhexify( src_str, hex_src_string );
-    dst_len   = unhexify( dst_str, hex_dst_string );
+    key_len   = mbedtls_test_unhexify( key_str, hex_key_string );
+    nonce_len = mbedtls_test_unhexify( nonce_str, hex_nonce_string );
+    src_len   = mbedtls_test_unhexify( src_str, hex_src_string );
+    dst_len   = mbedtls_test_unhexify( dst_str, hex_dst_string );
 
     TEST_ASSERT( src_len   == dst_len );
     TEST_ASSERT( key_len   == 32U );
@@ -45,7 +45,7 @@ void chacha20_crypt( char *hex_key_string,
      */
     TEST_ASSERT( mbedtls_chacha20_crypt( key_str, nonce_str, counter, src_len, src_str, output ) == 0 );
 
-    hexify( dst_str, output, src_len );
+    mbedtls_test_hexify( dst_str, output, src_len );
     TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
 
     /*
@@ -60,7 +60,7 @@ void chacha20_crypt( char *hex_key_string,
     memset( output, 0x00, sizeof( output ) );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len, src_str, output ) == 0 );
 
-    hexify( dst_str, output, src_len );
+    mbedtls_test_hexify( dst_str, output, src_len );
     TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
 
     /*
@@ -75,7 +75,7 @@ void chacha20_crypt( char *hex_key_string,
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str, output ) == 0 );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len - 1, src_str + 1, output + 1 ) == 0 );
 
-    hexify( dst_str, output, src_len );
+    mbedtls_test_hexify( dst_str, output, src_len );
     TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
 
     mbedtls_chacha20_free( &ctx );

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -12,31 +12,33 @@ void chacha20_crypt( char *hex_key_string,
                      char *hex_nonce_string,
                      int counter,
                      char *hex_src_string,
-                     char *hex_dst_string )
+                     char *hex_expected_output_string )
 {
     unsigned char key_str[32]; /* size set by the standard */
     unsigned char nonce_str[12]; /* size set by the standard */
     unsigned char src_str[375]; /* max size of binary input */
-    unsigned char dst_str[751]; /* hex expansion of the above */
-    unsigned char output[751];
+    unsigned char expected_output_str[375];
+    unsigned char output[375];
+    unsigned char output_string[751]; /* ASCII string representation of output */
     size_t key_len;
     size_t nonce_len;
     size_t src_len;
-    size_t dst_len;
+    size_t expected_output_len;
     mbedtls_chacha20_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( src_str,    0x00, sizeof( src_str ) );
-    memset( dst_str,    0x00, sizeof( dst_str ) );
-    memset( output,     0x00, sizeof( output ) );
+    memset( key_str,       0x00, sizeof( key_str ) );
+    memset( nonce_str,     0x00, sizeof( nonce_str ) );
+    memset( src_str,       0x00, sizeof( src_str ) );
+    memset( output,        0x00, sizeof( output ) );
+    memset( output_string, 0x00, sizeof( output_string ) );
 
     key_len   = mbedtls_test_unhexify( key_str, hex_key_string );
     nonce_len = mbedtls_test_unhexify( nonce_str, hex_nonce_string );
     src_len   = mbedtls_test_unhexify( src_str, hex_src_string );
-    dst_len   = mbedtls_test_unhexify( dst_str, hex_dst_string );
+    expected_output_len = mbedtls_test_unhexify( expected_output_str,
+                                                 hex_expected_output_string );
 
-    TEST_ASSERT( src_len   == dst_len );
+    TEST_ASSERT( src_len   == expected_output_len );
     TEST_ASSERT( key_len   == 32U );
     TEST_ASSERT( nonce_len == 12U );
 
@@ -45,8 +47,8 @@ void chacha20_crypt( char *hex_key_string,
      */
     TEST_ASSERT( mbedtls_chacha20_crypt( key_str, nonce_str, counter, src_len, src_str, output ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string, hex_expected_output_string ) == 0 );
 
     /*
      * Test the streaming API
@@ -60,8 +62,9 @@ void chacha20_crypt( char *hex_key_string,
     memset( output, 0x00, sizeof( output ) );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len, src_str, output ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string,
+                         hex_expected_output_string ) == 0 );
 
     /*
      * Test the streaming API again, piecewise
@@ -75,8 +78,9 @@ void chacha20_crypt( char *hex_key_string,
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str, output ) == 0 );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len - 1, src_str + 1, output + 1 ) == 0 );
 
-    mbedtls_test_hexify( dst_str, output, src_len );
-    TEST_ASSERT( strcmp( (char*) dst_str, hex_dst_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_len );
+    TEST_ASSERT( strcmp( (char*) output_string,
+                         hex_expected_output_string ) == 0 );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -8,63 +8,55 @@
  */
 
 /* BEGIN_CASE */
-void chacha20_crypt( char *hex_key_string,
-                     char *hex_nonce_string,
+void chacha20_crypt( data_t *key_str,
+                     data_t *nonce_str,
                      int counter,
-                     char *hex_src_string,
-                     char *hex_expected_output_string )
+                     data_t *src_str,
+                     data_t *expected_output_str )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char src_str[375]; /* max size of binary input */
-    unsigned char expected_output_str[375];
     unsigned char output[375];
-    unsigned char output_string[751]; /* ASCII string representation of output */
-    size_t key_len;
-    size_t nonce_len;
-    size_t src_len;
-    size_t expected_output_len;
     mbedtls_chacha20_context ctx;
 
-    memset( key_str,       0x00, sizeof( key_str ) );
-    memset( nonce_str,     0x00, sizeof( nonce_str ) );
-    memset( src_str,       0x00, sizeof( src_str ) );
-    memset( output,        0x00, sizeof( output ) );
-    memset( output_string, 0x00, sizeof( output_string ) );
+    /*
+     * Buffers to store the ASCII string representation of output and
+     * expected_output_str.
+     */
+    unsigned char output_string[751] = { '\0' };
+    unsigned char expected_output_string[751] = { '\0' };
 
-    key_len   = mbedtls_test_unhexify( key_str, hex_key_string );
-    nonce_len = mbedtls_test_unhexify( nonce_str, hex_nonce_string );
-    src_len   = mbedtls_test_unhexify( src_str, hex_src_string );
-    expected_output_len = mbedtls_test_unhexify( expected_output_str,
-                                                 hex_expected_output_string );
+    memset( output, 0x00, sizeof( output ) );
 
-    TEST_ASSERT( src_len   == expected_output_len );
-    TEST_ASSERT( key_len   == 32U );
-    TEST_ASSERT( nonce_len == 12U );
+    TEST_ASSERT( src_str->len   == expected_output_str->len );
+    TEST_ASSERT( key_str->len   == 32U );
+    TEST_ASSERT( nonce_str->len == 12U );
 
     /*
      * Test the integrated API
      */
-    TEST_ASSERT( mbedtls_chacha20_crypt( key_str, nonce_str, counter, src_len, src_str, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_crypt( key_str->x, nonce_str->x, counter, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string, hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( expected_output_string,
+                         expected_output_str->x,
+                         expected_output_str->len);
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     /*
      * Test the streaming API
      */
     mbedtls_chacha20_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chacha20_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_setkey( &ctx, key_str->x ) == 0 );
 
-    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str, counter ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str->x, counter ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len, src_str, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string,
-                         hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     /*
      * Test the streaming API again, piecewise
@@ -72,15 +64,16 @@ void chacha20_crypt( char *hex_key_string,
 
     /* Don't free/init the context nor set the key again,
      * in order to test that starts() does the right thing. */
-    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str, counter ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_starts( &ctx, nonce_str->x, counter ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str, output ) == 0 );
-    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_len - 1, src_str + 1, output + 1 ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, 1, src_str->x, output ) == 0 );
+    TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len - 1,
+                                          src_str->x + 1, output + 1 ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_len );
-    TEST_ASSERT( strcmp( (char*) output_string,
-                         hex_expected_output_string ) == 0 );
+    mbedtls_test_hexify( output_string, output, src_str->len );
+    TEST_ASSERT( strcmp( (char *)output_string,
+                         (char *)expected_output_string ) == 0 );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_chachapoly.function
+++ b/tests/suites/test_suite_chachapoly.function
@@ -33,12 +33,12 @@ void mbedtls_chachapoly_enc( char *hex_key_string, char *hex_nonce_string, char 
     memset( output_str, 0x00, sizeof( output_str ) );
     memset( mac_str,    0x00, sizeof( mac_str ) );
 
-    aad_len    = unhexify( aad_str,    hex_aad_string    );
-    input_len  = unhexify( input_str,  hex_input_string  );
-    output_len = unhexify( output_str, hex_output_string );
-    key_len    = unhexify( key_str,    hex_key_string    );
-    nonce_len  = unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = unhexify( mac_str,    hex_mac_string    );
+    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
+    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
+    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
+    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
+    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
+    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
 
     TEST_ASSERT( key_len   == 32 );
     TEST_ASSERT( nonce_len == 12 );
@@ -87,12 +87,12 @@ void mbedtls_chachapoly_dec( char *hex_key_string, char *hex_nonce_string, char 
     memset( output_str, 0x00, sizeof( output_str ) );
     memset( mac_str,    0x00, sizeof( mac_str ) );
 
-    aad_len    = unhexify( aad_str,    hex_aad_string    );
-    input_len  = unhexify( input_str,  hex_input_string  );
-    output_len = unhexify( output_str, hex_output_string );
-    key_len    = unhexify( key_str,    hex_key_string    );
-    nonce_len  = unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = unhexify( mac_str,    hex_mac_string    );
+    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
+    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
+    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
+    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
+    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
+    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
 
     TEST_ASSERT( key_len   == 32 );
     TEST_ASSERT( nonce_len == 12 );

--- a/tests/suites/test_suite_chachapoly.function
+++ b/tests/suites/test_suite_chachapoly.function
@@ -8,53 +8,27 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_chachapoly_enc( char *hex_key_string, char *hex_nonce_string, char *hex_aad_string, char *hex_input_string, char *hex_output_string, char *hex_mac_string )
+void mbedtls_chachapoly_enc( data_t *key_str, data_t *nonce_str, data_t *aad_str, data_t *input_str, data_t *output_str, data_t *mac_str )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char aad_str[12]; /* max size of test data so far */
-    unsigned char input_str[265]; /* max size of binary input/output so far */
-    unsigned char output_str[265];
     unsigned char output[265];
-    unsigned char mac_str[16]; /* size set by the standard */
     unsigned char mac[16]; /* size set by the standard */
-    size_t input_len;
-    size_t output_len;
-    size_t aad_len;
-    size_t key_len;
-    size_t nonce_len;
-    size_t mac_len;
     mbedtls_chachapoly_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( aad_str,    0x00, sizeof( aad_str ) );
-    memset( input_str,  0x00, sizeof( input_str ) );
-    memset( output_str, 0x00, sizeof( output_str ) );
-    memset( mac_str,    0x00, sizeof( mac_str ) );
-
-    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
-    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
-    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
-    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
-    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
-
-    TEST_ASSERT( key_len   == 32 );
-    TEST_ASSERT( nonce_len == 12 );
-    TEST_ASSERT( mac_len   == 16 );
+    TEST_ASSERT( key_str->len   == 32 );
+    TEST_ASSERT( nonce_str->len == 12 );
+    TEST_ASSERT( mac_str->len   == 16 );
 
     mbedtls_chachapoly_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str->x ) == 0 );
 
     TEST_ASSERT( mbedtls_chachapoly_encrypt_and_tag( &ctx,
-                                      input_len, nonce_str,
-                                      aad_str, aad_len,
-                                      input_str, output, mac ) == 0 );
+                                      input_str->len, nonce_str->x,
+                                      aad_str->x, aad_str->len,
+                                      input_str->x, output, mac ) == 0 );
 
-    TEST_ASSERT( memcmp( output_str, output, output_len ) == 0 );
-    TEST_ASSERT( memcmp( mac_str, mac, 16U ) == 0 );
+    TEST_ASSERT( memcmp( output_str->x, output, output_str->len ) == 0 );
+    TEST_ASSERT( memcmp( mac_str->x, mac, 16U ) == 0 );
 
 exit:
     mbedtls_chachapoly_free( &ctx );
@@ -62,55 +36,29 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_chachapoly_dec( char *hex_key_string, char *hex_nonce_string, char *hex_aad_string, char *hex_input_string, char *hex_output_string, char *hex_mac_string, int ret_exp )
+void mbedtls_chachapoly_dec( data_t *key_str, data_t *nonce_str, data_t *aad_str, data_t *input_str, data_t *output_str, data_t *mac_str, int ret_exp )
 {
-    unsigned char key_str[32]; /* size set by the standard */
-    unsigned char nonce_str[12]; /* size set by the standard */
-    unsigned char aad_str[12]; /* max size of test data so far */
-    unsigned char input_str[265]; /* max size of binary input/output so far */
-    unsigned char output_str[265];
     unsigned char output[265];
-    unsigned char mac_str[16]; /* size set by the standard */
-    size_t input_len;
-    size_t output_len;
-    size_t aad_len;
-    size_t key_len;
-    size_t nonce_len;
-    size_t mac_len;
     int ret;
     mbedtls_chachapoly_context ctx;
 
-    memset( key_str,    0x00, sizeof( key_str ) );
-    memset( nonce_str,  0x00, sizeof( nonce_str ) );
-    memset( aad_str,    0x00, sizeof( aad_str ) );
-    memset( input_str,  0x00, sizeof( input_str ) );
-    memset( output_str, 0x00, sizeof( output_str ) );
-    memset( mac_str,    0x00, sizeof( mac_str ) );
-
-    aad_len    = mbedtls_test_unhexify( aad_str,    hex_aad_string    );
-    input_len  = mbedtls_test_unhexify( input_str,  hex_input_string  );
-    output_len = mbedtls_test_unhexify( output_str, hex_output_string );
-    key_len    = mbedtls_test_unhexify( key_str,    hex_key_string    );
-    nonce_len  = mbedtls_test_unhexify( nonce_str,  hex_nonce_string  );
-    mac_len    = mbedtls_test_unhexify( mac_str,    hex_mac_string    );
-
-    TEST_ASSERT( key_len   == 32 );
-    TEST_ASSERT( nonce_len == 12 );
-    TEST_ASSERT( mac_len   == 16 );
+    TEST_ASSERT( key_str->len   == 32 );
+    TEST_ASSERT( nonce_str->len == 12 );
+    TEST_ASSERT( mac_str->len   == 16 );
 
     mbedtls_chachapoly_init( &ctx );
 
-    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str ) == 0 );
+    TEST_ASSERT( mbedtls_chachapoly_setkey( &ctx, key_str->x ) == 0 );
 
     ret = mbedtls_chachapoly_auth_decrypt( &ctx,
-                                           input_len, nonce_str,
-                                           aad_str, aad_len,
-                                           mac_str, input_str, output );
+                                           input_str->len, nonce_str->x,
+                                           aad_str->x, aad_str->len,
+                                           mac_str->x, input_str->x, output );
 
     TEST_ASSERT( ret == ret_exp );
     if( ret_exp == 0 )
     {
-        TEST_ASSERT( memcmp( output_str, output, output_len ) == 0 );
+        TEST_ASSERT( memcmp( output_str->x, output, output_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1062,48 +1062,33 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_WITH_PADDING */
-void test_vec_crypt( int cipher_id, int operation, char *hex_key,
-                   char *hex_iv, char *hex_input, char *hex_result,
-                   int finish_result )
+void test_vec_crypt( int cipher_id, int operation, data_t *key,
+                     data_t *iv, data_t *input, data_t *result,
+                     int finish_result )
 {
-    unsigned char key[50];
-    unsigned char input[16];
-    unsigned char result[16];
-    unsigned char iv[16];
-    size_t key_len, iv_len, inputlen, resultlen;
     mbedtls_cipher_context_t ctx;
     unsigned char output[32];
     size_t outlen;
 
     mbedtls_cipher_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( input, 0x00, sizeof( input ) );
-    memset( result, 0x00, sizeof( result ) );
     memset( output, 0x00, sizeof( output ) );
-    memset( iv, 0x00, sizeof( iv ) );
 
     /* Prepare context */
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
                                        mbedtls_cipher_info_from_type( cipher_id ) ) );
 
-    key_len = mbedtls_test_unhexify( key, hex_key );
-    inputlen =  mbedtls_test_unhexify( input, hex_input );
-    resultlen = mbedtls_test_unhexify( result, hex_result );
-
-    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, operation ) );
+    TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key->x, 8 * key->len, operation ) );
     if( MBEDTLS_MODE_CBC == ctx.cipher_info->mode )
         TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, MBEDTLS_PADDING_NONE ) );
 
-    iv_len = mbedtls_test_unhexify( iv, hex_iv );
-
-    TEST_ASSERT( finish_result == mbedtls_cipher_crypt( &ctx, iv_len ? iv : NULL,
-                                                        iv_len, input, inputlen,
+    TEST_ASSERT( finish_result == mbedtls_cipher_crypt( &ctx, iv->len ? iv->x : NULL,
+                                                        iv->len, input->x, input->len,
                                                         output, &outlen ) );
-    TEST_ASSERT( resultlen == outlen );
+    TEST_ASSERT( result->len == outlen );
     /* check plaintext only if everything went fine */
     if( 0 == finish_result )
-        TEST_ASSERT( 0 == memcmp( output, result, outlen ) );
+        TEST_ASSERT( 0 == memcmp( output, result->x, outlen ) );
 
 exit:
     mbedtls_cipher_free( &ctx );

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -1087,15 +1087,15 @@ void test_vec_crypt( int cipher_id, int operation, char *hex_key,
     TEST_ASSERT( 0 == mbedtls_cipher_setup( &ctx,
                                        mbedtls_cipher_info_from_type( cipher_id ) ) );
 
-    key_len = unhexify( key, hex_key );
-    inputlen =  unhexify( input, hex_input );
-    resultlen = unhexify( result, hex_result );
+    key_len = mbedtls_test_unhexify( key, hex_key );
+    inputlen =  mbedtls_test_unhexify( input, hex_input );
+    resultlen = mbedtls_test_unhexify( result, hex_result );
 
     TEST_ASSERT( 0 == mbedtls_cipher_setkey( &ctx, key, 8 * key_len, operation ) );
     if( MBEDTLS_MODE_CBC == ctx.cipher_info->mode )
         TEST_ASSERT( 0 == mbedtls_cipher_set_padding_mode( &ctx, MBEDTLS_PADDING_NONE ) );
 
-    iv_len = unhexify( iv, hex_iv );
+    iv_len = mbedtls_test_unhexify( iv, hex_iv );
 
     TEST_ASSERT( finish_result == mbedtls_cipher_crypt( &ctx, iv_len ? iv : NULL,
                                                         iv_len, input, inputlen,

--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -360,13 +360,13 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     mbedtls_ecdh_init( &srv );
     mbedtls_ecdh_init( &cli );
 
-    z_len = unhexify( z, z_str );
+    z_len = mbedtls_test_unhexify( z, z_str );
 
     rnd_info_A.buf = rnd_buf_A;
-    rnd_info_A.length = unhexify( rnd_buf_A, dA_str );
+    rnd_info_A.length = mbedtls_test_unhexify( rnd_buf_A, dA_str );
 
     rnd_info_B.buf = rnd_buf_B;
-    rnd_info_B.length = unhexify( rnd_buf_B, dB_str );
+    rnd_info_B.length = mbedtls_test_unhexify( rnd_buf_B, dB_str );
 
     /* The ECDH context is not guaranteed ot have an mbedtls_ecp_group structure
      * in every configuration, therefore we load it separately. */

--- a/tests/suites/test_suite_ecdh.function
+++ b/tests/suites/test_suite_ecdh.function
@@ -340,7 +340,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE */
-void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
+void ecdh_restart( int id, data_t *dA, data_t *dB, data_t *z,
                    int enable, int max_ops, int min_restart, int max_restart )
 {
     int ret;
@@ -348,10 +348,6 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     unsigned char buf[1000];
     const unsigned char *vbuf;
     size_t len;
-    unsigned char z[MBEDTLS_ECP_MAX_BYTES];
-    size_t z_len;
-    unsigned char rnd_buf_A[MBEDTLS_ECP_MAX_BYTES];
-    unsigned char rnd_buf_B[MBEDTLS_ECP_MAX_BYTES];
     rnd_buf_info rnd_info_A, rnd_info_B;
     int cnt_restart;
     mbedtls_ecp_group grp;
@@ -360,13 +356,11 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     mbedtls_ecdh_init( &srv );
     mbedtls_ecdh_init( &cli );
 
-    z_len = mbedtls_test_unhexify( z, z_str );
+    rnd_info_A.buf = dA->x;
+    rnd_info_A.length = dA->len;
 
-    rnd_info_A.buf = rnd_buf_A;
-    rnd_info_A.length = mbedtls_test_unhexify( rnd_buf_A, dA_str );
-
-    rnd_info_B.buf = rnd_buf_B;
-    rnd_info_B.length = mbedtls_test_unhexify( rnd_buf_B, dB_str );
+    rnd_info_B.buf = dB->x;
+    rnd_info_B.length = dB->len;
 
     /* The ECDH context is not guaranteed ot have an mbedtls_ecp_group structure
      * in every configuration, therefore we load it separately. */
@@ -436,8 +430,8 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );
 
-    TEST_ASSERT( len == z_len );
-    TEST_ASSERT( memcmp( buf, z, len ) == 0 );
+    TEST_ASSERT( len == z->len );
+    TEST_ASSERT( memcmp( buf, z->x, len ) == 0 );
 
     /* client computes shared secret */
     memset( buf, 0, sizeof( buf ) );
@@ -453,8 +447,8 @@ void ecdh_restart( int id, char *dA_str, char *dB_str, char *z_str,
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );
 
-    TEST_ASSERT( len == z_len );
-    TEST_ASSERT( memcmp( buf, z, len ) == 0 );
+    TEST_ASSERT( len == z->len );
+    TEST_ASSERT( memcmp( buf, z->x, len ) == 0 );
 
 exit:
     mbedtls_ecp_group_free( &grp );

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -447,9 +447,9 @@ void ecdsa_read_restart( int id, char *k_str, char *h_str, char *s_str,
     mbedtls_ecdsa_init( &ctx );
     mbedtls_ecdsa_restart_init( &rs_ctx );
 
-    hash_len = unhexify(hash, h_str);
-    sig_len = unhexify(sig, s_str);
-    pk_len = unhexify(pk, k_str);
+    hash_len = mbedtls_test_unhexify(hash, h_str);
+    sig_len = mbedtls_test_unhexify(sig, s_str);
+    pk_len = mbedtls_test_unhexify(pk, k_str);
 
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_binary( &ctx.grp, &ctx.Q, pk, pk_len ) == 0 );
@@ -521,7 +521,7 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
 
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &ctx.d, 16, d_str ) == 0 );
-    slen_check = unhexify( sig_check, sig_str );
+    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -433,33 +433,26 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE */
-void ecdsa_read_restart( int id, char *k_str, char *h_str, char *s_str,
+void ecdsa_read_restart( int id, data_t *pk, data_t *hash, data_t *sig,
                          int max_ops, int min_restart, int max_restart )
 {
     mbedtls_ecdsa_context ctx;
     mbedtls_ecdsa_restart_ctx rs_ctx;
-    unsigned char hash[64];
-    unsigned char sig[200];
-    unsigned char pk[65];
-    size_t sig_len, hash_len, pk_len;
     int ret, cnt_restart;
 
     mbedtls_ecdsa_init( &ctx );
     mbedtls_ecdsa_restart_init( &rs_ctx );
 
-    hash_len = mbedtls_test_unhexify(hash, h_str);
-    sig_len = mbedtls_test_unhexify(sig, s_str);
-    pk_len = mbedtls_test_unhexify(pk, k_str);
-
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
-    TEST_ASSERT( mbedtls_ecp_point_read_binary( &ctx.grp, &ctx.Q, pk, pk_len ) == 0 );
+    TEST_ASSERT( mbedtls_ecp_point_read_binary( &ctx.grp, &ctx.Q,
+                                                pk->x, pk->len ) == 0 );
 
     mbedtls_ecp_set_max_ops( max_ops );
 
     cnt_restart = 0;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
@@ -467,29 +460,31 @@ void ecdsa_read_restart( int id, char *k_str, char *h_str, char *s_str,
     TEST_ASSERT( cnt_restart <= max_restart );
 
     /* try modifying r */
-    sig[10]++;
+
+    TEST_ASSERT( sig->len > 10 );
+    sig->x[10]++;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     TEST_ASSERT( ret == MBEDTLS_ERR_ECP_VERIFY_FAILED );
-    sig[10]--;
+    sig->x[10]--;
 
     /* try modifying s */
-    sig[sig_len - 1]++;
+    sig->x[sig->len - 1]++;
     do {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     TEST_ASSERT( ret == MBEDTLS_ERR_ECP_VERIFY_FAILED );
-    sig[sig_len - 1]--;
+    sig->x[sig->len - 1]--;
 
     /* Do we leak memory when aborting an operation?
      * This test only makes sense when we actually restart */
     if( min_restart > 0 )
     {
         ret = mbedtls_ecdsa_read_signature_restartable( &ctx,
-                            hash, hash_len, sig, sig_len, &rs_ctx );
+                            hash->x, hash->len, sig->x, sig->len, &rs_ctx );
         TEST_ASSERT( ret == MBEDTLS_ERR_ECP_IN_PROGRESS );
     }
 
@@ -501,7 +496,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:MBEDTLS_ECDSA_DETERMINISTIC */
 void ecdsa_write_restart( int id, char *d_str, int md_alg,
-                          char *msg, char *sig_str,
+                          char *msg, data_t *sig_check,
                           int max_ops, int min_restart, int max_restart )
 {
     int ret, cnt_restart;
@@ -509,19 +504,16 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
     mbedtls_ecdsa_context ctx;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
-    unsigned char sig_check[MBEDTLS_ECDSA_MAX_LEN];
-    size_t hlen, slen, slen_check;
+    size_t hlen, slen;
     const mbedtls_md_info_t *md_info;
 
     mbedtls_ecdsa_restart_init( &rs_ctx );
     mbedtls_ecdsa_init( &ctx );
     memset( hash, 0, sizeof( hash ) );
     memset( sig, 0, sizeof( sig ) );
-    memset( sig_check, 0, sizeof( sig_check ) );
 
     TEST_ASSERT( mbedtls_ecp_group_load( &ctx.grp, id ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &ctx.d, 16, d_str ) == 0 );
-    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
@@ -541,8 +533,8 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
-    TEST_ASSERT( slen == slen_check );
-    TEST_ASSERT( memcmp( sig, sig_check, slen ) == 0 );
+    TEST_ASSERT( slen == sig_check->len );
+    TEST_ASSERT( memcmp( sig, sig_check->x, slen ) == 0 );
 
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -37,7 +37,10 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
                         okm_len);
     TEST_ASSERT( ret == 0 );
 
-    // Run mbedtls_test_hexify on it so that it looks nicer if the assertion fails
+    /*
+     * Run mbedtls_test_hexify on it so that it looks nicer if the assertion
+     * fails.
+     */
     mbedtls_test_hexify( okm_hex, okm, okm_len );
     TEST_ASSERT( !strcmp( (char *)okm_hex, hex_okm_string ) );
 }

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -28,17 +28,17 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
 
-    ikm_len = unhexify( ikm, hex_ikm_string );
-    salt_len = unhexify( salt, hex_salt_string );
-    info_len = unhexify( info, hex_info_string );
-    okm_len = unhexify( expected_okm, hex_okm_string );
+    ikm_len = mbedtls_test_unhexify( ikm, hex_ikm_string );
+    salt_len = mbedtls_test_unhexify( salt, hex_salt_string );
+    info_len = mbedtls_test_unhexify( info, hex_info_string );
+    okm_len = mbedtls_test_unhexify( expected_okm, hex_okm_string );
 
     ret = mbedtls_hkdf( md, salt, salt_len, ikm, ikm_len, info, info_len, okm,
                         okm_len);
     TEST_ASSERT( ret == 0 );
 
-    // Run hexify on it so that it looks nicer if the assertion fails
-    hexify( okm_hex, okm, okm_len );
+    // Run mbedtls_test_hexify on it so that it looks nicer if the assertion fails
+    mbedtls_test_hexify( okm_hex, okm, okm_len );
     TEST_ASSERT( !strcmp( (char *)okm_hex, hex_okm_string ) );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -10,20 +10,20 @@
 
 /* BEGIN_CASE */
 void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
-                char *hex_info_string, char *hex_okm_string )
+                char *hex_info_string, char *hex_expected_okm_string )
 {
     int ret;
-    size_t ikm_len, salt_len, info_len, okm_len;
+    size_t ikm_len, salt_len, info_len, expected_okm_len;
     unsigned char ikm[128] = { '\0' };
     unsigned char salt[128] = { '\0' };
     unsigned char info[128] = { '\0' };
     unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
     /*
-     * okm_hex is the string representation of okm,
+     * okm_string is the ASCII string representation of okm,
      * so its size is twice the size of okm, and an extra null-termination.
      */
-    unsigned char okm_hex[257] = { '\0' };
+    unsigned char okm_string[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
@@ -31,18 +31,21 @@ void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
     ikm_len = mbedtls_test_unhexify( ikm, hex_ikm_string );
     salt_len = mbedtls_test_unhexify( salt, hex_salt_string );
     info_len = mbedtls_test_unhexify( info, hex_info_string );
-    okm_len = mbedtls_test_unhexify( expected_okm, hex_okm_string );
+    expected_okm_len = mbedtls_test_unhexify( expected_okm,
+                                              hex_expected_okm_string );
+
+    TEST_ASSERT( expected_okm_len <= sizeof( okm ) );
 
     ret = mbedtls_hkdf( md, salt, salt_len, ikm, ikm_len, info, info_len, okm,
-                        okm_len);
+                        expected_okm_len);
     TEST_ASSERT( ret == 0 );
 
     /*
      * Run mbedtls_test_hexify on it so that it looks nicer if the assertion
      * fails.
      */
-    mbedtls_test_hexify( okm_hex, okm, okm_len );
-    TEST_ASSERT( !strcmp( (char *)okm_hex, hex_okm_string ) );
+    mbedtls_test_hexify( okm_string, okm, expected_okm_len );
+    TEST_ASSERT( !strcmp( (char *)okm_string, hex_expected_okm_string ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -9,43 +9,36 @@
  */
 
 /* BEGIN_CASE */
-void test_hkdf( int md_alg, char *hex_ikm_string, char *hex_salt_string,
-                char *hex_info_string, char *hex_expected_okm_string )
+void test_hkdf( int md_alg, data_t *ikm, data_t *salt, data_t *info,
+                data_t *expected_okm )
 {
     int ret;
-    size_t ikm_len, salt_len, info_len, expected_okm_len;
-    unsigned char ikm[128] = { '\0' };
-    unsigned char salt[128] = { '\0' };
-    unsigned char info[128] = { '\0' };
-    unsigned char expected_okm[128] = { '\0' };
     unsigned char okm[128] = { '\0' };
     /*
-     * okm_string is the ASCII string representation of okm,
-     * so its size is twice the size of okm, and an extra null-termination.
+     * okm_string and expected_okm_string are the ASCII string representations
+     * of km and expected_okm, so their size should be twice the size of
+     * okm and expected_okm, and an extra null-termination.
      */
     unsigned char okm_string[257] = { '\0' };
+    unsigned char expected_okm_string[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
 
-    ikm_len = mbedtls_test_unhexify( ikm, hex_ikm_string );
-    salt_len = mbedtls_test_unhexify( salt, hex_salt_string );
-    info_len = mbedtls_test_unhexify( info, hex_info_string );
-    expected_okm_len = mbedtls_test_unhexify( expected_okm,
-                                              hex_expected_okm_string );
+    TEST_ASSERT( expected_okm->len <= sizeof( okm ) );
 
-    TEST_ASSERT( expected_okm_len <= sizeof( okm ) );
-
-    ret = mbedtls_hkdf( md, salt, salt_len, ikm, ikm_len, info, info_len, okm,
-                        expected_okm_len);
+    ret = mbedtls_hkdf( md, salt->x, salt->len, ikm->x, ikm->len,
+                        info->x, info->len, okm, expected_okm->len );
     TEST_ASSERT( ret == 0 );
 
     /*
-     * Run mbedtls_test_hexify on it so that it looks nicer if the assertion
-     * fails.
+     * Run mbedtls_test_hexify on okm and expected_okm so that it looks nicer
+     * if the assertion fails.
      */
-    mbedtls_test_hexify( okm_string, okm, expected_okm_len );
-    TEST_ASSERT( !strcmp( (char *)okm_string, hex_expected_okm_string ) );
+    mbedtls_test_hexify( okm_string, okm, expected_okm->len );
+    mbedtls_test_hexify( expected_okm_string,
+                         expected_okm->x, expected_okm->len );
+    TEST_ASSERT( !strcmp( (char *)okm_string, (char *)expected_okm_string ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -244,14 +244,14 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_nist_kw_wrap( int cipher_id, int mode,
                            char *key_hex, char *msg_hex,
-                           char *result_hex )
+                           char *expected_result_hex )
 {
     unsigned char key[32];
     unsigned char msg[512];
     unsigned char result[528];
     unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, output_len, result_len, i, padlen;
+    size_t key_len, msg_len, result_len, expected_result_len, i, padlen;
 
     mbedtls_nist_kw_init( &ctx );
 
@@ -261,19 +261,19 @@ void mbedtls_nist_kw_wrap( int cipher_id, int mode,
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    result_len = mbedtls_test_unhexify( expected_result, result_hex );
-    output_len = sizeof( result );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
+    result_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 1 )
                  == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg, msg_len,
-                 result, &output_len, sizeof( result ) ) == 0 );
+                 result, &result_len, sizeof( result ) ) == 0 );
 
-    TEST_ASSERT( output_len == result_len );
+    TEST_ASSERT( result_len == expected_result_len );
 
-    TEST_ASSERT( memcmp( expected_result, result, result_len ) == 0 );
+    TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
 
     padlen = ( msg_len % 8 != 0 ) ? 8 - (msg_len % 8 ) : 0;
     /* Check that the function didn't write beyond the end of the buffer. */
@@ -290,14 +290,14 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
                              char *key_hex, char *msg_hex,
-                             char *result_hex, int expected_ret )
+                             char *expected_result_hex, int expected_ret )
 {
     unsigned char key[32];
     unsigned char msg[528];
     unsigned char result[528];
     unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, output_len, result_len, i;
+    size_t key_len, msg_len, result_len, expected_result_len, i;
 
     mbedtls_nist_kw_init( &ctx );
 
@@ -308,23 +308,23 @@ void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
 
     key_len = mbedtls_test_unhexify( key, key_hex );
     msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    result_len = mbedtls_test_unhexify( expected_result, result_hex );
-    output_len = sizeof( result );
+    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
+    result_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 0 )
                  == 0 );
 
     /* Test with input == output */
     TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg, msg_len,
-                 result, &output_len, sizeof( result ) ) == expected_ret );
+                 result, &result_len, sizeof( result ) ) == expected_ret );
     if( expected_ret == 0 )
     {
-        TEST_ASSERT( output_len == result_len );
-        TEST_ASSERT( memcmp( expected_result, result, result_len ) == 0 );
+        TEST_ASSERT( result_len == expected_result_len );
+        TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
     }
     else
     {
-        TEST_ASSERT( output_len == 0 );
+        TEST_ASSERT( result_len == 0 );
     }
 
     /* Check that the function didn't write beyond the end of the buffer. */

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -259,9 +259,9 @@ void mbedtls_nist_kw_wrap( int cipher_id, int mode,
     memset( msg, 0x00, sizeof( msg ) );
     memset( result, '+', sizeof( result ) );
 
-    key_len = unhexify( key, key_hex );
-    msg_len = unhexify( msg, msg_hex );
-    result_len = unhexify( expected_result, result_hex );
+    key_len = mbedtls_test_unhexify( key, key_hex );
+    msg_len = mbedtls_test_unhexify( msg, msg_hex );
+    result_len = mbedtls_test_unhexify( expected_result, result_hex );
     output_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 1 )
@@ -306,9 +306,9 @@ void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
     memset( result, '+', sizeof( result ) );
     memset( expected_result, 0x00, sizeof( expected_result ) );
 
-    key_len = unhexify( key, key_hex );
-    msg_len = unhexify( msg, msg_hex );
-    result_len = unhexify( expected_result, result_hex );
+    key_len = mbedtls_test_unhexify( key, key_hex );
+    msg_len = mbedtls_test_unhexify( msg, msg_hex );
+    result_len = mbedtls_test_unhexify( expected_result, result_hex );
     output_len = sizeof( result );
 
     TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 0 )

--- a/tests/suites/test_suite_nist_kw.function
+++ b/tests/suites/test_suite_nist_kw.function
@@ -242,42 +242,31 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_nist_kw_wrap( int cipher_id, int mode,
-                           char *key_hex, char *msg_hex,
-                           char *expected_result_hex )
+void mbedtls_nist_kw_wrap( int cipher_id, int mode, data_t *key, data_t *msg,
+                           data_t *expected_result )
 {
-    unsigned char key[32];
-    unsigned char msg[512];
     unsigned char result[528];
-    unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, result_len, expected_result_len, i, padlen;
+    size_t result_len, i, padlen;
 
     mbedtls_nist_kw_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( result, '+', sizeof( result ) );
 
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    result_len = sizeof( result );
-
-    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 1 )
-                 == 0 );
+    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id,
+                                         key->x, key->len * 8, 1 ) == 0 );
 
     /* Test with input == output */
-    TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg, msg_len,
+    TEST_ASSERT( mbedtls_nist_kw_wrap( &ctx, mode, msg->x, msg->len,
                  result, &result_len, sizeof( result ) ) == 0 );
 
-    TEST_ASSERT( result_len == expected_result_len );
+    TEST_ASSERT( result_len == expected_result->len );
 
-    TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
+    TEST_ASSERT( memcmp( expected_result->x, result, result_len ) == 0 );
 
-    padlen = ( msg_len % 8 != 0 ) ? 8 - (msg_len % 8 ) : 0;
+    padlen = ( msg->len % 8 != 0 ) ? 8 - (msg->len % 8 ) : 0;
     /* Check that the function didn't write beyond the end of the buffer. */
-    for( i = msg_len + 8 + padlen; i < sizeof( result ); i++ )
+    for( i = msg->len + 8 + padlen; i < sizeof( result ); i++ )
     {
         TEST_ASSERT( result[i] == '+' );
     }
@@ -288,39 +277,27 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
-                             char *key_hex, char *msg_hex,
-                             char *expected_result_hex, int expected_ret )
+void mbedtls_nist_kw_unwrap( int cipher_id, int mode, data_t *key, data_t *msg,
+                             data_t *expected_result, int expected_ret )
 {
-    unsigned char key[32];
-    unsigned char msg[528];
     unsigned char result[528];
-    unsigned char expected_result[528];
     mbedtls_nist_kw_context ctx;
-    size_t key_len, msg_len, result_len, expected_result_len, i;
+    size_t result_len, i;
 
     mbedtls_nist_kw_init( &ctx );
 
-    memset( key, 0x00, sizeof( key ) );
-    memset( msg, 0x00, sizeof( msg ) );
     memset( result, '+', sizeof( result ) );
-    memset( expected_result, 0x00, sizeof( expected_result ) );
 
-    key_len = mbedtls_test_unhexify( key, key_hex );
-    msg_len = mbedtls_test_unhexify( msg, msg_hex );
-    expected_result_len = mbedtls_test_unhexify( expected_result, expected_result_hex );
-    result_len = sizeof( result );
-
-    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id, key, key_len * 8, 0 )
-                 == 0 );
+    TEST_ASSERT( mbedtls_nist_kw_setkey( &ctx, cipher_id,
+                                         key->x, key->len * 8, 0 ) == 0 );
 
     /* Test with input == output */
-    TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg, msg_len,
+    TEST_ASSERT( mbedtls_nist_kw_unwrap( &ctx, mode, msg->x, msg->len,
                  result, &result_len, sizeof( result ) ) == expected_ret );
     if( expected_ret == 0 )
     {
-        TEST_ASSERT( result_len == expected_result_len );
-        TEST_ASSERT( memcmp( expected_result, result, expected_result_len ) == 0 );
+        TEST_ASSERT( result_len == expected_result->len );
+        TEST_ASSERT( memcmp( expected_result->x, result, result_len ) == 0 );
     }
     else
     {
@@ -328,7 +305,7 @@ void mbedtls_nist_kw_unwrap( int cipher_id, int mode,
     }
 
     /* Check that the function didn't write beyond the end of the buffer. */
-    for( i = msg_len - 8; i < sizeof( result ); i++ )
+    for( i = msg->len - 8; i < sizeof( result ); i++ )
     {
         TEST_ASSERT( result[i] == '+' );
     }

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -679,7 +679,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_ECP_RESTARTABLE:MBEDTLS_ECDSA_C:MBEDTLS_ECDSA_DETERMINISTIC */
 void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
                               char *QX_str, char *QY_str,
-                              int md_alg, char *msg, char *sig_str,
+                              int md_alg, char *msg, data_t *sig_check,
                               int max_ops, int min_restart, int max_restart )
 {
     int ret, cnt_restart;
@@ -687,8 +687,7 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     mbedtls_pk_context prv, pub;
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     unsigned char sig[MBEDTLS_ECDSA_MAX_LEN];
-    unsigned char sig_check[MBEDTLS_ECDSA_MAX_LEN];
-    size_t hlen, slen, slen_check;
+    size_t hlen, slen;
     const mbedtls_md_info_t *md_info;
 
     mbedtls_pk_restart_init( &rs_ctx );
@@ -696,7 +695,6 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     mbedtls_pk_init( &pub );
     memset( hash, 0, sizeof( hash ) );
     memset( sig, 0, sizeof( sig ) );
-    memset( sig_check, 0, sizeof( sig_check ) );
 
     TEST_ASSERT( mbedtls_pk_setup( &prv, mbedtls_pk_info_from_type( pk_type ) ) == 0 );
     TEST_ASSERT( mbedtls_ecp_group_load( &mbedtls_pk_ec( prv )->grp, grp_id ) == 0 );
@@ -705,8 +703,6 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     TEST_ASSERT( mbedtls_pk_setup( &pub, mbedtls_pk_info_from_type( pk_type ) ) == 0 );
     TEST_ASSERT( mbedtls_ecp_group_load( &mbedtls_pk_ec( pub )->grp, grp_id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &mbedtls_pk_ec( pub )->Q, 16, QX_str, QY_str ) == 0 );
-
-    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
@@ -726,8 +722,8 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     } while( ret == MBEDTLS_ERR_ECP_IN_PROGRESS && ++cnt_restart );
 
     TEST_ASSERT( ret == 0 );
-    TEST_ASSERT( slen == slen_check );
-    TEST_ASSERT( memcmp( sig, sig_check, slen ) == 0 );
+    TEST_ASSERT( slen == sig_check->len );
+    TEST_ASSERT( memcmp( sig, sig_check->x, slen ) == 0 );
 
     TEST_ASSERT( cnt_restart >= min_restart );
     TEST_ASSERT( cnt_restart <= max_restart );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -706,7 +706,7 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     TEST_ASSERT( mbedtls_ecp_group_load( &mbedtls_pk_ec( pub )->grp, grp_id ) == 0 );
     TEST_ASSERT( mbedtls_ecp_point_read_string( &mbedtls_pk_ec( pub )->Q, 16, QX_str, QY_str ) == 0 );
 
-    slen_check = unhexify( sig_check, sig_str );
+    slen_check = mbedtls_test_unhexify( sig_check, sig_str );
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -23,15 +23,15 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
     memset( key,     0x00, sizeof( key ) );
     memset( mac,     0x00, sizeof( mac ) );
 
-    src_len = unhexify( src_str, hex_src_string );
-    unhexify( key, hex_key_string );
+    src_len = mbedtls_test_unhexify( src_str, hex_src_string );
+    mbedtls_test_unhexify( key, hex_key_string );
 
     /*
      * Test the integrated API
      */
     TEST_ASSERT( mbedtls_poly1305_mac( key, src_str, src_len, mac ) == 0 );
 
-    hexify( mac_str, mac, 16 );
+    mbedtls_test_hexify( mac_str, mac, 16 );
     TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
 
     /*
@@ -45,7 +45,7 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
 
     TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-    hexify( mac_str, mac, 16 );
+    mbedtls_test_hexify( mac_str, mac, 16 );
     TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
 
     /*
@@ -63,7 +63,7 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        hexify( mac_str, mac, 16 );
+        mbedtls_test_hexify( mac_str, mac, 16 );
         TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
     }
 
@@ -80,7 +80,7 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        hexify( mac_str, mac, 16 );
+        mbedtls_test_hexify( mac_str, mac, 16 );
         TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
     }
 

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -9,27 +9,20 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src_string  )
+void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
 {
-    unsigned char src_str[375]; /* max size of binary input */
-    unsigned char key[32]; /* size set by the standard */
     unsigned char mac[16]; /* size set by the standard */
     unsigned char mac_str[33]; /* hex expansion of the above */
-    size_t src_len;
     mbedtls_poly1305_context ctx;
 
-    memset( src_str, 0x00, sizeof( src_str ) );
     memset( mac_str, 0x00, sizeof( mac_str ) );
-    memset( key,     0x00, sizeof( key ) );
     memset( mac,     0x00, sizeof( mac ) );
-
-    src_len = mbedtls_test_unhexify( src_str, hex_src_string );
-    mbedtls_test_unhexify( key, hex_key_string );
 
     /*
      * Test the integrated API
      */
-    TEST_ASSERT( mbedtls_poly1305_mac( key, src_str, src_len, mac ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_mac( key->x, src_str->x,
+                                       src_str->len, mac ) == 0 );
 
     mbedtls_test_hexify( mac_str, mac, 16 );
     TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
@@ -39,9 +32,9 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
      */
     mbedtls_poly1305_init( &ctx );
 
-    TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-    TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, src_len ) == 0 );
+    TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, src_str->len ) == 0 );
 
     TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
@@ -54,12 +47,12 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
 
     /* Don't free/init the context, in order to test that starts() does the
      * right thing. */
-    if( src_len >= 1 )
+    if( src_str->len >= 1 )
     {
-        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 1, src_len - 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 1, src_str->len - 1 ) == 0 );
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
@@ -70,13 +63,13 @@ void mbedtls_poly1305( char *hex_key_string, char *hex_mac_string, char *hex_src
     /*
      * Again with more pieces
      */
-    if( src_len >= 2 )
+    if( src_str->len >= 2 )
     {
-        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_starts( &ctx, key->x ) == 0 );
 
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 1, 1 ) == 0 );
-        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str + 2, src_len - 2 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 1, 1 ) == 0 );
+        TEST_ASSERT( mbedtls_poly1305_update( &ctx, src_str->x + 2, src_str->len - 2 ) == 0 );
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 


### PR DESCRIPTION
## Description
Partial backport of #3438 
Fix #3459

To ease the partial backport I have also backported [72d628f](https://github.com/ARMmbed/mbedtls/commit/72d628f7f5a6014ededd3bff5f32d6b2f2109821) and [ff31eab](https://github.com/ARMmbed/mbedtls/commit/ff31eab9381496a8808c9affdf48dbe526ced887) (adding mbedtls_test_ prefix to unhexify and hexify and associated reformatting). 

The backport was almost straightforward but for:
test_suite_cipher.function:test_vec_crypt(): Removed `use_psa` parameter               
test_suite_ecdh.function:ecdh_start(): `rnd_buf_info` type instead of `mbedtls_test_rnd_buf_info`
test_suite_ccm.function:mbedtls_ccm_star_auth_decrypt: Changes TEST_EQUAL's to TEST_ASSERT's

## Status
CI check

