### PR TITLE
Platform hook for built-in keys with context in the integration code

### DIFF
--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1326,6 +1326,20 @@
  */
 #define MBEDTLS_PKCS1_V21
 
+/**
+ * \def MBEDTLS_PSA_BUILTIN_KEYS
+ *
+ * Enable support for built-in keys in the PSA API.
+ *
+ * If you enable this symbol, you must define the two functions
+ * mbedtls_psa_get_builtin_key() and mbedtls_psa_free_builtin_key().
+ *
+ * Module:  library/psa_crypto.c
+ * Requires: MBEDTLS_PSA_CRYPTO_C
+ *
+ */
+//#define MBEDTLS_PSA_BUILTIN_KEYS
+
 /** \def MBEDTLS_PSA_CRYPTO_DRIVERS
  *
  * Enable support for the experimental PSA crypto driver interface.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -647,6 +647,78 @@ mbedtls_ecp_group_id mbedtls_ecc_group_of_psa( psa_ecc_family_t curve,
 
 /**@}*/
 
+/** \defgroup psa_builtin_keys PSA built-in keys
+ * @{
+ */
+
+#if defined(MBEDTLS_PSA_BUILTIN_KEYS)
+/** The type of slot numbers that designate a built-in key.
+ *
+ * The meaning of slot numbers is platform-specific. Generally the set of
+ * valid slot numbers ranges from 0 to a small number.
+ */
+typedef uint32_t mbedtls_psa_builtin_key_slot_number_t;
+
+/** Retrieve or calculate the data about a built-in key.
+ *
+ * \param slot_number           A unique identifier for the built-in key.
+ *                              This identifier is determined by the key
+ *                              identifier specified by the application.
+ * \param[out] attributes       On entry, this contains the requested
+ *                              key identifier. All other attributes have
+ *                              their default value.
+ *                              On success, this must contain the attributes
+ *                              of the key, including its type, bit-size and
+ *                              usage policy.
+ * \param[out] key_data         On success, a pointer to the key data.
+ *                              For a transparent key (a key whose location
+ *                              is #PSA_KEY_LOCATION_LOCAL_STORAGE), this
+ *                              is a representation of the key that
+ *                              psa_import_key() would accept.
+ *                              For an opaque key (a key whose location is
+ *                              handled by a driver), this is a representation
+ *                              of the key that the driver will accept.
+ *                              The pointer must remain valid until the core
+ *                              subsequently calls
+ *                              mbedtls_psa_free_builtin_key().
+ * \param[out] key_data_size    On success, the size of the buffer that
+ *                              \p *key_data points to, in bytes.
+ *
+ * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_DOES_NOT_EXIST
+ * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ * \retval #PSA_ERROR_COMMUNICATION_FAILURE
+ */
+psa_status_t mbedtls_psa_get_builtin_key(
+    mbedtls_psa_builtin_key_slot_number_t slot_number,
+    psa_key_attributes_t *attributes,
+    uint8_t** key_data,
+    size_t *key_data_size );
+
+/** Free resources associated with an instance of a built-in key.
+ *
+ * The core calls mbedtls_psa_free_builtin_key() once after each successful
+ * call to mbedtls_psa_get_builtin_key(), with matching parameters.
+ *
+ * \param slot_number           A unique identifier for the built-in key.
+ *                              This is the value that was passed to
+ *                              mbedtls_psa_get_builtin_key().
+ * \param[in] attributes        The attributes of the key.
+ * \param[in] key_data          A pointer to the key data. This is the pointer
+ *                              that mbedtls_psa_get_builtin_key()
+ *                              passed out.
+ * \param key_data_size         The key data size passed out by
+ *                              mbedtls_psa_get_builtin_key().
+ */
+void mbedtls_psa_free_builtin_key(
+    mbedtls_psa_builtin_key_slot_number_t slot_number,
+    const psa_key_attributes_t *attributes,
+    uint8_t* key_data,
+    size_t key_data_size );
+#endif /* MBEDTLS_PSA_BUILTIN_KEYS */
+
+/**@}*/
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1667,6 +1667,22 @@
  */
 #define PSA_KEY_ID_VENDOR_MAX                   ((psa_key_id_t)0x7fffffff)
 
+/** The minimum value for a key identifier that is built into the
+ * implementation.
+ *
+ * This must be between #PSA_KEY_ID_VENDOR_MIN and #PSA_KEY_ID_VENDOR_MAX
+ * and is part of the library's ABI.
+ */
+#define MBEDTLS_PSA_KEY_ID_BUILTIN_MIN          ((psa_key_id_t)0x7fff0000)
+/** The maximum value for a key identifier that is built into the
+ * implementation.
+ *
+ * The range of # keys starting at #MBEDTLS_PSA_KEY_ID_BUILTIN_MIN
+ * must fall within #PSA_KEY_ID_VENDOR_MIN and #PSA_KEY_ID_VENDOR_MAX
+ * and must not intersect with any other set of implementation-chosen key
+ * identifiers.
+ */
+#define MBEDTLS_PSA_KEY_ID_BUILTIN_MAX          ((psa_key_id_t)0x7fffefff)
 
 #if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
 

--- a/library/version_features.c
+++ b/library/version_features.c
@@ -435,6 +435,9 @@ static const char * const features[] = {
 #if defined(MBEDTLS_PKCS1_V21)
     "MBEDTLS_PKCS1_V21",
 #endif /* MBEDTLS_PKCS1_V21 */
+#if defined(MBEDTLS_PSA_BUILTIN_KEYS)
+    "MBEDTLS_PSA_BUILTIN_KEYS",
+#endif /* MBEDTLS_PSA_BUILTIN_KEYS */
 #if defined(MBEDTLS_PSA_CRYPTO_DRIVERS)
     "MBEDTLS_PSA_CRYPTO_DRIVERS",
 #endif /* MBEDTLS_PSA_CRYPTO_DRIVERS */

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -1216,6 +1216,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PKCS1_V21 */
 
+#if defined(MBEDTLS_PSA_BUILTIN_KEYS)
+    if( strcmp( "MBEDTLS_PSA_BUILTIN_KEYS", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PSA_BUILTIN_KEYS );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PSA_BUILTIN_KEYS */
+
 #if defined(MBEDTLS_PSA_CRYPTO_DRIVERS)
     if( strcmp( "MBEDTLS_PSA_CRYPTO_DRIVERS", config ) == 0 )
     {


### PR DESCRIPTION
Allow a platform to declare some built-in keys. This can be, for example, keys that are derived from a hardware unique key, or keys that are pre-provisioned in a secure element.

Status: work in progress. @stevew817

* See [`include/mbedtls/config.h`](https://github.com/gilles-peskine-arm/mbedtls/blob/psa-builtin-keys/include/mbedtls/config.h) and [`include/psa/crypto.h`](https://github.com/gilles-peskine-arm/mbedtls/blob/psa-builtin-keys/include/psa/crypto_extra.h) for documentation.
* The implementation is untested code which I wrote only to estimate the impact and ensure that data is available where it needs to be. It will need to be heavily rewritten for [openless key management](https://github.com/ARMmbed/mbedtls/pull/3547).
* See [`tests/src/helpers.c`](https://github.com/gilles-peskine-arm/mbedtls/blob/psa-builtin-keys/tests/src/helpers.c) for sample usage. (This code is likely to move to a separate file.)
* There are no tests.
