### PR TITLE
fix return code

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -662,7 +662,7 @@ int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
         ret = MBEDTLS_ERR_PK_UNKNOWN_PK_ALG;
 
     if( ret == 0 && *p != end )
-        ret = MBEDTLS_ERR_PK_INVALID_PUBKEY
+        ret = MBEDTLS_ERR_PK_INVALID_PUBKEY +
               MBEDTLS_ERR_ASN1_LENGTH_MISMATCH;
 
     if( ret != 0 )


### PR DESCRIPTION
Fix #2512

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.

In all other cases, the invalid public key error, caused by an ASN1 length mismatch error, is calculated as:

https://github.com/ARMmbed/mbedtls/blob/5cb54f7b27e1ebc1602233f50c44c1ff05304852/library/pkparse.c#L638-L640

In the case this PR fixes, a `+` is missing:

https://github.com/ARMmbed/mbedtls/blob/5cb54f7b27e1ebc1602233f50c44c1ff05304852/library/pkparse.c#L664-L666

From a mathematical point of view, it doesn't matter, since in one case it expands as:

    -0x3B00 + -0x0066

And in the other as:

    -0x3B00 -0x0066

Which results in the same outcome.

However, should someone decide to change to defined values in the future, it might break compilation or come to a different outcome.

## Status
**READY**

## Requires Backporting

Yes, #3707 and #3708.

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
