### PR TITLE
[baremetal] ssl_server2: move memory allocation to the beginning

### DIFF
--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1643,6 +1643,103 @@ int main( int argc, char *argv[] )
     char *p, *q;
     const int *list;
 
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+    mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
+#if defined(MBEDTLS_MEMORY_DEBUG)
+    size_t current_heap_memory, peak_heap_memory, heap_blocks;
+#endif  /* MBEDTLS_MEMORY_DEBUG */
+#endif  /* MBEDTLS_MEMORY_BUFFER_ALLOC_C */
+
+    ssl         = mbedtls_calloc( 1, sizeof( *ssl ) );
+    conf        = mbedtls_calloc( 1, sizeof( *conf ) );
+    entropy     = mbedtls_calloc( 1, sizeof( *entropy) );
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+    cacert      = mbedtls_calloc( 1, sizeof( *cacert ) );
+    srvcert     = mbedtls_calloc( 1, sizeof( *srvcert ) );
+    pkey        = mbedtls_calloc( 1, sizeof( *pkey ) );
+    srvcert2    = mbedtls_calloc( 1, sizeof( *srvcert2 ) );
+    pkey2       = mbedtls_calloc( 1, sizeof( *pkey2 ) );
+#endif
+#if defined(MBEDTLS_SSL_CACHE_C)
+    cache       = mbedtls_calloc( 1, sizeof( *cache ) );
+#endif
+#if defined(MBEDTLS_TIMING_C)
+    timer       = mbedtls_calloc( 1, sizeof( *timer ) );
+#endif
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+    ticket_ctx  = mbedtls_calloc( 1, sizeof( *ticket_ctx ) );
+#endif
+#if defined(MBEDTLS_CTR_DRBG_C)
+    ctr_drbg    = mbedtls_calloc( 1, sizeof( *ctr_drbg ) );
+#else
+    hmac_drbg   = mbedtls_calloc( 1, sizeof( *hmac_drbg ) );
+#endif
+
+    if( ssl         == NULL || conf     == NULL ||
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+        cacert      == NULL || srvcert  == NULL ||
+        pkey        == NULL || srvcert2 == NULL ||
+        pkey2       == NULL ||
+#endif
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+        ticket_ctx  == NULL ||
+#endif
+#if defined(MBEDTLS_SSL_CACHE_C)
+        cache       == NULL ||
+#endif
+#if defined(MBEDTLS_TIMING_C)
+        timer       == NULL ||
+#endif
+#if defined(MBEDTLS_CTR_DRBG_C)
+        ctr_drbg    == NULL ||
+#else
+        hmac_drbg   == NULL ||
+#endif
+        entropy     == NULL)
+    {
+        mbedtls_printf( "Initial allocations failed!\n" );
+        goto exit;
+    }
+
+    /*
+     * Make sure memory references are valid in case we exit early.
+     */
+    mbedtls_net_init( &client_fd );
+    mbedtls_net_init( &listen_fd );
+    mbedtls_ssl_init( ssl );
+    mbedtls_ssl_config_init( conf );
+    mbedtls_entropy_init( entropy );
+#if defined(MBEDTLS_CTR_DRBG_C)
+    mbedtls_ctr_drbg_init( ctr_drbg );
+#else
+    mbedtls_hmac_drbg_init( hmac_drbg );
+#endif /* MBEDTLS_CTR_DRBG_C */
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+    mbedtls_x509_crt_init( cacert );
+    mbedtls_x509_crt_init( srvcert );
+    mbedtls_pk_init( pkey );
+    mbedtls_x509_crt_init( srvcert2 );
+    mbedtls_pk_init( pkey2 );
+#if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
+    memset( &ssl_async_keys, 0, sizeof( ssl_async_keys ) );
+#endif
+#endif
+#if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_FS_IO)
+    mbedtls_dhm_init( &dhm );
+#endif
+#if defined(MBEDTLS_SSL_CACHE_C)
+    mbedtls_ssl_cache_init( cache );
+#endif
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+    mbedtls_ssl_ticket_init( ticket_ctx );
+#endif
+#if defined(MBEDTLS_SSL_ALPN)
+    memset( (void *) alpn_list, 0, sizeof( alpn_list ) );
+#endif
+#if defined(MBEDTLS_SSL_COOKIE_C)
+    mbedtls_ssl_cookie_init( &cookie_ctx );
+#endif
+
 #if !defined(_WIN32)
     /* Abort cleanly on SIGTERM and SIGINT */
     signal( SIGTERM, term_handler );
@@ -2308,104 +2405,6 @@ int main( int argc, char *argv[] )
             }
         }
     }
-
-
-#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
-    mbedtls_memory_buffer_alloc_init( alloc_buf, sizeof(alloc_buf) );
-#if defined(MBEDTLS_MEMORY_DEBUG)
-    size_t current_heap_memory, peak_heap_memory, heap_blocks;
-#endif  /* MBEDTLS_MEMORY_DEBUG */
-#endif  /* MBEDTLS_MEMORY_BUFFER_ALLOC_C */
-
-    ssl         = mbedtls_calloc( 1, sizeof( *ssl ) );
-    conf        = mbedtls_calloc( 1, sizeof( *conf ) );
-    entropy     = mbedtls_calloc( 1, sizeof( *entropy) );
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    cacert      = mbedtls_calloc( 1, sizeof( *cacert ) );
-    srvcert     = mbedtls_calloc( 1, sizeof( *srvcert ) );
-    pkey        = mbedtls_calloc( 1, sizeof( *pkey ) );
-    srvcert2    = mbedtls_calloc( 1, sizeof( *srvcert2 ) );
-    pkey2       = mbedtls_calloc( 1, sizeof( *pkey2 ) );
-#endif
-#if defined(MBEDTLS_SSL_CACHE_C)
-    cache       = mbedtls_calloc( 1, sizeof( *cache ) );
-#endif
-#if defined(MBEDTLS_TIMING_C)
-    timer       = mbedtls_calloc( 1, sizeof( *timer ) );
-#endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
-    ticket_ctx  = mbedtls_calloc( 1, sizeof( *ticket_ctx ) );
-#endif
-#if defined(MBEDTLS_CTR_DRBG_C)
-    ctr_drbg    = mbedtls_calloc( 1, sizeof( *ctr_drbg ) );
-#else
-    hmac_drbg   = mbedtls_calloc( 1, sizeof( *hmac_drbg ) );
-#endif
-
-    if( ssl         == NULL || conf     == NULL ||
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-        cacert      == NULL || srvcert  == NULL ||
-        pkey        == NULL || srvcert2 == NULL ||
-        pkey2       == NULL ||
-#endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
-        ticket_ctx  == NULL ||
-#endif
-#if defined(MBEDTLS_SSL_CACHE_C)
-        cache       == NULL ||
-#endif
-#if defined(MBEDTLS_TIMING_C)
-        timer       == NULL ||
-#endif
-#if defined(MBEDTLS_CTR_DRBG_C)
-        ctr_drbg    == NULL ||
-#else
-        hmac_drbg   == NULL ||
-#endif
-        entropy     == NULL)
-    {
-        mbedtls_printf( "Initial allocations failed!\n" );
-        goto exit;
-    }
-
-    /*
-     * Make sure memory references are valid in case we exit early.
-     */
-    mbedtls_net_init( &client_fd );
-    mbedtls_net_init( &listen_fd );
-    mbedtls_ssl_init( ssl );
-    mbedtls_ssl_config_init( conf );
-    mbedtls_entropy_init( entropy );
-#if defined(MBEDTLS_CTR_DRBG_C)
-    mbedtls_ctr_drbg_init( ctr_drbg );
-#else
-    mbedtls_hmac_drbg_init( hmac_drbg );
-#endif /* MBEDTLS_CTR_DRBG_C */
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-    mbedtls_x509_crt_init( cacert );
-    mbedtls_x509_crt_init( srvcert );
-    mbedtls_pk_init( pkey );
-    mbedtls_x509_crt_init( srvcert2 );
-    mbedtls_pk_init( pkey2 );
-#if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
-    memset( &ssl_async_keys, 0, sizeof( ssl_async_keys ) );
-#endif
-#endif
-#if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_FS_IO)
-    mbedtls_dhm_init( &dhm );
-#endif
-#if defined(MBEDTLS_SSL_CACHE_C)
-    mbedtls_ssl_cache_init( cache );
-#endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
-    mbedtls_ssl_ticket_init( ticket_ctx );
-#endif
-#if defined(MBEDTLS_SSL_ALPN)
-    memset( (void *) alpn_list, 0, sizeof( alpn_list ) );
-#endif
-#if defined(MBEDTLS_SSL_COOKIE_C)
-    mbedtls_ssl_cookie_init( &cookie_ctx );
-#endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     if( unhexify( cid, opt.cid_val, &cid_len ) != 0 )


### PR DESCRIPTION
This way, even when an error is encountered early, the memory will be deallocated properly.
