### PR TITLE
[Baremetal] Change the UECC_SUCCESS return value to 0xCC

### DIFF
--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -85,9 +85,9 @@ extern "C" {
 /* Return values for functions, chosen with large Hamming distances between
  * them (especially to SUCESS) to mitigate the impact of fault injection
  * attacks flipping a low number of bits. */
-#define UECC_SUCCESS            0x00FFAAAA
-#define UECC_FAILURE            0x75555555
-#define UECC_FAULT_DETECTED     0x7aaaaaaa
+#define UECC_SUCCESS            0xCD
+#define UECC_FAILURE            0x52
+#define UECC_FAULT_DETECTED     0x3B
 
 /* Word size (4 bytes considering 32-bits architectures) */
 #define uECC_WORD_SIZE 4


### PR DESCRIPTION
Thanks to this change the produced ASM does not need an additional instruction to place the constant value in a register, but can compare it directly.
Signed-off-by: Andrzej Kurek <andrzej.kurek@arm.com>