### PR TITLE
cmake: Fix added sources to targets

### DIFF
--- a/programs/fuzz/CMakeLists.txt
+++ b/programs/fuzz/CMakeLists.txt
@@ -32,20 +32,24 @@ set(executables_with_common_c
 
 foreach(exe IN LISTS executables_no_common_c executables_with_common_c)
 
-    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
-
-    if (NOT FUZZINGENGINE_LIB)
-        target_link_libraries(${exe} ${libs})
-        set_property(TARGET ${exe} APPEND PROPERTY SOURCES onefile.c)
-    else()
-        target_link_libraries(${exe} ${libs} FuzzingEngine)
-        SET_TARGET_PROPERTIES(${exe} PROPERTIES LINKER_LANGUAGE CXX)
+    set(exe_sources ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
+    if(NOT FUZZINGENGINE_LIB)
+        list(APPEND exe_sources onefile.c)
     endif()
 
     # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
     list(FIND executables_with_common_c ${exe} exe_index)
-    if (${exe_index} GREATER -1)
-        set_property(TARGET ${exe} APPEND PROPERTY SOURCES common.c)
+    if(${exe_index} GREATER -1)
+        list(APPEND exe_sources common.c)
+    endif()
+
+    add_executable(${exe} ${exe_sources})
+
+    if (NOT FUZZINGENGINE_LIB)
+        target_link_libraries(${exe} ${libs})
+    else()
+        target_link_libraries(${exe} ${libs} FuzzingEngine)
+        SET_TARGET_PROPERTIES(${exe} PROPERTIES LINKER_LANGUAGE CXX)
     endif()
 
 endforeach()

--- a/programs/ssl/CMakeLists.txt
+++ b/programs/ssl/CMakeLists.txt
@@ -27,7 +27,13 @@ set(executables
 )
 
 foreach(exe IN LISTS executables)
-    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
+    set(extra_sources "")
+    if(exe STREQUAL "ssl_client2" OR exe STREQUAL "ssl_server2")
+        list(APPEND extra_sources
+            ${CMAKE_CURRENT_SOURCE_DIR}/../test/query_config.c)
+    endif()
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>
+        ${extra_sources})
     target_link_libraries(${exe} ${libs})
     target_include_directories(${exe} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tests/include)
 endforeach()

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -26,7 +26,13 @@ if(TEST_CPP)
 endif()
 
 foreach(exe IN LISTS executables_libs executables_mbedcrypto)
-    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>)
+    set(extra_sources "")
+    if(exe STREQUAL "query_compile_time_config")
+        list(APPEND extra_sources
+            ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
+    endif()
+    add_executable(${exe} ${exe}.c $<TARGET_OBJECTS:mbedtls_test>
+        ${extra_sources})
 
     # This emulates "if ( ... IN_LIST ... )" which becomes available in CMake 3.3
     list(FIND executables_libs ${exe} exe_index)
@@ -36,9 +42,6 @@ foreach(exe IN LISTS executables_libs executables_mbedcrypto)
         target_link_libraries(${exe} ${mbedcrypto_target})
     endif()
 endforeach()
-
-set_property(TARGET query_compile_time_config APPEND PROPERTY SOURCES
-             ${CMAKE_CURRENT_SOURCE_DIR}/query_config.c)
 
 install(TARGETS ${executables_libs} ${executables_mbedcrypto}
         DESTINATION "bin"


### PR DESCRIPTION
In cmake version < 3.0, the SOURCES property on targets cannot be
modified after the target is defined.  There are several instances in
the code that were using `target_properties()`, which is not available
in the older versions of cmake.  Unfortunately, the workaround in #3801
(381c1078fc) assumes that this SOURCES property can be modified.

Work around this by building up any necessary sources before declaring
the target.  This is more awkward, but needed to continue to be able to
support the old versions of cmake.

Fixes #3788

Signed-off-by: David Brown <david.brown@linaro.org>


## Status
**READY**

## Requires Backporting
Yes, but I don't think it applies.

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
```bash
$ mkdir build
$ cd build
$ cmake-2.18.12.2 ..
$ make
```