### PR TITLE
Don't redefine _GNU_SOURCE if it's already defined

### DIFF
--- a/ChangeLog.d/_GNU_SOURCE-redefined.txt
+++ b/ChangeLog.d/_GNU_SOURCE-redefined.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build when the macro _GNU_SOURCE is defined to a non-empty value.
+     Fix #3432.

--- a/ChangeLog.d/getrandom.txt
+++ b/ChangeLog.d/getrandom.txt
@@ -1,2 +1,0 @@
-Changes
-   Use glibc's getrandom() instead of syscall when glibc > 2.25.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -17,7 +17,7 @@
  *  limitations under the License.
  */
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(_GNU_SOURCE)
 /* Ensure that syscall() is available even when compiling with -std=c99 */
 #define _GNU_SOURCE
 #endif


### PR DESCRIPTION
* Revert https://github.com/ARMmbed/mbedtls/pull/3642 which [caused binaries compiled with a recent libc not to work with a slightly less recent libc anymore](https://github.com/ARMmbed/mbedtls/pull/3642/files#r497469871).
* Fix https://github.com/ARMmbed/mbedtls/issues/3432, specifically the core “`_GNU_SOURCE` redefined” part.

https://github.com/ARMmbed/mbedtls/issues/3432 also discusses generalizing to other libc. This is trickier and discussed in https://github.com/ARMmbed/mbedtls/pull/3731.

Backport: [2.16](https://github.com/ARMmbed/mbedtls/pull/3735). Not applicable to 2.7 because in 2.7 we didn't define `_GNU_SOURCE` automatically, it was up to the build environment.