### PR TITLE
Reduce padding buffer size in cbc mode

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -819,6 +819,16 @@
 #error "MBEDTLS_SSL_NO_SESSION_CACHE needs to be defined with MBEDTLS_SSL_NO_SESSION_RESUMPTION"
 #endif
 
+#if defined(MBEDTLS_SSL_CONF_PADDING_IN) &&  \
+    !defined(MBEDTLS_CIPHER_MODE_CBC)
+#error "MBEDTLS_SSL_CONF_PADDING_IN is only useful with MBEDTLS_CIPHER_MODE_CBC"
+#endif
+
+#if defined(MBEDTLS_SSL_CONF_PADDING_IN) &&  \
+    (MBEDTLS_SSL_CONF_PADDING_IN < 16)
+#error "MBEDTLS_SSL_CONF_PADDING_IN can't be smaller than a block size"
+#endif
+
 #if defined(MBEDTLS_THREADING_PTHREAD)
 #if !defined(MBEDTLS_THREADING_C) || defined(MBEDTLS_THREADING_IMPL)
 #error "MBEDTLS_THREADING_PTHREAD defined, but not all prerequisites"

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -190,7 +190,11 @@
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 #define MBEDTLS_SSL_PADDING_ADD_OUT         16 /* Currently we're always using minimal padding */
+#if defined(MBEDTLS_SSL_CONF_PADDING_IN)
+#define MBEDTLS_SSL_PADDING_ADD_IN          (MBEDTLS_SSL_CONF_PADDING_IN)
+#else
 #define MBEDTLS_SSL_PADDING_ADD_IN          256
+#endif /* MBEDTLS_SSL_CONF_PADDING_IN */
 #else
 #define MBEDTLS_SSL_PADDING_ADD_OUT         0
 #define MBEDTLS_SSL_PADDING_ADD_IN          0

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -189,9 +189,11 @@
 #endif
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
-#define MBEDTLS_SSL_PADDING_ADD            256
+#define MBEDTLS_SSL_PADDING_ADD_OUT         16 /* Currently we're always using minimal padding */
+#define MBEDTLS_SSL_PADDING_ADD_IN          256
 #else
-#define MBEDTLS_SSL_PADDING_ADD              0
+#define MBEDTLS_SSL_PADDING_ADD_OUT         0
+#define MBEDTLS_SSL_PADDING_ADD_IN          0
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -203,14 +205,15 @@
 #define MBEDTLS_SSL_PAYLOAD_OVERHEAD ( MBEDTLS_SSL_COMPRESSION_ADD +    \
                                        MBEDTLS_MAX_IV_LENGTH +          \
                                        MBEDTLS_SSL_MAC_ADD +            \
-                                       MBEDTLS_SSL_PADDING_ADD +        \
                                        MBEDTLS_SSL_MAX_CID_EXPANSION    \
                                        )
 
-#define MBEDTLS_SSL_IN_PAYLOAD_LEN ( MBEDTLS_SSL_PAYLOAD_OVERHEAD + \
-                                     ( MBEDTLS_SSL_IN_CONTENT_LEN ) )
+#define MBEDTLS_SSL_IN_PAYLOAD_LEN ( MBEDTLS_SSL_PAYLOAD_OVERHEAD +    \
+                                     MBEDTLS_SSL_PADDING_ADD_IN +      \
+                                    ( MBEDTLS_SSL_IN_CONTENT_LEN ) )
 
 #define MBEDTLS_SSL_OUT_PAYLOAD_LEN ( MBEDTLS_SSL_PAYLOAD_OVERHEAD + \
+                                      MBEDTLS_SSL_PADDING_ADD_OUT +  \
                                       ( MBEDTLS_SSL_OUT_CONTENT_LEN ) )
 
 /* The maximum number of buffered handshake messages. */


### PR DESCRIPTION
## Description
Hello,
I am currently in the process of including mbedtls into a really small embedded system. As I was looking to reduce my memory footprint, I noticed that there is some optimisations possibles in the way CBC padding is allocated and exploited.
I understand that TLS allowes CBC padding up to 256 bytes per message, but currently mbedtls only pad to round to the next block instead :
- [branch baremetal](https://github.com/ARMmbed/mbedtls/blob/baremetal/library/ssl_tls.c#L2850)
- [v2.18](https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.18/library/ssl_tls.c#L2394)
- [v2.24.0](https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.24.0/library/ssl_msg.c#L896)

However, the size allocated to accommodate the padding is still set to 256 bytes, in and out ( [branch baremetal](https://github.com/ARMmbed/mbedtls/blob/baremetal/include/mbedtls/ssl_internal.h#L191) ).
This pull request contains two commits :
- The first one only decrease the buffer size of outgoing messages to 16, which I believe is the biggest block size currently in use. I noticed that some blocksize are #define as constant, but not all of them so that's why I didn't use one of them. I believe this modification doesn't alter the ABI, as it is strictly internal.
- The second one introduce the configuration option MBEDTLS_SSL_CONF_PADDING_IN allowing one to set the buffer size of ingoing messages to a custom value. It is however not TLS compliant, so be careful to be in control of both ends if you want to change it. 

## Status
I tested both of these modifications with success on my little system. It allowed me to reduce my memory footprint by almost 500 bytes, which is about 20% of reduction ! But as my understanding of the codebase is far from perfect, all comments are welcomed, I might have missed something.

## Additional comments
My commits are not signed-of as the contributing guidelines mandate, but I am happy to wave all my right on this work to anyone if this is necessary :)


Thank you,
G4E.