### PR TITLE
[Backport 2.16] Backport clean-up in tests done in #3474

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -679,7 +679,7 @@ int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
     return( 0 );
 }
 
-int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
+int mbedtls_test_hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
 {
     int ret = 0;
     uint32_t i = 0;

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -108,6 +108,27 @@ typedef enum
        }                                                    \
     } while( 0 )
 
+/** Compare two buffers and fail the test case if they differ.
+ *
+ * This macro expands to an instruction, not an expression.
+ * It may jump to the \c exit label.
+ *
+ * \param p1        Pointer to the start of the first buffer.
+ * \param size1     Size of the first buffer in bytes.
+ *                  This expression may be evaluated multiple times.
+ * \param p2        Pointer to the start of the second buffer.
+ * \param size2     Size of the second buffer in bytes.
+ *                  This expression may be evaluated multiple times.
+ */
+#define ASSERT_COMPARE( p1, size1, p2, size2 )                          \
+    do                                                                  \
+    {                                                                   \
+        TEST_ASSERT( ( size1 ) == ( size2 ) );                          \
+        if( ( size1 ) != 0 )                                            \
+            TEST_ASSERT( memcmp( ( p1 ), ( p2 ), ( size1 ) ) == 0 );    \
+    }                                                                   \
+    while( 0 )
+
 /**
  * \brief   This macro tests the expression passed to it and skips the
  *          running test if it doesn't evaluate to 'true'.

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -319,17 +319,15 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_OFB */
 void aes_encrypt_ofb( int fragment_size, data_t *key_str,
                       data_t *iv_str, data_t *src_str,
-                      char *expected_output_string)
+                      data_t *expected_output )
 {
     unsigned char output[32];
-    unsigned char output_string[65];
     mbedtls_aes_context ctx;
     size_t iv_offset = 0;
     int in_buffer_len;
     unsigned char* src_str_next;
 
     memset( output, 0x00, sizeof( output ) );
-    memset( output_string, 0x00, sizeof( output_string ) );
     mbedtls_aes_init( &ctx );
 
     TEST_ASSERT( (size_t)fragment_size < sizeof( output ) );
@@ -344,12 +342,10 @@ void aes_encrypt_ofb( int fragment_size, data_t *key_str,
         TEST_ASSERT( mbedtls_aes_crypt_ofb( &ctx, fragment_size, &iv_offset,
                                             iv_str->x, src_str_next, output ) == 0 );
 
-        mbedtls_test_hexify( output_string, output, fragment_size );
-        TEST_ASSERT( strncmp( (char *) output_string, expected_output_string,
-                              ( 2 * fragment_size ) ) == 0 );
+        TEST_ASSERT( memcmp( output, expected_output->x, fragment_size ) == 0 );
 
         in_buffer_len -= fragment_size;
-        expected_output_string += ( fragment_size * 2 );
+        expected_output->x += fragment_size;
         src_str_next += fragment_size;
 
         if( in_buffer_len < fragment_size )

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -23,7 +23,8 @@ void aes_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -47,7 +48,8 @@ void aes_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -72,7 +74,9 @@ void aes_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -96,7 +100,9 @@ void aes_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -241,7 +247,8 @@ void aes_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -263,7 +270,8 @@ void aes_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -284,7 +292,9 @@ void aes_encrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_ENCRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -305,7 +315,9 @@ void aes_decrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_DECRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -23,7 +23,7 @@ void aes_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -47,7 +47,7 @@ void aes_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -72,7 +72,7 @@ void aes_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -96,7 +96,7 @@ void aes_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -241,7 +241,7 @@ void aes_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -263,7 +263,7 @@ void aes_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -284,7 +284,7 @@ void aes_encrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_ENCRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -305,7 +305,7 @@ void aes_decrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_DECRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -9,7 +9,7 @@
 
 /* BEGIN_CASE */
 void aes_encrypt_ecb( data_t * key_str, data_t * src_str,
-                      data_t * hex_dst_string, int setkey_result )
+                      data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -23,8 +23,7 @@ void aes_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
     }
 
 exit:
@@ -34,7 +33,7 @@ exit:
 
 /* BEGIN_CASE */
 void aes_decrypt_ecb( data_t * key_str, data_t * src_str,
-                      data_t * hex_dst_string, int setkey_result )
+                      data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -48,8 +47,7 @@ void aes_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_aes_crypt_ecb( &ctx, MBEDTLS_AES_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
     }
 
 exit:
@@ -59,7 +57,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void aes_encrypt_cbc( data_t * key_str, data_t * iv_str,
-                      data_t * src_str, data_t * hex_dst_string,
+                      data_t * src_str, data_t * dst,
                       int cbc_result )
 {
     unsigned char output[100];
@@ -74,9 +72,8 @@ void aes_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                          src_str->len, dst->len ) == 0 );
     }
 
 exit:
@@ -86,7 +83,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void aes_decrypt_cbc( data_t * key_str, data_t * iv_str,
-                      data_t * src_str, data_t * hex_dst_string,
+                      data_t * src_str, data_t * dst,
                       int cbc_result )
 {
     unsigned char output[100];
@@ -100,9 +97,8 @@ void aes_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                          src_str->len, dst->len ) == 0 );
     }
 
 exit:
@@ -234,7 +230,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aes_encrypt_cfb128( data_t * key_str, data_t * iv_str,
-                         data_t * src_str, data_t * hex_dst_string )
+                         data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -247,8 +243,7 @@ void aes_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -257,7 +252,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aes_decrypt_cfb128( data_t * key_str, data_t * iv_str,
-                         data_t * src_str, data_t * hex_dst_string )
+                         data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -270,8 +265,7 @@ void aes_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb128( &ctx, MBEDTLS_AES_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -280,7 +274,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aes_encrypt_cfb8( data_t * key_str, data_t * iv_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -292,9 +286,8 @@ void aes_encrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_ENCRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                      src_str->len, dst->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );
@@ -303,7 +296,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aes_decrypt_cfb8( data_t * key_str, data_t * iv_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_aes_context ctx;
@@ -315,9 +308,8 @@ void aes_decrypt_cfb8( data_t * key_str, data_t * iv_str,
     mbedtls_aes_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_aes_crypt_cfb8( &ctx, MBEDTLS_AES_DECRYPT, src_str->len, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                      src_str->len, dst->len ) == 0 );
 
 exit:
     mbedtls_aes_free( &ctx );

--- a/tests/suites/test_suite_arc4.function
+++ b/tests/suites/test_suite_arc4.function
@@ -8,8 +8,7 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_arc4_crypt( data_t * src_str, data_t * key_str,
-                         data_t * hex_dst_string )
+void mbedtls_arc4_crypt( data_t * src_str, data_t * key_str, data_t * dst )
 {
     unsigned char dst_str[1000];
     mbedtls_arc4_context ctx;
@@ -19,11 +18,11 @@ void mbedtls_arc4_crypt( data_t * src_str, data_t * key_str,
 
 
     mbedtls_arc4_setup(&ctx, key_str->x, key_str->len);
-    TEST_ASSERT( mbedtls_arc4_crypt(&ctx, src_str->len, src_str->x, dst_str ) == 0 );
+    TEST_ASSERT( mbedtls_arc4_crypt(&ctx, src_str->len,
+                                    src_str->x, dst_str ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( dst_str, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( dst_str, dst->x,
+                                      src_str->len, dst->len ) == 0 );
 
 exit:
     mbedtls_arc4_free( &ctx );

--- a/tests/suites/test_suite_arc4.function
+++ b/tests/suites/test_suite_arc4.function
@@ -21,7 +21,9 @@ void mbedtls_arc4_crypt( data_t * src_str, data_t * key_str,
     mbedtls_arc4_setup(&ctx, key_str->x, key_str->len);
     TEST_ASSERT( mbedtls_arc4_crypt(&ctx, src_str->len, src_str->x, dst_str ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( dst_str, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( dst_str, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_arc4_free( &ctx );

--- a/tests/suites/test_suite_arc4.function
+++ b/tests/suites/test_suite_arc4.function
@@ -21,7 +21,7 @@ void mbedtls_arc4_crypt( data_t * src_str, data_t * key_str,
     mbedtls_arc4_setup(&ctx, key_str->x, key_str->len);
     TEST_ASSERT( mbedtls_arc4_crypt(&ctx, src_str->len, src_str->x, dst_str ) == 0 );
 
-    TEST_ASSERT( hexcmp( dst_str, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( dst_str, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_arc4_free( &ctx );

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -207,14 +207,12 @@ exit:
 
 /* BEGIN_CASE */
 void aria_encrypt_ecb( data_t *key_str, data_t *src_str,
-                       char *hex_dst_string, int setkey_result )
+                       data_t *expected_output, int setkey_result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t i;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -227,9 +225,9 @@ void aria_encrypt_ecb( data_t *key_str, data_t *src_str,
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
                                                  output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str->len );
 
-        TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+        TEST_ASSERT( !memcmp( output,
+                              expected_output->x, expected_output->len) );
     }
 
 exit:
@@ -239,14 +237,12 @@ exit:
 
 /* BEGIN_CASE */
 void aria_decrypt_ecb( data_t *key_str, data_t *src_str,
-                       char *hex_dst_string, int setkey_result )
+                       data_t *expected_output, int setkey_result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t i;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -259,9 +255,9 @@ void aria_decrypt_ecb( data_t *key_str, data_t *src_str,
             TEST_ASSERT( mbedtls_aria_crypt_ecb( &ctx, src_str->x + i,
                                                  output + i ) == 0 );
         }
-        mbedtls_test_hexify( dst_str, output, src_str->len );
 
-        TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+        TEST_ASSERT( !memcmp( output,
+                              expected_output->x, expected_output->len) );
     }
 
 exit:
@@ -271,14 +267,12 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void aria_encrypt_cbc( data_t *key_str, data_t *iv_str,
-                       data_t *src_str, char *hex_dst_string,
+                       data_t *src_str, data_t *expected_output,
                        int cbc_result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -288,9 +282,8 @@ void aria_encrypt_cbc( data_t *key_str, data_t *iv_str,
                                          output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str->len );
-
-        TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+        TEST_ASSERT( !memcmp( output,
+                              expected_output->x, expected_output->len) );
     }
 
 exit:
@@ -300,14 +293,12 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void aria_decrypt_cbc( data_t *key_str, data_t *iv_str,
-                       data_t *src_str, char *hex_dst_string,
+                       data_t *src_str, data_t *expected_output,
                        int cbc_result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -317,9 +308,8 @@ void aria_decrypt_cbc( data_t *key_str, data_t *iv_str,
                                          output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        mbedtls_test_hexify( dst_str, output, src_str->len );
-
-        TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+        TEST_ASSERT( !memcmp( output,
+                              expected_output->x, expected_output->len) );
     }
 
 exit:
@@ -329,15 +319,13 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aria_encrypt_cfb128( data_t *key_str, data_t *iv_str,
-                          data_t *src_str, char *hex_dst_string,
+                          data_t *src_str, data_t *expected_output,
                           int result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -346,9 +334,8 @@ void aria_encrypt_cfb128( data_t *key_str, data_t *iv_str,
                                             src_str->len, &iv_offset,
                                             iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str->len );
 
-    TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -357,15 +344,13 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void aria_decrypt_cfb128( data_t *key_str, data_t *iv_str,
-                          data_t *src_str, char *hex_dst_string,
+                          data_t *src_str, data_t *expected_output,
                           int result  )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -374,9 +359,8 @@ void aria_decrypt_cfb128( data_t *key_str, data_t *iv_str,
                                             src_str->len, &iv_offset,
                                             iv_str->x, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str->len );
 
-    TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -385,16 +369,14 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
 void aria_encrypt_ctr( data_t *key_str, data_t *iv_str,
-                       data_t *src_str, char *hex_dst_string,
+                       data_t *src_str, data_t *expected_output,
                        int result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -402,9 +384,8 @@ void aria_encrypt_ctr( data_t *key_str, data_t *iv_str,
     TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
                                          iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str->len );
 
-    TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -413,16 +394,14 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
 void aria_decrypt_ctr( data_t *key_str, data_t *iv_str,
-                       data_t *src_str, char *hex_dst_string,
+                       data_t *src_str, data_t *expected_output,
                        int result )
 {
-    unsigned char dst_str[ARIA_MAX_DATA_STR];
     unsigned char output[ARIA_MAX_DATASIZE];
     unsigned char blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
     size_t iv_offset = 0;
 
-    memset( dst_str, 0x00, sizeof( dst_str ) );
     memset( output, 0x00, sizeof( output ) );
     mbedtls_aria_init( &ctx );
 
@@ -430,9 +409,8 @@ void aria_decrypt_ctr( data_t *key_str, data_t *iv_str,
     TEST_ASSERT( mbedtls_aria_crypt_ctr( &ctx, src_str->len, &iv_offset,
                                          iv_str->x, blk, src_str->x, output )
                  == result );
-    mbedtls_test_hexify( dst_str, output, src_str->len );
 
-    TEST_ASSERT( strcasecmp( (char *) dst_str, hex_dst_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
 
 exit:
     mbedtls_aria_free( &ctx );

--- a/tests/suites/test_suite_aria.function
+++ b/tests/suites/test_suite_aria.function
@@ -226,8 +226,8 @@ void aria_encrypt_ecb( data_t *key_str, data_t *src_str,
                                                  output + i ) == 0 );
         }
 
-        TEST_ASSERT( !memcmp( output,
-                              expected_output->x, expected_output->len) );
+        ASSERT_COMPARE( output, expected_output->len,
+                        expected_output->x, expected_output->len );
     }
 
 exit:
@@ -256,8 +256,8 @@ void aria_decrypt_ecb( data_t *key_str, data_t *src_str,
                                                  output + i ) == 0 );
         }
 
-        TEST_ASSERT( !memcmp( output,
-                              expected_output->x, expected_output->len) );
+        ASSERT_COMPARE( output, expected_output->len,
+                        expected_output->x, expected_output->len );
     }
 
 exit:
@@ -282,8 +282,8 @@ void aria_encrypt_cbc( data_t *key_str, data_t *iv_str,
                                          output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        TEST_ASSERT( !memcmp( output,
-                              expected_output->x, expected_output->len) );
+        ASSERT_COMPARE( output, expected_output->len,
+                        expected_output->x, expected_output->len );
     }
 
 exit:
@@ -308,8 +308,8 @@ void aria_decrypt_cbc( data_t *key_str, data_t *iv_str,
                                          output ) == cbc_result );
     if( cbc_result == 0 )
     {
-        TEST_ASSERT( !memcmp( output,
-                              expected_output->x, expected_output->len) );
+        ASSERT_COMPARE( output, expected_output->len,
+                        expected_output->x, expected_output->len );
     }
 
 exit:
@@ -335,7 +335,8 @@ void aria_encrypt_cfb128( data_t *key_str, data_t *iv_str,
                                             iv_str->x, src_str->x, output )
                  == result );
 
-    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
+    ASSERT_COMPARE( output, expected_output->len,
+                    expected_output->x, expected_output->len );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -360,7 +361,8 @@ void aria_decrypt_cfb128( data_t *key_str, data_t *iv_str,
                                             iv_str->x, src_str->x, output )
                  == result );
 
-    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
+    ASSERT_COMPARE( output, expected_output->len,
+                    expected_output->x, expected_output->len );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -385,7 +387,8 @@ void aria_encrypt_ctr( data_t *key_str, data_t *iv_str,
                                          iv_str->x, blk, src_str->x, output )
                  == result );
 
-    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
+    ASSERT_COMPARE( output, expected_output->len,
+                    expected_output->x, expected_output->len );
 
 exit:
     mbedtls_aria_free( &ctx );
@@ -410,7 +413,8 @@ void aria_decrypt_ctr( data_t *key_str, data_t *iv_str,
                                          iv_str->x, blk, src_str->x, output )
                  == result );
 
-    TEST_ASSERT( !memcmp( output, expected_output->x, expected_output->len) );
+    ASSERT_COMPARE( output, expected_output->len,
+                    expected_output->x, expected_output->len );
 
 exit:
     mbedtls_aria_free( &ctx );

--- a/tests/suites/test_suite_blowfish.function
+++ b/tests/suites/test_suite_blowfish.function
@@ -167,7 +167,7 @@ exit:
 
 /* BEGIN_CASE */
 void blowfish_encrypt_ecb( data_t * key_str, data_t * src_str,
-                           data_t * hex_dst_string, int setkey_result )
+                           data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_blowfish_context ctx;
@@ -181,8 +181,7 @@ void blowfish_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
     }
 
 exit:
@@ -192,7 +191,7 @@ exit:
 
 /* BEGIN_CASE */
 void blowfish_decrypt_ecb( data_t * key_str, data_t * src_str,
-                           data_t * hex_dst_string, int setkey_result )
+                           data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_blowfish_context ctx;
@@ -206,8 +205,7 @@ void blowfish_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
     }
 
 exit:
@@ -217,7 +215,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void blowfish_encrypt_cbc( data_t * key_str, data_t * iv_str,
-                           data_t * src_str, data_t * hex_dst_string,
+                           data_t * src_str, data_t * dst,
                            int cbc_result )
 {
     unsigned char output[100];
@@ -233,9 +231,8 @@ void blowfish_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                          src_str->len, dst->len ) == 0 );
     }
 
 exit:
@@ -245,7 +242,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void blowfish_decrypt_cbc( data_t * key_str, data_t * iv_str,
-                           data_t * src_str, data_t * hex_dst_string,
+                           data_t * src_str, data_t * dst,
                            int cbc_result )
 {
     unsigned char output[100];
@@ -260,9 +257,8 @@ void blowfish_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:
@@ -272,8 +268,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void blowfish_encrypt_cfb64( data_t * key_str, data_t * iv_str,
-                             data_t * src_str, data_t * hex_dst_string
-                             )
+                             data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_blowfish_context ctx;
@@ -286,9 +281,8 @@ void blowfish_encrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                      dst->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -297,8 +291,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void blowfish_decrypt_cfb64( data_t * key_str, data_t * iv_str,
-                             data_t * src_str, data_t * hex_dst_string
-                             )
+                             data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_blowfish_context ctx;
@@ -311,9 +304,8 @@ void blowfish_decrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                      dst->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -322,7 +314,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CTR */
 void blowfish_encrypt_ctr( data_t * key_str, data_t * iv_str,
-                           data_t * src_str, data_t * hex_dst_string )
+                           data_t * src_str, data_t * dst )
 {
     unsigned char stream_str[100];
     unsigned char output[100];
@@ -337,9 +329,8 @@ void blowfish_encrypt_ctr( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_ctr( &ctx, src_str->len, &iv_offset, iv_str->x, stream_str, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                      dst->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );

--- a/tests/suites/test_suite_blowfish.function
+++ b/tests/suites/test_suite_blowfish.function
@@ -181,7 +181,7 @@ void blowfish_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -205,7 +205,7 @@ void blowfish_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -231,7 +231,7 @@ void blowfish_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -256,7 +256,7 @@ void blowfish_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -280,7 +280,7 @@ void blowfish_encrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -303,7 +303,7 @@ void blowfish_decrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -327,7 +327,7 @@ void blowfish_encrypt_ctr( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_ctr( &ctx, src_str->len, &iv_offset, iv_str->x, stream_str, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );

--- a/tests/suites/test_suite_blowfish.function
+++ b/tests/suites/test_suite_blowfish.function
@@ -181,7 +181,8 @@ void blowfish_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          8, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -205,7 +206,8 @@ void blowfish_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_blowfish_crypt_ecb( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          8, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -231,7 +233,9 @@ void blowfish_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -256,7 +260,9 @@ void blowfish_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0)
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -280,7 +286,9 @@ void blowfish_encrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_ENCRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -303,7 +311,9 @@ void blowfish_decrypt_cfb64( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_cfb64( &ctx, MBEDTLS_BLOWFISH_DECRYPT, src_str->len, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );
@@ -327,7 +337,9 @@ void blowfish_encrypt_ctr( data_t * key_str, data_t * iv_str,
     mbedtls_blowfish_setkey( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_blowfish_crypt_ctr( &ctx, src_str->len, &iv_offset, iv_str->x, stream_str, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_blowfish_free( &ctx );

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -175,7 +175,7 @@ exit:
 
 /* BEGIN_CASE */
 void camellia_encrypt_ecb( data_t * key_str, data_t * src_str,
-                           data_t * hex_dst_string, int setkey_result )
+                           data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_camellia_context ctx;
@@ -189,8 +189,7 @@ void camellia_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
     }
 
 exit:
@@ -200,7 +199,7 @@ exit:
 
 /* BEGIN_CASE */
 void camellia_decrypt_ecb( data_t * key_str, data_t * src_str,
-                           data_t * hex_dst_string, int setkey_result )
+                           data_t * dst, int setkey_result )
 {
     unsigned char output[100];
     mbedtls_camellia_context ctx;
@@ -214,8 +213,7 @@ void camellia_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
     }
 
 exit:
@@ -225,8 +223,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void camellia_encrypt_cbc( data_t * key_str, data_t * iv_str,
-                           data_t * src_str, data_t * hex_dst_string,
-                           int cbc_result )
+                           data_t * src_str, data_t * dst, int cbc_result )
 {
     unsigned char output[100];
     mbedtls_camellia_context ctx;
@@ -240,9 +237,8 @@ void camellia_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:
@@ -252,7 +248,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void camellia_decrypt_cbc( data_t * key_str, data_t * iv_str,
-                           data_t * src_str, data_t * hex_dst_string,
+                           data_t * src_str, data_t * dst,
                            int cbc_result )
 {
     unsigned char output[100];
@@ -267,9 +263,8 @@ void camellia_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:
@@ -279,8 +274,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void camellia_encrypt_cfb128( data_t * key_str, data_t * iv_str,
-                              data_t * src_str,
-                              data_t * hex_dst_string )
+                              data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_camellia_context ctx;
@@ -293,8 +287,7 @@ void camellia_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );
@@ -304,7 +297,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CFB */
 void camellia_decrypt_cfb128( data_t * key_str, data_t * iv_str,
                               data_t * src_str,
-                              data_t * hex_dst_string )
+                              data_t * dst )
 {
     unsigned char output[100];
     mbedtls_camellia_context ctx;
@@ -317,8 +310,7 @@ void camellia_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 16, dst->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -189,7 +189,7 @@ void camellia_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -213,7 +213,7 @@ void camellia_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -238,7 +238,7 @@ void camellia_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -263,7 +263,7 @@ void camellia_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -287,7 +287,7 @@ void camellia_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );
@@ -310,7 +310,7 @@ void camellia_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );

--- a/tests/suites/test_suite_camellia.function
+++ b/tests/suites/test_suite_camellia.function
@@ -189,7 +189,8 @@ void camellia_encrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -213,7 +214,8 @@ void camellia_decrypt_ecb( data_t * key_str, data_t * src_str,
     {
         TEST_ASSERT( mbedtls_camellia_crypt_ecb( &ctx, MBEDTLS_CAMELLIA_DECRYPT, src_str->x, output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          16, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -238,7 +240,9 @@ void camellia_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -263,7 +267,9 @@ void camellia_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -287,7 +293,8 @@ void camellia_encrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_ENCRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );
@@ -310,7 +317,8 @@ void camellia_decrypt_cfb128( data_t * key_str, data_t * iv_str,
     mbedtls_camellia_setkey_enc( &ctx, key_str->x, key_str->len * 8 );
     TEST_ASSERT( mbedtls_camellia_crypt_cfb128( &ctx, MBEDTLS_CAMELLIA_DECRYPT, 16, &iv_offset, iv_str->x, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 16, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      16, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_camellia_free( &ctx );

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -152,7 +152,7 @@ exit:
 void mbedtls_ccm_auth_decrypt( int cipher_id, data_t * key,
                                data_t * msg, data_t * iv,
                                data_t * add, int tag_len, int result,
-                               data_t * hex_msg )
+                               data_t * expected_msg )
 {
     unsigned char tag[16];
     mbedtls_ccm_context ctx;
@@ -172,7 +172,7 @@ void mbedtls_ccm_auth_decrypt( int cipher_id, data_t * key,
 
     if( result == 0 )
     {
-        TEST_ASSERT( memcmp( msg->x, hex_msg->x, hex_msg->len ) == 0 );
+        TEST_ASSERT( memcmp( msg->x, expected_msg->x, expected_msg->len ) == 0 );
     }
     else
     {

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -28,8 +28,8 @@ void chacha20_crypt( data_t *key_str,
      */
     TEST_ASSERT( mbedtls_chacha20_crypt( key_str->x, nonce_str->x, counter, src_str->len, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( !memcmp( output, expected_output_str->x,
-                          expected_output_str->len ) );
+    ASSERT_COMPARE( output, expected_output_str->len,
+                    expected_output_str->x, expected_output_str->len );
 
     /*
      * Test the streaming API
@@ -43,8 +43,8 @@ void chacha20_crypt( data_t *key_str,
     memset( output, 0x00, sizeof( output ) );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( !memcmp( output, expected_output_str->x,
-                          expected_output_str->len ) );
+    ASSERT_COMPARE( output, expected_output_str->len,
+                    expected_output_str->x, expected_output_str->len );
 
     /*
      * Test the streaming API again, piecewise
@@ -59,8 +59,8 @@ void chacha20_crypt( data_t *key_str,
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len - 1,
                                           src_str->x + 1, output + 1 ) == 0 );
 
-    TEST_ASSERT( !memcmp( output, expected_output_str->x,
-                          expected_output_str->len ) );
+    ASSERT_COMPARE( output, expected_output_str->len,
+                    expected_output_str->x, expected_output_str->len );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_chacha20.function
+++ b/tests/suites/test_suite_chacha20.function
@@ -17,13 +17,6 @@ void chacha20_crypt( data_t *key_str,
     unsigned char output[375];
     mbedtls_chacha20_context ctx;
 
-    /*
-     * Buffers to store the ASCII string representation of output and
-     * expected_output_str.
-     */
-    unsigned char output_string[751] = { '\0' };
-    unsigned char expected_output_string[751] = { '\0' };
-
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( src_str->len   == expected_output_str->len );
@@ -35,12 +28,8 @@ void chacha20_crypt( data_t *key_str,
      */
     TEST_ASSERT( mbedtls_chacha20_crypt( key_str->x, nonce_str->x, counter, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( expected_output_string,
-                         expected_output_str->x,
-                         expected_output_str->len);
-    mbedtls_test_hexify( output_string, output, src_str->len );
-    TEST_ASSERT( strcmp( (char *)output_string,
-                         (char *)expected_output_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output_str->x,
+                          expected_output_str->len ) );
 
     /*
      * Test the streaming API
@@ -54,9 +43,8 @@ void chacha20_crypt( data_t *key_str,
     memset( output, 0x00, sizeof( output ) );
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len, src_str->x, output ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_str->len );
-    TEST_ASSERT( strcmp( (char *)output_string,
-                         (char *)expected_output_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output_str->x,
+                          expected_output_str->len ) );
 
     /*
      * Test the streaming API again, piecewise
@@ -71,9 +59,8 @@ void chacha20_crypt( data_t *key_str,
     TEST_ASSERT( mbedtls_chacha20_update( &ctx, src_str->len - 1,
                                           src_str->x + 1, output + 1 ) == 0 );
 
-    mbedtls_test_hexify( output_string, output, src_str->len );
-    TEST_ASSERT( strcmp( (char *)output_string,
-                         (char *)expected_output_string ) == 0 );
+    TEST_ASSERT( !memcmp( output, expected_output_str->x,
+                          expected_output_str->len ) );
 
     mbedtls_chacha20_free( &ctx );
 }

--- a/tests/suites/test_suite_des.function
+++ b/tests/suites/test_suite_des.function
@@ -15,8 +15,7 @@ void des_check_weak( data_t * key, int ret )
 /* END_CASE */
 
 /* BEGIN_CASE */
-void des_encrypt_ecb( data_t * key_str, data_t * src_str,
-                      data_t * hex_dst_string )
+void des_encrypt_ecb( data_t * key_str, data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_des_context ctx;
@@ -28,8 +27,7 @@ void des_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_enc( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -37,8 +35,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void des_decrypt_ecb( data_t * key_str, data_t * src_str,
-                      data_t * hex_dst_string )
+void des_decrypt_ecb( data_t * key_str, data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_des_context ctx;
@@ -50,8 +47,7 @@ void des_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_dec( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -60,8 +56,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void des_encrypt_cbc( data_t * key_str, data_t * iv_str,
-                      data_t * src_str, data_t * hex_dst_string,
-                      int cbc_result )
+                      data_t * src_str, data_t * dst, int cbc_result )
 {
     unsigned char output[100];
     mbedtls_des_context ctx;
@@ -75,9 +70,8 @@ void des_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:
@@ -87,7 +81,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void des_decrypt_cbc( data_t * key_str, data_t * iv_str,
-                      data_t * src_str, data_t * hex_dst_string,
+                      data_t * src_str, data_t * dst,
                       int cbc_result )
 {
     unsigned char output[100];
@@ -102,9 +96,8 @@ void des_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:
@@ -114,7 +107,7 @@ exit:
 
 /* BEGIN_CASE */
 void des3_encrypt_ecb( int key_count, data_t * key_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_des3_context ctx;
@@ -132,8 +125,7 @@ void des3_encrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -142,7 +134,7 @@ exit:
 
 /* BEGIN_CASE */
 void des3_decrypt_ecb( int key_count, data_t * key_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_des3_context ctx;
@@ -160,8 +152,7 @@ void des3_decrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -171,7 +162,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void des3_encrypt_cbc( int key_count, data_t * key_str,
                        data_t * iv_str, data_t * src_str,
-                       data_t * hex_dst_string, int cbc_result )
+                       data_t * dst, int cbc_result )
 {
     unsigned char output[100];
     mbedtls_des3_context ctx;
@@ -192,9 +183,8 @@ void des3_encrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                          src_str->len, dst->len ) == 0 );
     }
 
 exit:
@@ -205,7 +195,7 @@ exit:
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void des3_decrypt_cbc( int key_count, data_t * key_str,
                        data_t * iv_str, data_t * src_str,
-                       data_t * hex_dst_string, int cbc_result )
+                       data_t * dst, int cbc_result )
 {
     unsigned char output[100];
     mbedtls_des3_context ctx;
@@ -226,9 +216,8 @@ void des3_decrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, src_str->len,
+                                          dst->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_des.function
+++ b/tests/suites/test_suite_des.function
@@ -28,7 +28,7 @@ void des_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_enc( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -49,7 +49,7 @@ void des_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_dec( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -73,7 +73,7 @@ void des_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -98,7 +98,7 @@ void des_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -126,7 +126,7 @@ void des3_encrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -153,7 +153,7 @@ void des3_decrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -184,7 +184,7 @@ void des3_encrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -216,7 +216,7 @@ void des3_decrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_des.function
+++ b/tests/suites/test_suite_des.function
@@ -28,7 +28,8 @@ void des_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_enc( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -49,7 +50,8 @@ void des_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_des_setkey_dec( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_des_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des_free( &ctx );
@@ -73,7 +75,9 @@ void des_encrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -98,7 +102,9 @@ void des_decrypt_cbc( data_t * key_str, data_t * iv_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -126,7 +132,8 @@ void des3_encrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -153,7 +160,8 @@ void des3_decrypt_ecb( int key_count, data_t * key_str,
 
     TEST_ASSERT( mbedtls_des3_crypt_ecb( &ctx, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 
 exit:
     mbedtls_des3_free( &ctx );
@@ -184,7 +192,9 @@ void des3_encrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:
@@ -216,7 +226,9 @@ void des3_decrypt_cbc( int key_count, data_t * key_str,
     if( cbc_result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -756,7 +756,7 @@ void ecp_write_binary( int id, char * x, char * y, char * z, int format,
 
     if( ret == 0 )
     {
-        TEST_ASSERT( hexcmp( buf, out->x, olen, out->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( buf, out->x, olen, out->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -35,8 +35,8 @@ exit:
 /* BEGIN_CASE */
 void gcm_encrypt_and_tag( int cipher_id, data_t * key_str,
                           data_t * src_str, data_t * iv_str,
-                          data_t * add_str, data_t * hex_dst_string,
-                          int tag_len_bits, data_t * hex_tag_string,
+                          data_t * add_str, data_t * dst,
+                          int tag_len_bits, data_t * tag,
                           int init_result )
 {
     unsigned char output[128];
@@ -55,11 +55,10 @@ void gcm_encrypt_and_tag( int cipher_id, data_t * key_str,
     {
         TEST_ASSERT( mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_ENCRYPT, src_str->len, iv_str->x, iv_str->len, add_str->x, add_str->len, src_str->x, output, tag_len, tag_output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                          src_str->len,
-                                          hex_dst_string->len ) == 0 );
-        TEST_ASSERT( mbedtls_test_hexcmp( tag_output, hex_tag_string->x,
-                                          tag_len, hex_tag_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                          src_str->len, dst->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( tag_output, tag->x,
+                                          tag_len, tag->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -55,8 +55,11 @@ void gcm_encrypt_and_tag( int cipher_id, data_t * key_str,
     {
         TEST_ASSERT( mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_ENCRYPT, src_str->len, iv_str->x, iv_str->len, add_str->x, add_str->len, src_str->x, output, tag_len, tag_output ) == 0 );
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
-        TEST_ASSERT( mbedtls_test_hexcmp( tag_output, hex_tag_string->x, tag_len, hex_tag_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                          src_str->len,
+                                          hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( tag_output, hex_tag_string->x,
+                                          tag_len, hex_tag_string->len ) == 0 );
     }
 
 exit:
@@ -94,7 +97,9 @@ void gcm_decrypt_and_verify( int cipher_id, data_t * key_str,
         {
             TEST_ASSERT( ret == 0 );
 
-            TEST_ASSERT( mbedtls_test_hexcmp( output, pt_result->x, src_str->len, pt_result->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, pt_result->x,
+                                              src_str->len,
+                                              pt_result->len ) == 0 );
         }
     }
 

--- a/tests/suites/test_suite_gcm.function
+++ b/tests/suites/test_suite_gcm.function
@@ -55,8 +55,8 @@ void gcm_encrypt_and_tag( int cipher_id, data_t * key_str,
     {
         TEST_ASSERT( mbedtls_gcm_crypt_and_tag( &ctx, MBEDTLS_GCM_ENCRYPT, src_str->len, iv_str->x, iv_str->len, add_str->x, add_str->len, src_str->x, output, tag_len, tag_output ) == 0 );
 
-        TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
-        TEST_ASSERT( hexcmp( tag_output, hex_tag_string->x, tag_len, hex_tag_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( tag_output, hex_tag_string->x, tag_len, hex_tag_string->len ) == 0 );
     }
 
 exit:
@@ -94,7 +94,7 @@ void gcm_decrypt_and_verify( int cipher_id, data_t * key_str,
         {
             TEST_ASSERT( ret == 0 );
 
-            TEST_ASSERT( hexcmp( output, pt_result->x, src_str->len, pt_result->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, pt_result->x, src_str->len, pt_result->len ) == 0 );
         }
     }
 

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -14,13 +14,6 @@ void test_hkdf( int md_alg, data_t *ikm, data_t *salt, data_t *info,
 {
     int ret;
     unsigned char okm[128] = { '\0' };
-    /*
-     * okm_string and expected_okm_string are the ASCII string representations
-     * of km and expected_okm, so their size should be twice the size of
-     * okm and expected_okm, and an extra null-termination.
-     */
-    unsigned char okm_string[257] = { '\0' };
-    unsigned char expected_okm_string[257] = { '\0' };
 
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
@@ -31,14 +24,7 @@ void test_hkdf( int md_alg, data_t *ikm, data_t *salt, data_t *info,
                         info->x, info->len, okm, expected_okm->len );
     TEST_ASSERT( ret == 0 );
 
-    /*
-     * Run mbedtls_test_hexify on okm and expected_okm so that it looks nicer
-     * if the assertion fails.
-     */
-    mbedtls_test_hexify( okm_string, okm, expected_okm->len );
-    mbedtls_test_hexify( expected_okm_string,
-                         expected_okm->x, expected_okm->len );
-    TEST_ASSERT( !strcmp( (char *)okm_string, (char *)expected_okm_string ) );
+    TEST_ASSERT( !memcmp( okm, expected_okm->x, expected_okm->len ) );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -24,7 +24,8 @@ void test_hkdf( int md_alg, data_t *ikm, data_t *salt, data_t *info,
                         info->x, info->len, okm, expected_okm->len );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( !memcmp( okm, expected_okm->x, expected_okm->len ) );
+    ASSERT_COMPARE( okm            , expected_okm->len,
+                    expected_okm->x, expected_okm->len );
 }
 /* END_CASE */
 
@@ -48,12 +49,11 @@ void test_hkdf_extract( int md_alg, char *hex_ikm_string,
     ikm = unhexify_alloc( hex_ikm_string, &ikm_len );
     salt = unhexify_alloc( hex_salt_string, &salt_len );
     prk = unhexify_alloc( hex_prk_string, &prk_len );
-    TEST_ASSERT( prk_len == output_prk_len );
 
     ret = mbedtls_hkdf_extract( md, salt, salt_len, ikm, ikm_len, output_prk );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( !memcmp( output_prk, prk, prk_len ) );
+    ASSERT_COMPARE( output_prk, output_prk_len, prk, prk_len );
 
 exit:
     mbedtls_free(ikm);
@@ -89,7 +89,7 @@ void test_hkdf_expand( int md_alg, char *hex_info_string,
     ret = mbedtls_hkdf_expand( md, prk, prk_len, info, info_len,
                                output_okm, OKM_LEN );
     TEST_ASSERT( ret == 0 );
-    TEST_ASSERT( !memcmp( output_okm, okm, okm_len ) );
+    ASSERT_COMPARE( output_okm, okm_len, okm, okm_len );
 
 exit:
     mbedtls_free(info);

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -127,7 +127,7 @@ void md_info( int md_type, char * md_name, int md_size )
 
 /* BEGIN_CASE */
 void md_text( char * text_md_name, char * text_src_string,
-              data_t * hex_hash_string )
+              data_t * hash )
 {
     char md_name[100];
     unsigned char src_str[1000];
@@ -145,15 +145,14 @@ void md_text( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md( md_info, src_str, strlen( (char *) src_str ), output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE */
-void md_hex( char * text_md_name, data_t * src_str,
-             data_t * hex_hash_string )
+void md_hex( char * text_md_name, data_t * src_str, data_t * hash )
 {
     char md_name[100];
     unsigned char output[100];
@@ -169,15 +168,15 @@ void md_hex( char * text_md_name, data_t * src_str,
     TEST_ASSERT ( 0 == mbedtls_md( md_info, src_str->x, src_str->len, output ) );
 
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE */
 void md_text_multi( char * text_md_name, char * text_src_string,
-                    data_t * hex_hash_string )
+                    data_t * hash )
 {
     char md_name[100];
     unsigned char src_str[1000];
@@ -211,18 +210,18 @@ void md_text_multi( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len) == 0 );
+                                      hash->len) == 0 );
 
     /* Test clone */
     memset( output, 0x00, 100 );
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -231,8 +230,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE */
-void md_hex_multi( char * text_md_name, data_t * src_str,
-                   data_t * hex_hash_string )
+void md_hex_multi( char * text_md_name, data_t * src_str, data_t * hash )
 {
     char md_name[100];
     unsigned char output[100];
@@ -261,18 +259,18 @@ void md_hex_multi( char * text_md_name, data_t * src_str,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str->x + halfway, src_str->len - halfway) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 
     /* Test clone */
     memset( output, 0x00, 100 );
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -283,7 +281,7 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_md_hmac( char * text_md_name, int trunc_size,
                       data_t * key_str, data_t * src_str,
-                      data_t * hex_hash_string )
+                      data_t * hash )
 {
     char md_name[100];
     unsigned char output[100];
@@ -299,14 +297,14 @@ void mbedtls_md_hmac( char * text_md_name, int trunc_size,
 
     TEST_ASSERT ( mbedtls_md_hmac( md_info, key_str->x, key_str->len, src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      trunc_size, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE */
 void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
-                    data_t * src_str, data_t * hex_hash_string )
+                    data_t * src_str, data_t * hash )
 {
     char md_name[100];
     unsigned char output[100];
@@ -332,8 +330,8 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      trunc_size, hash->len ) == 0 );
 
     /* Test again, for reset() */
     memset( output, 0x00, 100 );
@@ -343,8 +341,8 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      trunc_size, hash->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -353,7 +351,7 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO */
 void mbedtls_md_file( char * text_md_name, char * filename,
-                      data_t * hex_hash_string )
+                      data_t * hash )
 {
     char md_name[100];
     unsigned char output[100];
@@ -368,8 +366,8 @@ void mbedtls_md_file( char * text_md_name, char * filename,
 
     TEST_ASSERT( mbedtls_md_file( md_info, filename, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
                                       mbedtls_md_get_size( md_info ),
-                                      hex_hash_string->len ) == 0 );
+                                      hash->len ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -145,7 +145,9 @@ void md_text( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md( md_info, src_str, strlen( (char *) src_str ), output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -168,7 +170,8 @@ void md_hex( char * text_md_name, data_t * src_str,
 
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                 mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -209,14 +212,17 @@ void md_text_multi( char * text_md_name, char * text_src_string,
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
     TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                 mbedtls_md_get_size( md_info ), hex_hash_string->len) == 0 );
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len) == 0 );
 
     /* Test clone */
     memset( output, 0x00, 100 );
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -255,14 +261,18 @@ void md_hex_multi( char * text_md_name, data_t * src_str,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str->x + halfway, src_str->len - halfway) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 
     /* Test clone */
     memset( output, 0x00, 100 );
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -289,7 +299,8 @@ void mbedtls_md_hmac( char * text_md_name, int trunc_size,
 
     TEST_ASSERT ( mbedtls_md_hmac( md_info, key_str->x, key_str->len, src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      trunc_size, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -321,7 +332,8 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      trunc_size, hex_hash_string->len ) == 0 );
 
     /* Test again, for reset() */
     memset( output, 0x00, 100 );
@@ -331,7 +343,8 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      trunc_size, hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -355,6 +368,8 @@ void mbedtls_md_file( char * text_md_name, char * filename,
 
     TEST_ASSERT( mbedtls_md_file( md_info, filename, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      mbedtls_md_get_size( md_info ),
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -145,7 +145,7 @@ void md_text( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md( md_info, src_str, strlen( (char *) src_str ), output ) );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -167,7 +167,7 @@ void md_hex( char * text_md_name, data_t * src_str,
     TEST_ASSERT ( 0 == mbedtls_md( md_info, src_str->x, src_str->len, output ) );
 
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
                  mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
@@ -208,7 +208,7 @@ void md_text_multi( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x,
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
                  mbedtls_md_get_size( md_info ), hex_hash_string->len) == 0 );
 
     /* Test clone */
@@ -216,7 +216,7 @@ void md_text_multi( char * text_md_name, char * text_src_string,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str + halfway, len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -255,14 +255,14 @@ void md_hex_multi( char * text_md_name, data_t * src_str,
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx, src_str->x + halfway, src_str->len - halfway) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx, output ) );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 
     /* Test clone */
     memset( output, 0x00, 100 );
 
     TEST_ASSERT ( 0 == mbedtls_md_update( &ctx_copy, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_finish( &ctx_copy, output ) );
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -289,7 +289,7 @@ void mbedtls_md_hmac( char * text_md_name, int trunc_size,
 
     TEST_ASSERT ( mbedtls_md_hmac( md_info, key_str->x, key_str->len, src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -321,7 +321,7 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
 
     /* Test again, for reset() */
     memset( output, 0x00, 100 );
@@ -331,7 +331,7 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     TEST_ASSERT ( 0 == mbedtls_md_hmac_update( &ctx, src_str->x + halfway, src_str->len - halfway ) );
     TEST_ASSERT ( 0 == mbedtls_md_hmac_finish( &ctx, output ) );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, trunc_size, hex_hash_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );
@@ -355,6 +355,6 @@ void mbedtls_md_file( char * text_md_name, char * filename,
 
     TEST_ASSERT( mbedtls_md_file( md_info, filename, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, mbedtls_md_get_size( md_info ), hex_hash_string->len ) == 0 );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -6,7 +6,7 @@
 /* END_HEADER */
 
 /* BEGIN_CASE depends_on:MBEDTLS_MD2_C */
-void md2_text( char * text_src_string, data_t * hex_hash_string )
+void md2_text( char * text_src_string, data_t * hash )
 {
     int ret;
     unsigned char src_str[100];
@@ -20,14 +20,13 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md2_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 ) ;
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      sizeof  output,
-                                      hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      sizeof  output, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_MD4_C */
-void md4_text( char * text_src_string, data_t * hex_hash_string )
+void md4_text( char * text_src_string, data_t * hash )
 {
     int ret;
     unsigned char src_str[100];
@@ -41,14 +40,13 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md4_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      sizeof  output,
-                                      hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      sizeof  output, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_MD5_C */
-void md5_text( char * text_src_string, data_t * hex_hash_string )
+void md5_text( char * text_src_string, data_t * hash )
 {
     int ret;
     unsigned char src_str[100];
@@ -62,14 +60,13 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md5_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      sizeof  output,
-                                      hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      sizeof  output, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_RIPEMD160_C */
-void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
+void ripemd160_text( char * text_src_string, data_t * hash )
 {
     int ret;
     unsigned char src_str[100];
@@ -83,9 +80,8 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_ripemd160_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      sizeof output,
-                                      hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
+                                      sizeof output, hash->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -20,7 +20,9 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md2_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 ) ;
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      sizeof  output,
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -39,7 +41,9 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md4_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      sizeof  output,
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -58,7 +62,9 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md5_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      sizeof  output,
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -77,7 +83,9 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_ripemd160_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      sizeof output,
+                                      hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -20,7 +20,7 @@ void md2_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md2_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 ) ;
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -39,7 +39,7 @@ void md4_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md4_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -58,7 +58,7 @@ void md5_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_md5_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof  output, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -77,7 +77,7 @@ void ripemd160_text( char * text_src_string, data_t * hex_hash_string )
     ret = mbedtls_ripemd160_ret( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, sizeof output, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -354,7 +354,7 @@ void mbedtls_mpi_write_binary( int radix_X, char * input_X,
     if( result == 0)
     {
 
-        TEST_ASSERT( hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
     }
 
 exit:
@@ -388,7 +388,7 @@ void mbedtls_mpi_read_file( int radix_X, char * input_file,
         TEST_ASSERT( mbedtls_mpi_write_binary( &X, buf, buflen ) == 0 );
 
 
-        TEST_ASSERT( hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -354,7 +354,8 @@ void mbedtls_mpi_write_binary( int radix_X, char * input_X,
     if( result == 0)
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x,
+                                          buflen, input_A->len ) == 0 );
     }
 
 exit:
@@ -388,7 +389,8 @@ void mbedtls_mpi_read_file( int radix_X, char * input_file,
         TEST_ASSERT( mbedtls_mpi_write_binary( &X, buf, buflen ) == 0 );
 
 
-        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x, buflen, input_A->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( buf, input_A->x,
+                                          buflen, input_A->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -12,7 +12,7 @@
 void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
                               int radix_E, char * input_E, int hash,
                               data_t * message_str, data_t * rnd_buf,
-                              data_t * result_hex_str, int result )
+                              data_t * result_str, int result )
 {
     unsigned char output[128];
     mbedtls_rsa_context ctx;
@@ -36,8 +36,8 @@ void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -50,7 +50,7 @@ exit:
 void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
                               int radix_Q, char * input_Q, int radix_N,
                               char * input_N, int radix_E, char * input_E,
-                              int hash, data_t * result_hex_str,
+                              int hash, data_t * result_str,
                               char * seed, data_t * message_str,
                               int result )
 {
@@ -78,13 +78,12 @@ void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
     TEST_ASSERT( mbedtls_rsa_complete( &ctx ) == 0 );
     TEST_ASSERT( mbedtls_rsa_check_privkey( &ctx ) == 0 );
 
-
     TEST_ASSERT( mbedtls_rsa_pkcs1_decrypt( &ctx, &rnd_pseudo_rand, &rnd_info, MBEDTLS_RSA_PRIVATE, &output_len, message_str->x, output, 1000 ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                           output_len,
-                                          result_hex_str->len) == 0 );
+                                          result_str->len) == 0 );
     }
 
 exit:
@@ -247,7 +246,7 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
                             char * input_Q, int radix_N, char * input_N,
                             int radix_E, char * input_E, int digest, int hash,
                             data_t * message_str, data_t * rnd_buf,
-                            data_t * result_hex_str, int result )
+                            data_t * result_str, int result )
 {
     unsigned char hash_result[MBEDTLS_MD_MAX_SIZE];
     unsigned char output[128];
@@ -283,8 +282,8 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -36,8 +36,7 @@ void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -83,7 +82,7 @@ void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, output_len, result_hex_str->len) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len) == 0 );
     }
 
 exit:
@@ -282,7 +281,7 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -36,7 +36,8 @@ void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -81,8 +82,9 @@ void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
     TEST_ASSERT( mbedtls_rsa_pkcs1_decrypt( &ctx, &rnd_pseudo_rand, &rnd_info, MBEDTLS_RSA_PRIVATE, &output_len, message_str->x, output, 1000 ) == result );
     if( result == 0 )
     {
-
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          output_len,
+                                          result_hex_str->len) == 0 );
     }
 
 exit:
@@ -281,7 +283,8 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -12,7 +12,7 @@
 void pkcs1_rsaes_oaep_encrypt( int mod, int radix_N, char * input_N,
                                int radix_E, char * input_E, int hash,
                                data_t * message_str, data_t * rnd_buf,
-                               data_t * result_hex_str, int result )
+                               data_t * result_str, int result )
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx;
@@ -36,8 +36,8 @@ void pkcs1_rsaes_oaep_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -50,7 +50,7 @@ exit:
 void pkcs1_rsaes_oaep_decrypt( int mod, int radix_P, char * input_P,
                                int radix_Q, char * input_Q, int radix_N,
                                char * input_N, int radix_E, char * input_E,
-                               int hash, data_t * result_hex_str,
+                               int hash, data_t * result_str,
                                char * seed, data_t * message_str,
                                int result )
 {
@@ -85,9 +85,9 @@ void pkcs1_rsaes_oaep_decrypt( int mod, int radix_P, char * input_P,
                                             sizeof( output ) ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                           output_len,
-                                          result_hex_str->len ) == 0 );
+                                          result_str->len ) == 0 );
     }
 
 exit:
@@ -102,7 +102,7 @@ void pkcs1_rsassa_pss_sign( int mod, int radix_P, char * input_P, int radix_Q,
                             char * input_Q, int radix_N, char * input_N,
                             int radix_E, char * input_E, int digest, int hash,
                             data_t * message_str, data_t * rnd_buf,
-                            data_t * result_hex_str, int result )
+                            data_t * result_str, int result )
 {
     unsigned char hash_result[MBEDTLS_MD_MAX_SIZE];
     unsigned char output[256];
@@ -139,8 +139,8 @@ void pkcs1_rsassa_pss_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -36,8 +36,7 @@ void pkcs1_rsaes_oaep_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -85,7 +84,7 @@ void pkcs1_rsaes_oaep_decrypt( int mod, int radix_P, char * input_P,
                                             sizeof( output ) ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -137,7 +136,7 @@ void pkcs1_rsassa_pss_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -36,7 +36,8 @@ void pkcs1_rsaes_oaep_encrypt( int mod, int radix_N, char * input_N,
     TEST_ASSERT( mbedtls_rsa_pkcs1_encrypt( &ctx, &rnd_buffer_rand, &info, MBEDTLS_RSA_PUBLIC, message_str->len, message_str->x, output ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -84,7 +85,9 @@ void pkcs1_rsaes_oaep_decrypt( int mod, int radix_P, char * input_P,
                                             sizeof( output ) ) == result );
     if( result == 0 )
     {
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          output_len,
+                                          result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -136,7 +139,8 @@ void pkcs1_rsassa_pss_sign( int mod, int radix_P, char * input_P, int radix_Q,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_pkcs5.function
+++ b/tests/suites/test_suite_pkcs5.function
@@ -24,7 +24,7 @@ void pbkdf2_hmac( int hash, data_t * pw_str, data_t * salt_str,
     TEST_ASSERT( mbedtls_pkcs5_pbkdf2_hmac( &ctx, pw_str->x, pw_str->len, salt_str->x, salt_str->len,
                                      it_cnt, key_len, key ) == 0 );
 
-    TEST_ASSERT( hexcmp( key, result_key_string->x, key_len, result_key_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( key, result_key_string->x, key_len, result_key_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );

--- a/tests/suites/test_suite_pkcs5.function
+++ b/tests/suites/test_suite_pkcs5.function
@@ -24,7 +24,8 @@ void pbkdf2_hmac( int hash, data_t * pw_str, data_t * salt_str,
     TEST_ASSERT( mbedtls_pkcs5_pbkdf2_hmac( &ctx, pw_str->x, pw_str->len, salt_str->x, salt_str->len,
                                      it_cnt, key_len, key ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( key, result_key_string->x, key_len, result_key_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( key, result_key_string->x,
+                                      key_len, result_key_string->len ) == 0 );
 
 exit:
     mbedtls_md_free( &ctx );

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -9,14 +9,12 @@
  */
 
 /* BEGIN_CASE */
-void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
+void mbedtls_poly1305( data_t *key, data_t *expected_mac, data_t *src_str )
 {
     unsigned char mac[16]; /* size set by the standard */
-    unsigned char mac_str[33]; /* hex expansion of the above */
     mbedtls_poly1305_context ctx;
 
-    memset( mac_str, 0x00, sizeof( mac_str ) );
-    memset( mac,     0x00, sizeof( mac ) );
+    memset( mac, 0x00, sizeof( mac ) );
 
     /*
      * Test the integrated API
@@ -24,8 +22,7 @@ void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
     TEST_ASSERT( mbedtls_poly1305_mac( key->x, src_str->x,
                                        src_str->len, mac ) == 0 );
 
-    mbedtls_test_hexify( mac_str, mac, 16 );
-    TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
+    TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
 
     /*
      * Test the streaming API
@@ -38,8 +35,7 @@ void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
 
     TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-    mbedtls_test_hexify( mac_str, mac, 16 );
-    TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
+    TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
 
     /*
      * Test the streaming API again, piecewise
@@ -56,8 +52,7 @@ void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        mbedtls_test_hexify( mac_str, mac, 16 );
-        TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
+        TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
     }
 
     /*
@@ -73,8 +68,7 @@ void mbedtls_poly1305( data_t *key, char *hex_mac_string, data_t *src_str )
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        mbedtls_test_hexify( mac_str, mac, 16 );
-        TEST_ASSERT( strcmp( (char *) mac_str, hex_mac_string ) == 0 );
+        TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
     }
 
     mbedtls_poly1305_free( &ctx );

--- a/tests/suites/test_suite_poly1305.function
+++ b/tests/suites/test_suite_poly1305.function
@@ -22,7 +22,8 @@ void mbedtls_poly1305( data_t *key, data_t *expected_mac, data_t *src_str )
     TEST_ASSERT( mbedtls_poly1305_mac( key->x, src_str->x,
                                        src_str->len, mac ) == 0 );
 
-    TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
+    ASSERT_COMPARE( mac, expected_mac->len,
+                    expected_mac->x, expected_mac->len );
 
     /*
      * Test the streaming API
@@ -35,7 +36,8 @@ void mbedtls_poly1305( data_t *key, data_t *expected_mac, data_t *src_str )
 
     TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-    TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
+    ASSERT_COMPARE( mac, expected_mac->len,
+                    expected_mac->x, expected_mac->len );
 
     /*
      * Test the streaming API again, piecewise
@@ -52,7 +54,8 @@ void mbedtls_poly1305( data_t *key, data_t *expected_mac, data_t *src_str )
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
+        ASSERT_COMPARE( mac, expected_mac->len,
+                        expected_mac->x, expected_mac->len );
     }
 
     /*
@@ -68,7 +71,8 @@ void mbedtls_poly1305( data_t *key, data_t *expected_mac, data_t *src_str )
 
         TEST_ASSERT( mbedtls_poly1305_finish( &ctx, mac ) == 0 );
 
-        TEST_ASSERT( !memcmp( mac, expected_mac->x, expected_mac->len ) );
+        ASSERT_COMPARE( mac, expected_mac->len,
+                        expected_mac->x, expected_mac->len );
     }
 
     mbedtls_poly1305_free( &ctx );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -506,7 +506,8 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -586,7 +587,8 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
                                          output ) == 0 );
 
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                      ctx.len, result_hex_str->len ) == 0 );
 
 #if defined(MBEDTLS_PKCS1_V15)
     /* For PKCS#1 v1.5, there is an alternative way to generate signatures */
@@ -608,7 +610,9 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
 
         if( res == 0 )
         {
-            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                              ctx.len,
+                                              result_hex_str->len ) == 0 );
         }
     }
 #endif /* MBEDTLS_PKCS1_V15 */
@@ -714,7 +718,8 @@ void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -752,7 +757,8 @@ void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -800,7 +806,9 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          output_len,
+                                          result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -837,7 +845,8 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
     /* And now with the copy */
@@ -852,7 +861,8 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -902,7 +912,9 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
         if( result == 0 )
         {
 
-            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                              ctx.len,
+                                              result_hex_str->len ) == 0 );
         }
     }
 
@@ -919,7 +931,9 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx2.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+                                          ctx2.len,
+                                          result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -506,7 +506,7 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -586,7 +586,7 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
                                          output ) == 0 );
 
 
-    TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
 
 #if defined(MBEDTLS_PKCS1_V15)
     /* For PKCS#1 v1.5, there is an alternative way to generate signatures */
@@ -608,7 +608,7 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
 
         if( res == 0 )
         {
-            TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
         }
     }
 #endif /* MBEDTLS_PKCS1_V15 */
@@ -714,7 +714,7 @@ void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -752,7 +752,7 @@ void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -800,7 +800,7 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, output_len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -837,7 +837,7 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
     /* And now with the copy */
@@ -852,7 +852,7 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
     }
 
 exit:
@@ -902,7 +902,7 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
         if( result == 0 )
         {
 
-            TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx.len, result_hex_str->len ) == 0 );
         }
     }
 
@@ -919,7 +919,7 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
     if( result == 0 )
     {
 
-        TEST_ASSERT( hexcmp( output, result_hex_str->x, ctx2.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x, ctx2.len, result_hex_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -470,7 +470,7 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
                              int digest, int mod, int radix_P, char * input_P,
                              int radix_Q, char * input_Q, int radix_N,
                              char * input_N, int radix_E, char * input_E,
-                             data_t * result_hex_str, int result )
+                             data_t * result_str, int result )
 {
     unsigned char hash_result[MBEDTLS_MD_MAX_SIZE];
     unsigned char output[256];
@@ -506,8 +506,8 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -556,7 +556,7 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
                          int padding_mode, int mod, int radix_P,
                          char * input_P, int radix_Q, char * input_Q,
                          int radix_N, char * input_N, int radix_E,
-                         char * input_E, data_t * result_hex_str )
+                         char * input_E, data_t * result_str )
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx;
@@ -587,8 +587,8 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
                                          output ) == 0 );
 
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                      ctx.len, result_hex_str->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                      ctx.len, result_str->len ) == 0 );
 
 #if defined(MBEDTLS_PKCS1_V15)
     /* For PKCS#1 v1.5, there is an alternative way to generate signatures */
@@ -610,9 +610,9 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
 
         if( res == 0 )
         {
-            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                               ctx.len,
-                                              result_hex_str->len ) == 0 );
+                                              result_str->len ) == 0 );
         }
     }
 #endif /* MBEDTLS_PKCS1_V15 */
@@ -690,7 +690,7 @@ exit:
 void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
                                 int mod, int radix_N, char * input_N,
                                 int radix_E, char * input_E,
-                                data_t * result_hex_str, int result )
+                                data_t * result_str, int result )
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx;
@@ -718,8 +718,8 @@ void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -732,7 +732,7 @@ exit:
 void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
                                 int mod, int radix_N, char * input_N,
                                 int radix_E, char * input_E,
-                                data_t * result_hex_str, int result )
+                                data_t * result_str, int result )
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx;
@@ -757,8 +757,8 @@ void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -772,7 +772,7 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
                                 int mod, int radix_P, char * input_P,
                                 int radix_Q, char * input_Q, int radix_N,
                                 char * input_N, int radix_E, char * input_E,
-                                int max_output, data_t * result_hex_str,
+                                int max_output, data_t * result_str,
                                 int result )
 {
     unsigned char output[32];
@@ -806,9 +806,9 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                           output_len,
-                                          result_hex_str->len ) == 0 );
+                                          result_str->len ) == 0 );
     }
 
 exit:
@@ -821,7 +821,7 @@ exit:
 /* BEGIN_CASE */
 void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
                          char * input_N, int radix_E, char * input_E,
-                         data_t * result_hex_str, int result )
+                         data_t * result_str, int result )
 {
     unsigned char output[256];
     mbedtls_rsa_context ctx, ctx2; /* Also test mbedtls_rsa_copy() while at it */
@@ -845,8 +845,8 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
     /* And now with the copy */
@@ -861,8 +861,8 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
-                                          ctx.len, result_hex_str->len ) == 0 );
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
+                                          ctx.len, result_str->len ) == 0 );
     }
 
 exit:
@@ -876,7 +876,7 @@ exit:
 void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
                           char * input_P, int radix_Q, char * input_Q,
                           int radix_N, char * input_N, int radix_E,
-                          char * input_E, data_t * result_hex_str,
+                          char * input_E, data_t * result_str,
                           int result )
 {
     unsigned char output[256];
@@ -912,9 +912,9 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
         if( result == 0 )
         {
 
-            TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+            TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                               ctx.len,
-                                              result_hex_str->len ) == 0 );
+                                              result_str->len ) == 0 );
         }
     }
 
@@ -931,9 +931,9 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
     if( result == 0 )
     {
 
-        TEST_ASSERT( mbedtls_test_hexcmp( output, result_hex_str->x,
+        TEST_ASSERT( mbedtls_test_hexcmp( output, result_str->x,
                                           ctx2.len,
-                                          result_hex_str->len ) == 0 );
+                                          result_str->len ) == 0 );
     }
 
 exit:

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -52,7 +52,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA1_C */
-void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
+void mbedtls_sha1( data_t * src_str, data_t * hash )
 {
     unsigned char output[41];
 
@@ -61,8 +61,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha1_ret( src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      20, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 20, hash->len ) == 0 );
 }
 /* END_CASE */
 
@@ -123,7 +122,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
-void sha224( data_t * src_str, data_t * hex_hash_string )
+void sha224( data_t * src_str, data_t * hash )
 {
     unsigned char output[57];
 
@@ -132,13 +131,12 @@ void sha224( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      28, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 28, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA256_C */
-void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
+void mbedtls_sha256( data_t * src_str, data_t * hash )
 {
     unsigned char output[65];
 
@@ -147,8 +145,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      32, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 32, hash->len ) == 0 );
 }
 /* END_CASE */
 
@@ -209,7 +206,7 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA512_C */
-void sha384( data_t * src_str, data_t * hex_hash_string )
+void sha384( data_t * src_str, data_t * hash )
 {
     unsigned char output[97];
 
@@ -218,13 +215,12 @@ void sha384( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      48, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 48, hash->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SHA512_C */
-void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
+void mbedtls_sha512( data_t * src_str, data_t * hash )
 {
     unsigned char output[129];
 
@@ -233,8 +229,7 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
-                                      64, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 64, hash->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -61,7 +61,8 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha1_ret( src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      20, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -131,7 +132,8 @@ void sha224( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      28, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -145,7 +147,8 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      32, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -215,7 +218,8 @@ void sha384( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      48, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -229,7 +233,8 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x,
+                                      64, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -61,7 +61,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha1_ret( src_str->x, src_str->len, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 20, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -131,7 +131,7 @@ void sha224( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 28, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -145,7 +145,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 32, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -215,7 +215,7 @@ void sha384( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 48, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -229,7 +229,7 @@ void mbedtls_sha512( data_t * src_str, data_t * hex_hash_string )
 
     TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 0 ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_hash_string->x, 64, hex_hash_string->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -804,21 +804,21 @@ void x509_get_time( int tag, char * time_str, int ret, int year, int mon,
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_X509_RSASSA_PSS_SUPPORT */
-void x509_parse_rsassa_pss_params( data_t * hex_params, int params_tag,
+void x509_parse_rsassa_pss_params( data_t * params, int params_tag,
                                    int ref_msg_md, int ref_mgf_md,
                                    int ref_salt_len, int ref_ret )
 {
     int my_ret;
-    mbedtls_x509_buf params;
+    mbedtls_x509_buf buf;
     mbedtls_md_type_t my_msg_md, my_mgf_md;
     int my_salt_len;
 
-    params.p = hex_params->x;
-    params.len = hex_params->len;
-    params.tag = params_tag;
+    buf.p = params->x;
+    buf.len = params->len;
+    buf.tag = params_tag;
 
-    my_ret = mbedtls_x509_get_rsassa_pss_params( &params, &my_msg_md, &my_mgf_md,
-                                         &my_salt_len );
+    my_ret = mbedtls_x509_get_rsassa_pss_params( &buf, &my_msg_md, &my_mgf_md,
+                                                 &my_salt_len );
 
     TEST_ASSERT( my_ret == ref_ret );
 

--- a/tests/suites/test_suite_xtea.function
+++ b/tests/suites/test_suite_xtea.function
@@ -9,7 +9,7 @@
 
 /* BEGIN_CASE */
 void xtea_encrypt_ecb( data_t * key_str, data_t * src_str,
-                       data_t * hex_dst_string )
+                       data_t * dst )
 {
     unsigned char output[100];
     mbedtls_xtea_context ctx;
@@ -20,14 +20,12 @@ void xtea_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE */
-void xtea_decrypt_ecb( data_t * key_str, data_t * src_str,
-                       data_t * hex_dst_string )
+void xtea_decrypt_ecb( data_t * key_str, data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_xtea_context ctx;
@@ -38,14 +36,13 @@ void xtea_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x, 8, dst->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void xtea_encrypt_cbc( data_t * key_str, data_t * iv_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_xtea_context ctx;
@@ -57,15 +54,14 @@ void xtea_encrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                      src_str->len, dst->len ) == 0 );
 }
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_CIPHER_MODE_CBC */
 void xtea_decrypt_cbc( data_t * key_str, data_t * iv_str,
-                       data_t * src_str, data_t * hex_dst_string )
+                       data_t * src_str, data_t * dst )
 {
     unsigned char output[100];
     mbedtls_xtea_context ctx;
@@ -77,9 +73,8 @@ void xtea_decrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
-                                      src_str->len,
-                                      hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, dst->x,
+                                      src_str->len, dst->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_xtea.function
+++ b/tests/suites/test_suite_xtea.function
@@ -20,7 +20,8 @@ void xtea_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -37,7 +38,8 @@ void xtea_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      8, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -55,7 +57,9 @@ void xtea_encrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -73,7 +77,9 @@ void xtea_decrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x,
+                                      src_str->len,
+                                      hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_xtea.function
+++ b/tests/suites/test_suite_xtea.function
@@ -20,7 +20,7 @@ void xtea_encrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -37,7 +37,7 @@ void xtea_decrypt_ecb( data_t * key_str, data_t * src_str,
     mbedtls_xtea_setup( &ctx, key_str->x );
     TEST_ASSERT( mbedtls_xtea_crypt_ecb( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, 8, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -55,7 +55,7 @@ void xtea_encrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_ENCRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 
@@ -73,7 +73,7 @@ void xtea_decrypt_cbc( data_t * key_str, data_t * iv_str,
     TEST_ASSERT( mbedtls_xtea_crypt_cbc( &ctx, MBEDTLS_XTEA_DECRYPT, src_str->len, iv_str->x,
                                  src_str->x, output ) == 0 );
 
-    TEST_ASSERT( hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
+    TEST_ASSERT( mbedtls_test_hexcmp( output, hex_dst_string->x, src_str->len, hex_dst_string->len ) == 0 );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Partial backport of #3474

To ease the partial backport, I have also backported de70b16 and 2dbba99 (adding mbedtls_test_ prefix to hexcmp and associated reformatting).

The backport was almost straightforward. The conflict resolutions were essentially about removing code that is in development but not in 2.16.

## Status
READY