### PR TITLE
[baremetal] Replace the mbedtls_platform_memcmp deprecation with a define

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -217,32 +217,8 @@ void *mbedtls_platform_memcpy( void *dst, const void *src, size_t num );
  */
 int mbedtls_platform_memmove( void *dst, const void *src, size_t num );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
+#define mbedtls_platform_memcmp mbedtls_platform_memequal
 
-/**
- * \brief       Secure memcmp
- *
- *              This is a constant-time version of memcmp(), but without checking
- *              if the bytes are greater or lower. The order is also randomised
- *              using the RNG in order to further harden against side-channel attacks.
- *
- * \param buf1  First buffer to compare.
- * \param buf2  Second buffer to compare against.
- * \param num   The length of the buffers in bytes.
- *
- * \deprecated  Superseded by mbedtls_platform_memequal(), and is only an alias to it.
- *
- * \return      0 if the buffers were equal or an unspecified non-zero value
- *              otherwise.
- */
-int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num );
-
-#endif
 /**
  * \brief       Secure check if the buffers have the same data.
  *

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -230,13 +230,6 @@ int mbedtls_platform_memmove( void *dst, const void *src, size_t num )
     return MBEDTLS_ERR_PLATFORM_ALLOC_FAILED;
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-int mbedtls_platform_memcmp( const void *buf1, const void *buf2, size_t num )
-{
-    return( mbedtls_platform_memequal( buf1, buf2, num ) );
-}
-#endif /* MBEDTLS_DEPRECATED_REMOVED */
-
 int mbedtls_platform_memequal( const void *buf1, const void *buf2, size_t num )
 {
     volatile const unsigned char *A = (volatile const unsigned char *) buf1;

--- a/tests/scripts/list-macros.sh
+++ b/tests/scripts/list-macros.sh
@@ -10,7 +10,7 @@ fi
 HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h' )
 
 sed -n -e 's/.*#define \([a-zA-Z0-9_]*\).*/\1/p' $HEADERS \
-    | egrep -v '^(asm|inline|EMIT|_CRT_SECURE_NO_DEPRECATE)$|^MULADDC_' \
+    | egrep -v '^(asm|inline|EMIT|mbedtls_platform_memcmp|_CRT_SECURE_NO_DEPRECATE)$|^MULADDC_' \
     | sort -u > macros
 
 wc -l macros


### PR DESCRIPTION
Signed-off-by: Andrzej Kurek <andrzej.kurek@arm.com>
