### PR TITLE
[minor] Added Cscope to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ massif-*
 /GSYMS
 /GTAGS
 /TAGS
+/cscope*.out
 /tags


### PR DESCRIPTION
## Description

Added a pattern for CScope [http://cscope.sourceforge.net/] to .gitignore.

## Status
**READY**

## Requires Backporting
Probably not, unless CScope is used heavily in the LTS versions.

NO  

## Migrations
NO

## Steps to test or reproduce
```
# Create a list of files to index
find . -type f | egrep ".*(h|c|function)$" > cscope.files
# Build CScope index files 
cscope -bq -u -Iinclude
ls cscope* 
git status 
```
