### PR TITLE
Backport 2.16: Fix an incorrect error code if RSA private operation glitched

### DIFF
--- a/ChangeLog.d/rsa_private-ret.txt
+++ b/ChangeLog.d/rsa_private-ret.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix an incorrect error code if an RSA private operation glitched.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1106,10 +1106,10 @@ cleanup:
     mbedtls_mpi_free( &C );
     mbedtls_mpi_free( &I );
 
-    if( ret != 0 )
+    if( ret != 0 && ret >= -0x007f )
         return( MBEDTLS_ERR_RSA_PRIVATE_FAILED + ret );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_PKCS1_V21)


### PR DESCRIPTION
`mbedtls_rsa_private()` could return the sum of two RSA error codes instead of a valid error code in some rare circumstances. Fix this.

There is no non-regression test because the circumstances are too hard to arrange in a unit test.

I found the bug while working on a bigger feature, so the fix for `development` is in the pull request for that feature: #3912.
