### PR TITLE
Fix some PSA-related identifiers

### DIFF
--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -228,11 +228,11 @@ typedef struct
 #if defined(MBEDTLS_MD_C)
 typedef enum
 {
-    TLS12_PRF_STATE_INIT,       /* no input provided */
-    TLS12_PRF_STATE_SEED_SET,   /* seed has been set */
-    TLS12_PRF_STATE_KEY_SET,    /* key has been set */
-    TLS12_PRF_STATE_LABEL_SET,  /* label has been set */
-    TLS12_PRF_STATE_OUTPUT      /* output has been started */
+    PSA_TLS12_PRF_STATE_INIT,       /* no input provided */
+    PSA_TLS12_PRF_STATE_SEED_SET,   /* seed has been set */
+    PSA_TLS12_PRF_STATE_KEY_SET,    /* key has been set */
+    PSA_TLS12_PRF_STATE_LABEL_SET,  /* label has been set */
+    PSA_TLS12_PRF_STATE_OUTPUT      /* output has been started */
 } psa_tls12_prf_key_derivation_state_t;
 
 typedef struct psa_tls12_prf_key_derivation_s

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5839,7 +5839,7 @@ static psa_status_t psa_tls12_prf_set_seed( psa_tls12_prf_key_derivation_t *prf,
                                             const uint8_t *data,
                                             size_t data_length )
 {
-    if( prf->state != TLS12_PRF_STATE_INIT )
+    if( prf->state != PSA_TLS12_PRF_STATE_INIT )
         return( PSA_ERROR_BAD_STATE );
 
     if( data_length != 0 )
@@ -5852,7 +5852,7 @@ static psa_status_t psa_tls12_prf_set_seed( psa_tls12_prf_key_derivation_t *prf,
         prf->seed_length = data_length;
     }
 
-    prf->state = TLS12_PRF_STATE_SEED_SET;
+    prf->state = PSA_TLS12_PRF_STATE_SEED_SET;
 
     return( PSA_SUCCESS );
 }
@@ -5863,14 +5863,14 @@ static psa_status_t psa_tls12_prf_set_key( psa_tls12_prf_key_derivation_t *prf,
                                            size_t data_length )
 {
     psa_status_t status;
-    if( prf->state != TLS12_PRF_STATE_SEED_SET )
+    if( prf->state != PSA_TLS12_PRF_STATE_SEED_SET )
         return( PSA_ERROR_BAD_STATE );
 
     status = psa_hmac_setup_internal( &prf->hmac, data, data_length, hash_alg );
     if( status != PSA_SUCCESS )
         return( status );
 
-    prf->state = TLS12_PRF_STATE_KEY_SET;
+    prf->state = PSA_TLS12_PRF_STATE_KEY_SET;
 
     return( PSA_SUCCESS );
 }
@@ -5879,7 +5879,7 @@ static psa_status_t psa_tls12_prf_set_label( psa_tls12_prf_key_derivation_t *prf
                                              const uint8_t *data,
                                              size_t data_length )
 {
-    if( prf->state != TLS12_PRF_STATE_KEY_SET )
+    if( prf->state != PSA_TLS12_PRF_STATE_KEY_SET )
         return( PSA_ERROR_BAD_STATE );
 
     if( data_length != 0 )
@@ -5892,7 +5892,7 @@ static psa_status_t psa_tls12_prf_set_label( psa_tls12_prf_key_derivation_t *prf
         prf->label_length = data_length;
     }
 
-    prf->state = TLS12_PRF_STATE_LABEL_SET;
+    prf->state = PSA_TLS12_PRF_STATE_LABEL_SET;
 
     return( PSA_SUCCESS );
 }


### PR DESCRIPTION
A minor bug I discovered while working on something else:

* Add a `PSA_` prefix to some identifiers that are declared publicly, but not meant for use in application code.