### PR TITLE
  Better constant-flow idioms for TLS-CBC padding checks

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1146,7 +1146,7 @@ static void mbedtls_ssl_cf_memcpy_if_eq( unsigned char *dst,
 {
     /* mask = c1 == c2 ? 0xff : 0x00 */
     const size_t equal = mbedtls_ssl_cf_bool_eq( c1, c2 );
-    const unsigned char mask = mbedtls_ssl_cf_mask_from_bit( equal );
+    const unsigned char mask = (unsigned char) mbedtls_ssl_cf_mask_from_bit( equal );
 
     /* dst[i] = c1 != c2 ? dst[i] : src[i] */
     for( size_t i = 0; i < len; i++ )

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1045,6 +1045,82 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
 /*
+ * Constant-flow mask generation for "less than" comparison:
+ * - if x < y,  return all bits 1, that is (size_t) -1
+ * - otherwise, return all bits 0, that is 0
+ *
+ * Use only bit operations to avoid branches that could be used by some
+ * compilers on some platforms to translate comparison operators.
+ */
+static size_t mbedtls_ssl_cf_mask_lt(size_t x, size_t y)
+{
+    /* This has the msb set if and only if x < y */
+    const size_t sub = x - y;
+
+    /* sub1 = (x < y) in {0, 1} */
+    const size_t sub1 = sub >> ( sizeof( sub ) * 8 - 1 );
+
+    /* MSVC has a warning about unary minus on unsigned integer types,
+     * but this is well-defined and precisely what we want to do here. */
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4146 )
+#endif
+    /* mask = (x < y) ? 0xff... : 0x00... */
+    const size_t mask = -sub1;
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+
+    return( mask );
+}
+
+/*
+ * Constant-flow mask generation for "greater or equal" comparison:
+ * - if x >= y, return all bits 1, that is (size_t) -1
+ * - otherwise, return all bits 0, that is 0
+ *
+ * Use only bit operations to avoid branches that could be used by some
+ * compilers on some platforms to translate comparison operators.
+ */
+static size_t mbedtls_ssl_cf_mask_ge(size_t x, size_t y)
+{
+    return( ~mbedtls_ssl_cf_mask_lt(x, y) );
+}
+
+/*
+ * Constant-flow boolean "equal" comparison:
+ * return x == y
+ *
+ * Use only bit operations to avoid branches that could be used by some
+ * compilers on some platforms to translate comparison operators.
+ */
+static size_t mbedtls_ssl_cf_bool_eq(size_t x, size_t y)
+{
+    /* diff = 0 if x == y, non-zero otherwise */
+    const size_t diff = x ^ y;
+
+    /* MSVC has a warning about unary minus on unsigned integer types,
+     * but this is well-defined and precisely what we want to do here. */
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4146 )
+#endif
+
+    /* diff_msb's most significant bit is equal to x != y */
+    const size_t diff_msb = ( diff | -diff );
+
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif
+
+    /* diff1 = (x != y) in {0, 1} */
+    const size_t diff1 = diff_msb >> ( sizeof( diff_msb ) * 8 - 1 );
+
+    return( 1 ^ diff1 );
+}
+
+/*
  * Constant-flow conditional memcpy:
  *  - if c1 == c2, equivalent to memcpy(dst, src, len),
  *  - otherwise, a no-op,
@@ -1071,7 +1147,7 @@ static void mbedtls_ssl_cf_memcpy_if_eq( unsigned char *dst,
     /* diff_msb's most significant bit is equal to c1 != c2 */
     const size_t diff_msb = ( diff | -diff );
 
-    /* diff1 = c1 != c2 */
+    /* diff1 = (c1 != c2) in {0, 1} */
     const size_t diff1 = diff_msb >> ( sizeof( diff_msb ) * 8 - 1 );
 
     /* mask = c1 != c2 ? 0xff : 0x00 */
@@ -1528,8 +1604,11 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 
         if( auth_done == 1 )
         {
-            correct *= ( rec->data_len >= padlen + 1 );
-            padlen  *= ( rec->data_len >= padlen + 1 );
+            const size_t mask = mbedtls_ssl_cf_mask_ge(
+                                rec->data_len,
+                                padlen + 1 );
+            correct &= mask;
+            padlen  &= mask;
         }
         else
         {
@@ -1543,8 +1622,11 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
             }
 #endif
 
-            correct *= ( rec->data_len >= transform->maclen + padlen + 1 );
-            padlen  *= ( rec->data_len >= transform->maclen + padlen + 1 );
+            const size_t mask = mbedtls_ssl_cf_mask_ge(
+                                rec->data_len,
+                                transform->maclen + padlen + 1 );
+            correct &= mask;
+            padlen  &= mask;
         }
 
         padlen++;
@@ -1555,6 +1637,9 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_PROTO_SSL3)
         if( transform->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
         {
+            /* This is the SSL 3.0 path, we don't have to worry about Lucky
+             * 13, because there's a strictly worse padding attack built in
+             * the protocol (known as part of POODLE), so branches are OK. */
             if( padlen > transform->ivlen )
             {
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
@@ -1578,7 +1663,6 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
              * `min(256,plaintext_len)` reads (but take into account
              * only the last `padlen` bytes for the padding check). */
             size_t pad_count = 0;
-            size_t real_count = 0;
             volatile unsigned char* const check = data;
 
             /* Index of first padding byte; it has been ensured above
@@ -1590,10 +1674,15 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 
             for( idx = start_idx; idx < rec->data_len; idx++ )
             {
-                real_count |= ( idx >= padding_idx );
-                pad_count += real_count * ( check[idx] == padlen - 1 );
+                /* pad_count += (idx >= padding_idx) &&
+                 *              (chech[idx] == padlen - 1);
+                 */
+                const size_t mask = mbedtls_ssl_cf_mask_ge( idx, padding_idx );
+                const size_t equal = mbedtls_ssl_cf_bool_eq( check[idx],
+                                                             padlen - 1 );
+                pad_count += mask & equal;
             }
-            correct &= ( pad_count == padlen );
+            correct &= mbedtls_ssl_cf_bool_eq( pad_count, padlen );
 
 #if defined(MBEDTLS_SSL_DEBUG_ALL)
             if( padlen > 0 && correct == 0 )


### PR DESCRIPTION
## Description

Resolves #3472 

__Note on scope:__ as a follow-up it would be interesting to see if code can be shared with other places that do constant-flow comparisons, for example in the SSL module there's also ssl_parse_encrypted_pms(), but I decided it was out of scope of this PR, in order to avoid design questions. In the longer term, it would probably even be interesting to have a small library of such functions that could be shared with (PSA) Crypto and perhaps even other tf.org projects, but that's obviously even more out of scope. For now I've just tried to avoid too much repetition among the functions used by CBC (which btw is mainly about code maintainability, not code size as the compile will likely inline a lot even with -Os/-Oz).

__Note on testing:__ I don't think it would be that useful to add a unit-test for say mbedtls_ssl_cf_mask_ge() with MemSan/Valgrind constant-time checking, because those checks would be run on x86 or A-class, where the previous code was already constant-time anyway, and the function is so small I'm not sure it makes sense.

I'm undecided whether it would make sense to have a unit test for this function (or other similar small functions) just to check correctness of the results, though, because it's so small. Opinions welcome.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO


