### PR TITLE
cmake: Avoid using target_properties for old cmake

### DIFF
--- a/programs/fuzz/CMakeLists.txt
+++ b/programs/fuzz/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(exe IN LISTS executables_no_common_c executables_with_common_c)
 
     if (NOT FUZZINGENGINE_LIB)
         target_link_libraries(${exe} ${libs})
-        target_sources(${exe} PRIVATE onefile.c)
+        set_property(TARGET ${exe} APPEND PROPERTY SOURCES onefile.c)
     else()
         target_link_libraries(${exe} ${libs} FuzzingEngine)
         SET_TARGET_PROPERTIES(${exe} PROPERTIES LINKER_LANGUAGE CXX)
@@ -45,7 +45,7 @@ foreach(exe IN LISTS executables_no_common_c executables_with_common_c)
     # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
     list(FIND executables_with_common_c ${exe} exe_index)
     if (${exe_index} GREATER -1)
-        target_sources(${exe} PRIVATE common.c)
+        set_property(TARGET ${exe} APPEND PROPERTY SOURCES common.c)
     endif()
 
 endforeach()

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -32,8 +32,8 @@ foreach(exe IN LISTS executables)
     target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
 endforeach()
 
-target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
-target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
+set_property(TARGET ssl_client2 APPEND PROPERTY SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
+set_property(TARGET ssl_server2 APPEND PROPERTY SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
 
 if(THREADS_FOUND)
     add_executable(ssl_pthread_server ssl_pthread_server.c $<TARGET_OBJECTS:mbedtls_test>)

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -37,7 +37,8 @@ foreach(exe IN LISTS executables_libs executables_mbedcrypto)
     endif()
 endforeach()
 
-target_sources(query_compile_time_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
+set_property(TARGET query_compile_time_config APPEND PROPERTY SOURCES
+             ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 
 install(TARGETS ${executables_libs} ${executables_mbedcrypto}
         DESTINATION "bin"


### PR DESCRIPTION
CMake versions less than 3.0 do not support the `target_sources`
command.  In order to be able to support v2.8.12.2 of cmake, directly
set the SOURCES property instead of using the target_sources command.

A future patch could reverse this, if the project decides to forgo
support for cmake versions less than 3.0.

Fixes #3801

Signed-off-by: David Brown <david.brown@linaro.org>

## Status
**READY/**

## Requires Backporting

Yes 2.16

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [x] Backported

Backport to 2.16: #3851

## Steps to test or reproduce
Build using cmake 2.8.12.2.
