### PR TITLE
Improve travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ after_failure:
 env:
   global:
     - SEED=1
+    - LOG_FAILURE_ON_STDOUT=1
     - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
 
 addons:

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1232,7 +1232,7 @@ run_client() {
             cp $CLI_OUT c-cli-${TESTS}.log
             echo "  ! outputs saved to c-srv-${TESTS}.log, c-cli-${TESTS}.log"
 
-            if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot -o "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
+            if [ "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
                 echo "  ! server output:"
                 cat c-srv-${TESTS}.log
                 echo "  ! ==================================================="


### PR DESCRIPTION
## Description

Enable full logging in when a test case fails in `compat.sh` and `ssl-opt.sh`. This doesn't affect normal (passing) runs.

While at it, clean up some old stuff in `compat.sh`. A similar clean-up was done in `ssl-opt.sh` in #3404 

## Status
**READY**

Yes - CI improvement 

- [ ] 2.16
- [ ] 2.7
