### PR TITLE
[Backport 2.16] NetBSD/OpenBSD symbol availability fix

### DIFF
--- a/ChangeLog.d/arc4random_buf-implicit.txt
+++ b/ChangeLog.d/arc4random_buf-implicit.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Make arc4random_buf available on NetBSD and OpenBSD when _POSIX_C_SOURCE is
+     defined. Fix contributed in #3571. Adopted for LTS branch 2.16 in #3602.

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -25,6 +25,15 @@
 #endif
 #endif
 
+/*
+ * for arc4random_buf() from <stdlib.h>
+ */
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
+#elif defined(__OpenBSD__)
+#define _BSD_SOURCE 1
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include <mbedtls/config.h>
 #else


### PR DESCRIPTION
This is a backport of #3571.

Edit: added OpenBSD counterpart (see [stdlib.h#L316-L319](https://github.com/openbsd/src/blob/master/include/stdlib.h#L316-L319) and [cdefs.h#L392-L395](https://github.com/openbsd/src/blob/master/sys/sys/cdefs.h#L392-L395))