### PR TITLE
Backport 2.7: Fix typo in mbedtls_ssl_set_bio description.

### DIFF
--- a/ChangeLog.d/comment_typo_in_mbedtls_ssl_set_bio.txt
+++ b/ChangeLog.d/comment_typo_in_mbedtls_ssl_set_bio.txt
@@ -1,0 +1,3 @@
+Changes
+   * Fix comment typo in mbedtls_ssl_set_bio_description.
+

--- a/ChangeLog.d/comment_typo_in_mbedtls_ssl_set_bio.txt
+++ b/ChangeLog.d/comment_typo_in_mbedtls_ssl_set_bio.txt
@@ -1,3 +1,2 @@
 Changes
-   * Fix comment typo in mbedtls_ssl_set_bio_description.
-
+   * Fix comment typo in documentation of mbedtls_ssl_set_bio.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1140,7 +1140,7 @@ void mbedtls_ssl_conf_dbg( mbedtls_ssl_config *conf,
  * \note           For DTLS, you need to provide either a non-NULL
  *                 f_recv_timeout callback, or a f_recv that doesn't block.
  *
- * \note           See the documentations of \c mbedtls_ssl_sent_t,
+ * \note           See the documentations of \c mbedtls_ssl_send_t,
  *                 \c mbedtls_ssl_recv_t and \c mbedtls_ssl_recv_timeout_t for
  *                 the conventions those callbacks must follow.
  *


### PR DESCRIPTION
This is a trivial backport of  #3569.