### PR TITLE
[Backport 2.16] NetBSD 9.0 build fixes

### DIFF
--- a/ChangeLog.d/fix-build-netbsd.txt
+++ b/ChangeLog.d/fix-build-netbsd.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix building library/net_sockets.c and the ssl_mail_client program on
+     NetBSD. NetBSD conditionals were added for the backport to avoid the risk
+     of breaking a platform. Original fix contributed by Nia Alarie in #3422.
+     Adapted for long-term support branch 2.16 in #3558.

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -51,6 +51,10 @@
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
 
+#if defined(__NetBSD__)
+#define _XOPEN_SOURCE 600 /* sockaddr_storage */
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
@@ -345,8 +349,9 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
 
     struct sockaddr_storage client_addr;
 
-#if defined(__socklen_t_defined) || defined(_SOCKLEN_T) ||  \
-    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t)
+#if defined(__socklen_t_defined) || defined(_SOCKLEN_T) || \
+    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t) || \
+    ( defined(__NetBSD__) && defined(socklen_t) )
     socklen_t n = (socklen_t) sizeof( client_addr );
     socklen_t type_len = (socklen_t) sizeof( type );
 #else

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -51,6 +51,10 @@
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
 
+#if defined(__NetBSD__)
+#define _XOPEN_SOURCE 600
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else


### PR DESCRIPTION
NetBSD conditionals have been added because it was decided in #3422 not to backport the fix.