### PR TITLE
PSA Crypto: Don't skip key data removal when SE driver is not in use

### DIFF
--- a/ChangeLog.d/psa_close_key_memory_leak_fix.txt
+++ b/ChangeLog.d/psa_close_key_memory_leak_fix.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix memory leak that occured when calling psa_close_key() on a
+     wrapped key with MBEDTLS_PSA_CRYPTO_SE_C defined.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1197,7 +1197,8 @@ static psa_status_t psa_get_transparent_key( psa_key_handle_t handle,
 static psa_status_t psa_remove_key_data_from_memory( psa_key_slot_t *slot )
 {
 #if defined(MBEDTLS_PSA_CRYPTO_SE_C)
-    if( psa_key_slot_is_external( slot ) )
+    if( psa_get_se_driver( slot->attr.lifetime, NULL, NULL ) &&
+        psa_key_slot_is_external( slot ) )
     {
         /* No key material to clean. */
     }


### PR DESCRIPTION

## Description
Closing a wrapped key with the new SE driver interface while
MBEDTLS_PSA_CRYPTO_SE_C is also enabled leads to the key material not
being freed, even though an old SE driver is not in use, leading to a
memory leak. This is because a wrapped key is also considered external.

This commit extends the check for skipping by checking whether an
old-style SE driver is registered with the provided slot, in addition to
checking whether the key is external.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog updated
- [ ] Backported


## Steps to test or reproduce
The following snippet reproduces the leak:

```C
#define PSA_KEY_LOCATION_SLI_SE_OPAQUE   ((psa_key_location_t)0x000001UL)

static void close_opaque_key_target(void)
{
    psa_key_handle_t handle = 0;
    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;

    psa_set_key_algorithm(&attributes, 0);
    psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
    psa_set_key_bits( &attributes, 256 );
    psa_set_key_lifetime(&attributes,
                         PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(
                           PSA_KEY_PERSISTENCE_DEFAULT,
                           PSA_KEY_LOCATION_SLI_SE_OPAQUE));
    psa_set_key_id(&attributes, 0x1337);

    PSA_ASSERT( psa_generate_key( &attributes, &handle ) );
    PSA_ASSERT( psa_close_key( handle ) );
exit:
    psa_destroy_key( handle );
}
```