### PR TITLE
Fix the build with MBEDTLS_USE_PSA_CRYPTO without ECDSA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ jobs:
       script:
         - tests/scripts/all.sh -k test_full_cmake_gcc_asan
 
-    - name: check compilation guards
-      script:
-        - tests/scripts/all.sh -k 'test_depends_*' 'build_key_exchanges'
-
     - name: macOS
       os: osx
       compiler: clang

--- a/ChangeLog.d/bugfix_PR3294.txt
+++ b/ChangeLog.d/bugfix_PR3294.txt
@@ -1,8 +1,4 @@
 Bugfix
-   * Add guards in pk_wrap.c to ensure if ECDSA is not defined, errors are
-     returned. Remove warnings in pk.c for unused variables. Add new test
-     (test_depends_pkalgs_psa) to all.sh to confirm when USE_PSA_CRYPTO 
-     is defined that features are working properly. Fixes issue reported in
-     #3294 where undefined reference errors occur when using USE_PSA_CRYPTO
-     and removing ECDSA support.
+   * Fix build failure in configurations where MBEDTLS_USE_PSA_CRYPTO is
+     enabled but ECDSA is disabled. Contributed by jdurkop. Fixes #3294.
 

--- a/ChangeLog.d/bugfix_PR3294.txt
+++ b/ChangeLog.d/bugfix_PR3294.txt
@@ -1,0 +1,8 @@
+Bugfix
+   * Add guards in pk_wrap.c to ensure if ECDSA is not defined, errors are
+     returned. Remove warnings in pk.c for unused variables. Add new test
+     (test_depends_pkalgs_psa) to all.sh to confirm when USE_PSA_CRYPTO 
+     is defined that features are working properly. Fixes issue reported in
+     #3294 where undefined reference errors occur when using USE_PSA_CRYPTO
+     and removing ECDSA support.
+

--- a/library/pk.c
+++ b/library/pk.c
@@ -593,6 +593,9 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
                                psa_algorithm_t hash_alg )
 {
 #if !defined(MBEDTLS_ECP_C)
+    ((void) pk);
+    ((void) handle);
+    ((void) hash_alg);
     return( MBEDTLS_ERR_PK_TYPE_MISMATCH );
 #else
     const mbedtls_ecp_keypair *ec;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -553,11 +553,12 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     unsigned char buf[30 + 2 * MBEDTLS_ECP_MAX_BYTES];
     unsigned char *p;
     mbedtls_pk_info_t pk_info = mbedtls_eckey_info;
-    psa_algorithm_t psa_sig_md, psa_md;
+    psa_algorithm_t psa_sig_md = PSA_ALG_ECDSA_ANY;
     size_t curve_bits;
     psa_ecc_family_t curve =
         mbedtls_ecc_group_to_psa( ctx->grp.id, &curve_bits );
     const size_t signature_part_size = ( ctx->grp.nbits + 7 ) / 8;
+    ((void) md_alg);
 
     if( curve == 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
@@ -570,11 +571,6 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     key_len = mbedtls_pk_write_pubkey( &p, buf, &key );
     if( key_len <= 0 )
         return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-
-    psa_md = mbedtls_psa_translate_md( md_alg );
-    if( psa_md == 0 )
-        return( MBEDTLS_ERR_PK_BAD_INPUT_DATA );
-    psa_sig_md = PSA_ALG_ECDSA( psa_md );
 
     psa_set_key_type( &attributes, PSA_KEY_TYPE_ECC_PUBLIC_KEY( curve ) );
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_VERIFY_HASH );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -34,7 +34,7 @@
 #include "mbedtls/ecp.h"
 #endif
 
-#if defined(MBEDTLS_ECDSA_C) || defined(MBEDTLS_USE_PSA_CRYPTO)
+#if defined(MBEDTLS_ECDSA_C)
 #include "mbedtls/ecdsa.h"
 #endif
 
@@ -1012,8 +1012,8 @@ static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
     ((void) sig_len);
     ((void) f_rng);
     ((void) p_rng);
-    return( PSA_ERROR_NOT_SUPPORTED );
-#else
+    return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
+#else /* !MBEDTLS_ECDSA_C */
     const psa_key_handle_t *key = (const psa_key_handle_t *) ctx;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg = PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
@@ -1044,7 +1044,7 @@ static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     /* transcode it to ASN.1 sequence */
     return( pk_ecdsa_sig_asn1_from_psa( sig, sig_len, buf_len ) );
-#endif
+#endif /* !MBEDTLS_ECDSA_C */
 }
 
 const mbedtls_pk_info_t mbedtls_pk_opaque_info = {

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -996,7 +996,7 @@ static int pk_ecdsa_sig_asn1_from_psa( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
-#endif
+#endif /* MBEDTLS_ECDSA_C */
 
 static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -34,7 +34,7 @@
 #include "mbedtls/ecp.h"
 #endif
 
-#if defined(MBEDTLS_ECDSA_C)
+#if defined(MBEDTLS_ECDSA_C) || defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/ecdsa.h"
 #endif
 
@@ -912,6 +912,8 @@ static int pk_opaque_can_do( mbedtls_pk_type_t type )
             type == MBEDTLS_PK_ECDSA );
 }
 
+#if defined(MBEDTLS_ECDSA_C)
+
 /*
  * Simultaneously convert and move raw MPI from the beginning of a buffer
  * to an ASN.1 MPI at the end of the buffer.
@@ -994,11 +996,24 @@ static int pk_ecdsa_sig_asn1_from_psa( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
+#endif
+
 static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    unsigned char *sig, size_t *sig_len,
                    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
 {
+#if !defined(MBEDTLS_ECDSA_C)
+    ((void) ctx);
+    ((void) md_alg);
+    ((void) hash);
+    ((void) hash_len);
+    ((void) sig);
+    ((void) sig_len);
+    ((void) f_rng);
+    ((void) p_rng);
+    return( PSA_ERROR_NOT_SUPPORTED );
+#else
     const psa_key_handle_t *key = (const psa_key_handle_t *) ctx;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_algorithm_t alg = PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
@@ -1029,6 +1044,7 @@ static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 
     /* transcode it to ASN.1 sequence */
     return( pk_ecdsa_sig_asn1_from_psa( sig, sig_len, buf_len ) );
+#endif
 }
 
 const mbedtls_pk_info_t mbedtls_pk_opaque_info = {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1179,6 +1179,12 @@ component_test_depends_curves () {
     record_status tests/scripts/curves.pl
 }
 
+component_test_depends_curves_psa () {
+    msg "test/build: curves.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    record_status tests/scripts/curves.pl
+}
+
 component_test_depends_hashes () {
     msg "test/build: depends-hashes.pl (gcc)" # ~ 2 min
     record_status tests/scripts/depends-hashes.pl

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1184,6 +1184,12 @@ component_test_depends_hashes () {
     record_status tests/scripts/depends-hashes.pl
 }
 
+component_test_depends_pkalgs_psa () {
+    msg "test/build: depends-pkalgs.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    record_status tests/scripts/depends-pkalgs.pl
+}
+
 component_test_depends_pkalgs () {
     msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
     record_status tests/scripts/depends-pkalgs.pl

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1196,14 +1196,14 @@ component_test_depends_hashes_psa () {
     record_status tests/scripts/depends-hashes.pl
 }
 
-component_test_depends_pkalgs_psa () {
-    msg "test/build: depends-pkalgs.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
-    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+component_test_depends_pkalgs () {
+    msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
     record_status tests/scripts/depends-pkalgs.pl
 }
 
-component_test_depends_pkalgs () {
-    msg "test/build: depends-pkalgs.pl (gcc)" # ~ 2 min
+component_test_depends_pkalgs_psa () {
+    msg "test/build: depends-pkalgs.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
     record_status tests/scripts/depends-pkalgs.pl
 }
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1190,6 +1190,12 @@ component_test_depends_hashes () {
     record_status tests/scripts/depends-hashes.pl
 }
 
+component_test_depends_hashes_psa () {
+    msg "test/build: depends-hashes.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
+    scripts/config.py set MBEDTLS_USE_PSA_CRYPTO
+    record_status tests/scripts/depends-hashes.pl
+}
+
 component_test_depends_pkalgs_psa () {
     msg "test/build: depends-pkalgs.pl with MBEDTLS_USE_PSA_CRYPTO defined (gcc)"
     scripts/config.py set MBEDTLS_USE_PSA_CRYPTO

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -775,8 +775,8 @@ void pk_ec_test_vec( int type, int id, data_t * key, data_t * hash,
     TEST_ASSERT( mbedtls_ecp_point_read_binary( &eckey->grp, &eckey->Q,
                                         key->x, key->len ) == 0 );
 
-    // MBEDTLS_MD_SHA1 is a dummy - it is ignored, but has to be other than MBEDTLS_MD_NONE.
-    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_SHA1,
+    // MBEDTLS_MD_NONE is used since it will be ignored.
+    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_NONE,
                             hash->x, hash->len, sig->x, sig->len ) == ret );
 
 exit:


### PR DESCRIPTION
## Description
This commit is fixing an issue when an undefined reference occurs when using MBEDTLS_USE_PSA_CRYPTO and removing ECDSA support. New guards added to pk_wrap.c and updates to fix unused function parameter warnings in pk_wrap.c and pk.c. Also created two new tests in all.sh to verify basic features are working when MBEDTLS_USE_PSA_CRYPTO is enabled.

Fixes #3294 

## Status
READY

## Requires Backporting
NO

## Migrations
NO

## Steps to test or reproduce
Reproduce:
Enable MBEDTLS_USE_PSA_CRYPTO and remove ECDSA_C and build setup. It will show the undefined reference warning without these changes. 

Test:
After these changes are applied the build will work properly. 
Added new tests to all.sh to easily confirm basics with USE_PSA_CRYPTO are working properly: test_depends_pkalgs_psa and test_depends_curves_psa