### PR TITLE
Move record-consumption logic out of datagram-fetching routine

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -4507,27 +4507,24 @@ static int ssl_consume_current_message( mbedtls_ssl_context *ssl )
         /*
          * Move to the next record in the already read datagram if applicable
          */
-        if( ssl->next_record_offset != 0 )
+        if( ssl->in_left < ssl->next_record_offset )
         {
-            if( ssl->in_left < ssl->next_record_offset )
-            {
-                MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
-                return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
-            }
-
-            ssl->in_left -= ssl->next_record_offset;
-
-            if( ssl->in_left != 0 )
-            {
-                MBEDTLS_SSL_DEBUG_MSG( 2, ( "next record in same datagram, offset: %d",
-                                            ssl->next_record_offset ) );
-                memmove( ssl->in_hdr,
-                         ssl->in_hdr + ssl->next_record_offset,
-                         ssl->in_left );
-            }
-
-            ssl->next_record_offset = 0;
+            MBEDTLS_SSL_DEBUG_MSG( 1, ( "should never happen" ) );
+            return( MBEDTLS_ERR_SSL_INTERNAL_ERROR );
         }
+
+        ssl->in_left -= ssl->next_record_offset;
+
+        if( ssl->in_left != 0 )
+        {
+            MBEDTLS_SSL_DEBUG_MSG( 2, ( "next record in same datagram, offset: %d",
+                                        ssl->next_record_offset ) );
+            memmove( ssl->in_hdr,
+                     ssl->in_hdr + ssl->next_record_offset,
+                     ssl->in_left );
+        }
+
+        ssl->next_record_offset = 0;
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 


### PR DESCRIPTION
When processing the stack of datagrams, (D)TLS records, messages, the preparation of _new_ content is logically separate from the disposal of old, already processed content.

Previously, however, in case of DTLS the datagram fetching routine `mbedtls_ssl_fetch_input()` not only implemented the fetching of a new datagram, but also the logic of disposing of the last record.

This PR moves the record-disposal logic from `mbedtls_ssl_fetch_input()` to `ssl_consume_current_message()`.