### PR TITLE
Ensure that only one definition of ASSERT is present

### DIFF
--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -516,6 +516,9 @@ static const size_t test_lengths[2] =
     375U
 };
 
+/* Make sure no other definition is already present. */
+#undef ASSERT
+
 #define ASSERT( cond, args )            \
     do                                  \
     {                                   \

--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -472,6 +472,9 @@ static const unsigned char test_mac[1][16] =
     }
 };
 
+/* Make sure no other definition is already present. */
+#undef ASSERT
+
 #define ASSERT( cond, args )            \
     do                                  \
     {                                   \

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -509,6 +509,9 @@ static const unsigned char test_mac[2][16] =
     }
 };
 
+/* Make sure no other definition is already present. */
+#undef ASSERT
+
 #define ASSERT( cond, args )            \
     do                                  \
     {                                   \

--- a/undef_assert_before_defining_it.txt
+++ b/undef_assert_before_defining_it.txt
@@ -1,0 +1,3 @@
+Changes
+   * Undefine the ASSERT macro before defining it locally, in case it is defined
+     in a platform header. Contributed by Abdelatif Guettouche in #3557.


### PR DESCRIPTION
## Description
If a previous definition of ASSERT has sneaked in through included files an "ASSERT redefined" warnings would show up.

## Status
**READY**

## Steps to test or reproduce
Build with MBEDTLS_SELF_TEST enabled.
