### PR TITLE
Remove psa header files in uninstall part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ install: no_test
 
 uninstall:
 	rm -rf $(DESTDIR)/include/mbedtls
+	rm -rf $(DESTDIR)/include/psa
 	rm -f $(DESTDIR)/lib/libmbedtls.*
 	rm -f $(DESTDIR)/lib/libmbedx509.*
 	rm -f $(DESTDIR)/lib/libmbedcrypto.*


### PR DESCRIPTION
Uninstall psa header files which installed to DESTDIR.

Signed-off-by: Wu, Jheng-Jhong <goodwater.wu@gmail.com>
Signed-off-by: Victor Wu <victor_wu@bizlinktech.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.

When installing mbedtls, psa headers install to DESTDIR, but it doesn't uninstall when doing uninstalling.
Therefore, add a line to uninstall psa header files which installed to DESTDIR.

## Status
**READY/IN DEVELOPMENT/HOLD**
READY
## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?
development
## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

make install
make uninstall