### PR TITLE
[Backport 2.16] Make the aes xts methods independent from MBEDTLS_AES_SETKEY_DEC_ALT

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -735,6 +735,7 @@ exit:
 
     return( ret );
 }
+#endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 static int mbedtls_aes_xts_decode_keys( const unsigned char *key,
@@ -812,8 +813,6 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
     return mbedtls_aes_setkey_dec( &ctx->crypt, key1, key1bits );
 }
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
-
-#endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
 
 #define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                     \
     do                                                          \


### PR DESCRIPTION
This is the 2.16 backport of #3823.
No changes made to the original PR.

This is fix for the MBEDTLS_AES_SETKEY_DEC_ALT macro switch is including the aes xts methods
and building with a custom mbedtls_aes_setkey_dec function will disable the aes xts methods.
The fix is separating the aes xts methods and the MBEDTLS_AES_SETKEY_DEC_ALT can only
switch the presence of the mbedtls_aes_setkey_dec function.

Fixes #3818.