### PR TITLE
replace user rand by platform rand in ecc delays

### DIFF
--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -300,6 +300,15 @@ uint32_t mbedtls_platform_random_in_range( uint32_t num );
  */
 void mbedtls_platform_random_delay( void );
 
+/**
+ * \brief       RNG-function for getting a random buffer.
+ *
+ * \param buf   Buffer for random data
+ * \param len   Length of the buffer in bytes
+ *
+ */
+void mbedtls_platform_random_buf( uint8_t *buf, size_t len);
+
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -319,6 +319,25 @@ uint32_t mbedtls_platform_random_uint32( void )
               mbedtls_platform_random_uint16() );
 }
 
+void mbedtls_platform_random_buf( uint8_t *buf, size_t len )
+{
+    uint16_t val;
+
+    while( len > 1 )
+    {
+        val = mbedtls_platform_random_uint16();
+        buf[len-1] = (uint8_t)val;
+        buf[len-2] = (uint8_t)(val>>8);
+        len -= 2;
+    }
+    if( len == 1 )
+    {
+        buf[0] = (uint8_t)mbedtls_platform_random_uint16();
+    }
+
+    return;
+}
+
 uint32_t mbedtls_platform_random_in_range( uint32_t num )
 {
     uint32_t result;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -67,6 +67,7 @@
 #include "mbedtls/platform_util.h"
 #include "mbedtls/sha256.h"
 #include <string.h>
+#include "mbedtls/platform_util.h"
 
 /* Parameters for curve NIST P-256 aka secp256r1 */
 const uECC_word_t curve_p[NUM_ECC_WORDS] = {
@@ -427,7 +428,7 @@ void ecc_wait_state_reset(ecc_wait_state_t *ws)
 		return;
 
 	ws->i = 0;
-	g_rng_function(ws->delays, sizeof(ws->delays));
+	mbedtls_platform_random_buf(ws->delays, sizeof(ws->delays));
 }
 
 /* Computes result = left * right. Result must be 2 * num_words long.


### PR DESCRIPTION
Signed-off-by: Shelly Liberman <shelly.liberman@arm.com>

## Description
Replace user random function by platform non cryptographic random generator in random delays  during ecc calculations.
This replacement improve run time of ecc calculations as non crypto random is much faster


## Status
READY