### PR TITLE
Fix several configuration-related issues

### DIFF
--- a/ChangeLog.d/error-include-string.txt
+++ b/ChangeLog.d/error-include-string.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix conditions for including string.h in error.c. Fixes #3866.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3856,7 +3856,9 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
 #include "mbedtls/config_psa.h"
+#endif
 
 #include "mbedtls/check_config.h"
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2057,7 +2057,11 @@
  * API to be configured separately from support through the mbedtls API.
  *
  * Uncomment this to enable use of PSA Crypto configuration settings which
- * can be found in include/psa/crypto_config.h
+ * can be found in include/psa/crypto_config.h.
+ *
+ * If you enable this option and write your own configuration file, you must
+ * include mbedtls/config_psa.h in your configuration file. The default
+ * provided mbedtls/config.h contains the necessary inclusion.
  *
  * This feature is still experimental and is not ready for production since
  * it is not completed.

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -41,6 +41,10 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+/* Translate between classic MBEDTLS_xxx feature symbols and PSA_xxx
+ * feature symbols. */
+#include "mbedtls/config_psa.h"
+
 /* PSA requires several types which C99 provides in stdint.h. */
 #include <stdint.h>
 

--- a/library/error.c
+++ b/library/error.c
@@ -19,20 +19,20 @@
 
 #include "common.h"
 
+#include "mbedtls/error.h"
+
+#if defined(MBEDTLS_ERROR_C) || defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+
 #if defined(MBEDTLS_ERROR_C)
-#include <string.h>
-#endif
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
 #define mbedtls_snprintf snprintf
-#define mbedtls_time_t   time_t
 #endif
 
-#if defined(MBEDTLS_ERROR_C)
-
 #include <stdio.h>
+#include <string.h>
 
 #if defined(MBEDTLS_AES_C)
 #include "mbedtls/aes.h"
@@ -960,8 +960,6 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
 
 #else /* MBEDTLS_ERROR_C */
 
-#if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
-
 /*
  * Provide an non-function in case MBEDTLS_ERROR_C is not defined
  */
@@ -973,6 +971,6 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         buf[0] = '\0';
 }
 
-#endif /* MBEDTLS_ERROR_STRERROR_DUMMY */
-
 #endif /* MBEDTLS_ERROR_C */
+
+#endif /* MBEDTLS_ERROR_C || MBEDTLS_ERROR_STRERROR_DUMMY */

--- a/library/error.c
+++ b/library/error.c
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+#if defined(MBEDTLS_ERROR_C)
 #include <string.h>
 #endif
 

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -26,10 +26,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_ERROR_C)
+#if !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_ERROR_C) || \
+    !defined(MBEDTLS_SSL_TLS_C)
 int main( void )
 {
-    printf("MBEDTLS_X509_CRT_PARSE_C and/or MBEDTLS_ERROR_C not defined.\n");
+    printf("MBEDTLS_X509_CRT_PARSE_C and/or MBEDTLS_ERROR_C and/or "
+           "MBEDTLS_SSL_TLS_C not defined.\n");
     return( 0 );
 }
 #else

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -19,20 +19,20 @@
 
 #include "common.h"
 
+#include "mbedtls/error.h"
+
+#if defined(MBEDTLS_ERROR_C) || defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+
 #if defined(MBEDTLS_ERROR_C)
-#include <string.h>
-#endif
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
 #define mbedtls_snprintf snprintf
-#define mbedtls_time_t   time_t
 #endif
 
-#if defined(MBEDTLS_ERROR_C)
-
 #include <stdio.h>
+#include <string.h>
 
 HEADER_INCLUDED
 
@@ -149,8 +149,6 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
 
 #else /* MBEDTLS_ERROR_C */
 
-#if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
-
 /*
  * Provide an non-function in case MBEDTLS_ERROR_C is not defined
  */
@@ -162,6 +160,6 @@ void mbedtls_strerror( int ret, char *buf, size_t buflen )
         buf[0] = '\0';
 }
 
-#endif /* MBEDTLS_ERROR_STRERROR_DUMMY */
-
 #endif /* MBEDTLS_ERROR_C */
+
+#endif /* MBEDTLS_ERROR_C || MBEDTLS_ERROR_STRERROR_DUMMY */

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-#if defined(MBEDTLS_ERROR_STRERROR_DUMMY)
+#if defined(MBEDTLS_ERROR_C)
 #include <string.h>
 #endif
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1895,6 +1895,20 @@ component_test_no_64bit_multiplication () {
     make test
 }
 
+component_test_no_strings () {
+    msg "build: no strings" # ~10s
+    scripts/config.py full
+    # Disable options that activate a large amount of string constants.
+    scripts/config.py unset MBEDTLS_DEBUG_C
+    scripts/config.py unset MBEDTLS_ERROR_C
+    scripts/config.py set MBEDTLS_ERROR_STRERROR_DUMMY
+    scripts/config.py unset MBEDTLS_VERSION_FEATURES
+    make CFLAGS='-Werror -Os'
+
+    msg "test: no strings" # ~ 10s
+    make test
+}
+
 component_build_arm_none_eabi_gcc () {
     msg "build: ${ARM_NONE_EABI_GCC_PREFIX}gcc -O1" # ~ 10s
     scripts/config.py baremetal

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -28,6 +28,9 @@ use warnings;
 use strict;
 
 my %configs = (
+    'config-ccm-psk-tls1_2.h' => {
+        'compat' => '-m tls1_2 -f \'^TLS-PSK-WITH-AES-...-CCM-8\'',
+    },
     'config-mini-tls1_1.h' => {
         'compat' => '-m tls1_1 -f \'^DES-CBC3-SHA$\|^TLS-RSA-WITH-3DES-EDE-CBC-SHA$\'', #'
     },
@@ -35,9 +38,6 @@ my %configs = (
         'compat' => "-m tls1_2 -f 'ECDHE-ECDSA.*AES.*GCM' -p mbedTLS",
     },
     'config-symmetric-only.h' => {
-    },
-    'config-ccm-psk-tls1_2.h' => {
-        'compat' => '-m tls1_2 -f \'^TLS-PSK-WITH-AES-...-CCM-8\'',
     },
     'config-thread.h' => {
         'opt' => '-f ECJPAKE.*nolog',

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -34,6 +34,10 @@ my %configs = (
     'config-mini-tls1_1.h' => {
         'compat' => '-m tls1_1 -f \'^DES-CBC3-SHA$\|^TLS-RSA-WITH-3DES-EDE-CBC-SHA$\'', #'
     },
+    'config-no-entropy.h' => {
+    },
+    'config-psa-crypto.h' => {
+    },
     'config-suite-b.h' => {
         'compat' => "-m tls1_2 -f 'ECDHE-ECDSA.*AES.*GCM' -p mbedTLS",
     },


### PR DESCRIPTION
Bug fixes:

* Fix the build with user configuration files that have forked from the default `config.h` or have been written from scratch, and that enable `MBEDTLS_PSA_CRYPTO_C`. Such configurations broke when #3712 started using the new configuration mechanism `MBEDTLS_PSA_CRYPTO_CONFIG` and introduced the header `mbedtls/config_psa.h`. This new header must be included even with the old configuration mechanism, but we can't rely on `config.h` to do it.
* Fix the build when `MBEDTLS_ERROR_C` is defined but not `MBEDTLS_ERROR_STRERROR_DUMMY`. This was accidentally broken when tweaking header inclusions in https://github.com/ARMmbed/mbedtls/pull/2958/files#diff-b37646397b0ddf118d2813bff10075ce7f875bcd98aa708af43b096bf8bb6dd6. Fix #3866.
* Fix the build when X.509 is enabled but not TLS (missing build dependency in `ssl_context_info`).

Fix related test gaps:

* Add missing configurations from `configs/*.h` to `test-ref-configs.pl` (`config-no-entropy.h`, `config-psa-crypto.h`).
* Ensure that `MBEDTLS_ERROR_C` without `MBEDTLS_ERROR_STRERROR_DUMMY` is tested (via `config-no-entropy.h` — not ideal but it'll do).
* Ensure that `MBEDTLS_ERROR_STRERROR_DUMMY` without `MBEDTLS_ERROR_C` is tested (new `all.sh` component).

Other improvements:

* Simplify header inclusions and conditional guards in `error.c`.

Needs backports: for the test gaps (one missing entry in `test-ref-configs.pl`, no testing of `MBEDTLS_ERROR_STRERROR_DUMMY`). At first glance there's no actual bug in 2.16 or 2.7.
