### PR TITLE
Report the first unit test failure, not the last one

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -407,6 +407,12 @@ void test_set_step( unsigned long step )
 
 void test_fail( const char *test, int line_no, const char* filename )
 {
+    if( test_info.result == TEST_RESULT_FAILED )
+    {
+        /* We've already recorded the test as having failed. Don't
+         * overwrite any previous information about the failure. */
+        return;
+    }
     test_info.result = TEST_RESULT_FAILED;
     test_info.test = test;
     test_info.line_no = line_no;

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -596,7 +596,7 @@ void mbedtls_mpi_lt_mpi_ct( int size_X, char * input_X,
                             int size_Y, char * input_Y,
                             int input_ret, int input_err )
 {
-    unsigned ret;
+    unsigned ret = -1;
     unsigned input_uret = input_ret;
     mbedtls_mpi X, Y;
     mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y );


### PR DESCRIPTION
If `test_fail` is called multiple times in the same test case, report the location of the first failure, not the last one.

With this change, you no longer need to take care in tests that use auxiliary functions not to fail in the main function if the auxiliary function has failed.

I can't think of any reason to preserve the old behavior of keeping the location of the last failure. We're currently avoiding double failures because the second call to `test_fail` would overwrite the location information. If we are currently calling `test_fail` twice on some code paths, it would be by mistake. `mbedtls_param_failed` is a special case that partially pre-records a non-failure, but even in that case we expect `test_fail` not to have been called before.

Demonstration:
```
git checkout gilles-peskine-arm/test-fail-report-first-development-demonstrate
make lib
cd tests
make test_suite_xtea
./test_suite_xtea
git checkout gilles-peskine-arm/test-fail-report-first-development-demonstrate~1
make test_suite_xtea
./test_suite_xtea
```

Backports: [2.16](https://github.com/ARMmbed/mbedtls/pull/3626), [2.7](https://github.com/ARMmbed/mbedtls/pull/3627)
