### PR TITLE
Fix possible memory leak when MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -12709,6 +12709,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
 #endif
         mbedtls_platform_zeroize( ssl->out_buf, out_buf_len );
         mbedtls_free( ssl->out_buf );
+        ssl->out_buf = NULL;
     }
 
     if( ssl->in_buf != NULL )
@@ -12720,6 +12721,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
 #endif
         mbedtls_platform_zeroize( ssl->in_buf, in_buf_len );
         mbedtls_free( ssl->in_buf );
+        ssl->in_buf = NULL;
     }
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)


### PR DESCRIPTION
## Description
Fixes memoryleak when MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH  is defined.
Fixes https://armiot.atlassian.net/browse/IOTPMI-2276, see ticket for more details.

When mbedtls_ssl_free is called, ssl->in_buf is freed but not set as null.
mbedtls_ssl_free continues to call mbedtls_ssl_handshake_free -> handle_buffer_resizing and now ssl->in_buf is not allocated but as it's not nulled it's resized and new buffer set to ssl->in_buf
Now next time mbedtls_ssl_setup is called it will alloc ssl->in_buf over the resized buffer.

## Status
**IN DEVELOPMENT

## Requires Backporting
Yes

Which branch?
baremetal

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
See Description.