### PR TITLE
Add macro to check error code additions/combinations

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -114,6 +114,16 @@ extern "C" {
 #define MBEDTLS_ERR_ERROR_GENERIC_ERROR       -0x0001  /**< Generic error */
 #define MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED -0x006E  /**< This is a bug in the library */
 
+#if defined(MBEDTLS_TEST_HOOKS)
+void (*mbedtls_test_err_add_hook)( int, int, const char *, int );
+int mbedtls_err_add( int high, int low, const char *file, int line );
+#define MBEDTLS_ERR_ADD( high, low )  \
+    ( mbedtls_err_add( high, low, __FILE__, __LINE__ ) )
+#else
+#define MBEDTLS_ERR_ADD( high, low ) \
+    ( high + low )
+#endif
+
 /**
  * \brief Translate a mbed TLS error code into a string representation,
  *        Result is truncated if necessary and always includes a terminating

--- a/library/error.c
+++ b/library/error.c
@@ -210,6 +210,13 @@
 #include "mbedtls/xtea.h"
 #endif
 
+#if defined(MBEDTLS_TEST_HOOKS)
+int mbedtls_err_add( int high, int low, const char *file, int line ) {
+    if( mbedtls_test_err_add_hook != NULL )
+        (*mbedtls_test_err_add_hook)( high, low, file, line );
+    return ( high + low );
+}
+#endif
 
 const char * mbedtls_high_level_strerr( int error_code )
 {

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -102,7 +102,7 @@ int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
         ( D != NULL && ( ret = mbedtls_mpi_copy( &ctx->D, D ) ) != 0 ) ||
         ( E != NULL && ( ret = mbedtls_mpi_copy( &ctx->E, E ) ) != 0 ) )
     {
-        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
     }
 
     if( N != NULL )
@@ -142,7 +142,7 @@ int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
 cleanup:
 
     if( ret != 0 )
-        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
 
     return( 0 );
 }
@@ -293,7 +293,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
         if( ( ret = mbedtls_mpi_mul_mpi( &ctx->N, &ctx->P,
                                          &ctx->Q ) ) != 0 )
         {
-            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+            return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
         }
 
         ctx->len = mbedtls_mpi_size( &ctx->N );
@@ -308,7 +308,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
         ret = mbedtls_rsa_deduce_primes( &ctx->N, &ctx->E, &ctx->D,
                                          &ctx->P, &ctx->Q );
         if( ret != 0 )
-            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+            return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
 
     }
     else if( d_missing )
@@ -318,7 +318,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
                                                          &ctx->E,
                                                          &ctx->D ) ) != 0 )
         {
-            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+            return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
         }
     }
 
@@ -333,7 +333,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
         ret = mbedtls_rsa_deduce_crt( &ctx->P,  &ctx->Q,  &ctx->D,
                                       &ctx->DP, &ctx->DQ, &ctx->QP );
         if( ret != 0 )
-            return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+            return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
     }
 #endif /* MBEDTLS_RSA_NO_CRT */
 
@@ -461,13 +461,13 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
         ( DQ != NULL && ( ret = mbedtls_mpi_copy( DQ, &ctx->DQ ) ) != 0 ) ||
         ( QP != NULL && ( ret = mbedtls_mpi_copy( QP, &ctx->QP ) ) != 0 ) )
     {
-        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
     }
 #else
     if( ( ret = mbedtls_rsa_deduce_crt( &ctx->P, &ctx->Q, &ctx->D,
                                         DP, DQ, QP ) ) != 0 )
     {
-        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_BAD_INPUT_DATA, ret ) );
     }
 #endif
 
@@ -629,7 +629,7 @@ cleanup:
     if( ret != 0 )
     {
         mbedtls_rsa_free( ctx );
-        return( MBEDTLS_ERR_RSA_KEY_GEN_FAILED + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_KEY_GEN_FAILED, ret ) );
     }
 
     return( 0 );
@@ -761,7 +761,7 @@ cleanup:
     mbedtls_mpi_free( &T );
 
     if( ret != 0 )
-        return( MBEDTLS_ERR_RSA_PUBLIC_FAILED + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_PUBLIC_FAILED, ret ) );
 
     return( 0 );
 }
@@ -1190,7 +1190,7 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
 
     /* Generate a random octet string seed */
     if( ( ret = f_rng( p_rng, p, hlen ) ) != 0 )
-        return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_RNG_FAILED, ret ) );
 
     p += hlen;
 
@@ -1279,7 +1279,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
 
             /* Check if RNG failed to generate data */
             if( rng_dl == 0 || ret != 0 )
-                return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+                return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_RNG_FAILED, ret ) );
 
             p++;
         }
@@ -1857,7 +1857,7 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
 
     /* Generate salt of length slen */
     if( ( ret = f_rng( p_rng, salt, slen ) ) != 0 )
-        return( MBEDTLS_ERR_RSA_RNG_FAILED + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_RNG_FAILED, ret ) );
 
     /* Note: EMSA-PSS encoding is over the length of N - 1 bits */
     msb = mbedtls_mpi_bitlen( &ctx->N ) - 1;

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1077,7 +1077,7 @@ cleanup:
     mbedtls_mpi_free( &I );
 
     if( ret != 0 )
-        return( MBEDTLS_ERR_RSA_PRIVATE_FAILED + ret );
+        return( MBEDTLS_ERR_ADD( MBEDTLS_ERR_RSA_PRIVATE_FAILED, ret ) );
 
     return( 0 );
 }

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -190,4 +190,13 @@ void* mbedtls_test_param_failed_get_state_buf( void );
 void mbedtls_test_param_failed_reset_state( void );
 #endif /* MBEDTLS_CHECK_PARAMS */
 
+#if defined(MBEDTLS_TEST_HOOKS)
+/**
+ * \brief	Check that a pure high-level error code is being combined with a
+ *			pure low-level error code as otherwise the resultant error code
+ *			would be corrupted.
+ */
+void mbedtls_test_err_add_check( int high, int low,
+                                 const char *file, int line);
+#endif
 #endif /* TEST_HELPERS_H */

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -249,7 +249,7 @@ void mbedtls_param_failed( const char *failure_condition,
 void mbedtls_test_err_add_check( int high, int low,
                                  const char *file, int line )
 {
-    if ( high < -0x0FFF && low > -0x007F )
+    if ( high > -0x1000 || low < -0x007F )
     {
         mbedtls_fprintf( stderr, "\nIncorrect error code addition at %s:%d\n",
                                 file, line );

--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -244,3 +244,16 @@ void mbedtls_param_failed( const char *failure_condition,
     }
 }
 #endif /* MBEDTLS_CHECK_PARAMS */
+
+#if defined(MBEDTLS_TEST_HOOKS)
+void mbedtls_test_err_add_check( int high, int low,
+                                 const char *file, int line )
+{
+    if ( high < -0x0FFF && low > -0x007F )
+    {
+        mbedtls_fprintf( stderr, "\nIncorrect error code addition at %s:%d\n",
+                                file, line );
+        mbedtls_exit( 1 );
+    }
+}
+#endif /* MBEDTLS_TEST_HOOKS */

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -33,6 +33,10 @@
 #include "psa/crypto.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+#if defined(MBEDTLS_TEST_HOOKS)
+#include "mbedtls/error.h"
+#endif
+
 /* Test code may use deprecated identifiers only if the preprocessor symbol
  * MBEDTLS_TEST_DEPRECATED is defined. When building tests, set
  * MBEDTLS_TEST_DEPRECATED explicitly if MBEDTLS_DEPRECATED_WARNING is
@@ -265,6 +269,10 @@ $platform_code
  */
 int main( int argc, const char *argv[] )
 {
+#if defined(MBEDTLS_TEST_HOOKS)
+    mbedtls_test_err_add_hook = &mbedtls_test_err_add_check;
+#endif
+
     int ret = mbedtls_test_platform_setup();
     if( ret != 0 )
     {


### PR DESCRIPTION
## Description
This PR adds a new macro `MBEDTLS_ERR_ADD` to aid in testing that error codes are correctly combined together. This macro performs a check, when `MBEDTLS_TEST_HOOKS` is enabled, to determine whether the returned error code would be corrupted. If the returned error code will be corrupted the test will fail and report the location of the error otherwise there is no change in behaviour.

`MBEDTLS_ERR_ADD` will replace all occurrences of error code addition/combination in the codebase so that these errors (such as the one found in #3911) can be found before being introduced.

## Status
**IN DEVELOPMENT**

## Requires Backporting
Unsure.

## Additional comments
While this does not fix the example given in #3911, it does give us greater confidence that incorrect error codes will not be added in the future.

## Todos
- [ ] Add changelog
- [ ] Replace other occurrences
- [ ] Backports?


## Steps to test or reproduce
- Enable `MBEDTLS_TEST_HOOKS` (`./scripts/config.pl set MBEDTLS_TEST_HOOKS`).
- Run tests