### PR TITLE
Make debug_func respect the MBEDTLS_DEBUG_C configuration macro

### DIFF
--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -103,8 +103,10 @@ struct mbedtls_pk_info_t
     void (*rs_free_func)( void *rs_ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
+#if defined(MBEDTLS_DEBUG_C)
     /** Interface with the debug module */
     void (*debug_func)( const void *ctx, mbedtls_pk_debug_item *items );
+#endif /* MBEDTLS_DEBUG_C */
 
 };
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)

--- a/library/pk.c
+++ b/library/pk.c
@@ -543,6 +543,7 @@ size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx )
     return( ctx->pk_info->get_bitlen( ctx->pk_ctx ) );
 }
 
+#if defined(MBEDTLS_DEBUG_C)
 /*
  * Export debug information
  */
@@ -558,6 +559,7 @@ int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *item
     ctx->pk_info->debug_func( ctx->pk_ctx, items );
     return( 0 );
 }
+#endif /* MBEDTLS_DEBUG_C */
 
 /*
  * Access the PK type name

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -1061,7 +1061,9 @@ const mbedtls_pk_info_t mbedtls_pk_opaque_info = {
     NULL, /* restart alloc - not relevant */
     NULL, /* restart free - not relevant */
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     NULL, /* debug - could be done later, or even left NULL */
+#endif
 };
 
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -210,7 +210,9 @@ const mbedtls_pk_info_t mbedtls_rsa_info = {
     NULL,
     NULL,
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     rsa_debug,
+#endif
 };
 #endif /* MBEDTLS_RSA_C */
 
@@ -437,7 +439,9 @@ const mbedtls_pk_info_t mbedtls_eckey_info = {
     eckey_rs_alloc,
     eckey_rs_free,
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     eckey_debug,
+#endif
 };
 
 /*
@@ -469,7 +473,9 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
     NULL,
     NULL,
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     eckey_debug,            /* Same underlying key structure */
+#endif
 };
 #endif /* MBEDTLS_ECP_C */
 
@@ -739,7 +745,9 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
     ecdsa_rs_alloc,
     ecdsa_rs_free,
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     eckey_debug,        /* Compatible key structures */
+#endif
 };
 #endif /* MBEDTLS_ECDSA_C */
 
@@ -867,7 +875,9 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
     NULL,
     NULL,
 #endif
+#if defined(MBEDTLS_DEBUG_C)
     NULL,
+#endif
 };
 
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */


### PR DESCRIPTION
## Description
I found that the `rsa_debug` function is compiled into the binary file even though the `MBEDTLS_DEBUG_C` macro definition is commented out, because the function pointer is stored in `mbedtls_rsa_info`.

I think `rsa_debug` seems to be meaningless when `MBEDTLS_DEBUG_C` is commented out.
`debug_func` should respect the `MBEDTLS_DEBUG_C` configuration macro.

## Status
READY

## Requires Backporting
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
