### PR TITLE
[baremetal] Avoid array overrun in regularize_k

### DIFF
--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -1028,10 +1028,7 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 			 uECC_word_t *k1)
 {
-	bitcount_t num_n_bits = NUM_ECC_BITS;
-
-	uECC_word_t carry = uECC_vli_add(k0, k, curve_n) ||
-				 uECC_vli_testBit(k0, num_n_bits);
+	uECC_word_t carry = uECC_vli_add(k0, k, curve_n);
 
 	uECC_vli_add(k1, k0, curve_n);
 


### PR DESCRIPTION
Strip down of original tinycrypt code incorrectly removed the test for `num_n_bits` not being a whole number of words that would have eliminated the "short carry" test. This is inspecting a bit off the end of the array.

