### PR TITLE
Allow mbed library to ignore critical extensions

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2013,6 +2013,20 @@
 //#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
 
 /**
+ * \def MBEDTLS_X509_ALLOW_UNSUPPORTED_CRL_CRITICAL_EXTENSION
+ *
+ * If set, the X509 parser will not break-off when parsing an X509 CRL
+ * and encountering an unknown critical extension. Currently, all extensions
+ * are unknown, including issuingDistributionPoint, which must be critical
+ * and is commonly used.
+ *
+ * \warning Depending on your PKI use, enabling this can be a security risk!
+ *
+ * Uncomment to prevent an error.
+ */
+//#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRL_CRITICAL_EXTENSION
+
+/**
  * \def MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK
  *
  * If set, this enables the X.509 API `mbedtls_x509_crt_verify_with_ca_cb()`

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -158,10 +158,13 @@ static int x509_get_crl_ext( unsigned char **p,
             return( MBEDTLS_ERR_X509_INVALID_EXTENSIONS +
                     MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
 
+#if !defined MBEDTLS_X509_ALLOW_UNSUPPORTED_CRL_CRITICAL_EXTENSION
         /* Abort on (unsupported) critical extensions */
         if( is_critical )
             return( MBEDTLS_ERR_X509_INVALID_EXTENSIONS +
                     MBEDTLS_ERR_ASN1_UNEXPECTED_TAG );
+#endif
+
     }
 
     if( *p != end )


### PR DESCRIPTION
Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things

Signed-off-by:` David LeBlanc

## Description
Many cert authorities issue CRLs with the issuingDistributionPoint extension, which must be critical. Without this fix, this library cannot parse many commonly seen CRLs. This fixes this issue - https://github.com/ARMmbed/mbedtls/issues/2605


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
I would backport this, since it means that many consumers can't do revocation checking.

Which branch?
Don't know, up to maintainers.

## Migrations
This is opt-in, so no migration needed

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Set the new #define, and then parse a DigiCert CR, see that it works.
