### PR TITLE
Fix type conversion bug in `ssl_context_info` example program.

### DIFF
--- a/ChangeLog.d/fgetc_integer_conversion.txt
+++ b/ChangeLog.d/fgetc_integer_conversion.txt
@@ -1,0 +1,3 @@
+Bugfix
+    * Fix type conversion bug in ssl_context_info example program
+      which lead to compiler warnings on some platforms.

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -379,13 +379,14 @@ size_t read_next_b64_code( uint8_t **b64, size_t *max_len )
     int valid_balance = 0;  /* balance between valid and invalid characters */
     size_t len = 0;
     char pad = 0;
-    char c = 0;
+    int cur_char;
 
-    while( EOF != c )
+    while( ( cur_char = fgetc( b64_file ) ) != EOF )
     {
-        char c_valid = 0;
+        char c;
+        int c_valid = 0;
 
-        c = (char) fgetc( b64_file );
+        c = (char) cur_char;
 
         if( pad > 0 )
         {


### PR DESCRIPTION
Previously, some code in `programs/ssl/ssl_context_info.c` converted the return value from `fgetc()` to `char` immediately, and then compared it to `EOF`. This doesn't work since `EOF` is a special value outside of the range of `char` (when embedded in `int`).

The PR fixes the code to store the result of `fgetc()` as an `int`, compare to `EOF`, and only on mismatch convert it to `char` for further processing.

## Status
**READY**

## Requires Backporting
NO  

