### PR TITLE
Heap allocation wrappers for testing

### DIFF
--- a/tests/configs/config-wrapper-test-memory.h
+++ b/tests/configs/config-wrapper-test-memory.h
@@ -1,0 +1,43 @@
+/* config.h wrapper that declares and enables memory management wrappers
+ * used for testing.
+ *
+ * Use this configuration file only when building the library, not when
+ * building tests and sample programs, so that the wrappers are only used
+ * for memory allocations made from library code.
+ *
+ * See the documentation of mbedtls_test_calloc_wrapper() in
+ * `tests/include/test/memory_wrappers.h` for more information.
+ */
+/*
+ *  Copyright (C) 2020, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+/* Don't #define MBEDTLS_CONFIG_H, let config.h do it. */
+
+#include "mbedtls/config.h"
+
+/* This includes MBEDTLS_CONFIG_FILE recursively. But since MBEDTLS_CONFIG_H
+ * is now defined, the recursive inclusion is effectively empty. */
+#include "../include/test/memory_wrappers.h"
+
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_CALLOC_MACRO mbedtls_test_calloc_wrapper
+#define MBEDTLS_PLATFORM_FREE_MACRO mbedtls_test_free_wrapper
+
+#endif /* MBEDTLS_CONFIG_H */

--- a/tests/include/test/memory.h
+++ b/tests/include/test/memory.h
@@ -63,11 +63,18 @@ void mbedtls_test_memory_teardown( void );
 void mbedtls_test_memory_get_stats( size_t *allocations, size_t *bytes,
                                         size_t *failed, size_t *leaks );
 
+#include "memory_wrappers.h"
+
 #else /* MBEDTLS_TEST_MEMORY_WRAPPERS */
 
 /* If the wrappers are disabled, define hooks that do nothing. */
 #define mbedtls_test_memory_setup( ) ( (void) 0 )
 #define mbedtls_test_memory_teardown( ) ( (void) 0 )
+
+/* Make the wrappers available for the sake of the few test cases that
+ * allocate memory that is freed in library code or vice versa. */
+#define mbedtls_test_calloc_wrapper( n, size ) mbedtls_calloc( n, size )
+#define mbedtls_test_free_wrapper( ptr ) mbedtls_free( ptr )
 
 #endif /* MBEDTLS_TEST_MEMORY_WRAPPERS */
 

--- a/tests/include/test/memory.h
+++ b/tests/include/test/memory.h
@@ -35,6 +35,8 @@
 
 #if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
 
+#include <stddef.h>
+
 /** Hook to call immediately before starting to execute a test case.
  */
 void mbedtls_test_memory_setup( void );
@@ -43,6 +45,23 @@ void mbedtls_test_memory_setup( void );
  * its pass/fail status but before printing out the outcome.
  */
 void mbedtls_test_memory_teardown( void );
+
+/** Obtain statistics about allocations since the last call to
+ * mbedtls_test_memory_setup().
+ *
+ * \param allocations   The total number of calls to mbedtls_calloc()
+ *                      (excluding zero-sized allocations).
+ * \param bytes         The total number of allocated bytes.
+ *                      This is typically a lot larger than the total
+ *                      memory consumption.
+ * \param failed        The number of failed allocations.
+ * \param leaks         The number of calls to mbedtls_calloc() minus
+ *                      the number of calls to mbedtls_free()
+ *                      (excluding zero-sized allocations and calls to
+ *                      `mbedtls_free(NULL)`).
+ */
+void mbedtls_test_memory_get_stats( size_t *allocations, size_t *bytes,
+                                        size_t *failed, size_t *leaks );
 
 #else /* MBEDTLS_TEST_MEMORY_WRAPPERS */
 

--- a/tests/include/test/memory.h
+++ b/tests/include/test/memory.h
@@ -1,0 +1,55 @@
+/**
+ * \file memory.h
+ *
+ * \brief   This file declares features related to instrumenting memory
+ *          management in the library for benchmarking or testing purposes.
+ */
+
+/*
+ *  Copyright (C) 2020, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef TEST_MEMORY_H
+#define TEST_MEMORY_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
+
+/** Hook to call immediately before starting to execute a test case.
+ */
+void mbedtls_test_memory_setup( void );
+
+/** Hook to call immediately after executing a test case, after establishing
+ * its pass/fail status but before printing out the outcome.
+ */
+void mbedtls_test_memory_teardown( void );
+
+#else /* MBEDTLS_TEST_MEMORY_WRAPPERS */
+
+/* If the wrappers are disabled, define hooks that do nothing. */
+#define mbedtls_test_memory_setup( ) ( (void) 0 )
+#define mbedtls_test_memory_teardown( ) ( (void) 0 )
+
+#endif /* MBEDTLS_TEST_MEMORY_WRAPPERS */
+
+#endif /* TEST_MEMORY_H */

--- a/tests/include/test/memory_wrappers.h
+++ b/tests/include/test/memory_wrappers.h
@@ -46,7 +46,10 @@
  * Note that you must also arrange for this header to be included in
  * the configuration file, so that the functions are declared.
  *
- * These wrappers are not meant to be enabled when compiling test code.
+ * This wrapper is not meant to be enabled when compiling test code.
+ * However test code must use this wrapper when allocating memory
+ * that will be freed by a call to mbedtls_free() inside the library.
+ *
  * The typical way to enable the memory wrappers are:
  * - Compile the library with `MBEDTLS_CONFIG_FILE` set to
  *   `"tests/configs/config-wrapper-test-memory.h"`.
@@ -58,6 +61,10 @@ void *mbedtls_test_calloc_wrapper( size_t n, size_t size );
  *
  * This wrapper must be used in conjunction with mbedtls_test_free_wrapper().
  * See the documentation of this function for details.
+ *
+ * This wrapper is not meant to be enabled when compiling test code.
+ * However test code must use this wrapper when free memory
+ * that has been allocated by a call to mbedtls_calloc() inside the library.
  */
 void mbedtls_test_free_wrapper( void *ptr );
 

--- a/tests/include/test/memory_wrappers.h
+++ b/tests/include/test/memory_wrappers.h
@@ -1,0 +1,64 @@
+/**
+ * \file memory.h
+ *
+ * \brief   This file declares wrappers for mbedtls_calloc() and mbedtls_free().
+ */
+
+/*
+ *  Copyright (C) 2020, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef TEST_MEMORY_WRAPPERS_H
+#define TEST_MEMORY_WRAPPERS_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+
+/** Wrapper around mbedtls_calloc() meant to be used from library code.
+ *
+ * This wrapper must be used in conjunctin with mbedtls_test_free_wrapper().
+ *
+ * To enable the wrappers, compile the library with the following
+ * preprocessor symbols defined:
+ * - #MBEDTLS_PLATFORM_MEMORY;
+ * - #MBEDTLS_PLATFORM_CALLOC_MACRO set to mbedtls_test_calloc_wrapper();
+ * - #MBEDTLS_PLATFORM_FREE_MACRO set to mbedtls_test_free_wrapper().
+ * Note that you must also arrange for this header to be included in
+ * the configuration file, so that the functions are declared.
+ *
+ * These wrappers are not meant to be enabled when compiling test code.
+ * The typical way to enable the memory wrappers are:
+ * - Compile the library with `MBEDTLS_CONFIG_FILE` set to
+ *   `"tests/configs/config-wrapper-test-memory.h"`.
+ * - Compile the tests with `-DMBEDTLS_TEST_MEMORY_WRAPPERS`.
+ */
+void *mbedtls_test_calloc_wrapper( size_t n, size_t size );
+
+/** Wrapper around mbedtls_free() meant to be used from library code.
+ *
+ * This wrapper must be used in conjunction with mbedtls_test_free_wrapper().
+ * See the documentation of this function for details.
+ */
+void mbedtls_test_free_wrapper( void *ptr );
+
+#endif /* TEST_MEMORY_WRAPPERS_H */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1515,6 +1515,24 @@ component_test_malloc_0_null () {
     if_build_succeeded tests/ssl-opt.sh -e 'proxy'
 }
 
+component_test_memory_wrappers () {
+    msg "build: library with test memory wrappers"
+    scripts/config.py full
+    # The library needs to be built with MBEDTLS_PLATFORM_MEMORY, but
+    # config-wrapper-test-memory.h will take care of that. The tests must
+    # not be built with MBEDTLS_PLATFORM_MEMORY since we want to use the
+    # native calloc/free in the wrapper code and for allocations made by
+    # test code.
+    scripts/config.py unset MBEDTLS_PLATFORM_MEMORY
+    make CC=gcc CFLAGS="'-DMBEDTLS_CONFIG_FILE=\"$PWD/tests/configs/config-wrapper-test-memory.h\"' $ASAN_CFLAGS -O3" LDFLAGS="$ASAN_CFLAGS" lib
+
+    msg "build: tests with test memory wrappers"
+    make CC=gcc CFLAGS="-DMBEDTLS_TEST_MEMORY_WRAPPERS $ASAN_CFLAGS -O3" LDFLAGS="$ASAN_CFLAGS" tests
+
+    msg "test: with memory wrappers"
+    make test
+}
+
 component_test_aes_fewer_tables () {
     msg "build: default config with AES_FEWER_TABLES enabled"
     scripts/config.py set MBEDTLS_AES_FEWER_TABLES

--- a/tests/src/memory.c
+++ b/tests/src/memory.c
@@ -31,22 +31,60 @@
 #define mbedtls_free       free
 #endif
 
+#include <string.h>
+
+typedef struct
+{
+    size_t total_allocations; /* Total calls to calloc */
+    size_t total_bytes; /* Total bytes allocated */
+    size_t active_allocations; /* Calls to calloc that are not yet freed */
+    size_t failed_allocations; /* Calls to calloc that have failed */
+} mbedtls_test_memory_stats_t;
+static mbedtls_test_memory_stats_t stats;
+
 void mbedtls_test_memory_setup( void )
 {
+    memset( &stats, 0, sizeof( stats ) );
 }
 
 void mbedtls_test_memory_teardown( void )
 {
 }
 
+void mbedtls_test_memory_get_stats( size_t *allocations, size_t *bytes,
+                                    size_t *failed, size_t *leaks )
+{
+    *allocations = stats.total_allocations;
+    *bytes = stats.total_bytes;
+    *failed = stats.failed_allocations;
+    *leaks = stats.active_allocations;
+}
+
 void *mbedtls_test_calloc_wrapper( size_t n, size_t size )
 {
+    /* Zero-size allocations do not count. This way, if the underlying calloc
+     * function returns NULL, we know that the allocation has failed. */
+    if( n == 0 || size == 0 )
+        return( NULL );
+    ++stats.total_allocations;
     void *ptr = mbedtls_calloc( n, size );
+    if( ptr == NULL )
+    {
+        ++stats.failed_allocations;
+    }
+    else
+    {
+        ++stats.active_allocations;
+        stats.total_bytes += n * size;
+    }
     return( ptr );
 }
 
 void mbedtls_test_free_wrapper( void *ptr )
 {
+    if( ptr == NULL )
+        return;
+    --stats.active_allocations;
     mbedtls_free( ptr );
 }
 

--- a/tests/src/memory.c
+++ b/tests/src/memory.c
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2020, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#include <test/helpers.h>
+#include <test/memory.h>
+#include <test/memory_wrappers.h>
+
+#if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc     calloc
+#define mbedtls_free       free
+#endif
+
+void mbedtls_test_memory_setup( void )
+{
+}
+
+void mbedtls_test_memory_teardown( void )
+{
+}
+
+void *mbedtls_test_calloc_wrapper( size_t n, size_t size )
+{
+    void *ptr = mbedtls_calloc( n, size );
+    return( ptr );
+}
+
+void mbedtls_test_free_wrapper( void *ptr )
+{
+    mbedtls_free( ptr );
+}
+
+#endif /* MBEDTLS_TEST_MEMORY_WRAPPERS */

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -445,6 +445,17 @@ void test_skip( const char *test, int line_no, const char* filename )
     test_info.filename = filename;
 }
 
+/** Reset test failure information.
+ *
+ * Call this function before running a test case.
+ */
+static void reset_test_failure( )
+{
+        test_info.result = TEST_RESULT_SUCCESS;
+        test_info.paramfail_test_state = PARAMFAIL_TESTSTATE_IDLE;
+        test_info.step = (unsigned long)( -1 );
+}
+
 #if defined(MBEDTLS_CHECK_PARAMS)
 void mbedtls_param_failed( const char *failure_condition,
                            const char *file,

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -180,6 +180,30 @@ typedef enum
     }                                                             \
     while( 0 )
 
+/** Similar to ASSERT_ALLOC, but if the test memory wrappers are active,
+ * go through the wrapper. Use this for an allocation which will be
+ * freed via a call to mbedtls_free() inside the library. Call
+ * mbedtls_test_wrapper_alloc() to free the block in the test cleanup.
+ */
+#if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
+#define ASSERT_ALLOC_VIA_WRAPPER( pointer, length )               \
+    do                                                            \
+    {                                                             \
+        TEST_ASSERT( ( pointer ) == NULL );                       \
+        if( ( length ) != 0 )                                     \
+        {                                                         \
+            ( pointer ) = mbedtls_test_calloc_wrapper(            \
+                sizeof( *( pointer ) ),                           \
+                ( length ) );                                     \
+            TEST_ASSERT( ( pointer ) != NULL );                   \
+        }                                                         \
+    }                                                             \
+    while( 0 )
+#else
+#define ASSERT_ALLOC_VIA_WRAPPER( pointer, length )     \
+    ASSERT_ALLOC( pointer, length )
+#endif
+
 /** Compare two buffers and fail the test case if they differ.
  *
  * This macro expands to an instruction, not an expression.

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -374,6 +374,35 @@ static int run_test_snprintf( void )
             test_snprintf( 5, "123",         3 ) != 0 );
 }
 
+#if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
+/** \brief Report memory statistics for this test case.
+ *
+ * \param total_errors  Incremented if there was a memory leak.
+ */
+void report_memory_stats( unsigned *total_errors )
+{
+    size_t allocations;
+    size_t bytes;
+    size_t failed;
+    size_t leaks;
+    mbedtls_test_memory_get_stats( &allocations, &bytes, &failed, &leaks );
+    if( allocations != 0 )
+    {
+        mbedtls_fprintf( stdout, "  %zu allocations", allocations );
+        if( failed != 0 )
+            mbedtls_fprintf( stdout, " (%zu failed)", failed );
+        mbedtls_fprintf( stdout, ", %zu total bytes\n", bytes );
+    }
+    if( leaks != 0 )
+    {
+        ++( *total_errors );
+        mbedtls_fprintf( stdout,
+                         "  FAIL: There were %zu leaked allocations.\n",
+                         leaks );
+    }
+}
+#endif
+
 /** \brief Write the description of the test case to the outcome CSV file.
  *
  * \param outcome_file  The file to write to.
@@ -777,6 +806,9 @@ int execute_tests( int argc , const char ** argv )
                     mbedtls_fprintf( stdout, "line %d, %s",
                                      test_info.line_no, test_info.filename );
                 }
+#if defined(MBEDTLS_TEST_MEMORY_WRAPPERS)
+                report_memory_stats( &total_errors );
+#endif
                 fflush( stdout );
             }
             else if( ret == DISPATCH_INVALID_TEST_DATA )

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -711,10 +711,6 @@ int execute_tests( int argc , const char ** argv )
             // If there are no unmet dependencies execute the test
             if( unmet_dep_count == 0 )
             {
-                test_info.result = TEST_RESULT_SUCCESS;
-                test_info.paramfail_test_state = PARAMFAIL_TESTSTATE_IDLE;
-                test_info.step = (unsigned long)( -1 );
-
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
                 /* Suppress all output from the library unless we're verbose
                  * mode

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -31,6 +31,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "test/memory.h"
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -166,6 +168,8 @@ $dispatch_code
  */
 void execute_function_ptr(TestWrapper_t fp, void **params)
 {
+    mbedtls_test_memory_setup( );
+
 #if defined(MBEDTLS_CHECK_PARAMS)
     if ( setjmp( param_fail_jmp ) == 0 )
     {
@@ -181,6 +185,8 @@ void execute_function_ptr(TestWrapper_t fp, void **params)
 #else
     fp( params );
 #endif
+
+    mbedtls_test_memory_teardown( );
 }
 
 /**

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -170,6 +170,7 @@ void execute_function_ptr(TestWrapper_t fp, void **params)
 {
     mbedtls_test_memory_setup( );
 
+    reset_test_failure( );
 #if defined(MBEDTLS_CHECK_PARAMS)
     if ( setjmp( param_fail_jmp ) == 0 )
     {

--- a/tests/suites/target_test.function
+++ b/tests/suites/target_test.function
@@ -384,8 +384,6 @@ int execute_tests( int args, const char ** argv )
     while ( 1 )
     {
         ret = 0;
-        test_info.result = TEST_RESULT_SUCCESS;
-        test_info.step = (unsigned long)( -1 );
         data_len = 0;
 
         data = receive_data( &data_len );

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -749,10 +749,11 @@ void free_named_data( int with_oid, int with_val, int with_next )
     mbedtls_asn1_named_data head =
         { {0x06, 0, NULL}, {0, 0, NULL}, NULL, 0 };
 
+    /* These allocations should be freed in mbedtls_asn1_free_named_data(). */
     if( with_oid )
-        ASSERT_ALLOC( head.oid.p, 1 );
+        ASSERT_ALLOC_VIA_WRAPPER( head.oid.p, 1 );
     if( with_val )
-        ASSERT_ALLOC( head.val.p, 1 );
+        ASSERT_ALLOC_VIA_WRAPPER( head.val.p, 1 );
     if( with_next )
         head.next = &next;
 
@@ -768,7 +769,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:!MBEDTLS_TEST_MEMORY_WRAPPERS */
 void free_named_data_list( int length )
 {
     mbedtls_asn1_named_data *head = NULL;
@@ -777,7 +778,8 @@ void free_named_data_list( int length )
     for( i = 0; i < length; i++ )
     {
         mbedtls_asn1_named_data *new = NULL;
-        ASSERT_ALLOC( new, sizeof( mbedtls_asn1_named_data ) );
+        /* Should be freed in mbedtls_asn1_free_named_data_list() */
+        ASSERT_ALLOC_VIA_WRAPPER( new, sizeof( mbedtls_asn1_named_data ) );
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -379,8 +379,9 @@ void store_named_data_find( data_t *oid0, data_t *oid1,
 exit:
     if( found != NULL && found == head && found != pointers[from] )
     {
-        mbedtls_free( found->oid.p );
-        mbedtls_free( found );
+        /* Allocated in mbedtls_asn1_store_named_data() */
+        mbedtls_test_free_wrapper( found->oid.p );
+        mbedtls_test_free_wrapper( found );
     }
     for( i = 0; i < ARRAY_LENGTH( nd ); i++ )
         mbedtls_free( nd[i].oid.p );
@@ -399,7 +400,8 @@ void store_named_data_val_found( int old_len, int new_len )
 
     if( old_len != 0 )
     {
-        ASSERT_ALLOC( nd.val.p, (size_t) old_len );
+        /* Old data that mbedtls_asn1_store_named_data() will free */
+        ASSERT_ALLOC_VIA_WRAPPER( nd.val.p, (size_t) old_len );
         old_val = nd.val.p;
         nd.val.len = old_len;
         memset( old_val, 'x', old_len );
@@ -426,7 +428,8 @@ void store_named_data_val_found( int old_len, int new_len )
         TEST_ASSERT( found->val.p != old_val );
 
 exit:
-    mbedtls_free( nd.val.p );
+    /* Copy allocated by mbedtls_asn1_store_named_data() */
+    mbedtls_test_free_wrapper( nd.val.p );
 }
 /* END_CASE */
 
@@ -463,11 +466,12 @@ void store_named_data_val_new( int new_len )
     }
 
 exit:
+    /* Copies allocated by mbedtls_asn1_store_named_data() */
     if( found != NULL )
     {
-        mbedtls_free( found->oid.p );
-        mbedtls_free( found->val.p );
+        mbedtls_test_free_wrapper( found->oid.p );
+        mbedtls_test_free_wrapper( found->val.p );
     }
-    mbedtls_free( found );
+    mbedtls_test_free_wrapper( found );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -105,7 +105,8 @@ void parse_storage_data_check( data_t *file_data,
                     key_data, key_data_length );
 
 exit:
-    mbedtls_free( key_data );
+    /* Allocated in psa_parse_key_data_from_storage() */
+    mbedtls_test_free_wrapper( key_data );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1423,6 +1423,10 @@ cleanup:
 /*
  * Populate a session structure for serialization tests.
  * Choose dummy values, mostly non-0 to distinguish from the init default.
+ *
+ * Call mbedtls_test_calloc_wrapper() to allocate substructures of session,
+ * to match the way they will be freed (mbedtls_free() called inside
+ * mbedtls_ssl_session_free()).
  */
 static int ssl_populate_session( mbedtls_ssl_session *session,
                                  int ticket_len,
@@ -1450,7 +1454,8 @@ static int ssl_populate_session( mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
         /* Move temporary CRT. */
-        session->peer_cert = mbedtls_calloc( 1, sizeof( *session->peer_cert ) );
+        session->peer_cert =
+            mbedtls_test_calloc_wrapper( 1, sizeof( *session->peer_cert ) );
         if( session->peer_cert == NULL )
             return( -1 );
         *session->peer_cert = tmp_crt;
@@ -1458,7 +1463,7 @@ static int ssl_populate_session( mbedtls_ssl_session *session,
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
         /* Calculate digest of temporary CRT. */
         session->peer_cert_digest =
-            mbedtls_calloc( 1, MBEDTLS_SSL_PEER_CERT_DIGEST_DFL_LEN );
+            mbedtls_test_calloc_wrapper( 1, MBEDTLS_SSL_PEER_CERT_DIGEST_DFL_LEN );
         if( session->peer_cert_digest == NULL )
             return( -1 );
         ret = mbedtls_md( mbedtls_md_info_from_type(
@@ -1483,7 +1488,7 @@ static int ssl_populate_session( mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
     if( ticket_len != 0 )
     {
-        session->ticket = mbedtls_calloc( 1, ticket_len );
+        session->ticket = mbedtls_test_calloc_wrapper( 1, ticket_len );
         if( session->ticket == NULL )
             return( -1 );
         memset( session->ticket, 33, ticket_len );

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -347,7 +347,8 @@ exit:
     {
         parsed_prv = parsed_cur;
         parsed_cur = parsed_cur->next;
-        mbedtls_free( parsed_prv );
+        /* Allocated in mbedtls_x509_get_name() */
+        mbedtls_test_free_wrapper( parsed_prv );
     }
 }
 /* END_CASE */

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -187,6 +187,7 @@ void x509_csr_check_opaque( char *key_file, int md_type, int key_usage,
 exit:
     mbedtls_x509write_csr_free( &req );
     mbedtls_pk_free( &key );
+    mbedtls_psa_crypto_free( );
 }
 /* END_CASE */
 

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -235,6 +235,7 @@
     <ClInclude Include="..\..\tests\include\test\helpers.h" />
     <ClInclude Include="..\..\tests\include\test\macros.h" />
     <ClInclude Include="..\..\tests\include\test\memory.h" />
+    <ClInclude Include="..\..\tests\include\test\memory_wrappers.h" />
     <ClInclude Include="..\..\tests\include\test\psa_crypto_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\psa_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\random.h" />
@@ -337,6 +338,7 @@
     <ClCompile Include="..\..\library\x509write_csr.c" />
     <ClCompile Include="..\..\library\xtea.c" />
     <ClCompile Include="..\..\tests\src\helpers.c" />
+    <ClCompile Include="..\..\tests\src\memory.c" />
     <ClCompile Include="..\..\tests\src\random.c" />
     <ClCompile Include="..\..\3rdparty\everest\library\everest.c" />
     <ClCompile Include="..\..\3rdparty\everest\library\Hacl_Curve25519_joined.c" />

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -234,6 +234,7 @@
     <ClInclude Include="..\..\include\psa\crypto_values.h" />
     <ClInclude Include="..\..\tests\include\test\helpers.h" />
     <ClInclude Include="..\..\tests\include\test\macros.h" />
+    <ClInclude Include="..\..\tests\include\test\memory.h" />
     <ClInclude Include="..\..\tests\include\test\psa_crypto_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\psa_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\random.h" />


### PR DESCRIPTION
Introduce a framework for counting the heap allocations made in the unit tests.

You can build the library with `mbedtls_calloc` and `mbedtls_free` referring to wrapper functions defined in the test code, and build the test code with these functions and some reporting code included. See the documentation in [`tests/include/test/memory_wrappers.h`](https://github.com/gilles-peskine-arm/mbedtls/blob/-wrappers-development/tests/include/test/memory.h) and [`component_test_memory_wrappers` in `all.sh`](https://github.com/gilles-peskine-arm/mbedtls/blob/calloc-wrappers-development/tests/scripts/all.sh#L1518).

There is also a simple memory leak detector (just counting calls to calloc and free, and complaining if the number isn't the same).

### Status: experimental

The code works to some extent, but may need more debugging and cleanup. I welcome design feedback. Detailed code review would be premature. I may rebase without warning.

Known issues:

* The build instructions are awkward and fragile. I don't know if there's a better way. The problem here is that the library code needs to be built with `mbedtls_{calloc,free}` pointing to wrappers defined by the test suite, whereas the test code needs to be built with those being the “real” functions. This may not matter since this is test code that doesn't need to work in all configurations.
* The summary report from `run-test-suites.pl` doesn't include leak information, so it's confusing when all the test cases pass functionally speaking but there are leaks ([example](https://jenkins-internal.mbed.com/blue/rest/organizations/jenkins/pipelines/mbed-tls-restricted-pr/branches/PR-723-head/runs/3/nodes/255/steps/2082/log/?start=0)): you see “FAILED”, but 0 test cases failed.
