### PR TITLE
Programs cmake cleanup 2.7

### DIFF
--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(targets
     ssl_fork_server
     ssl_mail_client
     ssl_server
+    ssl_server2
 )
 
 if(USE_PKCS11_HELPER_LIBRARY)

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -8,12 +8,12 @@ set(libs
 set(targets
     dtls_client
     dtls_server
+    mini_client
     ssl_client1
     ssl_client2
-    ssl_server
     ssl_fork_server
     ssl_mail_client
-    mini_client
+    ssl_server
 )
 
 if(USE_PKCS11_HELPER_LIBRARY)
@@ -30,17 +30,14 @@ target_link_libraries(dtls_client ${libs})
 add_executable(dtls_server dtls_server.c)
 target_link_libraries(dtls_server ${libs})
 
+add_executable(mini_client mini_client.c)
+target_link_libraries(mini_client ${libs})
+
 add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
 add_executable(ssl_client2 ssl_client2.c)
 target_link_libraries(ssl_client2 ${libs})
-
-add_executable(ssl_server ssl_server.c)
-target_link_libraries(ssl_server ${libs})
-
-add_executable(ssl_server2 ssl_server2.c)
-target_link_libraries(ssl_server2 ${libs})
 
 add_executable(ssl_fork_server ssl_fork_server.c)
 target_link_libraries(ssl_fork_server ${libs})
@@ -48,8 +45,11 @@ target_link_libraries(ssl_fork_server ${libs})
 add_executable(ssl_mail_client ssl_mail_client.c)
 target_link_libraries(ssl_mail_client ${libs})
 
-add_executable(mini_client mini_client.c)
-target_link_libraries(mini_client ${libs})
+add_executable(ssl_server ssl_server.c)
+target_link_libraries(ssl_server ${libs})
+
+add_executable(ssl_server2 ssl_server2.c)
+target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)
     add_executable(ssl_pthread_server ssl_pthread_server.c)


### PR DESCRIPTION
This is a partial backport of #3438, covering only the one applicable bug fix in programs/*/CmakeLists.txt. It is smaller than the [2.16 backport](https://github.com/ARMmbed/mbedtls/pull/3460):

* “programs: ssl: cmake: Reorder declaration of executables”: similar to 2.16.
* “programs: ssl: cmake: Add missing executables”: as in 2.16.
* “programs: cmake: Fix relative path warnings”: not applicable.
