### PR TITLE
Add arm-linux-gnueabi-gcc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
           - gcc-arm-none-eabi
           - libnewlib-arm-none-eabi
           - gcc-arm-linux-gnueabi
+          - libc6-dev-armel-cross
       language: python # Needed to get pip for Python 3
       python: 3.5 # version from Ubuntu 16.04
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jobs:
           - graphviz
           - gcc-arm-none-eabi
           - libnewlib-arm-none-eabi
+          - gcc-arm-linux-gnueabi
       language: python # Needed to get pip for Python 3
       python: 3.5 # version from Ubuntu 16.04
       install:
@@ -22,7 +23,7 @@ jobs:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
         - tests/scripts/all.sh -k test_ref_configs
-        - tests/scripts/all.sh -k build_arm_none_eabi_gcc_arm5vte build_arm_none_eabi_gcc_m0plus
+        - tests/scripts/all.sh -k build_arm_linux_gnueabi_gcc_arm5vte build_arm_none_eabi_gcc_m0plus
 
     - name: full configuration
       script:

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2396,7 +2396,7 @@ component_build_arm_none_eabi_gcc_arm5vte () {
     scripts/config.py baremetal
     # This is an imperfect substitute for
     # component_build_arm_linux_gnueabi_gcc_arm5vte
-    # in case the gcc-arm-linux-gnueabihf toolchain is not available
+    # in case the gcc-arm-linux-gnueabi toolchain is not available
     make CC="${ARM_NONE_EABI_GCC_PREFIX}gcc" AR="${ARM_NONE_EABI_GCC_PREFIX}ar" CFLAGS='-std=c99 -Werror -Wall -Wextra -march=armv5te -O1' LDFLAGS='-march=armv5te' SHELL='sh -x' lib
 
     msg "size: ${ARM_NONE_EABI_GCC_PREFIX}gcc -march=armv5te -O1"


### PR DESCRIPTION
## Description

Add a build with arm-linux-gnueabi-gcc - compared to existing Arm builds, this allows building the programs and tests, in order to catch platform-dependent issues there too (previously we only cross-built the library to Arm).

See https://github.com/ARMmbed/mbedtls/pull/3449#issuecomment-675313720

See also. https://github.com/ARMmbed/mbedtls/issues/3299


## Status
**READY**

## Requires Backporting
Yes - testing improvement 

- [x] 2.16 #4855
- [x] 2.2x #4856

## Additional comments

* [x] The newly added test on Travis is expected to fail until #3449 is merged.
* [x] This PR depends on https://github.com/ARMmbed/mbedtls-test/pull/190 or https://github.com/ARMmbed/mbedtls-test/pull/191 getting merged and the new Docker image deployed.