### PR TITLE
[minor] Fix printf errors in tests/ssl-opt.sh on MacOS

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -756,12 +756,12 @@ run_test() {
         fi
 
         check_osrv_dtls
-        printf "# $NAME\n$SRV_CMD\n" > $SRV_OUT
+        printf "# %s\n%\n" "$NAME" "$SRV_CMD" > $SRV_OUT
         provide_input | $SRV_CMD >> $SRV_OUT 2>&1 &
         SRV_PID=$!
         wait_server_start "$SRV_PORT" "$SRV_PID"
 
-        printf "# $NAME\n$CLI_CMD\n" > $CLI_OUT
+        printf "# %s\n%\n" "$NAME" "$CLI_CMD" > $CLI_OUT
         eval "$CLI_CMD" >> $CLI_OUT 2>&1 &
         wait_client_done
 


### PR DESCRIPTION

Signed-off-by: Omer Shapira <omer.shapira@gmail.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
When running `tests/ssl-opt.sh` on MacOS, the builtin `printf` command fails with errors on some invocations of `printf "# $XXX\n$YYY" `, with error message similar to:

```
Renego ext: gnutls server strict, client default ....................... ./ssl-opt.sh: line 759: printf: `S': invalid format character
PASS

```

This turns out to be due to the `zsh` on MacOS not interpolating the environment variables in the format string when using the builtin `printf` command.

This diff replaces the erroneous invocations with a safer "interpret as string" format characters.

## Status
**READY**

## Requires Backporting

Yes 
LTS branches

## Migrations
If there is any API change, what's the incentive and logic for it.
There is no API change.

NO 

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
```
mkdir -p build
cd build
cmake ..
make
cd tests
./ssl-opt.sh 2>&1 | grep 'invalid format character'
```
