### PR TITLE
Use a fake random key in AES calculations

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -87,6 +87,7 @@ typedef struct mbedtls_aes_context
 {
     int nr;                     /*!< The number of rounds. */
     uint32_t *rk;               /*!< AES round keys. */
+    uint32_t frk[8];            /*!< Fake AES round keys. */
 #if defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH) && !defined(MBEDTLS_PADLOCK_C)
     uint32_t buf[44];           /*!< Unaligned data buffer */
 #else /* MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -87,7 +87,9 @@ typedef struct mbedtls_aes_context
 {
     int nr;                     /*!< The number of rounds. */
     uint32_t *rk;               /*!< AES round keys. */
+#if defined(MBEDTLS_AES_SCA_COUNTERMEASURES)
     uint32_t frk[8];            /*!< Fake AES round keys. */
+#endif
 #if defined(MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH) && !defined(MBEDTLS_PADLOCK_C)
     uint32_t buf[44];           /*!< Unaligned data buffer */
 #else /* MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH */

--- a/library/aes.c
+++ b/library/aes.c
@@ -675,6 +675,7 @@ void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx )
 }
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
+#if defined(MBEDTLS_AES_SCA_COUNTERMEASURES)
 static void mbedtls_generate_fake_key( unsigned int keybits, mbedtls_aes_context *ctx )
 {
     unsigned int qword;
@@ -684,6 +685,7 @@ static void mbedtls_generate_fake_key( unsigned int keybits, mbedtls_aes_context
         ctx->frk[ qword - 1 ] = mbedtls_platform_random_uint32();
     }
 }
+#endif /* MBEDTLS_AES_SCA_COUNTERMEASURES */
 
 /*
  * AES key schedule (encryption)
@@ -729,7 +731,9 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
     else
 #endif
     ctx->rk = RK = ctx->buf;
+#if defined(MBEDTLS_AES_SCA_COUNTERMEASURES)
     mbedtls_generate_fake_key( keybits, ctx );
+#endif
 
 #if defined(MBEDTLS_AESNI_C) && defined(MBEDTLS_HAVE_X86_64)
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_AES ) )
@@ -869,7 +873,9 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
     else
 #endif
     ctx->rk = RK = ctx->buf;
+#if defined(MBEDTLS_AES_SCA_COUNTERMEASURES)
     mbedtls_generate_fake_key( keybits, ctx );
+#endif
 
     /* Also checks keybits */
     if( ( ret = mbedtls_aes_setkey_enc( &cty, key, keybits ) ) != 0 )
@@ -1084,6 +1090,7 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
 
     aes_data_real.rk_ptr = ctx->rk;
     aes_data_fake.rk_ptr = ctx->frk;
+
     aes_data_table[0] = &aes_data_real;
     aes_data_table[1] = &aes_data_fake;
 
@@ -1364,6 +1371,7 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
 
     aes_data_real.rk_ptr = ctx->rk;
     aes_data_fake.rk_ptr = ctx->frk;
+
     aes_data_table[0] = &aes_data_real;
     aes_data_table[1] = &aes_data_fake;
 


### PR DESCRIPTION
This PR is based on https://github.com/ARMmbed/mbedtls/pull/3456.
Please only review commit de506a8. 