### PR TITLE
cmake: Avoid using target_properties for old cmake

### DIFF
--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -37,8 +37,8 @@ target_link_libraries(mini_client ${libs})
 add_executable(ssl_client1 ssl_client1.c)
 target_link_libraries(ssl_client1 ${libs})
 
-add_executable(ssl_client2 ssl_client2.c)
-target_sources(ssl_client2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
+add_executable(ssl_client2 ssl_client2.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 target_link_libraries(ssl_client2 ${libs})
 
 add_executable(ssl_fork_server ssl_fork_server.c)
@@ -50,8 +50,8 @@ target_link_libraries(ssl_mail_client ${libs})
 add_executable(ssl_server ssl_server.c)
 target_link_libraries(ssl_server ${libs})
 
-add_executable(ssl_server2 ssl_server2.c)
-target_sources(ssl_server2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
+add_executable(ssl_server2 ssl_server2.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 target_link_libraries(ssl_server2 ${libs})
 
 if(THREADS_FOUND)

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -27,8 +27,8 @@ target_link_libraries(udp_proxy ${libs})
 add_executable(zeroize zeroize.c)
 target_link_libraries(zeroize ${libs})
 
-add_executable(query_compile_time_config query_compile_time_config.c)
-target_sources(query_compile_time_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../ssl/query_config.c)
+add_executable(query_compile_time_config query_compile_time_config.c
+               ${CMAKE_CURRENT_SOURCE_DIR}/../ssl/query_config.c)
 target_link_libraries(query_compile_time_config ${libs})
 
 install(TARGETS selftest benchmark udp_proxy query_compile_time_config


### PR DESCRIPTION
CMake versions less than 3.0 do not support the `target_sources`
command.  In order to be able to support v2.8.12.2 of cmake, add the
extra targets directly to the target command.

This is a backport from the development branch, except that the uses in
this branch are simpler, and modifying the SOURCES property directly is
not needed.

Fixes #3801

Signed-off-by: David Brown <david.brown@linaro.org>

Backport of #3845. This backport follows the same spirit, but the uses of target_sources in the 2.16 branch are much simpler than in the development branch, and it is easier to just add the extra targets to the main executable command.