### PR TITLE
adjusting size of sliding window array to correct size.

### DIFF
--- a/ChangeLog.d/adjusting sliding_window_size_PR3592.txt
+++ b/ChangeLog.d/adjusting sliding_window_size_PR3592.txt
@@ -1,0 +1,3 @@
+Changes
+   * Reduce stack usage significantly during sliding window exponentiation.
+     Reported in #3591 and fix contributed in #3592 by Daniel Otte.

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -61,7 +61,7 @@
  * Maximum window size used for modular exponentiation. Default: 6
  * Minimum value: 1. Maximum value: 6.
  *
- * Result is an array of ( 2 << MBEDTLS_MPI_WINDOW_SIZE ) MPIs used
+ * Result is an array of ( 2 ** MBEDTLS_MPI_WINDOW_SIZE ) MPIs used
  * for the sliding window calculation. (So 64 by default)
  *
  * Reduction in size, reduces speed.

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -66,7 +66,7 @@
  *
  * Reduction in size, reduces speed.
  */
-#define MBEDTLS_MPI_WINDOW_SIZE                           6        /**< Maximum windows size used. */
+#define MBEDTLS_MPI_WINDOW_SIZE                           6        /**< Maximum window size used. */
 #endif /* !MBEDTLS_MPI_WINDOW_SIZE */
 
 #if !defined(MBEDTLS_MPI_MAX_SIZE)

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3414,7 +3414,7 @@
  */
 
 /* MPI / BIGNUM options */
-//#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum windows size used. */
+//#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum window size used. */
 //#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
 
 /* CTR_DRBG options */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2101,7 +2101,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     size_t i, j, nblimbs;
     size_t bufsize, nbits;
     mbedtls_mpi_uint ei, mm, state;
-    mbedtls_mpi RR, T, W[ 2 << MBEDTLS_MPI_WINDOW_SIZE ], Apos;
+    mbedtls_mpi RR, T, W[ 1 << MBEDTLS_MPI_WINDOW_SIZE ], Apos;
     int neg;
 
     MPI_VALIDATE_RET( X != NULL );


### PR DESCRIPTION
Probably the `W[2 << MBEDTLS_MPI_WINDOW_SIZE]` notation is based on a transcription of 2**MBEDTLS_MPI_WINDOW_SIZE.

This PR fixes #3591 [edited by mpg to use github keyword]

## Status
**READY**

## Requires Backporting
This change is easy to backport, but is not strictly required.

I would recommend to backport it to all LTS branches.

## Migrations
No API changes

## Additional comments
This change would improve stack usage significantly.

## Todos
- [x] Changelog updated
- [x] Backported

