### PR TITLE
Backport 2.7: Report the first unit test failure, not the last one

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -165,6 +165,12 @@ test_info;
 
 void test_fail( const char *test, int line_no, const char* filename )
 {
+    if( test_info.failed )
+    {
+        /* We've already recorded the test as having failed. Don't
+         * overwrite any previous information about the failure. */
+        return;
+    }
     test_info.failed = 1;
     test_info.test = test;
     test_info.line_no = line_no;

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -337,7 +337,7 @@ void mbedtls_mpi_lt_mpi_ct( int size_X, char * input_X,
                             int size_Y, char * input_Y,
                             int input_ret, int input_err )
 {
-    unsigned ret;
+    unsigned ret = -1;
     unsigned input_uret = input_ret;
     mbedtls_mpi X, Y;
     mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y );


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3625

The old test framework had the same behavior and essentially the same code.
