### PR TITLE
Restore tinycrypt implementation of regularize_k()

### DIFF
--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -1610,10 +1610,20 @@ static void EccPoint_mult(uECC_word_t * result, const uECC_word_t * point,
 static uECC_word_t regularize_k(const uECC_word_t * const k, uECC_word_t *k0,
 			 uECC_word_t *k1)
 {
+	wordcount_t num_n_words = NUM_ECC_WORDS;	
 	bitcount_t num_n_bits = NUM_ECC_BITS;
 
+	/* With our constant NUM_ECC_BITS and NUM_ECC_WORDS the
+	 * check (num_n_bits < ((bitcount_t)num_n_words * uECC_WORD_SIZE * 8) always would have "false" result (256 < 256),
+	 * therefore Coverity warning may be detected. Removing of this line without changing the entire check will cause to 
+	 * array overrun.
+	 * The entire check is not changed on purpose  to be aligned with original tinycrypt
+	 * implementation and to allow upstreaming to other curves if required.
+	 * Coverity specific annotation may be added to silence warning if exists.    
+	*/
 	uECC_word_t carry = uECC_vli_add(k0, k, curve_n) ||
-				 uECC_vli_testBit(k0, num_n_bits);
+			     (num_n_bits < ((bitcount_t)num_n_words * uECC_WORD_SIZE * 8) &&
+			     uECC_vli_testBit(k0, num_n_bits));
 
 	uECC_vli_add(k1, k0, curve_n);
 


### PR DESCRIPTION
Restore original tinycrypt implementation of regularize_k() function . 
The fix provide more general solution to array overrun problem that found out by Kevin Bracey in https://github.com/ARMmbed/mbedtls/pull/3749

