### PR TITLE
Backport 2.7: Support building on e2k (Elbrus) architecture

### DIFF
--- a/ChangeLog.d/e2k-support.txt
+++ b/ChangeLog.d/e2k-support.txt
@@ -1,0 +1,5 @@
+Features
+   * Support building on e2k (Elbrus) architecture: correctly enable
+     -Wformat-signedness, and fix the code that causes signed-one-bit-field
+     and sign-compare warnings. Contributed by makise-homura (Igor Molchanov)
+     <akemi_homura@kurisa.ch>.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2581,7 +2581,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
+            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && (size_t)ret > SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1,
                     ( "f_recv returned %d bytes but only %lu were requested",
@@ -2636,7 +2636,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
-        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > SIZE_MAX ) )
+        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && (size_t)ret > SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1,
                 ( "f_send returned %d bytes but only %lu bytes were sent",

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2581,7 +2581,7 @@ int mbedtls_ssl_fetch_input( mbedtls_ssl_context *ssl, size_t nb_want )
             if( ret < 0 )
                 return( ret );
 
-            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && (size_t)ret > SIZE_MAX ) )
+            if ( (size_t)ret > len || ( INT_MAX > SIZE_MAX && ret > (int)SIZE_MAX ) )
             {
                 MBEDTLS_SSL_DEBUG_MSG( 1,
                     ( "f_recv returned %d bytes but only %lu were requested",
@@ -2636,7 +2636,7 @@ int mbedtls_ssl_flush_output( mbedtls_ssl_context *ssl )
         if( ret <= 0 )
             return( ret );
 
-        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && (size_t)ret > SIZE_MAX ) )
+        if( (size_t)ret > ssl->out_left || ( INT_MAX > SIZE_MAX && ret > (int)SIZE_MAX ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1,
                 ( "f_send returned %d bytes but only %lu bytes were sent",

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -117,7 +117,7 @@ int main( int argc, char **argv )
     {
     usage:
         mbedtls_printf( USAGE );
-        mbedtls_exit( exit_code );
+        goto exit;
     }
 
     for( i = 1; i < argc; i++ )

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -87,7 +87,7 @@ typedef UINT32 uint32_t;
 /* A compile-time constant with the value 0. If `const_expr` is not a
  * compile-time constant with a nonzero value, cause a compile-time error. */
 #define STATIC_ASSERT_EXPR( const_expr )                                \
-    ( 0 && sizeof( struct { int STATIC_ASSERT : 1 - 2 * ! ( const_expr ); } ) )
+    ( 0 && sizeof( struct { unsigned int STATIC_ASSERT : 1 - 2 * ! ( const_expr ); } ) )
 /* Return the scalar value `value` (possibly promoted). This is a compile-time
  * constant if `value` is. `condition` must be a compile-time constant.
  * If `condition` is false, arrange to cause a compile-time error. */


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3574

Signed-off-by: makise-homura <akemi_homura@kurisa.ch>

## Description
This pull request introduces support for building mbedtls 2.7 on Elbrus hardware platform (which is based on Russian [Elbrus](https://en.wikipedia.org/wiki/Elbrus-8S) CPU family) with its native lcc (eLbrus Compiler Collection) compiler.

## Status
**READY**

## Requires Backporting
This is actually a backport.

## Migrations
NO

## Additional comments
This PR fixes the issues causing `-Wsigned-one-bit-field` and `-Wsign-compare` warnings, and probably incorrect execution flow of `dh_genprime`.

Suggested in PR #3574 discussion.

## Todos
- [x] Changelog updated

## Steps to test or reproduce
To reproduce, you should have an Elbrus workstation with OS Elbrus >= 5.0-rc2 and CPU which is Elbrus-8C (Elbrus-8S) or newer (you may ask contributor for SSH access to demo station).
Building with `mkdir build; cd build; cmake .. && make -j16` should succeed and produce no warnings.