### PR TITLE
Fix compat.sh with ubuntu 16.04 gnutls

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -967,11 +967,6 @@ setup_arguments()
             else
                 M_CLIENT_ARGS="$M_CLIENT_ARGS crt_file=none key_file=none"
             fi
-
-            # Allow SHA-1. It's disabled by default for security reasons but
-            # our tests still use certificates signed with it.
-            M_SERVER_ARGS="$M_SERVER_ARGS allow_sha1=1"
-            M_CLIENT_ARGS="$M_CLIENT_ARGS allow_sha1=1"
             ;;
 
         "PSK")
@@ -984,11 +979,6 @@ setup_arguments()
             M_CLIENT_ARGS="$M_CLIENT_ARGS psk=6162636465666768696a6b6c6d6e6f70 crt_file=none key_file=none"
             O_CLIENT_ARGS="$O_CLIENT_ARGS -psk 6162636465666768696a6b6c6d6e6f70"
             G_CLIENT_ARGS="$G_CLIENT_ARGS --pskusername Client_identity --pskkey=6162636465666768696a6b6c6d6e6f70"
-
-            # Allow SHA-1. It's disabled by default for security reasons but
-            # our tests still use certificates signed with it.
-            M_SERVER_ARGS="$M_SERVER_ARGS allow_sha1=1"
-            M_CLIENT_ARGS="$M_CLIENT_ARGS allow_sha1=1"
             ;;
     esac
 }


### PR DESCRIPTION
## Description

Recent(ish) Ubuntu 16.04 packages for GnuTLS 3.4.10 (the basic (as opposed to legacy) version used by `compat.sh` and `ssl-opt.sh`) have two patches backported from recent GnuTLS versions (not present in upstream 3.4.10) that affect `compat.sh`:

- disable CBC-SHA256 and CBC-SHA384 by default
- stop accepting SHA-1 signatures in certificate chains

This cause failures of `compat.sh` on Travis (which uses the Ubuntu packages), while it passes on Jenkins (which compiles 3.4.10 from upstream sources).

This PR makes `compat.sh` work again the version of GnuTLS packaged in Ubuntu 16.04, fixing the Travis job.

Fixes #3520

See also #3018 that did the same for `ssl-opt.sh` but forgot `compat.sh`.

## Status
**READY**

## Requires Backporting
Yes - tests!  

- [x] 2.16 - #3593  
- [ ] 2.7
