### PR TITLE
Allow tweaking PSA_KEY_SLOT_COUNT

### DIFF
--- a/ChangeLog.d/psa_allow_tweaking_library_configuration.txt
+++ b/ChangeLog.d/psa_allow_tweaking_library_configuration.txt
@@ -1,0 +1,5 @@
+Features
+   * The PSA crypto subsystem can now be configured to use less static RAM by
+     tweaking the setting for the maximum amount of keys simultaneously in RAM.
+     PSA_KEY_SLOT_COUNT sets the maximum number of volatile keys that can
+     exist simultaneously. It has a sensible default if not overridden.

--- a/ChangeLog.d/psa_allow_tweaking_library_configuration.txt
+++ b/ChangeLog.d/psa_allow_tweaking_library_configuration.txt
@@ -1,5 +1,5 @@
 Features
    * The PSA crypto subsystem can now be configured to use less static RAM by
      tweaking the setting for the maximum amount of keys simultaneously in RAM.
-     PSA_KEY_SLOT_COUNT sets the maximum number of volatile keys that can
-     exist simultaneously. It has a sensible default if not overridden.
+     MBEDTLS_PSA_KEY_SLOT_COUNT sets the maximum number of volatile keys that
+     can exist simultaneously. It has a sensible default if not overridden.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3671,7 +3671,7 @@
  */
 //#define MBEDTLS_PSA_HMAC_DRBG_MD_TYPE MBEDTLS_MD_SHA256
 
-/** \def PSA_KEY_SLOT_COUNT
+/** \def MBEDTLS_PSA_KEY_SLOT_COUNT
  * Restrict the PSA library to supporting a maximum amount of simultaneously
  * loaded keys. A loaded key is a key stored by the PSA Crypto core as a
  * volatile key, or a persistent key which is loaded temporarily by the
@@ -3680,7 +3680,7 @@
  * If this option is unset, the library will fall back to a default value of
  * 32 keys.
  */
-//#define PSA_KEY_SLOT_COUNT 32
+//#define MBEDTLS_PSA_KEY_SLOT_COUNT 32
 
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3671,6 +3671,17 @@
  */
 //#define MBEDTLS_PSA_HMAC_DRBG_MD_TYPE MBEDTLS_MD_SHA256
 
+/** \def PSA_KEY_SLOT_COUNT
+ * Restrict the PSA library to supporting a maximum amount of simultaneously
+ * loaded keys. A loaded key is a key stored by the PSA Crypto core as a
+ * volatile key, or a persistent key which is loaded temporarily by the
+ * library as part of a crypto operation in flight.
+ *
+ * If this option is unset, the library will fall back to a default value of
+ * 32 keys.
+ */
+//#define PSA_KEY_SLOT_COUNT 32
+
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -40,8 +40,8 @@ extern "C" {
 #define PSA_CRYPTO_ITS_RANDOM_SEED_UID 0xFFFFFF52
 
 /* See config.h for definition */
-#if !defined(PSA_KEY_SLOT_COUNT)
-#define PSA_KEY_SLOT_COUNT 32
+#if !defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
+#define MBEDTLS_PSA_KEY_SLOT_COUNT 32
 #endif
 
 /** \addtogroup attributes

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -39,6 +39,10 @@ extern "C" {
 /* UID for secure storage seed */
 #define PSA_CRYPTO_ITS_RANDOM_SEED_UID 0xFFFFFF52
 
+/* See config.h for definition */
+#if !defined(PSA_KEY_SLOT_COUNT)
+#define PSA_KEY_SLOT_COUNT 32
+#endif
 
 /** \addtogroup attributes
  * @{

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -45,7 +45,7 @@
 
 typedef struct
 {
-    psa_key_slot_t key_slots[PSA_KEY_SLOT_COUNT];
+    psa_key_slot_t key_slots[MBEDTLS_PSA_KEY_SLOT_COUNT];
     unsigned key_slots_initialized : 1;
 } psa_global_data_t;
 
@@ -128,13 +128,13 @@ static psa_status_t psa_get_and_lock_key_slot_in_memory(
         if( status != PSA_SUCCESS )
             return( status );
 
-        for( slot_idx = 0; slot_idx < PSA_KEY_SLOT_COUNT; slot_idx++ )
+        for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
         {
             slot = &global_data.key_slots[ slot_idx ];
             if( mbedtls_svc_key_id_equal( key, slot->attr.id ) )
                 break;
         }
-        status = ( slot_idx < PSA_KEY_SLOT_COUNT ) ?
+        status = ( slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT ) ?
                  PSA_SUCCESS : PSA_ERROR_DOES_NOT_EXIST;
     }
 
@@ -161,7 +161,7 @@ void psa_wipe_all_key_slots( void )
 {
     size_t slot_idx;
 
-    for( slot_idx = 0; slot_idx < PSA_KEY_SLOT_COUNT; slot_idx++ )
+    for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
     {
         psa_key_slot_t *slot = &global_data.key_slots[ slot_idx ];
         slot->lock_count = 1;
@@ -184,7 +184,7 @@ psa_status_t psa_get_empty_key_slot( psa_key_id_t *volatile_key_id,
     }
 
     selected_slot = unlocked_persistent_key_slot = NULL;
-    for( slot_idx = 0; slot_idx < PSA_KEY_SLOT_COUNT; slot_idx++ )
+    for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
     {
         psa_key_slot_t *slot = &global_data.key_slots[ slot_idx ];
         if( ! psa_is_key_slot_occupied( slot ) )
@@ -453,7 +453,7 @@ void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats )
 
     memset( stats, 0, sizeof( *stats ) );
 
-    for( slot_idx = 0; slot_idx < PSA_KEY_SLOT_COUNT; slot_idx++ )
+    for( slot_idx = 0; slot_idx < MBEDTLS_PSA_KEY_SLOT_COUNT; slot_idx++ )
     {
         const psa_key_slot_t *slot = &global_data.key_slots[ slot_idx ];
         if( psa_is_key_slot_locked( slot ) )

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -27,8 +27,8 @@
 
 /** Range of volatile key identifiers.
  *
- *  The last PSA_KEY_SLOT_COUNT identifiers of the implementation range
- *  of key identifiers are reserved for volatile key identifiers.
+ *  The last #MBEDTLS_PSA_KEY_SLOT_COUNT identifiers of the implementation
+ *  range of key identifiers are reserved for volatile key identifiers.
  *  A volatile key identifier is equal to #PSA_KEY_ID_VOLATILE_MIN plus the
  *  index of the key slot containing the volatile key definition.
  */
@@ -36,7 +36,7 @@
 /** The minimum value for a volatile key identifier.
  */
 #define PSA_KEY_ID_VOLATILE_MIN  ( PSA_KEY_ID_VENDOR_MAX - \
-                                   PSA_KEY_SLOT_COUNT + 1 )
+                                   MBEDTLS_PSA_KEY_SLOT_COUNT + 1 )
 
 /** The maximum value for a volatile key identifier.
  */

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -25,12 +25,6 @@
 #include "psa_crypto_core.h"
 #include "psa_crypto_se.h"
 
-/* Number of key slots (plus one because 0 is not used).
- * The value is a compile-time constant for now, for simplicity. */
-#if !defined(PSA_KEY_SLOT_COUNT)
-#define PSA_KEY_SLOT_COUNT 32
-#endif
-
 /** Range of volatile key identifiers.
  *
  *  The last PSA_KEY_SLOT_COUNT identifiers of the implementation range

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -27,7 +27,9 @@
 
 /* Number of key slots (plus one because 0 is not used).
  * The value is a compile-time constant for now, for simplicity. */
+#if !defined(PSA_KEY_SLOT_COUNT)
 #define PSA_KEY_SLOT_COUNT 32
+#endif
 
 /** Range of volatile key identifiers.
  *

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -49,7 +49,7 @@ extern "C" {
  * - Using the ITS backend, all key ids are ok except 0xFFFFFF52
  *   (#PSA_CRYPTO_ITS_RANDOM_SEED_UID) for which the file contains the
  *   device's random seed (if this feature is enabled).
- * - Only key ids from 1 to #PSA_KEY_SLOT_COUNT are actually used.
+ * - Only key ids from 1 to #MBEDTLS_PSA_KEY_SLOT_COUNT are actually used.
  *
  * Since we need to preserve the random seed, avoid using that key slot.
  * Reserve a whole range of key slots just in case something else comes up.

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -2634,6 +2634,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_PSA_HMAC_DRBG_MD_TYPE */
 
+#if defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
+    if( strcmp( "MBEDTLS_PSA_KEY_SLOT_COUNT", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_PSA_KEY_SLOT_COUNT );
+        return( 0 );
+    }
+#endif /* MBEDTLS_PSA_KEY_SLOT_COUNT */
+
 #if defined(MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT)
     if( strcmp( "MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT", config ) == 0 )
     {

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -933,9 +933,9 @@ void key_slot_eviction_to_import_new_key( int lifetime_arg )
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
 
     /*
-     * Create PSA_KEY_SLOT_COUNT persistent keys.
+     * Create MBEDTLS_PSA_KEY_SLOT_COUNT persistent keys.
      */
-    for( i = 0; i < PSA_KEY_SLOT_COUNT; i++ )
+    for( i = 0; i < MBEDTLS_PSA_KEY_SLOT_COUNT; i++ )
     {
         key = mbedtls_svc_key_id_make( i, i + 1 );
         psa_set_key_id( &attributes, key );
@@ -951,7 +951,7 @@ void key_slot_eviction_to_import_new_key( int lifetime_arg )
      * is removed from the RAM key slots. This makes room to store its
      * description in RAM.
      */
-    i = PSA_KEY_SLOT_COUNT;
+    i = MBEDTLS_PSA_KEY_SLOT_COUNT;
     key = mbedtls_svc_key_id_make( i, i + 1 );
     psa_set_key_id( &attributes, key );
     psa_set_key_lifetime( &attributes, lifetime );
@@ -966,15 +966,15 @@ void key_slot_eviction_to_import_new_key( int lifetime_arg )
                      MBEDTLS_SVC_KEY_ID_GET_KEY_ID( returned_key_id ) ) );
 
     /*
-     * Check that we can export all ( PSA_KEY_SLOT_COUNT + 1 ) keys,
+     * Check that we can export all ( MBEDTLS_PSA_KEY_SLOT_COUNT + 1 ) keys,
      * that they have the expected value and destroy them. In that process,
      * the description of the persistent key that was evicted from the RAM
      * slots when creating the last key is restored in a RAM slot to export
      * its value.
      */
-    for( i = 0; i <= PSA_KEY_SLOT_COUNT; i++ )
+    for( i = 0; i <= MBEDTLS_PSA_KEY_SLOT_COUNT; i++ )
     {
-        if( i < PSA_KEY_SLOT_COUNT )
+        if( i < MBEDTLS_PSA_KEY_SLOT_COUNT )
             key = mbedtls_svc_key_id_make( i, i + 1 );
         else
             key = returned_key_id;
@@ -1005,9 +1005,9 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation( )
     mbedtls_svc_key_id_t returned_key_id = MBEDTLS_SVC_KEY_ID_INIT;
     mbedtls_svc_key_id_t *keys = NULL;
 
-    TEST_ASSERT( PSA_KEY_SLOT_COUNT >= 1 );
+    TEST_ASSERT( MBEDTLS_PSA_KEY_SLOT_COUNT >= 1 );
 
-    ASSERT_ALLOC( keys, PSA_KEY_SLOT_COUNT );
+    ASSERT_ALLOC( keys, MBEDTLS_PSA_KEY_SLOT_COUNT );
     PSA_ASSERT( psa_crypto_init( ) );
 
     psa_set_key_usage_flags( &attributes,
@@ -1027,10 +1027,10 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation( )
     TEST_ASSERT( mbedtls_svc_key_id_equal( returned_key_id, persistent_key ) );
 
     /*
-     * Create PSA_KEY_SLOT_COUNT volatile keys
+     * Create MBEDTLS_PSA_KEY_SLOT_COUNT volatile keys
      */
     psa_set_key_lifetime( &attributes, PSA_KEY_LIFETIME_VOLATILE );
-    for( i = 0; i < PSA_KEY_SLOT_COUNT; i++ )
+    for( i = 0; i < MBEDTLS_PSA_KEY_SLOT_COUNT; i++ )
     {
         PSA_ASSERT( psa_import_key( &attributes,
                                     (uint8_t *) &i, sizeof( i ),
@@ -1050,12 +1050,12 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation( )
      * Check we can export the volatile key created last and that it has the
      * expected value. Then, destroy it.
      */
-    PSA_ASSERT( psa_export_key( keys[PSA_KEY_SLOT_COUNT - 1],
+    PSA_ASSERT( psa_export_key( keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1],
                                 exported, sizeof( exported ),
                                 &exported_length ) );
-    i = PSA_KEY_SLOT_COUNT - 1;
+    i = MBEDTLS_PSA_KEY_SLOT_COUNT - 1;
     ASSERT_COMPARE( exported, exported_length, (uint8_t *) &i, sizeof( i ) );
-    PSA_ASSERT( psa_destroy_key( keys[PSA_KEY_SLOT_COUNT - 1] ) );
+    PSA_ASSERT( psa_destroy_key( keys[MBEDTLS_PSA_KEY_SLOT_COUNT - 1] ) );
 
     /*
      * Check that we can now access the persistent key again.
@@ -1078,7 +1078,7 @@ void non_reusable_key_slots_integrity_in_case_of_key_slot_starvation( )
      * Check we can export the remaining volatile keys and that they have the
      * expected values.
      */
-    for( i = 0; i < ( PSA_KEY_SLOT_COUNT - 1 ); i++ )
+    for( i = 0; i < ( MBEDTLS_PSA_KEY_SLOT_COUNT - 1 ); i++ )
     {
         PSA_ASSERT( psa_export_key( keys[i],
                                     exported, sizeof( exported ),


### PR DESCRIPTION
## Description
For an easy tweak to the static RAM usage of PSA Crypto on constrained devices, I'd like to add the capability to override `PSA_KEY_SLOT_COUNT` and `PSA_MAX_KEY_BITS`. These are both declared as 'compile time constants' and their usage suggests that they are meant to be tweaked, however, the library did not provide a way to do so yet.


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Changelog updated


## Steps to test or reproduce
Covered by existing tests when running the test suite with the overridden defines.
