### PR TITLE
Backport 2.16: Don't redefine _GNU_SOURCE if it's already defined

### DIFF
--- a/ChangeLog.d/_GNU_SOURCE-redefined.txt
+++ b/ChangeLog.d/_GNU_SOURCE-redefined.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build when the macro _GNU_SOURCE is defined to a non-empty value.
+     Fix #3432.

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -44,7 +44,7 @@
  *  **********
  */
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(_GNU_SOURCE)
 /* Ensure that syscall() is available even when compiling with -std=c99 */
 #define _GNU_SOURCE
 #endif


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3734 (minus the revert, since the problematic commit was only applied to development).