### PR TITLE
Update mimimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #     will be removed as well as this note.
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 if(TEST_CPP)
     project("mbed TLS" C CXX)
 else()

--- a/ChangeLog.d/minimum_cmake_version_PR3802.txt
+++ b/ChangeLog.d/minimum_cmake_version_PR3802.txt
@@ -1,0 +1,3 @@
+Requirement changes
+* Update the minimum required CMake version to 2.8.12.
+* This silences a warning on CMake 3.19.0. #3801


### PR DESCRIPTION
Upgrade minimum cmake version to 3.15

* Patch for https://github.com/ARMmbed/mbedtls/issues/3801
* CMake will soon deprecate support for 2.x

Signed-off-by: Peter Toft <peter.toft@dirac.com>