### PR TITLE
Fix additional data length field check for CCM

### DIFF
--- a/ChangeLog.d/fix_ccm_add_length_check.txt
+++ b/ChangeLog.d/fix_ccm_add_length_check.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix an off-by-one error in the additional data length check for
+     CCM, which allowed encryption with a non-standard length field.
+     Fixes #3719.
+

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -175,7 +175,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     if( iv_len < 7 || iv_len > 13 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
-    if( add_len > 0xFF00 )
+    if( add_len >= 0xFF00 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
     q = 16 - 1 - (unsigned char) iv_len;

--- a/tests/suites/test_suite_ccm.data
+++ b/tests/suites/test_suite_ccm.data
@@ -41,9 +41,9 @@ ccm_lengths:5:10:5:18:MBEDTLS_ERR_CCM_BAD_INPUT
 CCM lengths #6 tag length not even
 ccm_lengths:5:10:5:7:MBEDTLS_ERR_CCM_BAD_INPUT
 
-CCM lengths #7 AD too long (2^16 - 2^8 + 1)
+CCM lengths #7 AD too long (2^16 - 2^8)
 depends_on:!MBEDTLS_CCM_ALT
-ccm_lengths:5:10:65281:8:MBEDTLS_ERR_CCM_BAD_INPUT
+ccm_lengths:5:10:65280:8:MBEDTLS_ERR_CCM_BAD_INPUT
 
 CCM lengths #8 msg too long for this IV length (2^16, q = 2)
 ccm_lengths:65536:13:5:8:MBEDTLS_ERR_CCM_BAD_INPUT


### PR DESCRIPTION
## Description
The CCM specification (NIST SP 800-38C) mandates that the formatting of
the additional data length l(a) changes when it is greater _or equal_ to
2^16 - 2^8 (>= 0xFF00). Since such lengths are not supported in mbed TLS,
the operation should fail in such cases.

This PR fixes an off-by-one error which allowed encryption/decryption
to be executed when l(a) was equal to 0xFF00, resulting in an
incorrect/non-standard length format being used.

Fixes #3719 

## Status
READY

## Requires Backporting
Not sure. The bug is not critical.

## Migrations
NO

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported
