### PR TITLE
Improve documentation in test_psa_constant_names.py

### DIFF
--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -94,8 +94,12 @@ class Inputs:
         self.dh_groups = set(['0xff'])
         self.key_types = set(['0xffff'])
         self.key_usage_flags = set(['0x80000000'])
-        # Hard-coded value for unknown algorithms
-        self.hash_algorithms = set(['0x020000fe'])
+        # Hard-coded values for unknown algorithms
+        #
+        # These have to have values that are correct for their respective
+        # PSA_ALG_IS_xxx macros, but are also not currently assigned and are
+        # not likely to be assigned in the near future.
+        self.hash_algorithms = set(['0x020000fe']) # 0x020000ff is PSA_ALG_ANY_HASH
         self.mac_algorithms = set(['0x0300ffff'])
         self.ka_algorithms = set(['0x09fc0000'])
         self.kdf_algorithms = set(['0x080000ff'])


### PR DESCRIPTION
## Description
Documentation improvements suggested by @mpg in #3948

## Status
**READY**

## Requires Backporting
No, PSA only

## Migrations
No, Documentation only.