### PR TITLE
Use arc4random_buf instead of rand on NetBSD

### DIFF
--- a/ChangeLog.d/netbsd-rand-arc4random_buf.txt
+++ b/ChangeLog.d/netbsd-rand-arc4random_buf.txt
@@ -1,0 +1,3 @@
+Changes
+   * Use arc4random_buf on NetBSD instead of rand implementation with cyclical
+     lower bits. Fix contributed in #3540.

--- a/ChangeLog.d/netbsd-rand-arc4random_buf.txt
+++ b/ChangeLog.d/netbsd-rand-arc4random_buf.txt
@@ -1,3 +1,3 @@
-Changes
+Bugfix
    * Use arc4random_buf on NetBSD instead of rand implementation with cyclical
      lower bits. Fix contributed in #3540.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -53,7 +53,7 @@
 #include "mbedtls/md.h"
 #endif
 
-#if defined(MBEDTLS_PKCS1_V15) && !defined(__OpenBSD__)
+#if defined(MBEDTLS_PKCS1_V15) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #include <stdlib.h>
 #endif
 
@@ -2569,7 +2569,7 @@ void mbedtls_rsa_free( mbedtls_rsa_context *ctx )
 #if defined(MBEDTLS_PKCS1_V15)
 static int myrand( void *rng_state, unsigned char *output, size_t len )
 {
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
     size_t i;
 
     if( rng_state != NULL )
@@ -2582,7 +2582,7 @@ static int myrand( void *rng_state, unsigned char *output, size_t len )
         rng_state = NULL;
 
     arc4random_buf( output, len );
-#endif /* !OpenBSD */
+#endif /* !OpenBSD && !NetBSD */
 
     return( 0 );
 }

--- a/tests/src/random.c
+++ b/tests/src/random.c
@@ -32,7 +32,7 @@ int mbedtls_test_rnd_std_rand( void *rng_state,
                                unsigned char *output,
                                size_t len )
 {
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
     size_t i;
 
     if( rng_state != NULL )
@@ -45,7 +45,7 @@ int mbedtls_test_rnd_std_rand( void *rng_state,
         rng_state = NULL;
 
     arc4random_buf( output, len );
-#endif /* !OpenBSD */
+#endif /* !OpenBSD && !NetBSD */
 
     return( 0 );
 }


### PR DESCRIPTION
This older implementation of rand generates the same small set of random numbers (or rather their lower bits) over and over again. A number of tests do not complete because of this. There exists already a conditional for OpenBSD making use of arc4random_buf instead which is also included in the C standard Library of NetBSD.

Backports: #3559 #3560 