### PR TITLE
Fix use-after-scope error in programs/ssl

### DIFF
--- a/ChangeLog.d/programs-ssl-use-after-scope.txt
+++ b/ChangeLog.d/programs-ssl-use-after-scope.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix use-after-scope error in programs/ssl/ssl_client2.c and ssl_server2.c

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2339,12 +2339,12 @@ int main( int argc, char *argv[] )
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
+    const mbedtls_ssl_srtp_profile forced_profile[] =
+                                { opt.force_srtp_profile, MBEDTLS_TLS_SRTP_UNSET };
     if( opt.use_srtp == 1 )
     {
         if( opt.force_srtp_profile != 0 )
         {
-            const mbedtls_ssl_srtp_profile forced_profile[] =
-                                        { opt.force_srtp_profile, MBEDTLS_TLS_SRTP_UNSET };
             ret = mbedtls_ssl_conf_dtls_srtp_protection_profiles ( &conf, forced_profile );
         }
         else

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -3151,11 +3151,11 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 
 #if defined(MBEDTLS_SSL_DTLS_SRTP)
+    const mbedtls_ssl_srtp_profile forced_profile[] = { opt.force_srtp_profile, MBEDTLS_TLS_SRTP_UNSET };
     if( opt.use_srtp == 1 )
     {
         if( opt.force_srtp_profile != 0 )
         {
-            const mbedtls_ssl_srtp_profile forced_profile[] = { opt.force_srtp_profile, MBEDTLS_TLS_SRTP_UNSET };
             ret = mbedtls_ssl_conf_dtls_srtp_protection_profiles( &conf, forced_profile );
         }
         else


### PR DESCRIPTION
## Description
This PR fixes a use-after-scope error in `programs/ssl/ssl_client2.c` and `programs/ssl/ssl_server2.c`.

## Status
**READY**

## Requires Backporting
NO

## Migrations
If there is any API change, what's the incentive and logic for it.

NO