### PR TITLE
Fix memory allocation in ccm tests

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -121,6 +121,7 @@ typedef struct data_tag
     TEST_ASSERT( ( expr1 ) == ( expr2 ) )
 
 /** Allocate memory dynamically and fail the test case if this fails.
+ * The allocated memory will be filled with zeros.
  *
  * You must set \p pointer to \c NULL before calling this macro and
  * put `mbedtls_free( pointer )` in the test's cleanup code.

--- a/tests/suites/test_suite_ccm.data
+++ b/tests/suites/test_suite_ccm.data
@@ -51,6 +51,9 @@ ccm_lengths:65536:13:5:8:MBEDTLS_ERR_CCM_BAD_INPUT
 CCM lengths #9 tag length 0
 ccm_lengths:5:10:5:0:MBEDTLS_ERR_CCM_BAD_INPUT
 
+CCM lengths #10 Large AD
+ccm_lengths:5:10:32768:8:0
+
 CCM* fixed tag lengths #1 all OK
 ccm_star_lengths:5:10:5:8:0
 

--- a/tests/suites/test_suite_ccm.function
+++ b/tests/suites/test_suite_ccm.function
@@ -41,17 +41,17 @@ void ccm_lengths( int msg_len, int iv_len, int add_len, int tag_len, int res )
     unsigned char key[16];
     unsigned char msg[10];
     unsigned char iv[14];
-    unsigned char add[10];
+    unsigned char *add = NULL;
     unsigned char out[10];
     unsigned char tag[18];
     int decrypt_ret;
 
     mbedtls_ccm_init( &ctx );
 
+    ASSERT_ALLOC_WEAK( add, add_len );
     memset( key, 0, sizeof( key ) );
     memset( msg, 0, sizeof( msg ) );
     memset( iv, 0, sizeof( iv ) );
-    memset( add, 0, sizeof( add ) );
     memset( out, 0, sizeof( out ) );
     memset( tag, 0, sizeof( tag ) );
 
@@ -70,6 +70,7 @@ void ccm_lengths( int msg_len, int iv_len, int add_len, int tag_len, int res )
         TEST_ASSERT( decrypt_ret == res );
 
 exit:
+    mbedtls_free( add );
     mbedtls_ccm_free( &ctx );
 }
 /* END_CASE */


### PR DESCRIPTION
## Description
The ccm tests were previously relying on unspecified behaviour in
the underlying implementation (i.e. that it rejects certain buffer
sizes without reading the buffer).

## Status
**READY**

## Requires Backporting
NO. Probably not required; this cleans up the test code to eliminate a potential issue but there are no active bugs.


## Steps to test or reproduce
Run test_suite_ccm
