### PR TITLE
Fix premature fopen() call in mbedtls_entropy_write_seed_file #3175

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -466,28 +466,27 @@ int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx )
 #if defined(MBEDTLS_FS_IO)
 int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *path )
 {
-    int ret = MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR;
-    FILE *f;
+    int ret;
+    FILE *f = NULL;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE];
-
-    if( ( f = fopen( path, "wb" ) ) == NULL )
-        return( MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR );
 
     if( ( ret = mbedtls_entropy_func( ctx, buf, MBEDTLS_ENTROPY_BLOCK_SIZE ) ) != 0 )
         goto exit;
 
-    if( fwrite( buf, 1, MBEDTLS_ENTROPY_BLOCK_SIZE, f ) != MBEDTLS_ENTROPY_BLOCK_SIZE )
+    ret = MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR;
+    if( ( f = fopen( path, "wb" ) ) != NULL )
     {
-        ret = MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR;
-        goto exit;
+        if( fwrite( buf, 1, MBEDTLS_ENTROPY_BLOCK_SIZE, f ) != MBEDTLS_ENTROPY_BLOCK_SIZE )
+            goto exit;
+        ret = 0;
     }
-
-    ret = 0;
 
 exit:
     mbedtls_platform_zeroize( buf, sizeof( buf ) );
 
-    fclose( f );
+    if( f )
+        fclose( f );
+
     return( ret );
 }
 


### PR DESCRIPTION
Signed-off-by: Victor Krasnoshchok <ct3da21164@protonmail.ch>

## Description
The PR fixes potential seed file corruption in case if `path` param of `mbedtls_entropy_write_seed_file` is equal to `MBEDTLS_PLATFORM_STD_NV_SEED_FILE` (or vice versa; i.e. the same file is used to read from and to write to). 


## Status
**READY**

## Requires Backporting
Yes
- [ ] 2.16
- [ ] 2.7

## Migrations
NO

## Steps to test
1. Define `MBEDTLS_ENTROPY_NV_SEED` in the active config (`config.h`); 
2. Edit `test_suite_entropy.data` in such a way to make `entropy_seed_file` to define the same name as `MBEDTLS_PLATFORM_STD_NV_SEED_FILE` (`seedfile` by default);
3. Build and run `test_suite_entropy` target - NV-file related tests should pass.
