### PR TITLE
[baremetal] Avoid narrow loop counters etc

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -547,7 +547,7 @@ static void aes_gen_tables( void )
  *  |0x10|0x03|0x10|0x10|0x10|0x04|0x00| ... |0x04|0x00|0x04|0x03|0x07|
  */
 #if defined(MBEDTLS_AES_SCA_COUNTERMEASURES)
-static int aes_sca_cm_data_randomize( uint8_t *tbl, uint8_t tbl_len )
+static int aes_sca_cm_data_randomize( uint8_t *tbl, int tbl_len )
 {
     int i = 0, j, is_even_pos, dummy_rounds, num;
 

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -40,6 +40,7 @@
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_util.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
@@ -157,8 +158,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
                            unsigned char *tag, size_t tag_len )
 {
     int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
-    unsigned char i;
-    unsigned char q;
+    uint_fast8_t i;
+    uint_fast8_t q;
     size_t len_left, olen;
     unsigned char b[16];
     unsigned char y[16];
@@ -183,7 +184,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     if( add_len > 0xFF00 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
-    q = 16 - 1 - (unsigned char) iv_len;
+    q = (uint_fast8_t) (16 - 1 - iv_len);
 
     /*
      * First block B_0:
@@ -368,7 +369,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
 {
     int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
     unsigned char check_tag[16];
-    unsigned char i;
+    uint_fast8_t i;
     int diff;
 
     CCM_VALIDATE_RET( ctx != NULL );

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -36,6 +36,7 @@
 #include "mbedtls/platform_util.h"
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #if defined(MBEDTLS_CHACHAPOLY_C)
@@ -591,7 +592,7 @@ static void add_pkcs_padding( unsigned char *output, size_t output_len,
         size_t data_len )
 {
     size_t padding_len = output_len - data_len;
-    unsigned char i;
+    uint_fast8_t i;
 
     for( i = 0; i < padding_len; i++ )
         output[data_len + i] = (unsigned char) padding_len;
@@ -601,7 +602,7 @@ static int get_pkcs_padding( unsigned char *input, size_t input_len,
         size_t *data_len )
 {
     size_t i, pad_idx;
-    unsigned char padding_len, bad = 0;
+    uint_fast8_t padding_len, bad = 0;
 
     if( NULL == input || NULL == data_len )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
@@ -631,7 +632,7 @@ static void add_one_and_zeros_padding( unsigned char *output,
                                        size_t output_len, size_t data_len )
 {
     size_t padding_len = output_len - data_len;
-    unsigned char i = 0;
+    uint_fast8_t i = 0;
 
     output[data_len] = 0x80;
     for( i = 1; i < padding_len; i++ )
@@ -642,7 +643,7 @@ static int get_one_and_zeros_padding( unsigned char *input, size_t input_len,
                                       size_t *data_len )
 {
     size_t i;
-    unsigned char done = 0, prev_done, bad;
+    uint_fast8_t done = 0, prev_done, bad;
 
     if( NULL == input || NULL == data_len )
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
@@ -670,7 +671,7 @@ static void add_zeros_and_len_padding( unsigned char *output,
                                        size_t output_len, size_t data_len )
 {
     size_t padding_len = output_len - data_len;
-    unsigned char i = 0;
+    uint_fast8_t i = 0;
 
     for( i = 1; i < padding_len; i++ )
         output[data_len + i - 1] = 0x00;

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -82,6 +82,7 @@
 #include "mbedtls/threading.h"
 #include "mbedtls/platform_util.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #if !defined(MBEDTLS_ECP_ALT)
@@ -183,7 +184,7 @@ static void ecp_restart_rsm_init( mbedtls_ecp_restart_mul_ctx *ctx )
  */
 static void ecp_restart_rsm_free( mbedtls_ecp_restart_mul_ctx *ctx )
 {
-    unsigned char i;
+    uint_fast8_t i;
 
     if( ctx == NULL )
         return;
@@ -1753,7 +1754,7 @@ static int ecp_select_comb( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                             unsigned char i )
 {
     int ret;
-    unsigned char ii, j;
+    uint_fast8_t ii, j;
 
     /* Ignore the "sign" bit and scale down */
     ii =  ( i & 0x7Fu ) >> 1;
@@ -2019,7 +2020,8 @@ static int ecp_mul_comb( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
                          mbedtls_ecp_restart_ctx *rs_ctx )
 {
     int ret;
-    unsigned char w, p_eq_g, i;
+    unsigned char w, p_eq_g;
+    uint_fast8_t i;
     size_t d;
     unsigned char T_size, T_ok;
     mbedtls_ecp_point *T;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -35,6 +35,8 @@
 
 #if defined(MBEDTLS_SSL_TLS_C)
 
+#include <stdint.h>
+
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
@@ -2932,7 +2934,7 @@ int mbedtls_ssl_encrypt_buf( mbedtls_ssl_context *ssl,
         else if( transform->ivlen == 12 && transform->fixed_ivlen == 12 )
         {
             /* ChachaPoly: fixed XOR sequence number */
-            unsigned char i;
+            uint_fast8_t i;
 
             mbedtls_platform_memcpy( iv, transform->iv_enc, transform->fixed_ivlen );
 
@@ -3317,7 +3319,7 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
         if( transform->ivlen == 12 && transform->fixed_ivlen == 12 )
         {
             /* ChachaPoly: fixed XOR sequence number */
-            unsigned char i;
+            uint_fast8_t i;
 
             mbedtls_platform_memcpy( iv, transform->iv_dec, transform->fixed_ivlen );
 
@@ -4021,7 +4023,7 @@ static int ssl_resend_hello_request( mbedtls_ssl_context *ssl )
         uint32_t ratio =
             mbedtls_ssl_conf_get_hs_timeout_max( ssl->conf ) /
             mbedtls_ssl_conf_get_hs_timeout_min( ssl->conf ) + 1;
-        unsigned char doublings = 1;
+        int_fast8_t doublings = 1;
 
         while( ratio != 0 )
         {
@@ -8604,7 +8606,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if( MBEDTLS_SSL_TRANSPORT_IS_DTLS( ssl->conf->transport ) )
     {
-        unsigned char i;
+        uint_fast8_t i;
 
         /* Remember current epoch settings for resending */
         ssl->handshake->alt_transform_out = ssl->transform_out;

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -160,7 +160,7 @@ static int uECC_check_curve_integrity(void)
 		0x76, 0x0a, 0xe2, 0xbc, 0xce, 0x2a, 0xa2, 0xc6,
 		0x38, 0xf2, 0x19, 0x1d, 0x76, 0x72, 0x93, 0x49,
 	};
-	unsigned char diff = 0;
+	int diff = 0;
 	unsigned char tmp1, tmp2;
 	volatile unsigned i;
 
@@ -177,7 +177,7 @@ static int uECC_check_curve_integrity(void)
 
 	/* i should be 32 */
 	mbedtls_platform_random_delay();
-	diff |= (unsigned char) i ^ 32;
+	diff |= i ^ 32;
 
 	return diff;
 }


### PR DESCRIPTION
Use `uint_fast8_t` instead of `unsigned char` in various loop-type situations. This avoids the need for a 16 or 32-bit system to insert explicit narrow-to-8-bit instructions.

Not the result of an exhaustive source analysis, rather inspecting the disassembly output for a cut-down Cortex-M0+ build looking for UXTB etc instructions, so there could well be more in the complete configuration.
