### PR TITLE
[Backport 2.16] Improve ssl-opt.sh logs

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -1259,7 +1259,7 @@ run_client() {
             cp $CLI_OUT c-cli-${TESTS}.log
             echo "  ! outputs saved to c-srv-${TESTS}.log, c-cli-${TESTS}.log"
 
-            if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot -o "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
+            if [ "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
                 echo "  ! server output:"
                 cat c-srv-${TESTS}.log
                 echo "  ! ==================================================="

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -657,7 +657,7 @@ run_test() {
 
         # run the commands
         if [ -n "$PXY_CMD" ]; then
-            printf "# $NAME\n$PXY_CMD\n" > $PXY_OUT
+            printf "# %s\n%s\n" "$NAME" "$PXY_CMD" > $PXY_OUT
             $PXY_CMD >> $PXY_OUT 2>&1 &
             PXY_PID=$!
             wait_proxy_start "$PXY_PORT" "$PXY_PID"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -626,7 +626,7 @@ run_test() {
 
     # if the test uses DTLS but no custom proxy, add a simple proxy
     # as it provides timing info that's useful to debug failures
-    if [ "X$PXY_CMD" = "X" -a "$DTLS" -eq 1 ]; then
+    if [ -z "$PXY_CMD" ] && [ "$DTLS" -eq 1 ]; then
         PXY_CMD="$P_PXY"
     fi
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -631,6 +631,12 @@ run_test() {
     # update DTLS variable
     detect_dtls "$SRV_CMD"
 
+    # if the test uses DTLS but no custom proxy, add a simple proxy
+    # as it provides timing info that's useful to debug failures
+    if [ "X$PXY_CMD" = "X" -a "$DTLS" -eq 1 ]; then
+        PXY_CMD="$P_PXY"
+    fi
+
     # prepend valgrind to our commands if active
     if [ "$MEMCHECK" -gt 0 ]; then
         if is_polar "$SRV_CMD"; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -628,6 +628,10 @@ run_test() {
     # as it provides timing info that's useful to debug failures
     if [ -z "$PXY_CMD" ] && [ "$DTLS" -eq 1 ]; then
         PXY_CMD="$P_PXY"
+        case " $SRV_CMD " in
+            *' server_addr=::1 '*)
+                PXY_CMD="$PXY_CMD server_addr=::1 listen_addr=::1";;
+        esac
     fi
 
     # fix client port

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -405,7 +405,7 @@ fail() {
     fi
     echo "  ! outputs saved to o-XXX-${TESTS}.log"
 
-    if [ "X${USER:-}" = Xbuildbot -o "X${LOGNAME:-}" = Xbuildbot -o "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
+    if [ "${LOG_FAILURE_ON_STDOUT:-0}" != 0 ]; then
         echo "  ! server output:"
         cat o-srv-${TESTS}.log
         echo "  ! ========================================================"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -653,19 +653,19 @@ run_test() {
 
         # run the commands
         if [ -n "$PXY_CMD" ]; then
-            echo "$PXY_CMD" > $PXY_OUT
+            printf "# $NAME\n$PXY_CMD\n" > $PXY_OUT
             $PXY_CMD >> $PXY_OUT 2>&1 &
             PXY_PID=$!
             wait_proxy_start "$PXY_PORT" "$PXY_PID"
         fi
 
         check_osrv_dtls
-        echo "$SRV_CMD" > $SRV_OUT
+        printf "# $NAME\n$SRV_CMD\n" > $SRV_OUT
         provide_input | $SRV_CMD >> $SRV_OUT 2>&1 &
         SRV_PID=$!
         wait_server_start "$SRV_PORT" "$SRV_PID"
 
-        echo "$CLI_CMD" > $CLI_OUT
+        printf "# $NAME\n$CLI_CMD\n" > $CLI_OUT
         eval "$CLI_CMD" >> $CLI_OUT 2>&1 &
         wait_client_done
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -621,13 +621,6 @@ run_test() {
         return
     fi
 
-    # fix client port
-    if [ -n "$PXY_CMD" ]; then
-        CLI_CMD=$( echo "$CLI_CMD" | sed s/+SRV_PORT/$PXY_PORT/g )
-    else
-        CLI_CMD=$( echo "$CLI_CMD" | sed s/+SRV_PORT/$SRV_PORT/g )
-    fi
-
     # update DTLS variable
     detect_dtls "$SRV_CMD"
 
@@ -635,6 +628,13 @@ run_test() {
     # as it provides timing info that's useful to debug failures
     if [ "X$PXY_CMD" = "X" -a "$DTLS" -eq 1 ]; then
         PXY_CMD="$P_PXY"
+    fi
+
+    # fix client port
+    if [ -n "$PXY_CMD" ]; then
+        CLI_CMD=$( echo "$CLI_CMD" | sed s/+SRV_PORT/$PXY_PORT/g )
+    else
+        CLI_CMD=$( echo "$CLI_CMD" | sed s/+SRV_PORT/$SRV_PORT/g )
     fi
 
     # prepend valgrind to our commands if active


### PR DESCRIPTION
This is the 2.16 backport of #3404 - all straightforward.

## Testing

```
tests/ssl-opt.sh -p -f 'Default'
ls tests/o-*.log
```
Check that there's a proxy log for the DTLS case but not for the TLS case.

```
tests/ssl-opt.sh -p -f "client reconnect"
head -n2 tests/o-pxy-*.log
```
Check that the proxy was added in all cases with the expected arguments, and that in the last test case (attacker-injected) the proxy command has the expected additional arguments.
