### PR TITLE
_POSIX_C_SOURCE fixes

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -24,9 +24,7 @@
  * Ensure gmtime_r is available even with -std=c99; must be defined before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
-#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
-#endif
 
 #include "common.h"
 
@@ -86,7 +84,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 #if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
        ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 200112L ) )
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
@@ -100,7 +98,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 200112L ) ) */
 
 struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf )

--- a/library/threading.c
+++ b/library/threading.c
@@ -23,9 +23,7 @@
  * Ensure gmtime_r is available even with -std=c99; must be defined before
  * config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
-#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L
-#endif
 
 #include "common.h"
 
@@ -44,7 +42,7 @@
 
 #if !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
        ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-         _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) )
+         _POSIX_THREAD_SAFE_FUNCTIONS >= 200112L ) )
 /*
  * This is a convenience shorthand macro to avoid checking the long
  * preprocessor conditions above. Ideally, we could expose this macro in
@@ -59,7 +57,7 @@
 
 #endif /* !( ( defined(_POSIX_VERSION) && _POSIX_VERSION >= 200809L ) ||     \
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                     \
-                _POSIX_THREAD_SAFE_FUNCTIONS >= 20112L ) ) */
+                _POSIX_THREAD_SAFE_FUNCTIONS >= 200112L ) ) */
 
 #endif /* MBEDTLS_HAVE_TIME_DATE && !MBEDTLS_PLATFORM_GMTIME_R_ALT */
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,11 +21,6 @@ if(NOT MBEDTLS_PYTHON_EXECUTABLE)
     message(FATAL_ERROR "Cannot build test suites without Python 3")
 endif()
 
-# Enable definition of various functions used throughout the testsuite
-# (gethostname, strdup, fileno...) even when compiling with -std=c99. Harmless
-# on non-POSIX platforms.
-add_definitions("-D_POSIX_C_SOURCE=200809L")
-
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.
 # "foo" as a skip pattern skips "test_suite_foo" and "test_suite_foo.bar"
 # but not "test_suite_foobar".

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,11 +18,6 @@ LOCAL_LDFLAGS = -L../library			\
 include ../3rdparty/Makefile.inc
 LOCAL_CFLAGS+=$(THIRDPARTY_INCLUDES)
 
-# Enable definition of various functions used throughout the testsuite
-# (gethostname, strdup, fileno...) even when compiling with -std=c99. Harmless
-# on non-POSIX platforms.
-LOCAL_CFLAGS += -D_POSIX_C_SOURCE=200809L
-
 ifndef SHARED
 MBEDLIBS=../library/libmbedcrypto.a ../library/libmbedx509.a ../library/libmbedtls.a
 else

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -20,9 +20,7 @@
  */
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
-#if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L // for fileno() from <stdio.h>
-#endif
 #endif
 
 #if !defined(MBEDTLS_CONFIG_FILE)


### PR DESCRIPTION
This is a work in progress intended to address several issues concerning the use of the _POSIX_C_SOURCE macro:

- POSIX version number typo in platform_util.c and threading.c
- There exists another issue in the same files: comparison `_POSIX_VERSION >= 200809L` after version 200112L is requested
- Make use of the _POSIX_C_SOURCE macro more consistent across all occurences by removing unnecessary conditionals and moving definitions from makefiles to source files. Rationale: make source files more self contained; document individual uses; address platform differences should the need arise, for example:
- Solaris 10 forces an error in feature_tests.h if C99 and a POSIX version other than 200112L are used or 200112L is used without C99. The same problem exists on Solaris 11 with gcc binary packages from OpenCSW. Currently LTS branch 2.16 uses `#define _POSIX_C_SOURCE 1` which is intended to be consistent with the (mostly) C89/GNU89 code. Since the branch also builds with C99, this could hint at a possible portability tradeoff vs. `#define _POSIX_C_SOURCE 200112L` (#3420, #3421; edit: 200112L variant exists on 2.16 already via #1198; further use of the macro was introduced with #1927, #3190/#3286)

Any help would be appreciated. In particular I would like to document but am still unsure about:

- Why 200809L specifically is requested in tests/Makefile and tests/CMakeLists.txt (edit: a strdup call was removed from development/2.16 with #3140/#3143, still present in 2.7)
- If gmtime_r is supposed to be optional or required for POSIX.1-2001 (edit: [optional](https://pubs.opengroup.org/onlinepubs/009695399/functions/gmtime.html); As detailed in #1927 it is impossible to reliably determine if the function is available without a configure script. Proposed solution: provide an implementation with mbed TLS)