### PR TITLE
Add PSA Crypto driver delegation for hashing functions

### DIFF
--- a/ChangeLog.d/psa-crypto-hash-acceleration.txt
+++ b/ChangeLog.d/psa-crypto-hash-acceleration.txt
@@ -1,0 +1,3 @@
+Features
+   * Hashing operations executed through the PSA API can now be accelerated
+     with a PSA Crypto driver.

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -93,6 +93,7 @@ struct psa_hash_operation_s
     unsigned int mbedtls_in_use : 1; /* Indicates mbed TLS is handling the operation. */
     union
     {
+        uint32_t dummy; /* Enable easier initializing of the union. */
         psa_operation_driver_context_t driver;
 #if defined(MBEDTLS_MD2_C)
         mbedtls_md2_context md2;

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -90,9 +90,10 @@ typedef struct {
 struct psa_hash_operation_s
 {
     psa_algorithm_t alg;
+    unsigned int mbedtls_in_use : 1; /* Indicates mbed TLS is handling the operation. */
     union
     {
-        unsigned dummy; /* Make the union non-empty even with no supported algorithms. */
+        psa_operation_driver_context_t driver;
 #if defined(MBEDTLS_MD2_C)
         mbedtls_md2_context md2;
 #endif
@@ -117,7 +118,7 @@ struct psa_hash_operation_s
     } ctx;
 };
 
-#define PSA_HASH_OPERATION_INIT {0, {0}}
+#define PSA_HASH_OPERATION_INIT {0, 0, {0}}
 static inline struct psa_hash_operation_s psa_hash_operation_init( void )
 {
     const struct psa_hash_operation_s v = PSA_HASH_OPERATION_INIT;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2976,10 +2976,10 @@ psa_status_t psa_hash_clone( const psa_hash_operation_t *source_operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( target_operation->alg != 0 )
+    /* To clone, the source must be in progress and the target must be free */
+    if( source_operation->alg == 0 || target_operation->alg != 0 )
         return( PSA_ERROR_BAD_STATE );
 
-#if defined(MBEDTLS_PSA_CRYPTO_DRIVERS)
     if ( source_operation->mbedtls_in_use == 0 )
     {
         status = psa_driver_wrapper_hash_clone( &source_operation->ctx.driver,
@@ -2990,12 +2990,9 @@ psa_status_t psa_hash_clone( const psa_hash_operation_t *source_operation,
          * that specific driver knows the context structure. */
         return( status );
     }
-#endif
 
     switch( source_operation->alg )
     {
-        case 0:
-            return( PSA_ERROR_BAD_STATE );
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_MD2)
         case PSA_ALG_MD2:
             mbedtls_md2_clone( &target_operation->ctx.md2,

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -119,6 +119,37 @@ psa_status_t psa_driver_wrapper_cipher_finish(
 psa_status_t psa_driver_wrapper_cipher_abort(
     psa_operation_driver_context_t *operation );
 
+/*
+ * Hashing functions
+ */
+psa_status_t psa_driver_wrapper_hash_compute(
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *hash, size_t hash_size,
+    size_t *hash_length );
+
+psa_status_t psa_driver_wrapper_hash_setup(
+    psa_operation_driver_context_t *operation,
+    psa_algorithm_t alg );
+
+psa_status_t psa_driver_wrapper_hash_clone(
+    const psa_operation_driver_context_t *source_operation,
+    psa_operation_driver_context_t *target_operation );
+
+psa_status_t psa_driver_wrapper_hash_update(
+    psa_operation_driver_context_t *operation,
+    const uint8_t *input,
+    size_t input_length );
+
+psa_status_t psa_driver_wrapper_hash_finish(
+    psa_operation_driver_context_t *operation,
+    uint8_t *hash,
+    size_t hash_size,
+    size_t *hash_length );
+
+psa_status_t psa_driver_wrapper_hash_abort(
+    psa_operation_driver_context_t *operation );
+
 #endif /* PSA_CRYPTO_DRIVER_WRAPPERS_H */
 
 /* End of automatically generated file. */

--- a/tests/include/test/drivers/hash.h
+++ b/tests/include/test/drivers/hash.h
@@ -1,0 +1,95 @@
+/*
+ * Test driver for hash functions.
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_TEST_DRIVERS_HASH_H
+#define PSA_CRYPTO_TEST_DRIVERS_HASH_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+#include <psa/crypto_driver_common.h>
+
+#if defined(MBEDTLS_SHA256_C)
+#include "mbedtls/sha256.h"
+#endif
+
+typedef struct {
+    psa_algorithm_t alg;
+    union {
+        uint32_t dummy;
+#if defined(MBEDTLS_SHA256_C)
+        mbedtls_sha256_context sha256;
+#endif
+    } context;
+} test_transparent_hash_operation_t;
+
+typedef struct {
+    /* If non-null, on success, copy this to the output. */
+    void *forced_output;
+    size_t forced_output_length;
+    /* If not PSA_SUCCESS, return this error code instead of processing the
+     * function call. */
+    psa_status_t forced_status;
+    /* Count the amount of times one of the signature driver functions is called. */
+    unsigned long hits;
+} test_driver_hash_hooks_t;
+
+#define TEST_DRIVER_HASH_INIT { NULL, 0, PSA_ERROR_NOT_SUPPORTED, 0 }
+static inline test_driver_hash_hooks_t test_driver_hash_hooks_init( void )
+{
+    const test_driver_hash_hooks_t v = TEST_DRIVER_HASH_INIT;
+    return( v );
+}
+
+extern test_driver_hash_hooks_t test_driver_hash_hooks;
+
+psa_status_t test_transparent_hash_compute(
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *hash, size_t hash_size,
+    size_t *hash_length );
+
+psa_status_t test_transparent_hash_setup(
+    test_transparent_hash_operation_t *operation,
+    psa_algorithm_t alg );
+
+psa_status_t test_transparent_hash_clone(
+    const test_transparent_hash_operation_t *source_operation,
+    test_transparent_hash_operation_t *target_operation );
+
+psa_status_t test_transparent_hash_update(
+    test_transparent_hash_operation_t *operation,
+    const uint8_t *input,
+    size_t input_length );
+
+psa_status_t test_transparent_hash_finish(
+    test_transparent_hash_operation_t *operation,
+    uint8_t *hash,
+    size_t hash_size,
+    size_t *hash_length );
+
+psa_status_t test_transparent_hash_abort(
+    test_transparent_hash_operation_t *operation );
+
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+#endif /* PSA_CRYPTO_TEST_DRIVERS_HASH_H */

--- a/tests/include/test/drivers/test_driver.h
+++ b/tests/include/test/drivers/test_driver.h
@@ -26,5 +26,6 @@
 #include "test/drivers/key_management.h"
 #include "test/drivers/cipher.h"
 #include "test/drivers/size.h"
+#include "test/drivers/hash.h"
 
 #endif /* PSA_CRYPTO_TEST_DRIVER_H */

--- a/tests/src/drivers/hash.c
+++ b/tests/src/drivers/hash.c
@@ -1,0 +1,249 @@
+/*
+ * Test driver for hash functions.
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_DRIVERS) && defined(PSA_CRYPTO_DRIVER_TEST)
+#include "psa/crypto.h"
+#include "psa_crypto_core.h"
+#include "test/drivers/hash.h"
+
+#if defined(MBEDTLS_SHA256_C)
+#include "mbedtls/sha256.h"
+#endif
+
+
+#include <string.h>
+
+/* Test driver implements SHA-256 only. Its default behaviour (when its return
+ * status is not overridden through the hooks) is to take care of all SHA-256
+ * operations when there's mbed TLS support for it, and return
+ * PSA_ERROR_NOT_SUPPORTED for all others.
+ * Set test_driver_hash_hooks.forced_status to PSA_ERROR_NOT_SUPPORTED to use
+ * fallback even for SHA-256. */
+test_driver_hash_hooks_t test_driver_hash_hooks = TEST_DRIVER_HASH_INIT;
+
+psa_status_t test_transparent_hash_compute(
+    psa_algorithm_t alg,
+    const uint8_t *input, size_t input_length,
+    uint8_t *hash, size_t hash_size,
+    size_t *hash_length )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( alg != PSA_ALG_SHA_256 )
+            return( PSA_ERROR_NOT_SUPPORTED );
+
+        if( hash_size < 32)
+            return( PSA_ERROR_BUFFER_TOO_SMALL );
+
+        *hash_length = 32;
+
+        return( mbedtls_to_psa_error(
+                    mbedtls_sha256_ret(
+                        input, input_length, hash, 0 ) ) );
+    }
+    else
+    {
+        if( test_driver_hash_hooks.forced_output != NULL )
+        {
+            if( hash_size < test_driver_hash_hooks.forced_output_length)
+                return( PSA_ERROR_BUFFER_TOO_SMALL );
+
+            memcpy(hash,
+                   test_driver_hash_hooks.forced_output,
+                   test_driver_hash_hooks.forced_output_length);
+            *hash_length = test_driver_hash_hooks.forced_output_length;
+        }
+        return( test_driver_hash_hooks.forced_status );
+    }
+#endif
+    (void) alg;
+    (void) input;
+    (void) input_length;
+    (void) hash;
+    (void) hash_size;
+    (void) hash_length;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+psa_status_t test_transparent_hash_setup(
+    test_transparent_hash_operation_t *operation,
+    psa_algorithm_t alg )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( alg != PSA_ALG_SHA_256 )
+            return( PSA_ERROR_NOT_SUPPORTED );
+
+        operation->alg = alg;
+        mbedtls_sha256_init(&operation->context.sha256);
+        return( mbedtls_to_psa_error(
+                    mbedtls_sha256_starts_ret(
+                        &operation->context.sha256, 0 ) ) );
+    }
+    else
+        return( test_driver_hash_hooks.forced_status );
+#endif
+    (void) operation;
+    (void) alg;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+psa_status_t test_transparent_hash_clone(
+    const test_transparent_hash_operation_t *source_operation,
+    test_transparent_hash_operation_t *target_operation )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( source_operation->alg != PSA_ALG_SHA_256 )
+        {
+            // Driver delegation tried to call us, but we never accepted
+            // this operation.
+            return( PSA_ERROR_BAD_STATE );
+        }
+
+        target_operation->alg = source_operation->alg;
+        mbedtls_sha256_clone(&target_operation->context.sha256,
+                             &source_operation->context.sha256);
+        return( PSA_SUCCESS );
+    }
+    else
+        return( test_driver_hash_hooks.forced_status );
+#endif
+    (void) source_operation;
+    (void) target_operation;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+psa_status_t test_transparent_hash_update(
+    test_transparent_hash_operation_t *operation,
+    const uint8_t *input,
+    size_t input_length )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( operation->alg != PSA_ALG_SHA_256 )
+            return( PSA_ERROR_BAD_STATE );
+
+        return( mbedtls_to_psa_error(
+                    mbedtls_sha256_update_ret(
+                        &operation->context.sha256,
+                        input,
+                        input_length) ) );
+    }
+    else
+        return( test_driver_hash_hooks.forced_status );
+#endif
+    (void) operation;
+    (void) input;
+    (void) input_length;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+psa_status_t test_transparent_hash_finish(
+    test_transparent_hash_operation_t *operation,
+    uint8_t *hash,
+    size_t hash_size,
+    size_t *hash_length )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( operation->alg != PSA_ALG_SHA_256 )
+            return( PSA_ERROR_BAD_STATE );
+
+        if( hash_size < 32 )
+            return( PSA_ERROR_BUFFER_TOO_SMALL );
+
+        psa_status_t status = mbedtls_to_psa_error(
+                                mbedtls_sha256_finish_ret(
+                                    &operation->context.sha256,
+                                    hash ) );
+        if( status == PSA_SUCCESS )
+            *hash_length = 32;
+
+        return( status );
+    }
+    else
+    {
+        if( test_driver_hash_hooks.forced_output != NULL )
+        {
+            if( hash_size < test_driver_hash_hooks.forced_output_length)
+                return( PSA_ERROR_BUFFER_TOO_SMALL );
+
+            memcpy(hash,
+                   test_driver_hash_hooks.forced_output,
+                   test_driver_hash_hooks.forced_output_length);
+            *hash_length = test_driver_hash_hooks.forced_output_length;
+        }
+        return( test_driver_hash_hooks.forced_status );
+    }
+#endif
+    (void) operation;
+    (void) hash;
+    (void) hash_size;
+    (void) hash_length;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+psa_status_t test_transparent_hash_abort(
+    test_transparent_hash_operation_t *operation )
+{
+    test_driver_hash_hooks.hits++;
+
+#if defined(MBEDTLS_SHA256_C)
+    if( test_driver_hash_hooks.forced_status == PSA_SUCCESS )
+    {
+        if( operation->alg == 0 )
+            return( PSA_SUCCESS );
+
+        if( operation->alg != PSA_ALG_SHA_256 )
+            return( PSA_ERROR_BAD_STATE );
+
+        mbedtls_sha256_free( &operation->context.sha256 );
+        operation->alg = 0;
+        return( PSA_SUCCESS );
+    }
+    else
+        return( test_driver_hash_hooks.forced_status );
+#endif
+    (void) operation;
+    return( test_driver_hash_hooks.forced_status );
+}
+
+#endif /* MBEDTLS_PSA_CRYPTO_DRIVERS && PSA_CRYPTO_DRIVER_TEST */

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.data
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.data
@@ -185,3 +185,6 @@ cipher_decrypt_multipart:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf715880
 
 Cipher driver: negative testing on all entry points
 cipher_entry_points:PSA_ALG_CTR:PSA_KEY_TYPE_AES:"2b7e151628aed2a6abf7158809cf4f3c":"2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a":"6bc1bee22e409f96e93d7e117393172a"
+
+Hash driver: check all expected driver entry points with standard usage
+hash_entry_points:PSA_ALG_SHA_256:"81a723d966":"7516fb8bb11350df2bf386bc3c33bd0f52cb4c67c6e4745e0488e62c2aea2605"

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -811,3 +811,102 @@ exit:
     test_driver_cipher_hooks = test_driver_cipher_hooks_init();
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void hash_entry_points( int alg_arg, data_t *message, data_t *expected_hash )
+{
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
+    psa_algorithm_t alg = alg_arg;
+    unsigned char *output = NULL;
+    size_t output_buffer_size = 0;
+    size_t function_output_length = 0;
+    psa_hash_operation_t operation = PSA_HASH_OPERATION_INIT;
+    test_driver_hash_hooks = test_driver_hash_hooks_init();
+
+    ASSERT_ALLOC( output, PSA_HASH_SIZE(alg) );
+    output_buffer_size = PSA_HASH_SIZE(alg);
+
+    PSA_ASSERT( psa_crypto_init( ) );
+
+    /* Test default case: success (one update) */
+    test_driver_hash_hooks.forced_status = PSA_SUCCESS;
+
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 1 );
+
+    PSA_ASSERT( psa_hash_abort( &operation ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 2 );
+
+    status = psa_hash_update( &operation,
+                              message->x, message->len );
+    TEST_EQUAL( status, PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 2 );
+
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 3 );
+
+    PSA_ASSERT( psa_hash_update( &operation,
+                                 message->x, message->len ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 4 );
+
+    PSA_ASSERT( psa_hash_finish( &operation,
+                                 output, output_buffer_size,
+                                 &function_output_length ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 6 );
+
+    ASSERT_COMPARE( output, function_output_length,
+                    expected_hash->x, expected_hash->len );
+
+    /* Test default case: success (multi-update) */
+    test_driver_hash_hooks.hits = 0;
+    function_output_length = 0;
+    memset(output, 0, output_buffer_size);
+    size_t part1_len = message->len / 2;
+
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 1 );
+
+    PSA_ASSERT( psa_hash_update( &operation,
+                                 message->x, part1_len ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 2 );
+
+    PSA_ASSERT( psa_hash_update( &operation,
+                                 &message->x[part1_len],
+                                 message->len - part1_len ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 3 );
+
+    PSA_ASSERT( psa_hash_finish( &operation,
+                                 output, output_buffer_size,
+                                 &function_output_length ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 5 );
+
+    ASSERT_COMPARE( output, function_output_length,
+                    expected_hash->x, expected_hash->len );
+
+    /* Test default case: success (all-in-one) */
+    test_driver_hash_hooks.hits = 0;
+    function_output_length = 0;
+    memset(output, 0, output_buffer_size);
+
+    PSA_ASSERT( psa_hash_compute( alg, message->x, message->len,
+                                  output, output_buffer_size,
+                                  &function_output_length) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 1 );
+
+    ASSERT_COMPARE( output, function_output_length,
+                    expected_hash->x, expected_hash->len );
+
+    /* Test all-in-one verify */
+    test_driver_hash_hooks.hits = 0;
+
+    PSA_ASSERT( psa_hash_compare( alg, message->x, message->len,
+                                  expected_hash->x, expected_hash->len ) );
+    TEST_EQUAL( test_driver_hash_hooks.hits, 1 );
+
+exit:
+    psa_hash_abort( &operation );
+    mbedtls_free( output );
+    PSA_DONE( );
+    test_driver_hash_hooks = test_driver_hash_hooks_init();
+}
+/* END_CASE */

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -239,6 +239,7 @@
     <ClInclude Include="..\..\tests\include\test\psa_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\random.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\cipher.h" />
+    <ClInclude Include="..\..\tests\include\test\drivers\hash.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\key_management.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\signature.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\size.h" />


### PR DESCRIPTION
## Description
Add driver delegation as per the already established paradigms and the design document in `docs/proposed/psa-driver-interface.md`.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog updated


## Steps to test or reproduce
Test coverage through `test_psa_crypto_drivers`, which compiles with driver support and the test driver.
* Fallback mechanism is exercised by all of the regular tests in test_suite_psa_crypto when driver support and the test driver are compiled in.
* The test driver actually being called is tested in `test_suite_psa_crypto_driver_wrappers`
