### PR TITLE
[Backport 2.7] Use arc4random_buf instead of rand on NetBSD

### DIFF
--- a/ChangeLog.d/netbsd-rand-arc4random_buf.txt
+++ b/ChangeLog.d/netbsd-rand-arc4random_buf.txt
@@ -1,0 +1,3 @@
+Changes
+   * Use arc4random_buf on NetBSD instead of rand implementation with cyclical
+     lower bits. Fix contributed in #3540.

--- a/ChangeLog.d/netbsd-rand-arc4random_buf.txt
+++ b/ChangeLog.d/netbsd-rand-arc4random_buf.txt
@@ -1,3 +1,3 @@
-Changes
+Bugfix
    * Use arc4random_buf on NetBSD instead of rand implementation with cyclical
      lower bits. Fix contributed in #3540.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -82,7 +82,7 @@
 #include "mbedtls/md.h"
 #endif
 
-#if defined(MBEDTLS_PKCS1_V15) && !defined(__OpenBSD__)
+#if defined(MBEDTLS_PKCS1_V15) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #include <stdlib.h>
 #endif
 
@@ -2404,7 +2404,7 @@ void mbedtls_rsa_free( mbedtls_rsa_context *ctx )
 #if defined(MBEDTLS_PKCS1_V15)
 static int myrand( void *rng_state, unsigned char *output, size_t len )
 {
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
     size_t i;
 
     if( rng_state != NULL )
@@ -2417,7 +2417,7 @@ static int myrand( void *rng_state, unsigned char *output, size_t len )
         rng_state = NULL;
 
     arc4random_buf( output, len );
-#endif /* !OpenBSD */
+#endif /* !OpenBSD && !NetBSD */
 
     return( 0 );
 }

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -330,7 +330,7 @@ unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
  */
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len )
 {
-#if !defined(__OpenBSD__)
+#if !defined(__OpenBSD__) && !defined(__NetBSD__)
     size_t i;
 
     if( rng_state != NULL )
@@ -343,7 +343,7 @@ static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len )
         rng_state = NULL;
 
     arc4random_buf( output, len );
-#endif /* !OpenBSD */
+#endif /* !OpenBSD && !NetBSD */
 
     return( 0 );
 }


### PR DESCRIPTION
This is a backport of #3540.