### PR TITLE
entropy: Adding brackets inside if/else

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -710,9 +710,13 @@ cleanup:
     if( verbose != 0 )
     {
         if( ret != 0 )
+        {
             mbedtls_printf( "failed\n" );
+        }
         else
+        {
             mbedtls_printf( "passed\n" );
+        }
 
         mbedtls_printf( "\n" );
     }


### PR DESCRIPTION
I tried to compile mbedtls while defining:

```#define MBEDTLS_PLATFORM_PRINTF_MACRO MY_PRETTY_PRINTF```

in my mbedtls_config.h. However, the compiler got confused at this point because of the missing brackets and expected something additional.
Adding these brackets, even if normally unnessesary, made my compiler get to calm again and guess that might be helpful for other people out there, too.
I believe the reason is simply that I defined:

```#define MY_PRETTY_PRINTF(...) printlog(__VA_ARGS__);```

So, the line, eg. `mbedtls_printf( "passed\n" );` will look like: `printlog( "passed\n" );;`, which is interpreted as two function calls since two semicolons are there.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)

## Status
**READY**

## Todos
- [ ] Tests
- [ ] Changelog updated
