### PR TITLE
Remove Extraneous bytes from buffer post pem write

### DIFF
--- a/ChangeLog.d/clean_pem_buffers.txt
+++ b/ChangeLog.d/clean_pem_buffers.txt
@@ -1,0 +1,6 @@
+Bugfix
+  * In PEM writing functions, fill the trailing part of the buffer with null
+    bytes. This guarantees that the corresponding parsing function can read
+    the buffer back, which was the case for mbedtls_x509write_{crt,csr}_pem
+    until this property was inadvertently broken in Mbed TLS 2.19.0.
+    Fixes #3682.

--- a/library/pem.c
+++ b/library/pem.c
@@ -478,8 +478,12 @@ int mbedtls_pem_write_buffer( const char *header, const char *footer,
     *p++ = '\0';
     *olen = p - buf;
 
+     /* Clean any remaining data previously written to the buffer */
+    memset( buf + *olen, 0, buf_len - *olen );
+
     mbedtls_free( encode_buf );
     return( 0 );
 }
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */
+

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -17,7 +17,7 @@ void pk_write_pubkey_check( char * key_file )
     unsigned char check_buf[5000];
     int ret;
     FILE *f;
-    size_t ilen;
+    size_t ilen, pem_len, buf_index;
 
     memset( buf, 0, sizeof( buf ) );
     memset( check_buf, 0, sizeof( check_buf ) );
@@ -28,12 +28,20 @@ void pk_write_pubkey_check( char * key_file )
     ret = mbedtls_pk_write_pubkey_pem( &key, buf, sizeof( buf ));
     TEST_ASSERT( ret == 0 );
 
+    pem_len = strlen( (char *) buf );
+
+    // check that the rest of the buffer remains clear
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
+
     f = fopen( key_file, "r" );
     TEST_ASSERT( f != NULL );
     ilen = fread( check_buf, 1, sizeof( check_buf ), f );
     fclose( f );
 
-    TEST_ASSERT( ilen == strlen( (char *) buf ) );
+    TEST_ASSERT( ilen == pem_len );
     TEST_ASSERT( memcmp( (char *) buf, (char *) check_buf, ilen ) == 0 );
 
 exit:
@@ -49,7 +57,7 @@ void pk_write_key_check( char * key_file )
     unsigned char check_buf[5000];
     int ret;
     FILE *f;
-    size_t ilen;
+    size_t ilen, pem_len, buf_index;
 
     memset( buf, 0, sizeof( buf ) );
     memset( check_buf, 0, sizeof( check_buf ) );
@@ -59,6 +67,14 @@ void pk_write_key_check( char * key_file )
 
     ret = mbedtls_pk_write_key_pem( &key, buf, sizeof( buf ));
     TEST_ASSERT( ret == 0 );
+
+    pem_len = strlen( (char *) buf );
+
+    // check that the rest of the buffer remains clear
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
 
     f = fopen( key_file, "r" );
     TEST_ASSERT( f != NULL );

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -104,7 +104,7 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     unsigned char buf[4096];
     unsigned char check_buf[4000];
     int ret;
-    size_t olen = 0, pem_len = 0;
+    size_t olen = 0, pem_len = 0, buf_index;
     int der_len = -1;
     FILE *f;
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
@@ -129,6 +129,11 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     TEST_ASSERT( ret == 0 );
 
     pem_len = strlen( (char *) buf );
+
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
 
     f = fopen( cert_req_check_file, "r" );
     TEST_ASSERT( f != NULL );
@@ -224,7 +229,7 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     unsigned char check_buf[5000];
     mbedtls_mpi serial;
     int ret;
-    size_t olen = 0, pem_len = 0;
+    size_t olen = 0, pem_len = 0, buf_index = 0;
     int der_len = -1;
     FILE *f;
     mbedtls_test_rnd_pseudo_info rnd_info;
@@ -292,6 +297,12 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     TEST_ASSERT( ret == 0 );
 
     pem_len = strlen( (char *) buf );
+
+    // check that the rest of the buffer remains clear
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
 
     f = fopen( cert_check_file, "r" );
     TEST_ASSERT( f != NULL );


### PR DESCRIPTION


## Description

In order to remove some big (4k) buffers from being created on the stack, the output buffer was re-used - in this case the raw der data is written to the buffer prior to being base64 encoded into an allocated buffer, and then overwritten with the pem data. However, even though the pem data is zero terminated, usually der data will remain in the buffer after the terminator.

Should this buffer get passed into mbedtls_x509_crt_parse() then it will likely fail to parse, as it decides whether or not a buffer is pem by checking the last byte of the buffer for being zero - if it isn't zero, it will attempt to parse as der, which will obviously fail.

This just ensures the buffer is cleaned to avoid the regression, there may be future work around this subject to make the area safer and tests to ensure this doesn't happen again.

This closes #3682 

## Status
**READY**

## Requires Backporting
YES 
[2.16](https://github.com/ARMmbed/mbedtls/pull/3935)
[2.7](https://github.com/ARMmbed/mbedtls/pull/3945)

(Bug did not affect the 2.7 branch, but wanted to add the tests)

## Migrations
NO

## Todos
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
See #3682 
