### PR TITLE
Move "internal use" sentence attached to the wrong function

### DIFF
--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -131,8 +131,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
 
 /**
  * \brief          This function finishes the SHA-512 operation, and writes
- *                 the result to the output buffer. This function is for
- *                 internal use only.
+ *                 the result to the output buffer.
  *
  * \param ctx      The SHA-512 context. This must be initialized
  *                 and have a hash operation started.
@@ -148,6 +147,7 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
 /**
  * \brief          This function processes a single data block within
  *                 the ongoing SHA-512 computation.
+ *                 This function is for internal use only.
  *
  * \param ctx      The SHA-512 context. This must be initialized.
  * \param data     The buffer holding one block of data. This


### PR DESCRIPTION
The sentence was placed in the wrong function's documentation in 27ff120a6121528de9f9a726dfd80a209ee05a1a.

A similar edit was made in `sha256.c` but the sentence was placed correctly there.

Backport: [2.16](https://github.com/ARMmbed/mbedtls/pull/3908), [2.7](https://github.com/ARMmbed/mbedtls/pull/3920)
