### PR TITLE
Backport 2.7: Add tests for buffer corruption after PEM write

### DIFF
--- a/library/pem.c
+++ b/library/pem.c
@@ -510,6 +510,9 @@ int mbedtls_pem_write_buffer( const char *header, const char *footer,
     *p++ = '\0';
     *olen = p - buf;
 
+    /* Clean any remaining data previously written to the buffer */
+    memset( buf + *olen, 0, buf_len - *olen );
+
     mbedtls_free( encode_buf );
     return( 0 );
 }

--- a/tests/suites/test_suite_pkwrite.function
+++ b/tests/suites/test_suite_pkwrite.function
@@ -17,7 +17,7 @@ void pk_write_pubkey_check( char *key_file )
     unsigned char check_buf[5000];
     int ret;
     FILE *f;
-    size_t ilen;
+    size_t ilen, pem_len, buf_index;
 
     memset( buf, 0, sizeof( buf ) );
     memset( check_buf, 0, sizeof( check_buf ) );
@@ -28,12 +28,20 @@ void pk_write_pubkey_check( char *key_file )
     ret = mbedtls_pk_write_pubkey_pem( &key, buf, sizeof( buf ));
     TEST_ASSERT( ret == 0 );
 
+    pem_len = strlen( (char *) buf );
+
+    // check that the rest of the buffer remains clear
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
+
     f = fopen( key_file, "r" );
     TEST_ASSERT( f != NULL );
     ilen = fread( check_buf, 1, sizeof( check_buf ), f );
     fclose( f );
 
-    TEST_ASSERT( ilen == strlen( (char *) buf ) );
+    TEST_ASSERT( ilen == pem_len );
     TEST_ASSERT( memcmp( (char *) buf, (char *) check_buf, ilen ) == 0 );
 
 exit:
@@ -49,7 +57,7 @@ void pk_write_key_check( char *key_file )
     unsigned char check_buf[5000];
     int ret;
     FILE *f;
-    size_t ilen;
+    size_t ilen, pem_len, buf_index;
 
     memset( buf, 0, sizeof( buf ) );
     memset( check_buf, 0, sizeof( check_buf ) );
@@ -60,12 +68,20 @@ void pk_write_key_check( char *key_file )
     ret = mbedtls_pk_write_key_pem( &key, buf, sizeof( buf ));
     TEST_ASSERT( ret == 0 );
 
+    pem_len = strlen( (char *) buf );
+
+    // check that the rest of the buffer remains clear
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
+
     f = fopen( key_file, "r" );
     TEST_ASSERT( f != NULL );
     ilen = fread( check_buf, 1, sizeof( check_buf ), f );
     fclose( f );
 
-    TEST_ASSERT( ilen == strlen( (char *) buf ) );
+    TEST_ASSERT( ilen == pem_len );
     TEST_ASSERT( memcmp( (char *) buf, (char *) check_buf, ilen ) == 0 );
 
 exit:

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -44,7 +44,7 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     unsigned char buf[4096];
     unsigned char check_buf[4000];
     int ret;
-    size_t olen = 0, pem_len = 0;
+    size_t olen = 0, pem_len = 0, buf_index;
     int der_len = -1;
     FILE *f;
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
@@ -69,6 +69,11 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     TEST_ASSERT( ret == 0 );
 
     pem_len = strlen( (char *) buf );
+
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
 
     f = fopen( cert_req_check_file, "r" );
     TEST_ASSERT( f != NULL );
@@ -112,7 +117,7 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     unsigned char check_buf[5000];
     mbedtls_mpi serial;
     int ret;
-    size_t olen = 0, pem_len = 0;
+    size_t olen = 0, pem_len = 0, buf_index;
     int der_len = -1;
     FILE *f;
     rnd_pseudo_info rnd_info;
@@ -180,6 +185,11 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
     TEST_ASSERT( ret == 0 );
 
     pem_len = strlen( (char *) buf );
+
+    for( buf_index = pem_len; buf_index < sizeof( buf ); ++buf_index )
+    {
+        TEST_ASSERT( buf[buf_index] == 0 );
+    }
 
     f = fopen( cert_check_file, "r" );
     TEST_ASSERT( f != NULL );


### PR DESCRIPTION
## Description

In order to remove some big (4k) buffers from being created on the stack, the output buffer was re-used - in this case the raw der data is written to the buffer prior to being base64 encoded into an allocated buffer, and then overwritten with the pem data. However, even though the pem data is zero terminated, usually der data will remain in the buffer after the terminator.

Should this buffer get passed into mbedtls_x509_crt_parse() then it will likely fail to parse, as it decides whether or not a buffer is pem by checking the last byte of the buffer for being zero - if it isn't zero, it will attempt to parse as der, which will obviously fail.

Please note that although this bug does not affect this branch, I wanted to add the tests anyway, to ensure this regression did not happen again. In order to get these tests to pass I would have had to add a memset to clear the buffers before two of the tests, so it seemed more clean just to backport the fix as well (i.e. zero the buffer after pem write)

This is a backport of #3898 

## Status
**READY**

## Steps to test or reproduce
See #3682 
