### PR TITLE
[baremetal] Further fixes - spurious resend in one of the ssl-opt.sh tests. 

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -7414,8 +7414,8 @@ not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
 requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reference" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
-            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=10000-20000" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=15000-25000" \
+            "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=15000-25000" \
             0 \
             -C "resend" \
             -S "The operation timed out" \
@@ -7425,7 +7425,7 @@ not_with_valgrind # spurious resend
 requires_config_disabled MBEDTLS_SSL_CONF_READ_TIMEOUT
 requires_config_enabled MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 run_test    "DTLS client reconnect from same port: reconnect" \
-            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=10000-20000" \
+            "$P_SRV dtls=1 exchanges=2 read_timeout=20000 hs_timeout=15000-25000" \
             "$P_CLI dtls=1 exchanges=2 debug_level=2 hs_timeout=15000-25000 reconnect_hard=1" \
             0 \
             -C "resend" \


### PR DESCRIPTION
One of the tests fairly consistently failed on the CI due to unreliable network, timeouting on client-side of recv.
Accodring to mbedtls_ssl_conf_handshake_timeout documentation:

```
 * \note           The 'min' value should typically be slightly above the
 *                 expected round-trip time to your peer, plus whatever time
 *                 it takes for the peer to process the message. For example,
 *                 if your RTT is about 600ms and you peer needs up to 1s to
 *                 do the cryptographic operations in the handshake, then you
 *                 should set 'min' slightly above 1600. Lower values of 'min'
 *                 might cause spurious resends which waste network resources,
 *                 while larger value of 'min' will increase overall latency
 *                 on unreliable network links.
```
This PR increases the min timeout considerably, leaving the max at the same distance from min.
Note: this is a follow-up pr for #4016.