### PR TITLE
Backport 2.16: Define _POSIX_C_SOURCE to be 200112L, as a minimum for C99.

### DIFF
--- a/ChangeLog.d/200112L.txt
+++ b/ChangeLog.d/200112L.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Set _POSIX_C_SOURCE to at least 200112L in C99 code. Reported in #3420 and
+     fix submitted in #3421 by Nia Alarie. Adopted for LTS branch 2.16 in #3658.

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -47,7 +47,7 @@
 /* Enable definition of fileno() even when compiling with -std=c99. Must be
  * set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 200112L
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -48,7 +48,7 @@
 /* Enable definition of fileno() even when compiling with -std=c99. Must be
  * set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 200112L
 
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -19,7 +19,7 @@
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #if !defined(_POSIX_C_SOURCE)
-#define _POSIX_C_SOURCE 1 // for fileno() from <stdio.h>
+#define _POSIX_C_SOURCE 200112L // for fileno() from <stdio.h>
 #endif
 #endif
 


### PR DESCRIPTION
Backport of #3421. `200112L` variant is already present on the branch (contrary to what was said in #3420).