### PR TITLE
Fix memory leak in mbedtls_md_setup with HMAC

### DIFF
--- a/ChangeLog.d/md_setup-leak.txt
+++ b/ChangeLog.d/md_setup-leak.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a memory leak in mbedtls_md_setup() when using HMAC under low memory
+     conditions. Reported and fix suggested by Guido Vranken in #3486.

--- a/library/md.c
+++ b/library/md.c
@@ -413,6 +413,10 @@ int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_inf
     if( md_info == NULL || ctx == NULL )
         return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
 
+    ctx->md_info = md_info;
+    ctx->md_ctx = NULL;
+    ctx->hmac_ctx = NULL;
+
     switch( md_info->type )
     {
 #if defined(MBEDTLS_MD2_C)
@@ -467,8 +471,6 @@ int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_inf
             return( MBEDTLS_ERR_MD_ALLOC_FAILED );
         }
     }
-
-    ctx->md_info = md_info;
 
     return( 0 );
 }


### PR DESCRIPTION
Fix #3486.

There is no non-regression test because we don't have the infrastructure to test low memory conditions. You can check manually by building the library and the test program that Guido posted in #3486.
```
scripts/config.py set MBEDTLS_PLATFORM_MEMORY
make CLFAGS='-fsanitize=address,undefined -fno-sanitize-recover=all -fno-common -g3' lib
cc -fsanitize=address,undefined -fno-sanitize-recover=all -fno-common -g3 a.c
./a.out
```

Before: Asan detects a memory leak. After: Asan is happy.

Things I reviewed for similar issues:

* The md module doesn't call malloc anywhere else.
* cipher contexts have two parts: an encryption context and an optional CMAC context. They do setup differently, and if the second allocation fails, the context is in a correct state for `mbedtls_cipher_free()` to free the first allocation.
* pk contexts only have a single part so this particular.

Reviewing the whole library for leaks in low-memory conditions is out of scope. Adding a framework to test for memory leaks in low-memory conditions is out of scope.

~Needs backports.~
