### PR TITLE
[baremetal] Fix the usage of ssl context after its nullified

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1435,7 +1435,8 @@ int ssl_populate_transform( mbedtls_ssl_transform *transform,
 
 #if !defined(MBEDTLS_SSL_HW_RECORD_ACCEL) && \
     !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
-    !defined(MBEDTLS_DEBUG_C)
+    !defined(MBEDTLS_DEBUG_C) && \
+    !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     ssl = NULL; /* make sure we don't use it except for those cases */
     (void) ssl;
 #endif


### PR DESCRIPTION
Previously, it was possible to access a null pointer even though the given configuration (with MBEDTLS_SSL_DTLS_CONNECTION_ID) should work.
