### PR TITLE
[baremetal] FI variables missing 'volatile'

### DIFF
--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -683,7 +683,7 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
  */
 static int ssl_generate_random( mbedtls_ssl_context *ssl )
 {
-    int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
+    volatile int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
     unsigned char *p = ssl->handshake->randbytes;
 #if defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t t;
@@ -2956,7 +2956,7 @@ static int ssl_in_server_key_exchange_parse( mbedtls_ssl_context *ssl,
         mbedtls_pk_type_t pk_alg = MBEDTLS_PK_NONE;
         unsigned char *params = ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl );
         size_t params_len = p - params;
-        void *rs_ctx = NULL;
+        void * volatile rs_ctx = NULL;
 
         mbedtls_pk_context * peer_pk;
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -66,7 +66,7 @@ static int mbedtls_ssl_switch_key( mbedtls_ssl_transform *transform,
 {
     unsigned char * key;
     int ret = MBEDTLS_ERR_PLATFORM_FAULT_DETECTED;
-    int flow_ctrl = 0;
+    volatile int flow_ctrl = 0;
 #if defined(MBEDTLS_VALIDATE_SSL_KEYS_INTEGRITY)
     uint32_t hash;
 #endif
@@ -11769,7 +11769,7 @@ int mbedtls_ssl_read( mbedtls_ssl_context *ssl, unsigned char *buf, size_t len )
 static int ssl_write_real( mbedtls_ssl_context *ssl,
                            const unsigned char *buf, size_t len )
 {
-    int ret = mbedtls_ssl_get_max_out_record_payload( ssl );
+    volatile int ret = mbedtls_ssl_get_max_out_record_payload( ssl );
     const size_t max_len = (size_t) ret;
 
     if( ret < 0 )

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2989,7 +2989,7 @@ static int x509_crt_find_parent_in(
     for( parent_crt = candidates; parent_crt != NULL;
          parent_crt = parent_crt->next )
     {
-        int parent_valid, parent_match, path_len_ok;
+        volatile int parent_valid, parent_match, path_len_ok;
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 check_signature:


### PR DESCRIPTION
Add missing volatile keywords before several fi-related variables.