### PR TITLE
Allow loading external wrapped keys

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2325,34 +2325,45 @@ psa_status_t psa_import_key( const psa_key_attributes_t *attributes,
     if( status != PSA_SUCCESS )
         goto exit;
 
-#if defined(MBEDTLS_PSA_CRYPTO_SE_C)
-    if( driver != NULL )
+    if( psa_key_lifetime_is_external( psa_get_key_lifetime( attributes ) ) )
     {
-        const psa_drv_se_t *drv = psa_get_se_driver_methods( driver );
-        /* The driver should set the number of key bits, however in
-         * case it doesn't, we initialize bits to an invalid value. */
-        size_t bits = PSA_MAX_KEY_BITS + 1;
-        if( drv->key_management == NULL ||
-            drv->key_management->p_import == NULL )
+#if defined(MBEDTLS_PSA_CRYPTO_SE_C)
+        if( driver != NULL )
         {
-            status = PSA_ERROR_NOT_SUPPORTED;
+            const psa_drv_se_t *drv = psa_get_se_driver_methods( driver );
+            /* The driver should set the number of key bits, however in
+             * case it doesn't, we initialize bits to an invalid value. */
+            size_t bits = PSA_MAX_KEY_BITS + 1;
+            if( drv->key_management == NULL ||
+                drv->key_management->p_import == NULL )
+            {
+                status = PSA_ERROR_NOT_SUPPORTED;
+                goto exit;
+            }
+            status = drv->key_management->p_import(
+                psa_get_se_driver_context( driver ),
+                slot->data.se.slot_number, attributes, data, data_length,
+                &bits );
+            if( status != PSA_SUCCESS )
+                goto exit;
+            if( bits > PSA_MAX_KEY_BITS )
+            {
+                status = PSA_ERROR_NOT_SUPPORTED;
+                goto exit;
+            }
+            slot->attr.bits = (psa_key_bits_t) bits;
+        }
+        else
+#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
+        {
+            /* Importing a key with external lifetime through the driver wrapper
+             * interface is not yet supported. Return as if this was an invalid
+             * lifetime. */
+            status = PSA_ERROR_INVALID_ARGUMENT;
             goto exit;
         }
-        status = drv->key_management->p_import(
-            psa_get_se_driver_context( driver ),
-            slot->data.se.slot_number, attributes, data, data_length,
-            &bits );
-        if( status != PSA_SUCCESS )
-            goto exit;
-        if( bits > PSA_MAX_KEY_BITS )
-        {
-            status = PSA_ERROR_NOT_SUPPORTED;
-            goto exit;
-        }
-        slot->attr.bits = (psa_key_bits_t) bits;
     }
     else
-#endif /* MBEDTLS_PSA_CRYPTO_SE_C */
     {
         status = psa_import_key_into_slot( slot, data, data_length );
         if( status != PSA_SUCCESS )

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -269,12 +269,6 @@ static psa_status_t psa_load_persistent_key_into_slot( psa_key_slot_t *slot )
     }
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
 
-    if ( key_data == NULL )
-    {
-        status = PSA_ERROR_STORAGE_FAILURE;
-        goto exit;
-    }
-
     status = psa_copy_key_material_into_slot( slot, key_data, key_data_length );
 
 exit:

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -374,8 +374,12 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
     uint8_t *storage_data;
     psa_status_t status;
 
+    /* All keys saved to persistent storage always have a key context */
+    if( data == NULL || data_length == 0 )
+        return( PSA_ERROR_INVALID_ARGUMENT );
+
     if( data_length > PSA_CRYPTO_MAX_STORAGE_SIZE )
-        return PSA_ERROR_INSUFFICIENT_STORAGE;
+        return( PSA_ERROR_INSUFFICIENT_STORAGE );
     storage_data_length = data_length + sizeof( psa_persistent_key_storage_format );
 
     storage_data = mbedtls_calloc( 1, storage_data_length );
@@ -425,6 +429,11 @@ psa_status_t psa_load_persistent_key( psa_core_key_attributes_t *attr,
 
     status = psa_parse_key_data_from_storage( loaded_data, storage_data_length,
                                               data, data_length, attr );
+
+    /* All keys saved to persistent storage always have a key context */
+    if( status == PSA_SUCCESS &&
+        ( *data == NULL || *data_length == 0 ) )
+        status = PSA_ERROR_STORAGE_FAILURE;
 
 exit:
     mbedtls_free( loaded_data );

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -115,8 +115,8 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
  * metadata and writes them to the appropriate output parameters.
  *
  * Note: This function allocates a buffer and returns a pointer to it through
- * the data parameter. On succesful return, the pointer is guaranteed to be
- * valid and contain at least one byte of data.
+ * the data parameter. On successful return, the pointer is guaranteed to be
+ * valid and the buffer contains at least one byte of data.
  * psa_free_persistent_key_data() must be called on the data buffer
  * afterwards to zeroize and free this buffer.
  *

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -86,6 +86,9 @@ int psa_is_key_present_in_storage( const mbedtls_svc_key_id_t key );
  * already occupied non-persistent key, as well as ensuring the key data is
  * validated.
  *
+ * Note: This function will only succeed for key buffers which are not
+ * empty. If passed a NULL pointer or zero-length, the function will fail
+ * with #PSA_ERROR_INVALID_ARGUMENT.
  *
  * \param[in] attr          The attributes of the key to save.
  *                          The key identifier field in the attributes
@@ -94,6 +97,7 @@ int psa_is_key_present_in_storage( const mbedtls_svc_key_id_t key );
  * \param data_length       The number of bytes that make up the key data.
  *
  * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_INVALID_ARGUMENT
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  * \retval #PSA_ERROR_INSUFFICIENT_STORAGE
  * \retval #PSA_ERROR_STORAGE_FAILURE
@@ -111,9 +115,10 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
  * metadata and writes them to the appropriate output parameters.
  *
  * Note: This function allocates a buffer and returns a pointer to it through
- * the data parameter. psa_free_persistent_key_data() must be called after
- * this function to zeroize and free this buffer, regardless of whether this
- * function succeeds or fails.
+ * the data parameter. On succesful return, the pointer is guaranteed to be
+ * valid and contain at least one byte of data.
+ * psa_free_persistent_key_data() must be called on the data buffer
+ * afterwards to zeroize and free this buffer.
  *
  * \param[in,out] attr      On input, the key identifier field identifies
  *                          the key to load. Other fields are ignored.

--- a/tests/suites/test_suite_psa_crypto_slot_management.data
+++ b/tests/suites/test_suite_psa_crypto_slot_management.data
@@ -107,10 +107,15 @@ Open failure: non-existent identifier
 depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
 open_fail:1:PSA_ERROR_DOES_NOT_EXIST
 
-Create failure: invalid lifetime
-create_fail:0x7fffffff:0:PSA_ERROR_INVALID_ARGUMENT
+Create failure: invalid lifetime for a persistent key
+depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
+create_fail:0x7fffffff:1:PSA_ERROR_INVALID_ARGUMENT
 
-Create failure: invalid key id (0)
+Create failure: invalid lifetime for a volatile key
+depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
+create_fail:0x7fffff00:0:PSA_ERROR_INVALID_ARGUMENT
+
+Create failure: invalid key id (0) for a persistent key
 depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
 create_fail:PSA_KEY_LIFETIME_PERSISTENT:0:PSA_ERROR_INVALID_HANDLE
 


### PR DESCRIPTION
## Description
This appears to be a bug related to handling how keys get loaded from storage. If the library is configured to include support for both the old-style SE interface and the new PSA driver interface, external keys wouldn't get loaded from storage.

I fixed a testing flaw related to external keys as well (probably an oversight during the openless changeover)

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO
