### PR TITLE
Allow builds with -std=c99 on LTS branch 2.7

### DIFF
--- a/ChangeLog.d/c99.txt
+++ b/ChangeLog.d/c99.txt
@@ -1,0 +1,2 @@
+Features
+   * Allow builds with -std=c99. Contributed in #3656.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -44,6 +44,11 @@
  *  **********
  */
 
+#if defined(__linux__)
+/* Ensure that syscall() is available even when compiling with -std=c99 */
+#define _GNU_SOURCE
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -44,6 +44,12 @@
  *  **********
  */
 
+/* Enable definition of getaddrinfo() even when compiling with -std=c99. Must
+ * be set before config.h, which pulls in glibc's features.h indirectly.
+ * Harmless on other platforms. */
+#define _POSIX_C_SOURCE 200112L
+#define _XOPEN_SOURCE 600 /* sockaddr_storage */
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -44,6 +44,11 @@
  *  **********
  */
 
+/* Enable definition of fileno() even when compiling with -std=c99. Must be
+ * set before config.h, which pulls in glibc's features.h indirectly.
+ * Harmless on other platforms. */
+#define _POSIX_C_SOURCE 200112L
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -45,6 +45,11 @@
  *  **********
  */
 
+/* Enable definition of fileno() even when compiling with -std=c99. Must be
+ * set before config.h, which pulls in glibc's features.h indirectly.
+ * Harmless on other platforms. */
+#define _POSIX_C_SOURCE 200112L
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -44,6 +44,12 @@
  *  **********
  */
 
+/* Enable definition of gethostname() even when compiling with -std=c99. Must
+ * be set before config.h, which pulls in glibc's features.h indirectly.
+ * Harmless on other platforms. */
+#define _POSIX_C_SOURCE 200112L
+#define _XOPEN_SOURCE 600
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -222,6 +222,19 @@ print TEST_FILE << "END";
  *
  */
 
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#define _POSIX_C_SOURCE 200112L // for fileno() from <stdio.h>
+#endif
+
+/*
+ * for arc4random_buf() from <stdlib.h>
+ */
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
+#elif defined(__OpenBSD__)
+#define _BSD_SOURCE 1
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include <mbedtls/config.h>
 #else

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -36,6 +36,7 @@ typedef UINT32 uint32_t;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#include <strings.h>
 #endif
 
 /*

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -268,7 +268,7 @@ int main(int argc, const char *argv[])
     /* Other Local variables */
     int arg_index = 1;
     const char *next_arg;
-    size_t testfile_index, i, cnt;
+    size_t testfile_index, i, cnt, len;
     int ret;
     unsigned total_errors = 0, total_tests = 0, total_skipped = 0;
     FILE *file;
@@ -400,14 +400,18 @@ int main(int argc, const char *argv[])
                         {
                             if( 0 != option_verbose )
                             {
+                                len = strlen( params[i] );
                                 unmet_dependencies[unmet_dep_count] =
-                                    strdup( params[i] );
+                                    malloc( len + 1 );
                                 if( unmet_dependencies[unmet_dep_count] == NULL )
                                 {
                                     mbedtls_fprintf( stderr,
                                                      "FATAL: Out of memory\n" );
                                     mbedtls_exit( MBEDTLS_EXIT_FAILURE );
                                 }
+                                strncpy( unmet_dependencies[unmet_dep_count],
+                                    params[i], len );
+                                unmet_dependencies[unmet_dep_count][len] = '\0';
                             }
                             unmet_dep_count++;
                         }


### PR DESCRIPTION
Includes (partial) backports of #1198, #3190, #3421, #3422 and #3571.