### PR TITLE
Add update option to check-generated-files

### DIFF
--- a/tests/git-scripts/pre-commit.sh
+++ b/tests/git-scripts/pre-commit.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# pre-commit.sh
+#
+# Copyright (c) 2017, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+# Purpose
+#
+# This script does quick sanity checks before commiting:
+#   - check that generated files are up-to-date.
+#
+# It is meant to be called as a git pre-commit hook, see README.md.
+#
+# From the git sample pre-commit hook:
+#   Called by "git commit" with no arguments.  The hook should
+#   exit with non-zero status after issuing an appropriate message if
+#   it wants to stop the commit.
+
+set -eu
+
+tests/scripts/check-generated-files.sh

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -23,9 +23,27 @@
 
 set -eu
 
+if [ $# -ne 0 ] && [ "$1" = "--help" ]; then
+    cat <<EOF
+$0 [-u]
+This script checks that all generated file are up-to-date. If some aren't, by
+default the scripts reports it and exits in error; with the -u option, it just
+updates them instead.
+
+  -u    Update the files rather than return an error for out-of-date files.
+EOF
+    exit
+fi
+
 if [ -d library -a -d include -a -d tests ]; then :; else
     echo "Must be run from mbed TLS root" >&2
     exit 1
+fi
+
+UPDATE=
+if [ $# -ne 0 ] && [ "$1" = "-u" ]; then
+    shift
+    UPDATE='y'
 fi
 
 check()
@@ -53,9 +71,15 @@ check()
     for FILE in $FILES; do
         if ! diff $FILE $FILE.bak >/dev/null 2>&1; then
             echo "'$FILE' was either modified or deleted by '$SCRIPT'"
-            exit 1
+            if [ -z "$UPDATE" ]; then
+                exit 1
+            fi
         fi
-        mv $FILE.bak $FILE
+        if [ -z "$UPDATE" ]; then
+            mv $FILE.bak $FILE
+        else
+            rm $FILE.bak
+        fi
 
         if [ -d $TO_CHECK ]; then
             # Create a grep regular expression that we can check against the
@@ -72,7 +96,9 @@ check()
         # Check if there are any new files
         if ls -1 $TO_CHECK | grep -v "$PATTERN" >/dev/null 2>&1; then
             echo "Files were created by '$SCRIPT'"
-            exit 1
+            if [ -z "$UPDATE" ]; then
+                exit 1
+            fi
         fi
     fi
 }


### PR DESCRIPTION
## Description

This PR:

- adds an `-u` option to `check-generate-files.sh` that causes it to just update the damn files rather than moan about them being out-of-date ;)
- adds a pre-commit hook that people can install if they want generated files to be checked before commiting.

This PR _does not_ make the pre-commit hook automagically update the files for you. That would require making the appropriate calls to `git add / git rm` from the pre-commit hook and this was a bit more than I felt like doing. This PR is not meant to be perfect, just a minor but non-zero improvement over the existing.

Workflow before:

- make a change that would require updating some file, but naturally forget about it and commit
- do other changes, as some point push
- either the pre-push hook or the CI notices some file is out-of-date
- figure out what `scripts/generate-xxx.yy` you should call, or just repeatedly run `check-generated-files.sh` until it stops complaining (undocumented feature: this converges)
- either add a new commit, cluttering the history with unimportant things, or rewrite the history, messing up with github reviews

Workflow after:

- make a change that would require updating some file, but naturally forget about it and commit
- the pre-commit hook catches it, you run `check-generated-files.sh -u`, successfully commit and happily go on with your day.

## Status
**READY**

## Requires Backporting

Yes - it's an improvement to developer workflow, so a good candidate for backporting.

- [x] 2.16
- [x] 2.7

