### PR TITLE
Dynamic SSL buffers

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -225,6 +225,17 @@
 #define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 #endif
 
+
+/*
+  * The default minimum allocation for fragment buffers.
+  * Making it larger trades off memory against the number of
+  * reallocations needed to make it big enough for cases where
+  * it needs to be bigger
+  */
+ #if !defined(MBEDTLS_SSL_BUFFER_MIN)
+ #define MBEDTLS_SSL_BUFFER_MIN 512
+ #endif
+
 /*
  * Maximum fragment length in bytes,
  * determines the size of each of the two internal I/O buffers.
@@ -1140,6 +1151,8 @@ struct mbedtls_ssl_context
     int in_msgtype;             /*!< record header: message type      */
     size_t in_msglen;           /*!< record header: message length    */
     size_t in_left;             /*!< amount of data read so far       */
+    uint16_t in_max_content_len;            /*!< allocated size of .buf, minus
+                                    MBEDTLS_SSL_BUFFER_OVERHEAD */
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     uint16_t in_epoch;          /*!< DTLS epoch for incoming records  */
     size_t next_record_offset;  /*!< offset of the next record in datagram
@@ -1171,11 +1184,13 @@ struct mbedtls_ssl_context
     unsigned char *out_len;     /*!< two-bytes message length field   */
     unsigned char *out_iv;      /*!< ivlen-byte IV                    */
     unsigned char *out_msg;     /*!< message contents (out_iv+ivlen)  */
+    unsigned char *out_offt;     /*!< read offset in application data  */
 
     int out_msgtype;            /*!< record header: message type      */
     size_t out_msglen;          /*!< record header: message length    */
     size_t out_left;            /*!< amount of data not yet written   */
-
+    uint16_t out_max_content_len;            /*!< allocated size of .buf, minus
+                                    MBEDTLS_SSL_BUFFER_OVERHEAD */
     unsigned char cur_out_ctr[8]; /*!<  Outgoing record sequence  number. */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/include/mbedtls/ssl_internal.h
+++ b/include/mbedtls/ssl_internal.h
@@ -773,6 +773,12 @@ void mbedtls_ssl_dtls_replay_update( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
                               const mbedtls_ssl_session *src );
+int mbedtls_ssl_alloc_record_buf( mbedtls_ssl_context *ssl,
+                                   int buffer_type,
+                                   size_t max_content_len );
+int mbedtls_ssl_confirm_content_len( mbedtls_ssl_context *ssl,
+                                      int buffer_type,
+                                      size_t content_len );
 
 /* constant-time buffer comparison */
 static inline int mbedtls_ssl_safer_memcmp( const void *a, const void *b, size_t n )


### PR DESCRIPTION
Dynamic SSL buffers

This commit adds changes from the dynamic_ssl_buffers PR(https://github.com/ARMmbed/mbedtls/pull/1208)

    Co-authored-by: Aditya Patwardhan <aditya.patwardhan@espressif.com>
    Revert the breaking changes introduced by the dynamic SSL buffers PR.
    Includes some required changes in the above PR (for rebasing).

## Description
Original work done in [PR](https://github.com/ARMmbed/mbedtls/pull/1208) by Andy Green <andy@warmcat.com> , I have rebased and addressed review comments to keep change backward compatible. The PR helps to reduce the amount of heap simultaneously used by mbedTLS. With local testing on esp32 I have noticed that the difference between minimum_heap_used with and w/o dynamic ssl buffers was considerable.

* the following results were obtained by running the [mqtt/ssl_mutual_auth](https://github.com/espressif/esp-idf/tree/master/examples/protocols/mqtt/ssl_mutual_auth)  example on esp32.

Status| Minimum free heap size
--|--
Without Dynamic SLL buffers(current)|  180472 bytes
With Dynamic SLL buffers|  196544 bytes


Larger value of  minimum free heap size denotes that the Mbedtls used less memory simultaneously. The memory spared by Mbedtls can be used by other tasks.

## Status
**READY**

## Requires Backporting
NO  


## Migrations
 NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

