### PR TITLE
Fix another use of uinitialized memory in ssl_parse_encrypted_pms

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3929,11 +3929,12 @@ static int ssl_parse_encrypted_pms( mbedtls_ssl_context *ssl,
     /* In case of a failure in decryption, the decryption may write less than
      * 2 bytes of output, but we always read the first two bytes. It doesn't
      * matter in the end because diff will be nonzero in that case due to
-     * peer_pmslen being less than 48, and we only care whether diff is 0.
-     * But do initialize peer_pms for robustness anyway. This also makes
-     * memory analyzers happy (don't access uninitialized memory, even
-     * if it's an unsigned char). */
+     * ret being nonzero, and we only care whether diff is 0.
+     * But do initialize peer_pms and peer_pmslen for robustness anyway. This
+     * also makes memory analyzers happy (don't access uninitialized memory,
+     * even if it's an unsigned char). */
     peer_pms[0] = peer_pms[1] = ~0;
+    peer_pmslen = 0;
 
     ret = ssl_decrypt_encrypted_pms( ssl, p, end,
                                      peer_pms,


### PR DESCRIPTION
## Description
This is a complement to commit 0a8352b4, which initialized the beginning of `peer_pms`, but did not initialize `peer_pmslen`.

## Status
**READY**

## Requires Backporting
NO (since the overall impact is low (removing a minor case of undefined behavior, and only in case decryption fails), I'd argue this is more of an enhancement and future-proofing than a fix per se, and thus backporting would not be necessary)

## Migrations
NO

## Additional comments
I took the liberty of mentioning the `peer_pmslen` variable in the comments, and re-arranging them not to exceed 80 characters per line.
A different patch might be to simply initialize the variable during declaration, but it would lack the comment explaining why.

## Todos
- [X] Tests
- [X] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
For reproduction, a fully-configured analysis with Frama-C/Eva would be necessary. Otherwise, you need to force a decryption failure in `ssl_decrypt_encrypted_pms` and initialize `peer_pmslen` to a canary value, then check it before the line where it is used, to see that the canary value has not been modified. I'm not sure why Valgrind did not report this issue as it did for the other variable, as indicated in the commit message from 0a8352b4; probably because it is not an array, and just a local variable in the stack.