### PR TITLE
Add library.json manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+    "name": "mbedtls",
+    "version": "2.23.0",
+    "description": "An open source, portable, easy to use, readable and flexible SSL library",
+    "keywords": "tls,ssl,crypto,cryptography-library",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ARMmbed/mbedtls.git"
+    },
+    "license": "Apache-2.0",
+    "build": {
+        "srcDir": "library",
+        "includeDir": "include"
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a manifest file that conforms to the spec given in
https://docs.platformio.org/en/latest/librarymanager/config.html

It helps the platform.io library manager to find and compile mbedtls correctly
and fixes https://github.com/platformio/platformio-core/issues/3589

## Status
**READY**

#### Updates to the PR
* Updated `version` field to be semantic version, not release tag (as per  https://github.com/platformio/platformio-core/issues/3589#issuecomment-657096225)