### PR TITLE
Timer/hardclock fixes

### DIFF
--- a/ChangeLog.d/sparc64-rdtick.txt
+++ b/ChangeLog.d/sparc64-rdtick.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix bug on sparc64 platforms where a privileged instruction is used to
+     access the TICK register. Contributed in #3620.

--- a/ChangeLog.d/timing-hardclock-fallback.txt
+++ b/ChangeLog.d/timing-hardclock-fallback.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Add support for hardened systems with restricted access to the CPU cycle
+     counter. Currently supported: NetBSD. Contributed in #3620.

--- a/ChangeLog.d/timing-monotonic.txt
+++ b/ChangeLog.d/timing-monotonic.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Use monotonic time instead of wall time throughout the timing module.
+     Contributed in #3620.

--- a/library/timing.c
+++ b/library/timing.c
@@ -139,18 +139,14 @@ unsigned long mbedtls_timing_hardclock( void )
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
     defined(__GNUC__) && defined(__sparc64__)
 
-#if defined(__OpenBSD__)
-#warning OpenBSD does not allow access to tick register using software version instead
-#else
 #define HAVE_HARDCLOCK
 
 unsigned long mbedtls_timing_hardclock( void )
 {
     unsigned long tick;
-    asm volatile( "rdpr %%tick, %0;" : "=&r" (tick) );
+    asm volatile( "rd %%tick, %0;" : "=&r" (tick) );
     return( tick );
 }
-#endif /* __OpenBSD__ */
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __sparc64__ */
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -1,5 +1,5 @@
 
-# To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
+# To compile on SunOS: add "-lrt -lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 CFLAGS	?= -O2

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 
-# To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
+# To compile on SunOS: add "-lrt -lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
 CFLAGS	?= -O2


### PR DESCRIPTION
- Use the RDTICK instruction instead of RDPR on sparc64 platforms: Apparently OpenBSD _does_ allow reads from the TICK register. The RDPR instruction is only available to privileged software however so this could not work on any operating system (nonprivileged software must use the RDTICK instruction instead).
- Add support for hardened systems with restricted access to the CPU cycle counter by reading system information when mbedtls_timing_hardclock is first called and using software clock if access is found to be restricted. This will still crash if access to the register is disabled afterwards. Currently supported: [NetBSD/i386 and amd64](https://github.com/NetBSD/src/commit/084a8872ba30ffdfbb690365326871adf409c4c9)
- Use monotonic time instead of wall time throughout the timer/hardclock module