### PR TITLE
Make PSA config options definitive

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1315,6 +1315,13 @@ component_test_psa_crypto_config_basic() {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     scripts/config.py set MBEDTLS_PSA_CRYPTO_DRIVERS
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
+    # Undefine all traditional configs that are defined by the
+    # config_psa.h file.  This will ensure that the config_psa does
+    # actually define all of these.
+    for conf in $(test/scripts/getdefines.py include/mbedtls/config_psa.h); do
+        scripts/config.py unset $conf
+    done
+
     # Need to define the correct symbol and include the test driver header path in order to build with the test driver
     make CC=gcc CFLAGS="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST -I../tests/include -O2" LDFLAGS="$ASAN_CFLAGS"
 
@@ -1329,6 +1336,13 @@ component_test_psa_crypto_config_no_driver() {
     scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
     scripts/config.py unset MBEDTLS_PSA_CRYPTO_DRIVERS
     scripts/config.py unset MBEDTLS_USE_PSA_CRYPTO
+    # Undefine all traditional configs that are defined by the
+    # config_psa.h file.  This will ensure that the config_psa does
+    # actually define all of these.
+    for conf in $(test/scripts/getdefines.py include/mbedtls/config_psa.h); do
+        scripts/config.py unset $conf
+    done
+
     make CC=gcc CFLAGS="$ASAN_CFLAGS -O2" LDFLAGS="$ASAN_CFLAGS"
 
     msg "test: full + MBEDTLS_PSA_CRYPTO_CONFIG minus MBEDTLS_PSA_CRYPTO_DRIVERS"

--- a/tests/scripts/getdefines.py
+++ b/tests/scripts/getdefines.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""Extract defines create by header
+
+Takes a single argument, which is the path to a header file.  This
+program scans that header for conditionalized defines.  The intended
+use is to scan config_psa.h to determine which legacy defines are
+defined by it, so that they can be unset in the main config file.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import sys
+
+# Parsing here is fairly naive, we look for defines of symbols, but we
+# don't start until the first if defined.
+ifdefined_re = re.compile(r'^#if defined')
+define_re = re.compile(r'#define (MBEDTLS_[A-Z0-9_]+)')
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: {} path-to-header.h".format(sys.argv[0]))
+        sys.exit(1)
+
+    found = False
+    seen = set()
+    with open(sys.argv[1]) as fd:
+        for line in fd:
+            m = ifdefined_re.match(line)
+            if m is not None:
+                found = True
+                continue
+
+            if not found:
+                continue
+
+            m = define_re.match(line)
+            if m is not None:
+                define = m.group(1)
+                if define in seen:
+                    continue
+                seen.add(define)
+                print(define)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When MBEDTLS_PSA_CRYPTO_CONFIG is enabled, we define appropriate
configurations with the legacy names.  Unfortunately, for the most part,
these are already defined by the existing configuration file.

To test this better, add code to all.sh and a small script to unset the definitions
that are set by config_psa.h.

Signed-off-by: David Brown <david.brown@linaro.org


## Status
**READY**

## Requires Backporting
NO  

## Migrations
There are no changes outside of CI.

NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported