### PR TITLE
Rename existing support macros for output buffer sizes for PSA Crypto API 1.0.0

### DIFF
--- a/ChangeLog.d/psa-crypto-rename-output-buffer-size-macros.txt
+++ b/ChangeLog.d/psa-crypto-rename-output-buffer-size-macros.txt
@@ -1,0 +1,9 @@
+API changes
+   * Renamed the PSA Crypto API output buffer size macros to bring them in line
+     with version 1.0.0 of the specification.
+
+New deprecations
+   * PSA_KEY_EXPORT_MAX_SIZE, PSA_HASH_SIZE, PSA_MAC_FINAL_SIZE,
+     PSA_BLOCK_CIPHER_BLOCK_SIZE, PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE and
+     PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN have been renamed, and the old names
+     deprecated.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -203,7 +203,7 @@ This example shows how to encrypt data using an AES (Advanced Encryption Standar
 void encrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 {
     enum {
-        block_size = PSA_BLOCK_CIPHER_BLOCK_SIZE(PSA_KEY_TYPE_AES),
+        block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES),
     };
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -288,7 +288,7 @@ This example shows how to decrypt encrypted data using an AES key in CBC mode wi
 void decrypt_with_symmetric_ciphers(const uint8_t *key, size_t key_len)
 {
     enum {
-        block_size = PSA_BLOCK_CIPHER_BLOCK_SIZE(PSA_KEY_TYPE_AES),
+        block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES),
     };
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -445,7 +445,7 @@ This example shows how to verify the SHA-256 hash of a message:
         0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
         0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad
     };
-    size_t expected_hash_len = PSA_HASH_SIZE(alg);
+    size_t expected_hash_len = PSA_HASH_LENGTH(alg);
 
     printf("Verify a hash...\t");
     fflush(stdout);
@@ -482,7 +482,7 @@ This example shows how to verify the SHA-256 hash of a message:
     mbedtls_psa_crypto_free();
 ```
 
-The API provides the macro `PSA_HASH_SIZE`, which returns the expected hash length (in bytes) for the specified algorithm.
+The API provides the macro `PSA_HASH_LENGTH`, which returns the expected hash length (in bytes) for the specified algorithm.
 
 #### Handling hash operation contexts
 

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -713,7 +713,7 @@ psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p data buffer is too small. You can determine a
  *         sufficient buffer size by calling
- *         #PSA_KEY_EXPORT_MAX_SIZE(\c type, \c bits)
+ *         #PSA_EXPORT_KEY_OUTPUT_SIZE(\c type, \c bits)
  *         where \c type is the key type
  *         and \c bits is the key size in bits.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
@@ -783,7 +783,7 @@ psa_status_t psa_export_key(mbedtls_svc_key_id_t key,
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p data buffer is too small. You can determine a
  *         sufficient buffer size by calling
- *         #PSA_KEY_EXPORT_MAX_SIZE(#PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(\c type), \c bits)
+ *         #PSA_EXPORT_KEY_OUTPUT_SIZE(#PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(\c type), \c bits)
  *         where \c type is the key type
  *         and \c bits is the key size in bits.
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
@@ -822,7 +822,7 @@ psa_status_t psa_export_public_key(mbedtls_svc_key_id_t key,
  * \param hash_size         Size of the \p hash buffer in bytes.
  * \param[out] hash_length  On success, the number of bytes
  *                          that make up the hash value. This is always
- *                          #PSA_HASH_SIZE(\p alg).
+ *                          #PSA_HASH_LENGTH(\p alg).
  *
  * \retval #PSA_SUCCESS
  *         Success.
@@ -1032,7 +1032,7 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
  * \param hash_size             Size of the \p hash buffer in bytes.
  * \param[out] hash_length      On success, the number of bytes
  *                              that make up the hash value. This is always
- *                              #PSA_HASH_SIZE(\c alg) where \c alg is the
+ *                              #PSA_HASH_LENGTH(\c alg) where \c alg is the
  *                              hash algorithm that is calculated.
  *
  * \retval #PSA_SUCCESS
@@ -1041,7 +1041,7 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
  *         The operation state is not valid (it must be active).
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p hash buffer is too small. You can determine a
- *         sufficient buffer size by calling #PSA_HASH_SIZE(\c alg)
+ *         sufficient buffer size by calling #PSA_HASH_LENGTH(\c alg)
  *         where \c alg is the hash algorithm that is calculated.
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
@@ -1479,7 +1479,7 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
  * \param mac_size          Size of the \p mac buffer in bytes.
  * \param[out] mac_length   On success, the number of bytes
  *                          that make up the MAC value. This is always
- *                          #PSA_MAC_FINAL_SIZE(\c key_type, \c key_bits, \c alg)
+ *                          #PSA_MAC_LENGTH(\c key_type, \c key_bits, \c alg)
  *                          where \c key_type and \c key_bits are the type and
  *                          bit-size respectively of the key and \c alg is the
  *                          MAC algorithm that is calculated.
@@ -1491,7 +1491,7 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
  *         operation).
  * \retval #PSA_ERROR_BUFFER_TOO_SMALL
  *         The size of the \p mac buffer is too small. You can determine a
- *         sufficient buffer size by calling PSA_MAC_FINAL_SIZE().
+ *         sufficient buffer size by calling PSA_MAC_LENGTH().
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_COMMUNICATION_FAILURE
  * \retval #PSA_ERROR_HARDWARE_FAILURE

--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -110,7 +110,18 @@ typedef MBEDTLS_PSA_DEPRECATED psa_algorithm_t mbedtls_deprecated_psa_algorithm_
     MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_SIGNATURE_MAX_SIZE )
 #define PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE( key_type, key_bits, alg ) \
     MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_SIGN_OUTPUT_SIZE( key_type, key_bits, alg ) )
-
+#define PSA_KEY_EXPORT_MAX_SIZE( key_type, key_bits ) \
+    PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits )
+#define PSA_BLOCK_CIPHER_BLOCK_SIZE( type ) \
+    PSA_BLOCK_CIPHER_BLOCK_LENGTH( type )
+#define PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE \
+    PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE
+#define PSA_HASH_SIZE( alg ) \
+    PSA_HASH_LENGTH( alg )
+#define PSA_MAC_FINAL_SIZE( key_type, key_bits, alg ) \
+    PSA_MAC_LENGTH( key_type, key_bits, alg )
+#define PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN \
+    PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE
 /*
  * Deprecated PSA Crypto function names (PSA Crypto API  <= 1.0 beta3)
  */

--- a/include/psa/crypto_compat.h
+++ b/include/psa/crypto_compat.h
@@ -111,17 +111,18 @@ typedef MBEDTLS_PSA_DEPRECATED psa_algorithm_t mbedtls_deprecated_psa_algorithm_
 #define PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE( key_type, key_bits, alg ) \
     MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_SIGN_OUTPUT_SIZE( key_type, key_bits, alg ) )
 #define PSA_KEY_EXPORT_MAX_SIZE( key_type, key_bits ) \
-    PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits )
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits ) )
 #define PSA_BLOCK_CIPHER_BLOCK_SIZE( type ) \
-    PSA_BLOCK_CIPHER_BLOCK_LENGTH( type )
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ) )
 #define PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE \
-    PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE )
 #define PSA_HASH_SIZE( alg ) \
-    PSA_HASH_LENGTH( alg )
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_HASH_LENGTH( alg ) )
 #define PSA_MAC_FINAL_SIZE( key_type, key_bits, alg ) \
-    PSA_MAC_LENGTH( key_type, key_bits, alg )
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_MAC_LENGTH( key_type, key_bits, alg ) )
 #define PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN \
-    PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE
+    MBEDTLS_DEPRECATED_CONSTANT( size_t, PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE )
+
 /*
  * Deprecated PSA Crypto function names (PSA Crypto API  <= 1.0 beta3)
  */

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -307,7 +307,7 @@
  * implementation to delay the output until it has a full block. */
 #define PSA_AEAD_UPDATE_OUTPUT_SIZE(alg, input_length)                  \
     (PSA_ALG_IS_AEAD_ON_BLOCK_CIPHER(alg) ?                             \
-     PSA_ROUND_UP_TO_MULTIPLE(PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE, (input_length)) : \
+     PSA_ROUND_UP_TO_MULTIPLE(PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE, (input_length)) : \
      (input_length))
 
 /** A sufficient ciphertext buffer size for psa_aead_finish().
@@ -358,7 +358,7 @@
 
 #define PSA_RSA_MINIMUM_PADDING_SIZE(alg)                         \
     (PSA_ALG_IS_RSA_OAEP(alg) ?                                   \
-     2 * PSA_HASH_LENGTH(PSA_ALG_RSA_OAEP_GET_HASH(alg)) + 1 :      \
+     2 * PSA_HASH_LENGTH(PSA_ALG_RSA_OAEP_GET_HASH(alg)) + 1 :    \
      11 /*PKCS#1v1.5*/)
 
 /**
@@ -667,7 +667,7 @@
  *         and AEAD algorithm that it recognizes, but does not support.
  */
 #define PSA_AEAD_NONCE_LENGTH(key_type, alg) \
-    (PSA_BLOCK_CIPHER_BLOCK_SIZE(key_type) == 16 && \
+    (PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type) == 16 && \
          (PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH(alg) == PSA_ALG_CCM || \
           PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH(alg) == PSA_ALG_GCM) ? 12 : \
      (key_type) == PSA_KEY_TYPE_CHACHA20 && \

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -188,10 +188,11 @@
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 0
 #endif
 
-/** This macro returns the maximum length of the PSK supported
- * by the TLS-1.2 PSK-to-MS key derivation
- * (#PSA_ALG_TLS12_PSK_TO_MS(\p hash_alg)). It is independent from the
- * choice of hash algorithms.
+/** This macro returns the maximum supported length of the PSK for the
+ * TLS-1.2 PSK-to-MS key derivation
+ * (#PSA_ALG_TLS12_PSK_TO_MS(\p hash_alg)).
+ *
+ * The maximum supported length does not depend on the chosen hash algorithm.
  *
  * Quoting RFC 4279, Sect 5.3:
  * TLS implementations supporting these ciphersuites MUST support
@@ -591,7 +592,8 @@
 #define PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(key_bits)   \
     (PSA_BITS_TO_BYTES(key_bits))
 
-/** Sufficient output buffer size for psa_export_key().
+/** Sufficient output buffer size for psa_export_key() or
+ * psa_export_public_key().
  *
  * This macro returns a compile-time constant if its arguments are
  * compile-time constants.
@@ -623,7 +625,7 @@
  *
  * \return If the parameters are valid and supported, return
  *         a buffer size in bytes that guarantees that
- *         psa_export_key() will not fail with
+ *         psa_export_key() or psa_export_public_key() will not fail with
  *         #PSA_ERROR_BUFFER_TOO_SMALL.
  *         If the parameters are a valid combination that is not supported
  *         by the implementation, this macro shall return either a

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -68,8 +68,8 @@
  *         An implementation may return either 0 or the correct size
  *         for a hash algorithm that it recognizes, but does not support.
  */
-#define PSA_HASH_SIZE(alg)                                      \
-    (                                                           \
+#define PSA_HASH_LENGTH(alg)                                        \
+    (                                                               \
         PSA_ALG_HMAC_GET_HASH(alg) == PSA_ALG_MD2 ? 16 :            \
         PSA_ALG_HMAC_GET_HASH(alg) == PSA_ALG_MD4 ? 16 :            \
         PSA_ALG_HMAC_GET_HASH(alg) == PSA_ALG_MD5 ? 16 :            \
@@ -188,10 +188,10 @@
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 0
 #endif
 
-/** \def PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN
- *
- * This macro returns the maximum length of the PSK supported
- * by the TLS-1.2 PSK-to-MS key derivation.
+/** This macro returns the maximum length of the PSK supported
+ * by the TLS-1.2 PSK-to-MS key derivation
+ * (#PSA_ALG_TLS12_PSK_TO_MS(\p hash_alg)). It is independent from the
+ * choice of hash algorithms.
  *
  * Quoting RFC 4279, Sect 5.3:
  * TLS implementations supporting these ciphersuites MUST support
@@ -200,16 +200,20 @@
  * keys is RECOMMENDED.
  *
  * Therefore, no implementation should define a value smaller than 64
- * for #PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN.
+ * for #PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE.
  */
-#define PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN 128
+#define PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE 128
 
 /** The maximum size of a block cipher supported by the implementation. */
-#define PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE 16
+#define PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE 16
 
 /** The size of the output of psa_mac_sign_finish(), in bytes.
  *
  * This is also the MAC size that psa_mac_verify_finish() expects.
+ *
+ * \warning This macro may evaluate its arguments multiple times or
+ *          zero times, so you should not pass arguments that contain
+ *          side effects.
  *
  * \param key_type      The type of the MAC key.
  * \param key_bits      The size of the MAC key in bits.
@@ -224,10 +228,10 @@
  * \return              Unspecified if the key parameters are not consistent
  *                      with the algorithm.
  */
-#define PSA_MAC_FINAL_SIZE(key_type, key_bits, alg)                     \
-    ((alg) & PSA_ALG_MAC_TRUNCATION_MASK ? PSA_MAC_TRUNCATED_LENGTH(alg) : \
-     PSA_ALG_IS_HMAC(alg) ? PSA_HASH_SIZE(PSA_ALG_HMAC_GET_HASH(alg)) : \
-     PSA_ALG_IS_BLOCK_CIPHER_MAC(alg) ? PSA_BLOCK_CIPHER_BLOCK_SIZE(key_type) : \
+#define PSA_MAC_LENGTH(key_type, key_bits, alg)                                   \
+    ((alg) & PSA_ALG_MAC_TRUNCATION_MASK ? PSA_MAC_TRUNCATED_LENGTH(alg) :        \
+     PSA_ALG_IS_HMAC(alg) ? PSA_HASH_LENGTH(PSA_ALG_HMAC_GET_HASH(alg)) :         \
+     PSA_ALG_IS_BLOCK_CIPHER_MAC(alg) ? PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type) : \
      ((void)(key_type), (void)(key_bits), 0))
 
 /** The maximum size of the output of psa_aead_encrypt(), in bytes.
@@ -326,7 +330,7 @@
  */
 #define PSA_AEAD_FINISH_OUTPUT_SIZE(alg)                                \
     (PSA_ALG_IS_AEAD_ON_BLOCK_CIPHER(alg) ?                             \
-     PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE :                                  \
+     PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE :                                  \
      0)
 
 /** A sufficient plaintext buffer size for psa_aead_verify().
@@ -349,12 +353,12 @@
  */
 #define PSA_AEAD_VERIFY_OUTPUT_SIZE(alg)                                \
     (PSA_ALG_IS_AEAD_ON_BLOCK_CIPHER(alg) ?                             \
-     PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE :                                  \
+     PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE :                                  \
      0)
 
 #define PSA_RSA_MINIMUM_PADDING_SIZE(alg)                         \
     (PSA_ALG_IS_RSA_OAEP(alg) ?                                   \
-     2 * PSA_HASH_SIZE(PSA_ALG_RSA_OAEP_GET_HASH(alg)) + 1 :      \
+     2 * PSA_HASH_LENGTH(PSA_ALG_RSA_OAEP_GET_HASH(alg)) + 1 :      \
      11 /*PKCS#1v1.5*/)
 
 /**
@@ -587,12 +591,12 @@
 #define PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(key_bits)   \
     (PSA_BITS_TO_BYTES(key_bits))
 
-/** Sufficient output buffer size for psa_export_key() or psa_export_public_key().
+/** Sufficient output buffer size for psa_export_key().
  *
  * This macro returns a compile-time constant if its arguments are
  * compile-time constants.
  *
- * \warning This function may call its arguments multiple times or
+ * \warning This macro may evaluate its arguments multiple times or
  *          zero times, so you should not pass arguments that contain
  *          side effects.
  *
@@ -605,7 +609,7 @@
  * if (status != PSA_SUCCESS) handle_error(...);
  * psa_key_type_t key_type = psa_get_key_type(&attributes);
  * size_t key_bits = psa_get_key_bits(&attributes);
- * size_t buffer_size = PSA_KEY_EXPORT_MAX_SIZE(key_type, key_bits);
+ * size_t buffer_size = PSA_EXPORT_KEY_OUTPUT_SIZE(key_type, key_bits);
  * psa_reset_key_attributes(&attributes);
  * uint8_t *buffer = malloc(buffer_size);
  * if (buffer == NULL) handle_error(...);
@@ -614,32 +618,12 @@
  * if (status != PSA_SUCCESS) handle_error(...);
  * \endcode
  *
- * For psa_export_public_key(), calculate the buffer size from the
- * public key type. You can use the macro #PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR
- * to convert a key pair type to the corresponding public key type.
- * \code{c}
- * psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
- * psa_status_t status;
- * status = psa_get_key_attributes(key, &attributes);
- * if (status != PSA_SUCCESS) handle_error(...);
- * psa_key_type_t key_type = psa_get_key_type(&attributes);
- * psa_key_type_t public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(key_type);
- * size_t key_bits = psa_get_key_bits(&attributes);
- * size_t buffer_size = PSA_KEY_EXPORT_MAX_SIZE(public_key_type, key_bits);
- * psa_reset_key_attributes(&attributes);
- * uint8_t *buffer = malloc(buffer_size);
- * if (buffer == NULL) handle_error(...);
- * size_t buffer_length;
- * status = psa_export_public_key(key, buffer, buffer_size, &buffer_length);
- * if (status != PSA_SUCCESS) handle_error(...);
- * \endcode
- *
  * \param key_type  A supported key type.
  * \param key_bits  The size of the key in bits.
  *
  * \return If the parameters are valid and supported, return
  *         a buffer size in bytes that guarantees that
- *         psa_sign_hash() will not fail with
+ *         psa_export_key() will not fail with
  *         #PSA_ERROR_BUFFER_TOO_SMALL.
  *         If the parameters are a valid combination that is not supported
  *         by the implementation, this macro shall return either a
@@ -647,14 +631,14 @@
  *         If the parameters are not valid, the
  *         return value is unspecified.
  */
-#define PSA_KEY_EXPORT_MAX_SIZE(key_type, key_bits)                     \
-    (PSA_KEY_TYPE_IS_UNSTRUCTURED(key_type) ? PSA_BITS_TO_BYTES(key_bits) : \
-     (key_type) == PSA_KEY_TYPE_RSA_KEY_PAIR ? PSA_KEY_EXPORT_RSA_KEY_PAIR_MAX_SIZE(key_bits) : \
+#define PSA_EXPORT_KEY_OUTPUT_SIZE(key_type, key_bits)                                              \
+    (PSA_KEY_TYPE_IS_UNSTRUCTURED(key_type) ? PSA_BITS_TO_BYTES(key_bits) :                         \
+     (key_type) == PSA_KEY_TYPE_RSA_KEY_PAIR ? PSA_KEY_EXPORT_RSA_KEY_PAIR_MAX_SIZE(key_bits) :     \
      (key_type) == PSA_KEY_TYPE_RSA_PUBLIC_KEY ? PSA_KEY_EXPORT_RSA_PUBLIC_KEY_MAX_SIZE(key_bits) : \
-     (key_type) == PSA_KEY_TYPE_DSA_KEY_PAIR ? PSA_KEY_EXPORT_DSA_KEY_PAIR_MAX_SIZE(key_bits) : \
+     (key_type) == PSA_KEY_TYPE_DSA_KEY_PAIR ? PSA_KEY_EXPORT_DSA_KEY_PAIR_MAX_SIZE(key_bits) :     \
      (key_type) == PSA_KEY_TYPE_DSA_PUBLIC_KEY ? PSA_KEY_EXPORT_DSA_PUBLIC_KEY_MAX_SIZE(key_bits) : \
-     PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) ? PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(key_bits) : \
-     PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) ? PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(key_bits) : \
+     PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) ? PSA_KEY_EXPORT_ECC_KEY_PAIR_MAX_SIZE(key_bits) :      \
+     PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) ? PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(key_bits) :  \
      0)
 
 /** The default nonce size for an AEAD algorithm, in bytes.
@@ -727,13 +711,13 @@
  *         and cipher algorithm that it recognizes, but does not support.
  */
 #define PSA_CIPHER_IV_LENGTH(key_type, alg) \
-    (PSA_BLOCK_CIPHER_BLOCK_SIZE(key_type) > 1 && \
+    (PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type) > 1 && \
         ((alg) == PSA_ALG_CTR || \
          (alg) == PSA_ALG_CFB || \
          (alg) == PSA_ALG_OFB || \
          (alg) == PSA_ALG_XTS || \
          (alg) == PSA_ALG_CBC_NO_PADDING || \
-         (alg) == PSA_ALG_CBC_PKCS7) ? PSA_BLOCK_CIPHER_BLOCK_SIZE(key_type) : \
+         (alg) == PSA_ALG_CBC_PKCS7) ? PSA_BLOCK_CIPHER_BLOCK_LENGTH(key_type) : \
      (key_type) == PSA_KEY_TYPE_CHACHA20 && \
          (alg) == PSA_ALG_STREAM_CIPHER ? 12 : \
      0)

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -363,7 +363,7 @@
  * used for.
  *
  * HMAC keys should generally have the same size as the underlying hash.
- * This size can be calculated with #PSA_HASH_SIZE(\c alg) where
+ * This size can be calculated with #PSA_HASH_LENGTH(\c alg) where
  * \c alg is the HMAC algorithm or the underlying hash algorithm. */
 #define PSA_KEY_TYPE_HMAC                           ((psa_key_type_t)0x1100)
 
@@ -594,9 +594,9 @@
  *
  * \warning This macro may evaluate its argument multiple times.
  */
-#define PSA_BLOCK_CIPHER_BLOCK_SIZE(type)            \
+#define PSA_BLOCK_CIPHER_BLOCK_LENGTH(type)                                     \
     (((type) & PSA_KEY_TYPE_CATEGORY_MASK) == PSA_KEY_TYPE_CATEGORY_SYMMETRIC ? \
-     1u << PSA_GET_KEY_TYPE_BLOCK_SIZE_EXPONENT(type) :                 \
+     1u << PSA_GET_KEY_TYPE_BLOCK_SIZE_EXPONENT(type) :                         \
      0u)
 
 /** Vendor-defined algorithm flag.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2736,7 +2736,7 @@ psa_status_t psa_hash_finish( psa_hash_operation_t *operation,
 {
     psa_status_t status;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    size_t actual_hash_length = PSA_HASH_SIZE( operation->alg );
+    size_t actual_hash_length = PSA_HASH_LENGTH( operation->alg );
 
     /* Fill the output buffer with something that isn't a valid hash
      * (barring an attack on the hash and deliberately-crafted input),
@@ -3213,7 +3213,7 @@ static psa_status_t psa_hmac_setup_internal( psa_hmac_internal_data *hmac,
 {
     uint8_t ipad[PSA_HMAC_MAX_HASH_BLOCK_SIZE];
     size_t i;
-    size_t hash_size = PSA_HASH_SIZE( hash_alg );
+    size_t hash_size = PSA_HASH_LENGTH( hash_alg );
     size_t block_size = psa_get_hash_block_size( hash_alg );
     psa_status_t status;
 
@@ -3329,7 +3329,7 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
             goto exit;
         }
 
-        operation->mac_size = PSA_HASH_SIZE( hash_alg );
+        operation->mac_size = PSA_HASH_LENGTH( hash_alg );
         /* Sanity check. This shouldn't fail on a valid configuration. */
         if( operation->mac_size == 0 ||
             operation->mac_size > sizeof( operation->ctx.hmac.opad ) )
@@ -3499,7 +3499,7 @@ static psa_status_t psa_mac_finish_internal( psa_mac_operation_t *operation,
 #if defined(MBEDTLS_CMAC_C)
     if( operation->alg == PSA_ALG_CMAC )
     {
-        uint8_t tmp[PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE];
+        uint8_t tmp[PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE];
         int ret = mbedtls_cipher_cmac_finish( &operation->ctx.cmac, tmp );
         if( ret == 0 )
             memcpy( mac, tmp, operation->mac_size );
@@ -4455,11 +4455,11 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
 #endif //MBEDTLS_CIPHER_MODE_WITH_PADDING
 
     operation->block_size = ( PSA_ALG_IS_STREAM_CIPHER( alg ) ? 1 :
-                              PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type ) );
+                              PSA_BLOCK_CIPHER_BLOCK_LENGTH( slot->attr.type ) );
     if( ( alg & PSA_ALG_CIPHER_FROM_BLOCK_FLAG ) != 0 &&
         alg != PSA_ALG_ECB_NO_PADDING )
     {
-        operation->iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( slot->attr.type );
+        operation->iv_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH( slot->attr.type );
     }
 #if defined(MBEDTLS_CHACHA20_C)
     else
@@ -4919,7 +4919,7 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
             /* CCM allows the following tag lengths: 4, 6, 8, 10, 12, 14, 16.
              * The call to mbedtls_ccm_encrypt_and_tag or
              * mbedtls_ccm_auth_decrypt will validate the tag length. */
-            if( PSA_BLOCK_CIPHER_BLOCK_SIZE( operation->slot->attr.type ) != 16 )
+            if( PSA_BLOCK_CIPHER_BLOCK_LENGTH( operation->slot->attr.type ) != 16 )
             {
                 status = PSA_ERROR_INVALID_ARGUMENT;
                 goto cleanup;
@@ -4941,7 +4941,7 @@ static psa_status_t psa_aead_setup( aead_operation_t *operation,
             /* GCM allows the following tag lengths: 4, 8, 12, 13, 14, 15, 16.
              * The call to mbedtls_gcm_crypt_and_tag or
              * mbedtls_gcm_auth_decrypt will validate the tag length. */
-            if( PSA_BLOCK_CIPHER_BLOCK_SIZE( operation->slot->attr.type ) != 16 )
+            if( PSA_BLOCK_CIPHER_BLOCK_LENGTH( operation->slot->attr.type ) != 16 )
             {
                 status = PSA_ERROR_INVALID_ARGUMENT;
                 goto cleanup;
@@ -5310,7 +5310,7 @@ static psa_status_t psa_key_derivation_hkdf_read( psa_hkdf_key_derivation_t *hkd
                                              uint8_t *output,
                                              size_t output_length )
 {
-    uint8_t hash_length = PSA_HASH_SIZE( hash_alg );
+    uint8_t hash_length = PSA_HASH_LENGTH( hash_alg );
     psa_status_t status;
 
     if( hkdf->state < HKDF_STATE_KEYED || ! hkdf->info_set )
@@ -5380,7 +5380,7 @@ static psa_status_t psa_key_derivation_tls12_prf_generate_next_block(
     psa_algorithm_t alg )
 {
     psa_algorithm_t hash_alg = PSA_ALG_HKDF_GET_HASH( alg );
-    uint8_t hash_length = PSA_HASH_SIZE( hash_alg );
+    uint8_t hash_length = PSA_HASH_LENGTH( hash_alg );
     psa_hash_operation_t backup = PSA_HASH_OPERATION_INIT;
     psa_status_t status, cleanup_status;
 
@@ -5490,7 +5490,7 @@ static psa_status_t psa_key_derivation_tls12_prf_read(
     size_t output_length )
 {
     psa_algorithm_t hash_alg = PSA_ALG_TLS12_PRF_GET_HASH( alg );
-    uint8_t hash_length = PSA_HASH_SIZE( hash_alg );
+    uint8_t hash_length = PSA_HASH_LENGTH( hash_alg );
     psa_status_t status;
     uint8_t offset, length;
 
@@ -5720,7 +5720,7 @@ static psa_status_t psa_key_derivation_setup_kdf(
     if( is_kdf_alg_supported )
     {
         psa_algorithm_t hash_alg = PSA_ALG_HKDF_GET_HASH( kdf_alg );
-        size_t hash_size = PSA_HASH_SIZE( hash_alg );
+        size_t hash_size = PSA_HASH_LENGTH( hash_alg );
         if( hash_size == 0 )
             return( PSA_ERROR_NOT_SUPPORTED );
         if( ( PSA_ALG_IS_TLS12_PRF( kdf_alg ) ||
@@ -5808,7 +5808,7 @@ static psa_status_t psa_hkdf_input( psa_hkdf_key_derivation_t *hkdf,
                                                sizeof( hkdf->prk ) );
             if( status != PSA_SUCCESS )
                 return( status );
-            hkdf->offset_in_block = PSA_HASH_SIZE( hash_alg );
+            hkdf->offset_in_block = PSA_HASH_LENGTH( hash_alg );
             hkdf->block_number = 0;
             hkdf->state = HKDF_STATE_KEYED;
             return( PSA_SUCCESS );
@@ -5926,10 +5926,10 @@ static psa_status_t psa_tls12_prf_psk_to_ms_set_key(
     size_t data_length )
 {
     psa_status_t status;
-    uint8_t pms[ 4 + 2 * PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN ];
+    uint8_t pms[ 4 + 2 * PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE ];
     uint8_t *cur = pms;
 
-    if( data_length > PSA_ALG_TLS12_PSK_TO_MS_MAX_PSK_LEN )
+    if( data_length > PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE )
         return( PSA_ERROR_INVALID_ARGUMENT );
 
     /* Quoting RFC 4279, Section 2:

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -263,7 +263,7 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
     switch( location )
     {
         case PSA_KEY_LOCATION_LOCAL_STORAGE:
-            buffer_size = PSA_KEY_EXPORT_MAX_SIZE( key_type, key_bits );
+            buffer_size = PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits );
 
             if( buffer_size == 0 )
                 return( PSA_ERROR_NOT_SUPPORTED );
@@ -280,7 +280,7 @@ static psa_status_t get_expected_key_size( const psa_key_attributes_t *attribute
             if( PSA_KEY_TYPE_IS_KEY_PAIR( key_type ) )
             {
                 int public_key_overhead = ( ( TEST_DRIVER_KEY_CONTEXT_STORE_PUBLIC_KEY == 1 ) ?
-                                           PSA_KEY_EXPORT_MAX_SIZE( key_type, key_bits ) : 0 );
+                                           PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits ) : 0 );
                 *expected_size = TEST_DRIVER_KEY_CONTEXT_BASE_SIZE
                                  + TEST_DRIVER_KEY_CONTEXT_PUBLIC_KEY_SIZE
                                  + public_key_overhead;

--- a/programs/psa/crypto_examples.c
+++ b/programs/psa/crypto_examples.c
@@ -159,7 +159,7 @@ static psa_status_t
 cipher_example_encrypt_decrypt_aes_cbc_nopad_1_block( void )
 {
     enum {
-        block_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( PSA_KEY_TYPE_AES ),
+        block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH( PSA_KEY_TYPE_AES ),
         key_bits = 256,
         part_size = block_size,
     };
@@ -207,7 +207,7 @@ exit:
 static psa_status_t cipher_example_encrypt_decrypt_aes_cbc_pkcs7_multi( void )
 {
     enum {
-        block_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( PSA_KEY_TYPE_AES ),
+        block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH( PSA_KEY_TYPE_AES ),
         key_bits = 256,
         input_size = 100,
         part_size = 10,
@@ -255,7 +255,7 @@ exit:
 static psa_status_t cipher_example_encrypt_decrypt_aes_ctr_multi( void )
 {
     enum {
-        block_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( PSA_KEY_TYPE_AES ),
+        block_size = PSA_BLOCK_CIPHER_BLOCK_LENGTH( PSA_KEY_TYPE_AES ),
         key_bits = 256,
         input_size = 100,
         part_size = 10,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -287,7 +287,7 @@ int check_key_attributes_sanity( mbedtls_svc_key_id_t key )
         TEST_ASSERT( bits <= PSA_VENDOR_ECC_MAX_CURVE_BITS );
     else if( PSA_KEY_TYPE_IS_RSA( type ) )
         TEST_ASSERT( bits <= PSA_VENDOR_RSA_MAX_KEY_BITS );
-    TEST_ASSERT( PSA_BLOCK_CIPHER_BLOCK_SIZE( type ) <= PSA_MAX_BLOCK_CIPHER_BLOCK_SIZE );
+    TEST_ASSERT( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ) <= PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE );
 
     ok = 1;
 
@@ -447,7 +447,7 @@ static int exercise_cipher_key( mbedtls_svc_key_id_t key,
             PSA_ASSERT( psa_get_key_attributes( key, &attributes ) );
             /* This should be PSA_CIPHER_GET_IV_SIZE but the API doesn't
              * have this macro yet. */
-            iv_length = PSA_BLOCK_CIPHER_BLOCK_SIZE(
+            iv_length = PSA_BLOCK_CIPHER_BLOCK_LENGTH(
                 psa_get_key_type( &attributes ) );
             maybe_invalid_padding = ! PSA_ALG_IS_STREAM_CIPHER( alg );
             psa_reset_key_attributes( &attributes );
@@ -550,7 +550,7 @@ static int exercise_signature_key( mbedtls_svc_key_id_t key,
          * the hash encoded in the algorithm. Use this input size
          * even for algorithms that allow other input sizes. */
         if( hash_alg != 0 )
-            payload_length = PSA_HASH_SIZE( hash_alg );
+            payload_length = PSA_HASH_LENGTH( hash_alg );
         PSA_ASSERT( psa_sign_hash( key, alg,
                                    payload, payload_length,
                                    signature, sizeof( signature ),
@@ -714,7 +714,7 @@ static psa_status_t key_agreement_with_self(
     private_key_type = psa_get_key_type( &attributes );
     key_bits = psa_get_key_bits( &attributes );
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR( private_key_type );
-    public_key_length = PSA_KEY_EXPORT_MAX_SIZE( public_key_type, key_bits );
+    public_key_length = PSA_EXPORT_KEY_OUTPUT_SIZE( public_key_type, key_bits );
     ASSERT_ALLOC( public_key, public_key_length );
     PSA_ASSERT( psa_export_public_key( key, public_key, public_key_length,
                                        &public_key_length ) );
@@ -755,7 +755,7 @@ static psa_status_t raw_key_agreement_with_self( psa_algorithm_t alg,
     private_key_type = psa_get_key_type( &attributes );
     key_bits = psa_get_key_bits( &attributes );
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR( private_key_type );
-    public_key_length = PSA_KEY_EXPORT_MAX_SIZE( public_key_type, key_bits );
+    public_key_length = PSA_EXPORT_KEY_OUTPUT_SIZE( public_key_type, key_bits );
     ASSERT_ALLOC( public_key, public_key_length );
     PSA_ASSERT( psa_export_public_key( key,
                                        public_key, public_key_length,
@@ -868,7 +868,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
     if( PSA_KEY_TYPE_IS_UNSTRUCTURED( type ) )
         TEST_EQUAL( exported_length, ( bits + 7 ) / 8 );
     else
-        TEST_ASSERT( exported_length <= PSA_KEY_EXPORT_MAX_SIZE( type, bits ) );
+        TEST_ASSERT( exported_length <= PSA_EXPORT_KEY_OUTPUT_SIZE( type, bits ) );
 
 #if defined(MBEDTLS_DES_C)
     if( type == PSA_KEY_TYPE_DES )
@@ -1037,8 +1037,8 @@ static int exercise_export_key( mbedtls_svc_key_id_t key,
         goto exit;
     }
 
-    exported_size = PSA_KEY_EXPORT_MAX_SIZE( psa_get_key_type( &attributes ),
-                                             psa_get_key_bits( &attributes ) );
+    exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE( psa_get_key_type( &attributes ),
+                                                psa_get_key_bits( &attributes ) );
     ASSERT_ALLOC( exported, exported_size );
 
     PSA_ASSERT( psa_export_key( key,
@@ -1078,8 +1078,8 @@ static int exercise_export_public_key( mbedtls_svc_key_id_t key )
 
     public_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEY_PAIR(
         psa_get_key_type( &attributes ) );
-    exported_size = PSA_KEY_EXPORT_MAX_SIZE( public_type,
-                                             psa_get_key_bits( &attributes ) );
+    exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE( public_type,
+                                                psa_get_key_bits( &attributes ) );
     ASSERT_ALLOC( exported, exported_size );
 
     PSA_ASSERT( psa_export_public_key( key,
@@ -1735,7 +1735,7 @@ void import_export( data_t *data,
                         reexported, reexported_length );
         PSA_ASSERT( psa_destroy_key( key2 ) );
     }
-    TEST_ASSERT( exported_length <= PSA_KEY_EXPORT_MAX_SIZE( type, psa_get_key_bits( &got_attributes ) ) );
+    TEST_ASSERT( exported_length <= PSA_EXPORT_KEY_OUTPUT_SIZE( type, psa_get_key_bits( &got_attributes ) ) );
 
 destroy:
     /* Destroy the key */
@@ -1795,7 +1795,7 @@ void import_export_public_key( data_t *data,
         PSA_ASSERT( psa_get_key_attributes( key, &attributes ) );
         bits = psa_get_key_bits( &attributes );
         TEST_ASSERT( expected_public_key->len <=
-                     PSA_KEY_EXPORT_MAX_SIZE( public_type, bits ) );
+                     PSA_EXPORT_KEY_OUTPUT_SIZE( public_type, bits ) );
         ASSERT_COMPARE( expected_public_key->x, expected_public_key->len,
                         exported, exported_length );
     }
@@ -2643,9 +2643,9 @@ void hash_compute_compare( int alg_arg, data_t *input,
 
     /* Compute with tight buffer */
     PSA_ASSERT( psa_hash_compute( alg, input->x, input->len,
-                                  output, PSA_HASH_SIZE( alg ),
+                                  output, PSA_HASH_LENGTH( alg ),
                                   &output_length ) );
-    TEST_EQUAL( output_length, PSA_HASH_SIZE( alg ) );
+    TEST_EQUAL( output_length, PSA_HASH_LENGTH( alg ) );
     ASSERT_COMPARE( output, output_length,
                     expected_output->x, expected_output->len );
 
@@ -2653,7 +2653,7 @@ void hash_compute_compare( int alg_arg, data_t *input,
     PSA_ASSERT( psa_hash_compute( alg, input->x, input->len,
                                   output, sizeof( output ),
                                   &output_length ) );
-    TEST_EQUAL( output_length, PSA_HASH_SIZE( alg ) );
+    TEST_EQUAL( output_length, PSA_HASH_LENGTH( alg ) );
     ASSERT_COMPARE( output, output_length,
                     expected_output->x, expected_output->len );
 
@@ -2785,7 +2785,7 @@ void hash_verify_bad_args( )
         0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8,
         0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
         0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55, 0xaa, 0xbb };
-    size_t expected_size = PSA_HASH_SIZE( alg );
+    size_t expected_size = PSA_HASH_LENGTH( alg );
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
 
     PSA_ASSERT( psa_crypto_init( ) );
@@ -2815,7 +2815,7 @@ void hash_finish_bad_args( )
 {
     psa_algorithm_t alg = PSA_ALG_SHA_256;
     unsigned char hash[PSA_HASH_MAX_SIZE];
-    size_t expected_size = PSA_HASH_SIZE( alg );
+    size_t expected_size = PSA_HASH_LENGTH( alg );
     psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
 
@@ -3119,7 +3119,7 @@ void mac_sign( int key_type_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *actual_mac = NULL;
     size_t mac_buffer_size =
-        PSA_MAC_FINAL_SIZE( key_type, PSA_BYTES_TO_BITS( key_data->len ), alg );
+        PSA_MAC_LENGTH( key_type, PSA_BYTES_TO_BITS( key_data->len ), alg );
     size_t mac_length = 0;
     const size_t output_sizes_to_test[] = {
         0,
@@ -3130,7 +3130,7 @@ void mac_sign( int key_type_arg,
     };
 
     TEST_ASSERT( mac_buffer_size <= PSA_MAC_MAX_SIZE );
-    /* We expect PSA_MAC_FINAL_SIZE to be exact. */
+    /* We expect PSA_MAC_LENGTH to be exact. */
     TEST_ASSERT( expected_mac->len == mac_buffer_size );
 
     PSA_ASSERT( psa_crypto_init( ) );
@@ -3342,14 +3342,14 @@ void cipher_bad_order( )
     psa_algorithm_t alg = PSA_ALG_CBC_PKCS7;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
-    unsigned char iv[PSA_BLOCK_CIPHER_BLOCK_SIZE(PSA_KEY_TYPE_AES)] = { 0 };
+    unsigned char iv[PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES)] = { 0 };
     const uint8_t key_data[] = {
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
         0xaa, 0xaa, 0xaa, 0xaa };
     const uint8_t text[] = {
         0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
         0xbb, 0xbb, 0xbb, 0xbb };
-    uint8_t buffer[PSA_BLOCK_CIPHER_BLOCK_SIZE(PSA_KEY_TYPE_AES)] = { 0 };
+    uint8_t buffer[PSA_BLOCK_CIPHER_BLOCK_LENGTH(PSA_KEY_TYPE_AES)] = { 0 };
     size_t length = 0;
 
     PSA_ASSERT( psa_crypto_init( ) );
@@ -3522,7 +3522,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     }
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     PSA_ASSERT( psa_cipher_update( &operation,
@@ -3590,7 +3590,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     }
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( first_part_size <= input->len );
@@ -3663,7 +3663,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     }
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( first_part_size <= input->len );
@@ -3734,7 +3734,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     }
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     PSA_ASSERT( psa_cipher_update( &operation,
@@ -3805,7 +3805,7 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
                                             &iv_length ) );
     }
     output1_size = ( (size_t) input->len +
-                     PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                     PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output1, output1_size );
 
     PSA_ASSERT( psa_cipher_update( &operation1, input->x, input->len,
@@ -3899,7 +3899,7 @@ void cipher_verify_output_multipart( int alg_arg,
     }
 
     output1_buffer_size = ( (size_t) input->len +
-                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                            PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output1, output1_buffer_size );
 
     TEST_ASSERT( first_part_size <= input->len );
@@ -5645,7 +5645,7 @@ void generate_key_rsa( int bits_arg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     uint8_t *exported = NULL;
     size_t exported_size =
-        PSA_KEY_EXPORT_MAX_SIZE( PSA_KEY_TYPE_RSA_PUBLIC_KEY, bits );
+        PSA_EXPORT_KEY_OUTPUT_SIZE( PSA_KEY_TYPE_RSA_PUBLIC_KEY, bits );
     size_t exported_length = SIZE_MAX;
     uint8_t *e_read_buffer = NULL;
     int is_default_public_exponent = 0;
@@ -5756,7 +5756,7 @@ void persistent_key_load_key_from_storage( data_t *data,
     psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
     unsigned char *first_export = NULL;
     unsigned char *second_export = NULL;
-    size_t export_size = PSA_KEY_EXPORT_MAX_SIZE( type, bits );
+    size_t export_size = PSA_EXPORT_KEY_OUTPUT_SIZE( type, bits );
     size_t first_exported_length;
     size_t second_exported_length;
 

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -326,7 +326,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     test_driver_cipher_hooks.hits = 0;
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     if( mock_output_arg )
@@ -418,7 +418,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     test_driver_cipher_hooks.hits = 0;
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( first_part_size <= input->len );
@@ -503,7 +503,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     test_driver_cipher_hooks.hits = 0;
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( first_part_size <= input->len );
@@ -591,7 +591,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     test_driver_cipher_hooks.hits = 0;
 
     output_buffer_size = ( (size_t) input->len +
-                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
+                           PSA_BLOCK_CIPHER_BLOCK_LENGTH( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     if( mock_output_arg )

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -156,7 +156,7 @@ void mac_algorithm_core( psa_algorithm_t alg, int classification_flags,
     algorithm_classification( alg, classification_flags );
 
     /* Length */
-    TEST_EQUAL( length, PSA_MAC_FINAL_SIZE( key_type, key_bits, alg ) );
+    TEST_EQUAL( length, PSA_MAC_LENGTH( key_type, key_bits, alg ) );
 
 exit: ;
 }
@@ -226,7 +226,7 @@ void hash_algorithm( int alg_arg, int length_arg )
     TEST_EQUAL( PSA_ALG_HKDF_GET_HASH( hkdf_alg ), alg );
 
     /* Hash length */
-    TEST_EQUAL( length, PSA_HASH_SIZE( alg ) );
+    TEST_EQUAL( length, PSA_HASH_LENGTH( alg ) );
     TEST_ASSERT( length <= PSA_HASH_MAX_SIZE );
 }
 /* END_CASE */
@@ -483,7 +483,7 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
 
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
-    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_SIZE( type ), block_size );
+    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 }
 /* END_CASE */
 
@@ -496,7 +496,7 @@ void stream_cipher_key_type( int type_arg )
 
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
-    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_SIZE( type ), 1 );
+    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), 1 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -293,8 +293,8 @@ static psa_status_t ram_fake_generate( psa_drv_se_context_t *context,
 {
     psa_status_t status;
     size_t required_storage =
-        PSA_KEY_EXPORT_MAX_SIZE( psa_get_key_type( attributes ),
-                                 psa_get_key_bits( attributes ) );
+        PSA_EXPORT_KEY_OUTPUT_SIZE( psa_get_key_type( attributes ),
+                                    psa_get_key_bits( attributes ) );
 
     DRIVER_ASSERT_RETURN( *pubkey_length == 0 );
     if( ! PSA_KEY_TYPE_IS_KEY_PAIR( psa_get_key_type( attributes ) ) )


### PR DESCRIPTION
This PR contains only the renames of the buffer size macros.
The newly introduced macros are in #3386.

Fixes parts of #3268