### PR TITLE
Backport 2.16: all.sh: Enable verbose failure messages for CMake

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -185,6 +185,9 @@ pre_initialize_variables () {
         export MAKEFLAGS="-j"
     fi
 
+    # Include more verbose output for failing tests run by CMake
+    export CTEST_OUTPUT_ON_FAILURE=1
+
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake
     ASAN_CFLAGS='-Werror -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=all'
 


### PR DESCRIPTION
Set the CMake-observed variable `CTEST_OUTPUT_ON_FAILURE`, so that when
a "make test" run by CMake fails, verbose test output about the detail
of failure is available.

Backport of https://github.com/ARMmbed/mbed-crypto/pull/52. Rebase of https://github.com/ARMmbed/mbedtls/pull/2434.