### PR TITLE
Add fix for cmake control of CMAKE_BUILD_TYPE only if mbedtls is the root project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,12 @@ option: \n\
     endif()
 endif()
 
-set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
-    CACHE STRING "Choose the type of build: None Debug Release Coverage ASan ASanDbg MemSan MemSanDbg Check CheckFull"
-    FORCE)
+# If this is the root project add longer list of available CMAKE_BUILD_TYPE values
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
+        CACHE STRING "Choose the type of build: None Debug Release Coverage ASan ASanDbg MemSan MemSanDbg Check CheckFull"
+        FORCE)
+endif()
 
 # Create a symbolic link from ${base_name} in the binary directory
 # to the corresponding path in the source directory.


### PR DESCRIPTION
The current CMakeLists.txt has problems when making integration to other projects also running cmake. 
The current code traverses the CMAKE_BUILD_TYPE to the mother project, which can be anything - thus clearly problematic.
Especially if the mother project has their own sanitizers setup the current code invalidates that from the mother project.

With the patch the code will let the project using mbedtls control the build types.

Solves: https://github.com/ARMmbed/mbedtls/issues/3789
Signed-off-by: peter-toft-greve