### PR TITLE
Added support for AES-ECB to the PSA Crypto implementation

### DIFF
--- a/ChangeLog.d/add-aes-ecb-to-psa.txt
+++ b/ChangeLog.d/add-aes-ecb-to-psa.txt
@@ -1,2 +1,2 @@
 Features
-   * Added support for AES-ECB to the PSA Crypto cipher API.
+   * Add support for ECB to the PSA cipher API.

--- a/ChangeLog.d/add-aes-ecb-to-psa.txt
+++ b/ChangeLog.d/add-aes-ecb-to-psa.txt
@@ -1,0 +1,2 @@
+Features
+   * Added support for AES-ECB to the PSA Crypto cipher API.

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -86,7 +86,7 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
     switch( mode )
     {
         case MBEDTLS_MODE_ECB:
-            return ( PSA_ALG_ECB_NO_PADDING );
+            return( PSA_ALG_ECB_NO_PADDING );
         case MBEDTLS_MODE_GCM:
             return( PSA_ALG_AEAD_WITH_TAG_LENGTH( PSA_ALG_GCM, taglen ) );
         case MBEDTLS_MODE_CCM:

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -85,6 +85,8 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
 {
     switch( mode )
     {
+        case MBEDTLS_MODE_ECB:
+            return ( PSA_ALG_ECB_NO_PADDING );
         case MBEDTLS_MODE_GCM:
             return( PSA_ALG_AEAD_WITH_TAG_LENGTH( PSA_ALG_GCM, taglen ) );
         case MBEDTLS_MODE_CCM:

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -982,10 +982,21 @@
 
 /** The Electronic Code Book (ECB) mode of a block cipher, with no padding.
  *
+ * \warning ECB mode does not protect the confidentiality of the encrypted data
+ * except in extremely narrow circumstances. It is recommended that applications
+ * only use ECB if they need to construct an operating mode that the
+ * implementation does not provide. Implementations are encouraged to provide
+ * the modes that applications need in preference to supporting direct access
+ * to ECB.
+ *
  * The underlying block cipher is determined by the key type.
  *
- * This symmetric cipher mode can only be used with messages whose lengths
- * are whole number of blocks for the chosen block cipher.
+ * This symmetric cipher mode can only be used with messages whose lengths are a
+ * multiple of the block size of the chosen block cipher.
+ *
+ * ECB mode does not accept an initialization vector (IV). When using a
+ * multi-part cipher operation with this algorithm, psa_cipher_generate_iv()
+ * and psa_cipher_set_iv() must not be called.
  */
 #define PSA_ALG_ECB_NO_PADDING                  ((psa_algorithm_t)0x04404400)
 

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -980,6 +980,15 @@
  */
 #define PSA_ALG_XTS                             ((psa_algorithm_t)0x044000ff)
 
+/** The Electronic Code Book (ECB) mode of a block cipher, with no padding.
+ *
+ * The underlying block cipher is determined by the key type.
+ *
+ * This symmetric cipher mode can only be used with messages whose lengths
+ * are whole number of blocks for the chosen block cipher.
+ */
+#define PSA_ALG_ECB_NO_PADDING                  ((psa_algorithm_t)0x04404400)
+
 /** The CBC block cipher chaining mode, with no padding.
  *
  * The underlying block cipher is determined by the key type.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3749,9 +3749,12 @@ static psa_status_t psa_cipher_init( psa_cipher_operation_t *operation,
     operation->alg = alg;
     operation->key_set = 0;
     operation->iv_set = 0;
-    if( alg == PSA_ALG_ECB_NO_PADDING ) {
+    if( alg == PSA_ALG_ECB_NO_PADDING )
+    {
         operation->iv_required = 0;
-    } else {
+    }
+    else
+    {
         operation->iv_required = 1;
     }
     operation->iv_size = 0;
@@ -3844,7 +3847,8 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
     operation->key_set = 1;
     operation->block_size = ( PSA_ALG_IS_STREAM_CIPHER( alg ) ? 1 :
                               PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type ) );
-    if( alg & PSA_ALG_CIPHER_FROM_BLOCK_FLAG && alg != PSA_ALG_ECB_NO_PADDING )
+    if( ( alg & PSA_ALG_CIPHER_FROM_BLOCK_FLAG ) != 0 &&
+        alg != PSA_ALG_ECB_NO_PADDING )
     {
         operation->iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type );
     }
@@ -4002,7 +4006,8 @@ psa_status_t psa_cipher_finish( psa_cipher_operation_t *operation,
     {
         if( operation->alg == PSA_ALG_ECB_NO_PADDING ||
             ( operation->alg == PSA_ALG_CBC_NO_PADDING &&
-              operation->ctx.cipher.operation == MBEDTLS_ENCRYPT ) ) {
+              operation->ctx.cipher.operation == MBEDTLS_ENCRYPT ) )
+        {
             status = PSA_ERROR_INVALID_ARGUMENT;
             goto error;
         }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2518,6 +2518,9 @@ static const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
             case PSA_ALG_OFB:
                 mode = MBEDTLS_MODE_OFB;
                 break;
+            case PSA_ALG_ECB_NO_PADDING:
+                mode = MBEDTLS_MODE_ECB;
+                break;
             case PSA_ALG_CBC_NO_PADDING:
                 mode = MBEDTLS_MODE_CBC;
                 break;
@@ -3746,7 +3749,11 @@ static psa_status_t psa_cipher_init( psa_cipher_operation_t *operation,
     operation->alg = alg;
     operation->key_set = 0;
     operation->iv_set = 0;
-    operation->iv_required = 1;
+    if( alg == PSA_ALG_ECB_NO_PADDING ) {
+        operation->iv_required = 0;
+    } else {
+        operation->iv_required = 1;
+    }
     operation->iv_size = 0;
     operation->block_size = 0;
     mbedtls_cipher_init( &operation->ctx.cipher );
@@ -3837,7 +3844,7 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
     operation->key_set = 1;
     operation->block_size = ( PSA_ALG_IS_STREAM_CIPHER( alg ) ? 1 :
                               PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type ) );
-    if( alg & PSA_ALG_CIPHER_FROM_BLOCK_FLAG )
+    if( alg & PSA_ALG_CIPHER_FROM_BLOCK_FLAG && alg != PSA_ALG_ECB_NO_PADDING )
     {
         operation->iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type );
     }
@@ -3991,12 +3998,14 @@ psa_status_t psa_cipher_finish( psa_cipher_operation_t *operation,
         return( PSA_ERROR_BAD_STATE );
     }
 
-    if( operation->ctx.cipher.operation == MBEDTLS_ENCRYPT &&
-        operation->alg == PSA_ALG_CBC_NO_PADDING &&
-        operation->ctx.cipher.unprocessed_len != 0 )
+    if( operation->ctx.cipher.unprocessed_len != 0 )
     {
+        if( operation->alg == PSA_ALG_ECB_NO_PADDING ||
+            ( operation->alg == PSA_ALG_CBC_NO_PADDING &&
+              operation->ctx.cipher.operation == MBEDTLS_ENCRYPT ) ) {
             status = PSA_ERROR_INVALID_ARGUMENT;
             goto error;
+        }
     }
 
     cipher_ret = mbedtls_cipher_finish( &operation->ctx.cipher,

--- a/tests/suites/test_suite_psa_crypto.data
+++ b/tests/suites/test_suite_psa_crypto.data
@@ -1126,9 +1126,17 @@ PSA cipher: bad order function calls
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_bad_order:
 
+PSA symmetric encrypt: AES-ECB, 0 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"":"":PSA_SUCCESS
+
 PSA symmetric encrypt: AES-ECB, 16 bytes, good
 depends_on:MBEDTLS_AES_C
 cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a":"3ad77bb40d7a3660a89ecaf32466ef97":PSA_SUCCESS
+
+PSA symmetric encrypt: AES-ECB, 32 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a3ad77bb40d7a3660a89ecaf32466ef97":"3ad77bb40d7a3660a89ecaf32466ef972249a2638c6f1c755a84f9681a9f08c1":PSA_SUCCESS
 
 PSA symmetric encrypt: AES-CBC-nopad, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1141,6 +1149,10 @@ cipher_encrypt:PSA_ALG_CBC_PKCS7:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4
 PSA symmetric encrypt: AES-CBC-PKCS#7, 15 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_encrypt:PSA_ALG_CBC_PKCS7:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e11739317":"6279b49d7f7a8dd87b685175d4276e24":PSA_SUCCESS
+
+PSA symmetric encrypt: AES-ECB, input too short (15 bytes)
+depends_on:MBEDTLS_AES_C
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e11739317":"3ad77bb40d7a3660a89ecaf32466ef":PSA_ERROR_INVALID_ARGUMENT
 
 PSA symmetric encrypt: AES-CBC-nopad, input too short
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1166,9 +1178,25 @@ PSA symmetric encrypt: 3-key 3DES-CBC-nopad, 8 bytes, good
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_encrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"2a2a2a2a2a2a2a2a":"eda4011239bc3ac9":"817ca7d69b80d86a":PSA_SUCCESS
 
+PSA symmetric encrypt: 2-key 3DES-ECB, 8 bytes, good
+depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce":"":"c78e2b38139610e3":"5d0652429c5b0ac7":PSA_SUCCESS
+
+PSA symmetric encrypt: 3-key 3DES-ECB, 8 bytes, good
+depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"":"c78e2b38139610e3":"817ca7d69b80d86a":PSA_SUCCESS
+
+PSA symmetric decrypt: AES-ECB, 0 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"":"":PSA_SUCCESS
+
 PSA symmetric decrypt: AES-ECB, 16 bytes, good
 depends_on:MBEDTLS_AES_C
 cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"396ee84fb75fdbb5c2b13c7fe5a654aa":"63cecc46a382414d5fa7d2b79387437f":PSA_SUCCESS
+
+PSA symmetric decrypt: AES-ECB, 32 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"3ad77bb40d7a3660a89ecaf32466ef972249a2638c6f1c755a84f9681a9f08c1":"6bc1bee22e409f96e93d7e117393172a3ad77bb40d7a3660a89ecaf32466ef97":PSA_SUCCESS
 
 PSA symmetric decrypt: AES-CBC-nopad, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1190,6 +1218,10 @@ PSA symmetric decrypt: AES-CTR, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"396ee84fb75fdbb5c2b13c7fe5a654aa":"dd3b5e5319b7591daab1e1a92687feb2":PSA_SUCCESS
 
+PSA symmetric decrypt: AES-ECB, input too short (15 bytes)
+depends_on:MBEDTLS_AES_C
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"396ee84fb75fdbb5c2b13c7fe5a654":"63cecc46a382414d5fa7d2b7938743":PSA_ERROR_INVALID_ARGUMENT
+
 PSA symmetric decrypt: AES-CBC-nopad, input too short (5 bytes)
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_decrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee223":"6bc1bee223":PSA_ERROR_BAD_STATE
@@ -1205,6 +1237,14 @@ cipher_decrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7
 PSA symmetric decrypt: 3-key 3DES-CBC-nopad, 8 bytes, good
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_decrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"2a2a2a2a2a2a2a2a":"817ca7d69b80d86a":"eda4011239bc3ac9":PSA_SUCCESS
+
+PSA symmetric decrypt: 2-key 3DES-ECB, 8 bytes, good
+depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce":"":"5d0652429c5b0ac7":"c78e2b38139610e3":PSA_SUCCESS
+
+PSA symmetric decrypt: 3-key 3DES-ECB, 8 bytes, good
+depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"":"817ca7d69b80d86a":"c78e2b38139610e3":PSA_SUCCESS
 
 PSA symmetric encrypt/decrypt: AES-ECB, 16 bytes, good
 depends_on:MBEDTLS_AES_C
@@ -1229,6 +1269,14 @@ cipher_verify_output:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4
 PSA symmetric encryption multipart: AES-ECB, 16+16 bytes
 depends_on:MBEDTLS_AES_C
 cipher_encrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":16:16:16:"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c"
+
+PSA symmetric encryption multipart: AES-ECB, 13+19 bytes
+depends_on:MBEDTLS_AES_C
+cipher_encrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":13:0:32:"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c"
+
+PSA symmetric encryption multipart: AES-ECB, 24+12 bytes
+depends_on:MBEDTLS_AES_C
+cipher_encrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":24:16:16:"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c"
 
 PSA symmetric encryption multipart: AES-CBC-nopad, 7+9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1298,6 +1346,14 @@ PSA symmetric decryption multipart: AES-ECB, 16+16 bytes
 depends_on:MBEDTLS_AES_C
 cipher_decrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c":16:16:16:"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef"
 
+PSA symmetric decryption multipart: AES-ECB, 11+21 bytes
+depends_on:MBEDTLS_AES_C
+cipher_decrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c":11:0:32:"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef"
+
+PSA symmetric decryption multipart: AES-ECB, 28+4 bytes
+depends_on:MBEDTLS_AES_C
+cipher_decrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c":28:16:16:"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef"
+
 PSA symmetric decryption multipart: AES-CBC-nopad, 7+9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_decrypt_multipart:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"a076ec9dfbe47d52afc357336f20743b":7:0:16:"6bc1bee22e409f96e93d7e117393172a"
@@ -1326,19 +1382,19 @@ PSA symmetric encryption multipart: AES-CTR, 11+5 bytes [#2]
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a":11:11:5:"8f9408fe80a81d3e813da3c7b0b2bd32"
 
-PSA symmetric encryption multipart: AES-CTR, 16+16 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 16+16 bytes [#2]
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":16:16:16:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 12+20 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 12+20 bytes [#2]
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":12:12:20:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 20+12 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 20+12 bytes [#2]
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":20:20:12:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 12+10 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 12+10 bytes [#2]
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597":12:12:10:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7b"
 

--- a/tests/suites/test_suite_psa_crypto.data
+++ b/tests/suites/test_suite_psa_crypto.data
@@ -1152,7 +1152,7 @@ cipher_encrypt:PSA_ALG_CBC_PKCS7:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4
 
 PSA symmetric encrypt: AES-ECB, input too short (15 bytes)
 depends_on:MBEDTLS_AES_C
-cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e11739317":"3ad77bb40d7a3660a89ecaf32466ef":PSA_ERROR_INVALID_ARGUMENT
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e11739317":"":PSA_ERROR_INVALID_ARGUMENT
 
 PSA symmetric encrypt: AES-CBC-nopad, input too short
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1306,23 +1306,23 @@ PSA symmetric encryption multipart: AES-CBC-nopad, 20+12 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_encrypt_multipart:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":20:16:16:"a076ec9dfbe47d52afc357336f20743b89906f2f9207ac02aa658cb4ef19c61f"
 
-PSA symmetric encryption multipart: AES-CTR, 11+5 bytes [#1]
+PSA symmetric encryption multipart: AES-CTR, 11+5 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a":11:11:5:"8f9408fe80a81d3e813da3c7b0b2bd32"
 
-PSA symmetric encryption multipart: AES-CTR, 16+16 bytes [#1]
+PSA symmetric encryption multipart: AES-CTR, 16+16 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":16:16:16:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 12+20 bytes [#1]
+PSA symmetric encryption multipart: AES-CTR, 12+20 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":12:12:20:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 20+12 bytes [#1]
+PSA symmetric encryption multipart: AES-CTR, 20+12 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":20:20:12:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric encryption multipart: AES-CTR, 12+10 bytes [#1]
+PSA symmetric encryption multipart: AES-CTR, 12+10 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597":12:12:10:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7b"
 
@@ -1378,23 +1378,23 @@ PSA symmetric decryption multipart: AES-CBC-nopad, 20+12 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_decrypt_multipart:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"a076ec9dfbe47d52afc357336f20743b89906f2f9207ac02aa658cb4ef19c61f":20:16:16:"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef"
 
-PSA symmetric encryption multipart: AES-CTR, 11+5 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 11+5 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a":11:11:5:"8f9408fe80a81d3e813da3c7b0b2bd32"
 
-PSA symmetric decryption multipart: AES-CTR, 16+16 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 16+16 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":16:16:16:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric decryption multipart: AES-CTR, 12+20 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 12+20 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":12:12:20:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric decryption multipart: AES-CTR, 20+12 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 20+12 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":20:20:12:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7baf71025f6ef6393ca587"
 
-PSA symmetric decryption multipart: AES-CTR, 12+10 bytes [#2]
+PSA symmetric decryption multipart: AES-CTR, 12+10 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a5434f378a597":12:12:10:"8f9408fe80a81d3e813da3c7b0b2bd321c965bb1de7b"
 

--- a/tests/suites/test_suite_psa_crypto.data
+++ b/tests/suites/test_suite_psa_crypto.data
@@ -346,7 +346,11 @@ PSA import RSA public key: maximum size exceeded
 depends_on:MBEDTLS_PK_PARSE_C:MBEDTLS_RSA_C
 import_rsa_made_up:PSA_VENDOR_RSA_MAX_KEY_BITS+8:0:PSA_ERROR_NOT_SUPPORTED
 
-PSA key policy: AES
+PSA key policy: AES ECB
+depends_on:MBEDTLS_AES_C
+check_key_policy:PSA_KEY_TYPE_AES:128:PSA_KEY_USAGE_ENCRYPT:PSA_ALG_ECB_NO_PADDING
+
+PSA key policy: AES CBC
 depends_on:MBEDTLS_AES_C
 check_key_policy:PSA_KEY_TYPE_AES:128:PSA_KEY_USAGE_ENCRYPT:PSA_ALG_CBC_NO_PADDING
 
@@ -1122,6 +1126,10 @@ PSA cipher: bad order function calls
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_bad_order:
 
+PSA symmetric encrypt: AES-ECB, 16 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_encrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a":"3ad77bb40d7a3660a89ecaf32466ef97":PSA_SUCCESS
+
 PSA symmetric encrypt: AES-CBC-nopad, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_encrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a":"a076ec9dfbe47d52afc357336f20743b":PSA_SUCCESS
@@ -1157,6 +1165,10 @@ cipher_encrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7
 PSA symmetric encrypt: 3-key 3DES-CBC-nopad, 8 bytes, good
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_encrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"2a2a2a2a2a2a2a2a":"eda4011239bc3ac9":"817ca7d69b80d86a":PSA_SUCCESS
+
+PSA symmetric decrypt: AES-ECB, 16 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_decrypt:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"396ee84fb75fdbb5c2b13c7fe5a654aa":"63cecc46a382414d5fa7d2b79387437f":PSA_SUCCESS
 
 PSA symmetric decrypt: AES-CBC-nopad, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1194,6 +1206,10 @@ PSA symmetric decrypt: 3-key 3DES-CBC-nopad, 8 bytes, good
 depends_on:MBEDTLS_DES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_decrypt:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_DES:"01020407080b0d0ec1c2c4c7c8cbcdce31323437383b3d3e":"2a2a2a2a2a2a2a2a":"817ca7d69b80d86a":"eda4011239bc3ac9":PSA_SUCCESS
 
+PSA symmetric encrypt/decrypt: AES-ECB, 16 bytes, good
+depends_on:MBEDTLS_AES_C
+cipher_verify_output:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"6bc1bee22e409f96e93d7e117393172a"
+
 PSA symmetric encrypt/decrypt: AES-CBC-nopad, 16 bytes, good
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_verify_output:PSA_ALG_CBC_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"6bc1bee22e409f96e93d7e117393172a"
@@ -1209,6 +1225,10 @@ cipher_verify_output:PSA_ALG_CBC_PKCS7:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158
 PSA symmetric encrypt/decrypt: AES-CTR
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_verify_output:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"6bc1bee22e409f96e93d7e117393172a"
+
+PSA symmetric encryption multipart: AES-ECB, 16+16 bytes
+depends_on:MBEDTLS_AES_C
+cipher_encrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef":16:16:16:"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c"
 
 PSA symmetric encryption multipart: AES-CBC-nopad, 7+9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC
@@ -1273,6 +1293,10 @@ cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf715880
 PSA symmetric encryption multipart: AES-CTR, 16+0 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CTR
 cipher_encrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a":16:16:0:"8f9408fe80a81d3e813da3c7b0b2bd32"
+
+PSA symmetric decryption multipart: AES-ECB, 16+16 bytes
+depends_on:MBEDTLS_AES_C
+cipher_decrypt_multipart:PSA_ALG_ECB_NO_PADDING:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"":"3ad77bb40d7a3660a89ecaf32466ef9755ed5e9e066820fa52c729886d18854c":16:16:16:"6bc1bee22e409f96e93d7e117393172a5434f378a597bcef1389318c7fc865ef"
 
 PSA symmetric decryption multipart: AES-CBC-nopad, 7+9 bytes
 depends_on:MBEDTLS_AES_C:MBEDTLS_CIPHER_MODE_CBC

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3349,7 +3349,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
 
     if( iv->len > 0 )
     {
-      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
     output_buffer_size = ( (size_t) input->len +
@@ -3416,7 +3416,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
 
     if( iv->len > 0 )
     {
-      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
     output_buffer_size = ( (size_t) input->len +
@@ -3488,7 +3488,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
                                           handle, alg ) );
 
     if( iv->len > 0 ) {
-      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
     output_buffer_size = ( (size_t) input->len +
@@ -3557,7 +3557,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
                                           handle, alg ) );
 
     if( iv->len > 0 ) {
-      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
     output_buffer_size = ( (size_t) input->len +
@@ -3626,9 +3626,9 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
                                           handle, alg ) );
 
     if( alg != PSA_ALG_ECB_NO_PADDING ) {
-      PSA_ASSERT( psa_cipher_generate_iv( &operation1,
-                                          iv, iv_size,
-                                          &iv_length ) );
+        PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                            iv, iv_size,
+                                            &iv_length ) );
     }
     output1_size = ( (size_t) input->len +
                      PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
@@ -3650,8 +3650,8 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     ASSERT_ALLOC( output2, output2_size );
 
     if( iv_length > 0 ) {
-      PSA_ASSERT( psa_cipher_set_iv( &operation2,
-                                     iv, iv_length ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                       iv, iv_length ) );
     }
 
     PSA_ASSERT( psa_cipher_update( &operation2, output1, output1_length,
@@ -3716,9 +3716,9 @@ void cipher_verify_output_multipart( int alg_arg,
                                           handle, alg ) );
 
     if( alg != PSA_ALG_ECB_NO_PADDING ) {
-      PSA_ASSERT( psa_cipher_generate_iv( &operation1,
-                                          iv, iv_size,
-                                          &iv_length ) );
+        PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                            iv, iv_size,
+                                            &iv_length ) );
     }
 
     output1_buffer_size = ( (size_t) input->len +
@@ -3751,8 +3751,8 @@ void cipher_verify_output_multipart( int alg_arg,
     ASSERT_ALLOC( output2, output2_buffer_size );
 
     if( iv_length > 0 ) {
-      PSA_ASSERT( psa_cipher_set_iv( &operation2,
-                                     iv, iv_length ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                       iv, iv_length ) );
     }
 
     PSA_ASSERT( psa_cipher_update( &operation2, output1, first_part_size,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3487,7 +3487,8 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
 
-    if( iv->len > 0 ) {
+    if( iv->len > 0 )
+    {
         PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
@@ -3556,7 +3557,8 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
 
-    if( iv->len > 0 ) {
+    if( iv->len > 0 )
+    {
         PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
     }
 
@@ -3625,7 +3627,8 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
                                           handle, alg ) );
 
-    if( alg != PSA_ALG_ECB_NO_PADDING ) {
+    if( alg != PSA_ALG_ECB_NO_PADDING )
+    {
         PSA_ASSERT( psa_cipher_generate_iv( &operation1,
                                             iv, iv_size,
                                             &iv_length ) );
@@ -3649,7 +3652,8 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     output2_size = output1_length;
     ASSERT_ALLOC( output2, output2_size );
 
-    if( iv_length > 0 ) {
+    if( iv_length > 0 )
+    {
         PSA_ASSERT( psa_cipher_set_iv( &operation2,
                                        iv, iv_length ) );
     }
@@ -3715,7 +3719,8 @@ void cipher_verify_output_multipart( int alg_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
                                           handle, alg ) );
 
-    if( alg != PSA_ALG_ECB_NO_PADDING ) {
+    if( alg != PSA_ALG_ECB_NO_PADDING )
+    {
         PSA_ASSERT( psa_cipher_generate_iv( &operation1,
                                             iv, iv_size,
                                             &iv_length ) );
@@ -3750,7 +3755,8 @@ void cipher_verify_output_multipart( int alg_arg,
     output2_buffer_size = output1_length;
     ASSERT_ALLOC( output2, output2_buffer_size );
 
-    if( iv_length > 0 ) {
+    if( iv_length > 0 )
+    {
         PSA_ASSERT( psa_cipher_set_iv( &operation2,
                                        iv, iv_length ) );
     }

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3347,7 +3347,11 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    if( iv->len > 0 )
+    {
+      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    }
+
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
@@ -3410,7 +3414,11 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    if( iv->len > 0 )
+    {
+      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    }
+
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
@@ -3479,7 +3487,9 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    if( iv->len > 0 ) {
+      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    }
 
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
@@ -3546,7 +3556,9 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    if( iv->len > 0 ) {
+      PSA_ASSERT( psa_cipher_set_iv( &operation, iv->x, iv->len ) );
+    }
 
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
@@ -3613,9 +3625,11 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_generate_iv( &operation1,
-                                        iv, iv_size,
-                                        &iv_length ) );
+    if( alg != PSA_ALG_ECB_NO_PADDING ) {
+      PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                          iv, iv_size,
+                                          &iv_length ) );
+    }
     output1_size = ( (size_t) input->len +
                      PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_size );
@@ -3635,8 +3649,11 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     output2_size = output1_length;
     ASSERT_ALLOC( output2, output2_size );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation2,
-                                   iv, iv_length ) );
+    if( iv_length > 0 ) {
+      PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                     iv, iv_length ) );
+    }
+
     PSA_ASSERT( psa_cipher_update( &operation2, output1, output1_length,
                                    output2, output2_size,
                                    &output2_length ) );
@@ -3698,9 +3715,12 @@ void cipher_verify_output_multipart( int alg_arg,
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
                                           handle, alg ) );
 
-    PSA_ASSERT( psa_cipher_generate_iv( &operation1,
-                                        iv, iv_size,
-                                        &iv_length ) );
+    if( alg != PSA_ALG_ECB_NO_PADDING ) {
+      PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                          iv, iv_size,
+                                          &iv_length ) );
+    }
+
     output1_buffer_size = ( (size_t) input->len +
                             PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_buffer_size );
@@ -3730,8 +3750,10 @@ void cipher_verify_output_multipart( int alg_arg,
     output2_buffer_size = output1_length;
     ASSERT_ALLOC( output2, output2_buffer_size );
 
-    PSA_ASSERT( psa_cipher_set_iv( &operation2,
-                                   iv, iv_length ) );
+    if( iv_length > 0 ) {
+      PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                     iv, iv_length ) );
+    }
 
     PSA_ASSERT( psa_cipher_update( &operation2, output1, first_part_size,
                                    output2, output2_buffer_size,

--- a/tests/suites/test_suite_psa_crypto_metadata.data
+++ b/tests/suites/test_suite_psa_crypto_metadata.data
@@ -122,6 +122,10 @@ Cipher: OFB
 depends_on:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_OFB
 cipher_algorithm:PSA_ALG_OFB:ALG_IS_STREAM_CIPHER
 
+Cipher: ECB-nopad
+depends_on:MBEDTLS_CIPHER_C
+cipher_algorithm:PSA_ALG_ECB_NO_PADDING:0
+
 Cipher: CBC-nopad
 depends_on:MBEDTLS_CIPHER_C:MBEDTLS_CIPHER_MODE_CBC
 cipher_algorithm:PSA_ALG_CBC_NO_PADDING:0


### PR DESCRIPTION
## Description
This PR implements support for `PSA_ALG_ECB_NO_PADDING` as defined in the PSA Crypto API spec v1.0.0. Feature was requested in #3277.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Tests
- [X] Documentation
- [x] Changelog updated


## Steps to test or reproduce
Tested through the PSA Crypto test suite.
