### PR TITLE
Backport 2.7: Move "internal use" sentence attached to the wrong function

### DIFF
--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -138,8 +138,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
 
 /**
  * \brief          This function finishes the SHA-512 operation, and writes
- *                 the result to the output buffer. This function is for
- *                 internal use only.
+ *                 the result to the output buffer.
  *
  * \param ctx      The SHA-512 context.
  * \param output   The SHA-384 or SHA-512 checksum result.
@@ -152,6 +151,7 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
 /**
  * \brief          This function processes a single data block within
  *                 the ongoing SHA-512 computation.
+ *                 This function is for internal use only.
  *
  * \param ctx      The SHA-512 context.
  * \param data     The buffer holding one block of data.


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/3907