### PR TITLE
Set CMake Max Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,18 @@
 #
 
 cmake_minimum_required(VERSION 2.8.12)
+
+# https://cmake.org/cmake/help/latest/policy/CMP0011.html
+# Setting this policy is required in CMake >= 3.18.0, otherwise a warning is generated. The OLD
+# policy setting is deprecated, and will be removed in future versions.
+cmake_policy(SET CMP0011 NEW)
+# https://cmake.org/cmake/help/latest/policy/CMP0012.html
+# Setting the CMP0012 policy to NEW is required for FindPython3 to work with CMake 3.18.2
+# (there is a bug in this particular version), otherwise, setting the CMP0012 policy is required
+# for CMake versions >= 3.18.3 otherwise a deprecated warning is generated. The OLD policy setting
+# is deprecated and will be removed in future versions.
+cmake_policy(SET CMP0012 NEW)
+
 if(TEST_CPP)
     project("mbed TLS" C CXX)
 else()


### PR DESCRIPTION
## Description

Make sure that CMake policy CMP0012 is set to NEW, without which FindPython3 and FindPython2 functionality becomes broken with CMake 3.18.2 if searching by location. This will be fixed in CMake 3.18.3, however this policy will remain the default, so this is a safe change. Ensure CMP0011 is set to NEW to avoid warnings being issued about policy push / pop with CMake 3.18.0 or newer.

This closes #3690

## Status
**READY**

## Requires Backporting
No (Newer version of FindPython3 not used in either LTS branch)

## Todos
- [ ] Tests

## Steps to test or reproduce
Project should now build with CMake version 3.18.2, which it won't without this patch.
