### PR TITLE
RFC: Fix builds with MBEDTLS_HAVE_TIME disabled and test

### DIFF
--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -68,7 +68,9 @@ extern "C" {
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
 #define MBEDTLS_PLATFORM_STD_SNPRINTF   mbedtls_platform_win32_snprintf /**< The default \c snprintf function to use.  */

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -52,10 +52,12 @@
 #define mbedtls_snprintf   snprintf
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO) || defined(EFIX64) || defined(EFI32)

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -63,10 +63,12 @@
 #include "mbedtls/threading.h"
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO)

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -4,15 +4,17 @@
 #include <stdlib.h>
 #include "mbedtls/ctr_drbg.h"
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 void dummy_init()
 {
-#if defined(MBEDTLS_PLATFORM_TIME_ALT)
+#if (defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_PLATFORM_TIME_ALT))
     mbedtls_platform_set_time( dummy_constant_time );
 #else
     fprintf(stderr, "Warning: fuzzing without constant time\n");

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -1,4 +1,13 @@
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct fuzzBufferOffset
@@ -8,7 +17,9 @@ typedef struct fuzzBufferOffset
     size_t Offset;
 } fuzzBufferOffset_t;
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time );
+#endif
 void dummy_init();
 
 int dummy_send( void *ctx, const unsigned char *buf, size_t len );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -671,12 +671,13 @@ static void my_debug( void *ctx, int level,
     fflush(  (FILE *) ctx  );
 }
 
-
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 int dummy_entropy( void *data, unsigned char *output, size_t len )
 {

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -41,7 +41,9 @@ int main( void )
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/base64.h"
@@ -300,6 +302,7 @@ void print_hex( const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
+#if defined(MBEDTLS_HAVE_TIME)
 void print_time( const time_t *time )
 {
     char buf[20];
@@ -315,6 +318,7 @@ void print_time( const time_t *time )
         printf( "unknown\n" );
     }
 }
+#endif
 
 /*
  * Print the input string if the bit is set in the value
@@ -598,7 +602,12 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
                 ( (uint64_t) ssl[7] );
         ssl += 8;
         printf( "\tstart time     : " );
+#if defined(MBEDTLS_HAVE_TIME)
         print_time( (time_t*) &start );
+#else
+        (void) start;
+        printf( "not supported\n" );
+#endif
     }
 
     CHECK_SSL_END( 2 );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -775,11 +775,13 @@ static void my_debug( void *ctx, int level,
     fflush(  (FILE *) ctx  );
 }
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 int dummy_entropy( void *data, unsigned char *output, size_t len )
 {
@@ -3107,8 +3109,10 @@ int main( int argc, char *argv[] )
     if( opt.cache_max != -1 )
         mbedtls_ssl_cache_set_max_entries( &cache, opt.cache_max );
 
+#if defined(MBEDTLS_HAVE_TIME)
     if( opt.cache_timeout != -1 )
         mbedtls_ssl_cache_set_timeout( &cache, opt.cache_timeout );
+#endif
 
     mbedtls_ssl_conf_session_cache( &conf, &cache,
                                    mbedtls_ssl_cache_get,

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -79,7 +79,9 @@
 #include "mbedtls/pkcs11.h"
 #include "mbedtls/pkcs12.h"
 #include "mbedtls/pkcs5.h"
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
 #include "mbedtls/ripemd160.h"

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -79,7 +79,9 @@
 #include "mbedtls/pkcs11.h"
 #include "mbedtls/pkcs12.h"
 #include "mbedtls/pkcs5.h"
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
 #include "mbedtls/ripemd160.h"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1197,6 +1197,12 @@ component_build_crypto_baremetal () {
   if_build_succeeded are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 
+component_build_baremetal () {
+  msg "build: make, baremetal config"
+  scripts/config.py baremetal
+  make CFLAGS="$BAREMETAL_INCLUDE_OVERRIDE -O1 -Werror"
+}
+
 component_test_depends_curves () {
     msg "test/build: curves.pl (gcc)" # ~ 4 min
     record_status tests/scripts/curves.pl


### PR DESCRIPTION
## Description

This attempts to bring together #3444 and (an earlier version of) #3449: it adds tests to catch bad uses of `time.h` when `MBEDTLS_HAVE_TIME` is not defined.

The idea is to create a replacement `/usr/include` that doesn't contain `time.h`. (I also exclude `pthread.h` and we could easily extend it to catch other headers that might be mistakenly depended upon.)

It involves parsing some gcc compiler output so I wanted to get some feedback before I do the changelog and backports.

## Status
IN DEVELOPMENT

## Requires Backporting
Yes 
  
`Which branch?` - I'm not sure and would appreciate guidance.

## Migrations
NO

## Additional comments
Ping @naynajain and @raoulstrackx.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Run the tests, specifically `build_baremetal` and `build_crypto_baremetal`.
