### PR TITLE
Add flow monitor for memory block operations

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -197,6 +197,7 @@ void *mbedtls_platform_memset( void *ptr, int value, size_t num );
  * \param num   The length of the buffers in bytes.
  *
  * \return      The value of \p dst.
+ * \return      NULL if a potential FI attack was detected.
  */
 void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -161,8 +161,11 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param buf   Buffer to be zeroized
  * \param len   Length of the buffer in bytes
  *
+ * \return      The value of \p buf if the operation was successful.
+ * \return      NULL if a potential FI attack was detected or input parameters
+ *              are not valid.
  */
-void mbedtls_platform_zeroize( void *buf, size_t len );
+void *mbedtls_platform_zeroize( void *buf, size_t len );
 
 /**
  * \brief       Secure memset
@@ -176,7 +179,8 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \param value Value to be used when setting the buffer.
  * \param num   The length of the buffer in bytes.
  *
- * \return      The value of \p ptr.
+ * \return      The value of \p ptr if the operation was successful.
+ * \return      NULL if a potential FI attack was detected.
  */
 void *mbedtls_platform_memset( void *ptr, int value, size_t num );
 

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -462,9 +462,10 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
     for( i = 0; i < ctx->source_count; i++ )
         ctx->source[i].size = 0;
 
-    mbedtls_platform_memcpy( output, buf, len );
-
-    ret = 0;
+    if( output == mbedtls_platform_memcpy( output, buf, len ) )
+    {
+        ret = 0;
+    }
 
 exit:
     mbedtls_platform_zeroize( buf, sizeof( buf ) );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -561,9 +561,13 @@ static int uecc_public_key_read_binary( mbedtls_uecc_keypair *uecc_keypair,
     if( buf[0] != 0x04 )
         return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
 
-    mbedtls_platform_memcpy( uecc_keypair->public_key, buf + 1, 2 * NUM_ECC_BYTES );
+    if( mbedtls_platform_memcpy( uecc_keypair->public_key, buf + 1, 2 * NUM_ECC_BYTES ) ==
+                                 uecc_keypair->public_key )
+    {
+        return( 0 );
+    }
 
-    return( 0 );
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 
 static int pk_get_ueccpubkey( unsigned char **p,
@@ -976,7 +980,11 @@ static int pk_parse_key_sec1_der( mbedtls_uecc_keypair *keypair,
     if( ( ret = mbedtls_asn1_get_tag( &p, end, &len, MBEDTLS_ASN1_OCTET_STRING ) ) != 0 )
         return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT + ret );
 
-    mbedtls_platform_memcpy( keypair->private_key, p, len );
+    if( mbedtls_platform_memcpy( keypair->private_key, p, len ) !=
+                                 keypair->private_key )
+    {
+        return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
+    }
 
     p += len;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1886,9 +1886,13 @@ static int ssl_compute_master( mbedtls_ssl_handshake_params *handshake,
         return( ret );
     }
 
-    mbedtls_platform_zeroize( handshake->premaster,
-                              sizeof(handshake->premaster) );
-    return( 0 );
+    if( handshake->premaster == mbedtls_platform_zeroize( 
+                    handshake->premaster, sizeof(handshake->premaster) ) )
+    {
+        return( 0 );
+    }
+
+    return( MBEDTLS_ERR_PLATFORM_FAULT_DETECTED );
 }
 
 int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -81,7 +81,10 @@ int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 	/* This function is designed for test purposes-only (such as validating NIST
 	 * test vectors) as it uses a provided value for d instead of generating
 	 * it uniformly at random. */
-	mbedtls_platform_memcpy (_private, d, NUM_ECC_BYTES);
+	if( mbedtls_platform_memcpy (_private, d, NUM_ECC_BYTES) != _private )
+	{
+		goto exit;
+	}
 
 	/* Computing public-key from private: */
 	ret = EccPoint_compute_public_key(_public, _private);

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -186,7 +186,9 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 	uECC_vli_nativeToBytes(secret, num_bytes, _public);
 
 	/* erasing temporary buffer used to store secret: */
-	mbedtls_platform_zeroize(_private, sizeof(_private));
+	if (_private == mbedtls_platform_zeroize(_private, sizeof(_private))) {
+		return r;
+	}
 
-	return r;
+	return UECC_FAULT_DETECTED;
 }


### PR DESCRIPTION
## Description
This PR adds a flow monitor to the functions `mbedtls_platform_memset()`, `mbedtls_platform_memcpy()` and `mbedtls_platform_zeroize()`. Several checks have also been added in security-sensitive places to see if these functions performed correctly. 

**Note:** The first commit "Rename mbedtls_platform_memcmp() to mbedtls_platform_memequal()" come from another PR

## Status
**READY**
