### PR TITLE
‘for’ loop initial declarations are only allowed in C99 or C11 mode

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1163,9 +1163,10 @@ static void mbedtls_ssl_cf_memcpy_if_eq( unsigned char *dst,
     /* mask = c1 == c2 ? 0xff : 0x00 */
     const size_t equal = mbedtls_ssl_cf_bool_eq( c1, c2 );
     const unsigned char mask = (unsigned char) mbedtls_ssl_cf_mask_from_bit( equal );
+    size_t i;
 
     /* dst[i] = c1 == c2 ? src[i] : dst[i] */
-    for( size_t i = 0; i < len; i++ )
+    for( i = 0; i < len; i++ )
         dst[i] = ( src[i] & mask ) | ( dst[i] & ~mask );
 }
 


### PR DESCRIPTION
## Description
‘for’ loop initial declarations are only allowed in C99 or C11 mode.


## Status
**READY**