### PR TITLE
[baremetal] Add a check for passed mod in uECC_vli_mmod, tinycrypt

### DIFF
--- a/include/tinycrypt/ecc.h
+++ b/include/tinycrypt/ecc.h
@@ -333,9 +333,10 @@ uECC_word_t uECC_vli_testBit(const uECC_word_t *vli, bitcount_t bit);
  * @param mod IN -- module
  * @param num_words IN -- number of words
  * @warning Currently only designed to work for curve_p or curve_n.
+ * @return UECC_SUCCESS if mod is valid, UECC_FAILURE otherwise.
  */
-void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
-		   const uECC_word_t *mod);
+int uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
+		          const uECC_word_t *mod);
 
 /*
  * @brief Computes modular product (using curve->mmod_fast)
@@ -375,9 +376,11 @@ uECC_word_t uECC_vli_equal(const uECC_word_t *left, const uECC_word_t *right);
  * @param right IN -- right term in product
  * @param mod IN -- mod
  * @param num_words IN -- number of words
+ * @return UECC_SUCCESS if mod is valid (currently only designed to work
+ * for curve_p or curve_n), UECC_FAILURE otherwise.
  */
-void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
-		      const uECC_word_t *right, const uECC_word_t *mod);
+int uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
+		             const uECC_word_t *right, const uECC_word_t *mod);
 
 /*
  * @brief Computes (1 / input) % mod

--- a/tinycrypt/ecc.c
+++ b/tinycrypt/ecc.c
@@ -1152,7 +1152,7 @@ void uECC_vli_modSub(uECC_word_t *result, const uECC_word_t *left,
 
 /* Computes result = product % mod, where product is 2N words long. */
 /* Currently only designed to work for curve_p or curve_n. */
-void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
+int uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 			   const uECC_word_t *mod)
 {
 	uECC_word_t mod_multiple[2 * NUM_ECC_WORDS];
@@ -1166,7 +1166,11 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 			   uECC_vli_numBits(mod);
 	wordcount_t word_shift = shift / uECC_WORD_BITS;
 	wordcount_t bit_shift = shift % uECC_WORD_BITS;
+
 	uECC_word_t carry = 0;
+	if(word_shift > NUM_ECC_WORDS)
+		return UECC_FAILURE;
+
 	uECC_vli_clear(mod_multiple);
 	if (bit_shift > 0) {
 		for(index = 0; index < (uECC_word_t)num_words; ++index) {
@@ -1195,14 +1199,15 @@ void uECC_vli_mmod(uECC_word_t *result, uECC_word_t *product,
 		uECC_vli_rshift1(mod_multiple + num_words);
 	}
 	uECC_vli_set(result, v[index]);
+	return UECC_SUCCESS;
 }
 
-void uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
+int uECC_vli_modMult(uECC_word_t *result, const uECC_word_t *left,
 			  const uECC_word_t *right, const uECC_word_t *mod)
 {
 	uECC_word_t product[2 * NUM_ECC_WORDS];
 	uECC_vli_mult_rnd(product, left, right, NULL);
-	uECC_vli_mmod(result, product, mod);
+	return uECC_vli_mmod(result, product, mod);
 }
 
 static void uECC_vli_modMult_rnd(uECC_word_t *result, const uECC_word_t *left,

--- a/tinycrypt/ecc_dh.c
+++ b/tinycrypt/ecc_dh.c
@@ -130,8 +130,9 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key)
 		}
 
 		/* computing modular reduction of _random (see FIPS 186.4 B.4.1): */
-		uECC_vli_mmod(_private, _random, curve_n);
-
+		ret = uECC_vli_mmod(_private, _random, curve_n);
+		if (ret != UECC_SUCCESS)
+			return ret;
 		/* Computing public-key from private: */
 		ret = EccPoint_compute_public_key(_public, _private);
 		/* don't try again if a fault was detected */


### PR DESCRIPTION
Previously, the passed mod could result in `word_shift` being above 8, making `uECC_vli_set` access `mod_multiple` index equal to and above `2 * NUM_ECC_WORDS`.
Note that this didn't happen in the library, since `curve_n` was always passed, making `word_shift` equal to 8.