### PR TITLE
PSA: support arbitrary data storage from opaque drivers

### DIFF
--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -273,7 +273,7 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
         case PSA_CRYPTO_TEST_DRIVER_LIFETIME:
-#ifdef TEST_KEY_CONTEXT_SIZE_FUNCTION
+#ifdef TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION
             *expected_size = test_size_function( key_type, key_bits );
             return( PSA_SUCCESS );
 #else /* TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION */

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -279,10 +279,19 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
 #else /* TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION */
             if( PSA_KEY_TYPE_IS_KEY_PAIR( key_type ) )
             {
+                int public_key_overhead = ( ( TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY == 1 ) ?
+                                           PSA_KEY_EXPORT_MAX_SIZE( key_type, key_bits ) : 0 );
+                *expected_size = TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
+                                 + TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE
+                                 + public_key_overhead;
+            }
+            else if( PSA_KEY_TYPE_IS_PUBLIC_KEY( attributes->core.type ) )
+            {
                 *expected_size = TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
                                  + TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE;
             }
-            else if( PSA_KEY_TYPE_IS_PUBLIC_KEY( attributes->core.type ) )
+            else if ( !PSA_KEY_TYPE_IS_KEY_PAIR( key_type ) &&
+                      !PSA_KEY_TYPE_IS_PUBLIC_KEY ( attributes->core.type ) )
             {
                 *expected_size = TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
                                  + TEST_DRIVER_KEY_CONTEXT_SYMMETRIC_FACTOR
@@ -300,7 +309,7 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
             return( PSA_ERROR_NOT_SUPPORTED );
     }
 }
-#endif /* PSA_CRYPTO_DRIVER_PRESENT */
+#endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 psa_status_t psa_driver_wrapper_generate_key( const psa_key_attributes_t *attributes,
                                               psa_key_slot_t *slot )

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -273,9 +273,6 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
         case PSA_CRYPTO_TEST_DRIVER_LIFETIME:
-            /* TBD: opaque driver support: need to calculate size through a
-             * driver-defined size function, since the size of an opaque (wrapped)
-             * key will be different for each implementation. */
 #ifdef TEST_KEY_CONTEXT_SIZE_FUNCTION
             *expected_size = test_size_function( key_type, key_bits );
             return( PSA_SUCCESS );

--- a/tests/include/test/drivers/size.h
+++ b/tests/include/test/drivers/size.h
@@ -38,20 +38,26 @@ typedef struct {
  * This macro returns the base size for the key context. It should include
  * the size for any driver context information stored with each key.
  */
-#define TEST_DRIVER_KEY_CONTEXT_BASE_SIZE          sizeof(test_driver_key_context_t)
+#define TEST_DRIVER_KEY_CONTEXT_BASE_SIZE          sizeof( test_driver_key_context_t )
 
 /** \def TEST_DRIVER_KEY_CONTEXT_KEY_PAIR_SIZE
  *
  * Number of bytes included in every key context for a key pair.
+ *
+ * This pair size is for an ECC 256-bit private/public key pair.
+ * Based on this value, the size of the private key can be derived by
+ * subtracting the public key size below from this one.
  */
 
-#define TEST_DRIVER_KEY_CONTEXT_KEY_PAIR_SIZE      0
+#define TEST_DRIVER_KEY_CONTEXT_KEY_PAIR_SIZE      65
 
 /** \def TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE
  *
  * Number of bytes included in every key context for a public key.
+ *
+ * For ECC public keys, it needs 257 bits so 33 bytes.
  */
-#define TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE    0
+#define TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE    33
 
 /** \def TEST_DRIVER_KEY_CONTEXT_SYMMETRIC_FACTOR
  *
@@ -63,8 +69,10 @@ typedef struct {
  *
  * If this is true for a key pair, the key context includes space for the public key.
  * If this is false, no additional space is added for the public key.
+ *
+ * For this instance, store the public key with the private one.
  */
-#define TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY   0
+#define TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY   1
 
 /** \def TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION
  *

--- a/tests/include/test/drivers/size.h
+++ b/tests/include/test/drivers/size.h
@@ -1,0 +1,87 @@
+/*
+ * Test driver for context size functions
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_TEST_DRIVERS_SIZE_H
+#define PSA_CRYPTO_TEST_DRIVERS_SIZE_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+#include <psa/crypto_driver_common.h>
+
+typedef struct {
+    unsigned int context;
+} test_driver_key_context_t;
+
+/** \def TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
+ *
+ * This macro returns the base size for the key context. It should include
+ * the size for any driver context information stored with each key.
+ */
+#define TEST_DRIVER_KEY_CONTEXT_BASE_SIZE          sizeof(test_driver_key_context_t)
+
+/** \def TEST_DRIVER_KEY_CONTEXT_KEY_PAIR_SIZE
+ *
+ * Number of bytes included in every key context for a key pair.
+ */
+
+#define TEST_DRIVER_KEY_CONTEXT_KEY_PAIR_SIZE      0
+
+/** \def TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE
+ *
+ * Number of bytes included in every key context for a public key.
+ */
+#define TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE    0
+
+/** \def TEST_DRIVER_KEY_CONTEXT_SYMMETRIC_FACTOR
+ *
+ * Every key context for a symmetric key includes this many times the key size.
+ */
+#define TEST_DRIVER_KEY_CONTEXT_SYMMETRIC_FACTOR   0
+
+/** \def TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY
+ *
+ * If this is true for a key pair, the key context includes space for the public key.
+ * If this is false, no additional space is added for the public key.
+ */
+#define TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY   0
+
+/** \def TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION
+ *
+ * If TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION is defined, the test driver
+ * provides a size_function entry point, otherwise, it does not.
+ *
+ * Some opaque drivers have the need to support a custom size for the storage
+ * of key and context information. The size_function provides the ability to
+ * provide that customization.
+ */
+//#define TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION
+
+#ifdef TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION
+size_t test_size_function(
+    const psa_key_type_t key_type,
+    const size_t key_bits );
+#endif /* TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION */
+
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+#endif /* PSA_CRYPTO_TEST_DRIVERS_KEYGEN_H */

--- a/tests/include/test/drivers/size.h
+++ b/tests/include/test/drivers/size.h
@@ -35,8 +35,8 @@ typedef struct {
 
 /** \def TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
  *
- * This macro returns the base size for the key context. It should include
- * the size for any driver context information stored with each key.
+ * This macro returns the base size for the key context. It is the size of the
+ * driver specific information stored in each key context.
  */
 #define TEST_DRIVER_KEY_CONTEXT_BASE_SIZE          sizeof( test_driver_key_context_t )
 
@@ -92,4 +92,4 @@ size_t test_size_function(
 #endif /* TEST_DRIVER_KEY_CONTEXT_SIZE_FUNCTION */
 
 #endif /* PSA_CRYPTO_DRIVER_TEST */
-#endif /* PSA_CRYPTO_TEST_DRIVERS_KEYGEN_H */
+#endif /* PSA_CRYPTO_TEST_DRIVERS_SIZE_H */

--- a/tests/src/drivers/size.c
+++ b/tests/src/drivers/size.c
@@ -1,5 +1,6 @@
 /*
- * Umbrella include for all of the test driver functionality
+ * Test driver for retrieving key context size.
+ * Only used by opaque drivers.
  */
 /*  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
@@ -17,14 +18,30 @@
  *  limitations under the License.
  */
 
-#ifndef PSA_CRYPTO_TEST_DRIVER_H
-#define PSA_CRYPTO_TEST_DRIVER_H
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
 
-#define PSA_CRYPTO_TEST_DRIVER_LIFETIME 0x7fffff
+#if defined(MBEDTLS_PSA_CRYPTO_DRIVERS) && defined(PSA_CRYPTO_DRIVER_TEST)
+#include "psa/crypto.h"
+#include "psa_crypto_core.h"
+#include "mbedtls/error.h"
 
-#include "test/drivers/signature.h"
-#include "test/drivers/keygen.h"
-#include "test/drivers/cipher.h"
 #include "test/drivers/size.h"
 
-#endif /* PSA_CRYPTO_TEST_DRIVER_H */
+#include <string.h>
+
+#ifdef TEST_KEY_CONTEXT_SIZE_FUNCTION
+size_t test_size_function(
+    const psa_key_type_t key_type,
+    const size_t key_bits )
+{
+    (void) key_type;
+    (void) key_bits;
+    return 0;
+}
+#endif /*TEST_KEY_CONTEXT_SIZE_FUNCTION */
+
+#endif /* MBEDTLS_PSA_CRYPTO_DRIVERS && PSA_CRYPTO_DRIVER_TEST */

--- a/tests/src/drivers/size.c
+++ b/tests/src/drivers/size.c
@@ -25,13 +25,8 @@
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_DRIVERS) && defined(PSA_CRYPTO_DRIVER_TEST)
-#include "psa/crypto.h"
-#include "psa_crypto_core.h"
-#include "mbedtls/error.h"
 
 #include "test/drivers/size.h"
-
-#include <string.h>
 
 #ifdef TEST_KEY_CONTEXT_SIZE_FUNCTION
 size_t test_size_function(

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -241,6 +241,7 @@
     <ClInclude Include="..\..\tests\include\test\drivers\cipher.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\keygen.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\signature.h" />
+    <ClInclude Include="..\..\tests\include\test\drivers\size.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\test_driver.h" />
     <ClInclude Include="..\..\library\common.h" />
     <ClInclude Include="..\..\library\psa_crypto_core.h" />


### PR DESCRIPTION
Added support for retrieving key context size from unified driver interface to PSA driver wrapper. This allows the PSA core to properly receive the key context size for opaque drivers. Not included are variations of drivers to validate all permutations of drivers to confirm sizing handled correctly.

Fix https://github.com/ARMmbed/mbedtls/issues/3289

## Status
READY

## Requires Backporting
NO 