### PR TITLE
Prevent triggering Clang 12 -Wstring-concatenation warning

### DIFF
--- a/library/md2.c
+++ b/library/md2.c
@@ -287,8 +287,7 @@ static const unsigned char md2_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md2_test_strlen[7] =

--- a/library/md2.c
+++ b/library/md2.c
@@ -287,8 +287,8 @@ static const unsigned char md2_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md2_test_strlen[7] =

--- a/library/md4.c
+++ b/library/md4.c
@@ -408,8 +408,8 @@ static const unsigned char md4_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md4_test_strlen[7] =

--- a/library/md4.c
+++ b/library/md4.c
@@ -408,8 +408,7 @@ static const unsigned char md4_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md4_test_strlen[7] =

--- a/library/md5.c
+++ b/library/md5.c
@@ -422,8 +422,8 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md5_test_buflen[7] =

--- a/library/md5.c
+++ b/library/md5.c
@@ -422,8 +422,7 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md5_test_buflen[7] =

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -478,8 +478,7 @@ static const unsigned char ripemd160_test_str[TESTS][81] =
     { "abcdefghijklmnopqrstuvwxyz" },
     { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") },
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" },
 };
 
 static const size_t ripemd160_test_strlen[TESTS] =

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -478,8 +478,8 @@ static const unsigned char ripemd160_test_str[TESTS][81] =
     { "abcdefghijklmnopqrstuvwxyz" },
     { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" },
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") },
 };
 
 static const size_t ripemd160_test_strlen[TESTS] =

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -516,8 +516,8 @@ void mbedtls_sha512( const unsigned char *input,
 static const unsigned char sha512_test_buf[3][113] =
 {
     { "abc" },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
+    { ("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") },
     { "" }
 };
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -516,8 +516,7 @@ void mbedtls_sha512( const unsigned char *input,
 static const unsigned char sha512_test_buf[3][113] =
 {
     { "abc" },
-    { ("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
     { "" }
 };
 


### PR DESCRIPTION
## Description

Wrap multi-line string literals in parentheses
to prevent a Clang 12 -Wstring-concatenation warning
(activated by -Wall), which caused the build to fail.

Fixes https://github.com/ARMmbed/mbedtls/issues/3586

Signed-off-by: Guido Vranken <guidovranken@gmail.com>

## Status
READY

## Requires Backporting
Yes

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Compile mbed TLS under the OSS-Fuzz Docker image, which can be launched using:

```
docker run -t -i --rm gcr.io/oss-fuzz-base/base-builder:latest bash
```
