### PR TITLE
Allow CMAC self test to skip tests for unsupported primitives

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -783,8 +783,8 @@ static int cmac_test_subkeys( int verbose,
         {
             /* When CMAC is implemented by an alternative implementation, or
              * the underlying primitive itself is implemented alternatively,
-             * certain features (e.g. AES-192) may be unavailable. This should
-             * not cause the selftest function to fail. */
+             * AES-192 may be unavailable. This should not cause the selftest
+             * function to fail. */
             if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
                   ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) &&
                   cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
@@ -867,8 +867,8 @@ static int cmac_test_wth_cipher( int verbose,
         {
             /* When CMAC is implemented by an alternative implementation, or
              * the underlying primitive itself is implemented alternatively,
-             * certain features (e.g. AES-192) may be unavailable. This should
-             * not cause the selftest function to fail. */
+             * AES-192 may be unavailable. This should not cause the selftest
+             * function to fail. */
             if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
                   ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) &&
                   cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -785,8 +785,9 @@ static int cmac_test_subkeys( int verbose,
              * the underlying primitive itself is implemented alternatively,
              * certain features (e.g. AES-192) may be unavailable. This should
              * not cause the selftest function to fail. */
-            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
-                ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) {
+            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED
+                  || ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE )
+                && cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
                 if( verbose != 0 )
                     mbedtls_printf( "skipped\n" );
                 goto next_test;
@@ -868,8 +869,9 @@ static int cmac_test_wth_cipher( int verbose,
              * the underlying primitive itself is implemented alternatively,
              * certain features (e.g. AES-192) may be unavailable. This should
              * not cause the selftest function to fail. */
-            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
-                ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) {
+            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED
+                  || ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE )
+                && cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
                 if( verbose != 0 )
                     mbedtls_printf( "skipped\n" );
                 continue;

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -785,9 +785,9 @@ static int cmac_test_subkeys( int verbose,
              * the underlying primitive itself is implemented alternatively,
              * certain features (e.g. AES-192) may be unavailable. This should
              * not cause the selftest function to fail. */
-            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED
-                  || ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE )
-                && cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
+            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
+                  ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) &&
+                  cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
                 if( verbose != 0 )
                     mbedtls_printf( "skipped\n" );
                 goto next_test;
@@ -869,9 +869,9 @@ static int cmac_test_wth_cipher( int verbose,
              * the underlying primitive itself is implemented alternatively,
              * certain features (e.g. AES-192) may be unavailable. This should
              * not cause the selftest function to fail. */
-            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED
-                  || ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE )
-                && cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
+            if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
+                  ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) &&
+                  cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
                 if( verbose != 0 )
                     mbedtls_printf( "skipped\n" );
                 continue;

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -793,6 +793,17 @@ static int cmac_test_subkeys( int verbose,
         if( ( ret = mbedtls_cipher_setkey( &ctx, key, keybits,
                                        MBEDTLS_ENCRYPT ) ) != 0 )
         {
+            /* When CMAC is implemented by an alternative implementation, or
+             * the underlying primitive itself is implemented alternatively,
+             * certain features (e.g. AES-192) may be unavailable. This should
+             * not cause the selftest function to fail. */
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
+                ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) {
+                if( verbose != 0 )
+                    mbedtls_printf( "skipped\n" );
+                goto next_test;
+            }
+
             if( verbose != 0 )
                 mbedtls_printf( "test execution failed\n" );
 
@@ -820,6 +831,7 @@ static int cmac_test_subkeys( int verbose,
         if( verbose != 0 )
             mbedtls_printf( "passed\n" );
 
+next_test:
         mbedtls_cipher_free( &ctx );
     }
 
@@ -864,6 +876,17 @@ static int cmac_test_wth_cipher( int verbose,
         if( ( ret = mbedtls_cipher_cmac( cipher_info, key, keybits, messages,
                                          message_lengths[i], output ) ) != 0 )
         {
+            /* When CMAC is implemented by an alternative implementation, or
+             * the underlying primitive itself is implemented alternatively,
+             * certain features (e.g. AES-192) may be unavailable. This should
+             * not cause the selftest function to fail. */
+            if( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
+                ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) {
+                if( verbose != 0 )
+                    mbedtls_printf( "skipped\n" );
+                continue;
+            }
+
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
             goto exit;

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -45,21 +45,9 @@
 #include "mbedtls/cmac.h"
 #include "mbedtls/platform_util.h"
 #include "mbedtls/error.h"
+#include "mbedtls/platform.h"
 
 #include <string.h>
-
-
-#if defined(MBEDTLS_PLATFORM_C)
-#include "mbedtls/platform.h"
-#else
-#include <stdlib.h>
-#define mbedtls_calloc     calloc
-#define mbedtls_free       free
-#if defined(MBEDTLS_SELF_TEST)
-#include <stdio.h>
-#define mbedtls_printf     printf
-#endif /* MBEDTLS_SELF_TEST */
-#endif /* MBEDTLS_PLATFORM_C */
 
 #if !defined(MBEDTLS_CMAC_ALT) || defined(MBEDTLS_SELF_TEST)
 


### PR DESCRIPTION
## Description
This is the same type of logic as was already applied in e.g. AES and GCM self tests. When the underlying primitive returns 'not supported' (either through the cipher interface or because there is an _ALT implementation), the relevant test is skipped instead of failing the selftest routine.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Documentation


## Steps to test or reproduce
Covered by existing testing. _ALT interfaces are currently not generally tested, that would be outside the scope of this PR.
