### PR TITLE
NetBSD/OpenBSD symbol availability fix

### DIFF
--- a/ChangeLog.d/arc4random_buf-implicit.txt
+++ b/ChangeLog.d/arc4random_buf-implicit.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Make arc4random_buf available on NetBSD and OpenBSD when _POSIX_C_SOURCE is
+     defined. Fix contributed in #3571.

--- a/tests/src/random.c
+++ b/tests/src/random.c
@@ -24,6 +24,15 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+/*
+ * for arc4random_buf() from <stdlib.h>
+ */
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
+#elif defined(__OpenBSD__)
+#define _BSD_SOURCE 1
+#endif
+
 #include <test/macros.h>
 #include <test/random.h>
 #include <string.h>


### PR DESCRIPTION
Defining _POSIX_C_SOURCE removes arc4random_buf from the namespace on NetBSD. This issue does not exist with the CMake build because unlike ./tests/Makefile ./CMakeLists.txt compiles tests/src/random.c without the -D_POSIX_C_SOURCE=200809L option.

Edit: added OpenBSD counterpart (see [stdlib.h#L316-L319](https://github.com/openbsd/src/blob/master/include/stdlib.h#L316-L319) and [cdefs.h#L392-L395](https://github.com/openbsd/src/blob/master/sys/sys/cdefs.h#L392-L395))