### PR TITLE
Add PSA Crypto driver delegation for MAC functions

### DIFF
--- a/ChangeLog.d/psa-crypto-mac-acceleration.txt
+++ b/ChangeLog.d/psa-crypto-mac-acceleration.txt
@@ -1,0 +1,3 @@
+Features
+   * MAC operations executed through the PSA API can now be accelerated with
+     a PSA Crypto driver.

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -142,10 +142,13 @@ struct psa_mac_operation_s
     unsigned int iv_set : 1;
     unsigned int has_input : 1;
     unsigned int is_sign : 1;
+    unsigned int mbedtls_in_use : 1;
+    unsigned int verify_through_compute : 1;
     uint8_t mac_size;
     union
     {
         unsigned dummy; /* Make the union non-empty even with no supported algorithms. */
+        psa_operation_driver_context_t driver;
 #if defined(MBEDTLS_MD_C)
         psa_hmac_internal_data hmac;
 #endif
@@ -155,7 +158,7 @@ struct psa_mac_operation_s
     } ctx;
 };
 
-#define PSA_MAC_OPERATION_INIT {0, 0, 0, 0, 0, 0, 0, {0}}
+#define PSA_MAC_OPERATION_INIT {0, 0, 0, 0, 0, 0, 0, 0, 0, {0}}
 static inline struct psa_mac_operation_s psa_mac_operation_init( void )
 {
     const struct psa_mac_operation_s v = PSA_MAC_OPERATION_INIT;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3312,7 +3312,6 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
         is_sign ? PSA_KEY_USAGE_SIGN_HASH : PSA_KEY_USAGE_VERIFY_HASH;
     uint8_t truncated = PSA_MAC_TRUNCATED_LENGTH( alg );
     psa_algorithm_t full_length_alg = PSA_ALG_FULL_LENGTH_MAC( alg );
-    psa_algorithm_t hash_alg;
 
     /* A context must be freshly initialized before it can be set up. */
     if( operation->alg != 0 )
@@ -3325,7 +3324,7 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
     /* Pre-populate size of full-length MAC */
     if( PSA_ALG_IS_HMAC( full_length_alg ) )
     {
-        hash_alg = PSA_ALG_HMAC_GET_HASH( alg );
+        psa_algorithm_t hash_alg = PSA_ALG_HMAC_GET_HASH( alg );
         if( hash_alg == 0 )
         {
             status = PSA_ERROR_NOT_SUPPORTED;
@@ -3437,7 +3436,7 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
         status = psa_hmac_setup_internal( &operation->ctx.hmac,
                                           slot->data.key.data,
                                           slot->data.key.bytes,
-                                          hash_alg );
+                                          PSA_ALG_HMAC_GET_HASH( alg ) );
     }
     else
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HMAC */

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -1070,6 +1070,7 @@ switch( location )
 
  #else /* PSA_CRYPTO_DRIVER_PRESENT && PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     (void) operation;
+    (void) slot;
     (void) alg;
 
      return( PSA_ERROR_NOT_SUPPORTED );
@@ -1152,6 +1153,7 @@ switch( location )
 
  #else /* PSA_CRYPTO_DRIVER_PRESENT && PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     (void) operation;
+    (void) slot;
     (void) alg;
 
      return( PSA_ERROR_NOT_SUPPORTED );

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -119,6 +119,55 @@ psa_status_t psa_driver_wrapper_cipher_finish(
 psa_status_t psa_driver_wrapper_cipher_abort(
     psa_operation_driver_context_t *operation );
 
+/*
+ * MAC calculation functions
+ */
+psa_status_t psa_driver_wrapper_mac_compute(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *input,
+    size_t input_length,
+    uint8_t *mac,
+    size_t mac_size,
+    size_t *mac_length );
+
+psa_status_t psa_driver_wrapper_mac_verify(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *input,
+    size_t input_length,
+    const uint8_t *mac,
+    size_t mac_length );
+
+psa_status_t psa_driver_wrapper_mac_sign_setup(
+    psa_operation_driver_context_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg );
+
+psa_status_t psa_driver_wrapper_mac_verify_setup(
+    psa_operation_driver_context_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg );
+
+psa_status_t psa_driver_wrapper_mac_update(
+    psa_operation_driver_context_t *operation,
+    const uint8_t *input,
+    size_t input_length );
+
+psa_status_t psa_driver_wrapper_mac_sign_finish(
+    psa_operation_driver_context_t *operation,
+    uint8_t *mac,
+    size_t mac_size,
+    size_t *mac_length );
+
+psa_status_t psa_driver_wrapper_mac_verify_finish(
+    psa_operation_driver_context_t *operation,
+    const uint8_t *mac,
+    size_t mac_length );
+
+psa_status_t psa_driver_wrapper_mac_abort(
+    psa_operation_driver_context_t *operation );
+
 #endif /* PSA_CRYPTO_DRIVER_WRAPPERS_H */
 
 /* End of automatically generated file. */

--- a/tests/include/test/drivers/mac.h
+++ b/tests/include/test/drivers/mac.h
@@ -1,0 +1,122 @@
+/*
+ * Test driver for MAC functions
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_TEST_DRIVERS_MAC_H
+#define PSA_CRYPTO_TEST_DRIVERS_MAC_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+#include <psa/crypto_driver_common.h>
+
+typedef struct {
+} test_transparent_mac_operation_t;
+
+typedef struct{
+    unsigned int initialised : 1;
+    test_transparent_mac_operation_t ctx;
+} test_opaque_mac_operation_t;
+
+typedef struct {
+    /* If non-null, on success, copy this to the output. */
+    void *forced_output;
+    size_t forced_output_length;
+    /* If not PSA_SUCCESS, return this error code instead of processing the
+     * function call. */
+    psa_status_t forced_status;
+    /* Count the amount of times one of the cipher driver functions is called. */
+    unsigned long hits;
+} test_driver_mac_hooks_t;
+
+#define TEST_DRIVER_MAC_INIT { NULL, 0, PSA_SUCCESS, 0 }
+static inline test_driver_mac_hooks_t test_driver_mac_hooks_init( void )
+{
+    const test_driver_mac_hooks_t v = TEST_DRIVER_MAC_INIT;
+    return( v );
+}
+
+extern test_driver_mac_hooks_t test_driver_mac_hooks;
+
+/*
+ * Transparent test driver
+ */
+
+psa_status_t test_transparent_mac_sign_setup(
+    test_transparent_mac_operation_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg );
+
+psa_status_t test_transparent_mac_verify_setup(
+    test_transparent_mac_operation_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg );
+
+psa_status_t test_transparent_mac_update(
+    test_transparent_mac_operation_t *operation,
+    const uint8_t *input, size_t input_length );
+
+psa_status_t test_transparent_mac_sign_finish(
+    test_transparent_mac_operation_t *operation,
+    uint8_t *mac, size_t mac_size, size_t *mac_length );
+
+psa_status_t test_transparent_mac_verify_finish(
+    test_transparent_mac_operation_t *operation,
+    const uint8_t *mac, size_t mac_length );
+
+psa_status_t test_transparent_mac_abort(
+    test_transparent_mac_operation_t *operation );
+
+/*
+ * Opaque test driver
+ */
+
+psa_status_t test_opaque_mac_sign_setup(
+    test_opaque_mac_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg );
+
+psa_status_t test_opaque_mac_verify_setup(
+    test_opaque_mac_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg );
+
+psa_status_t test_opaque_mac_update(
+    test_opaque_mac_operation_t *operation,
+    const uint8_t *input, size_t input_length );
+
+psa_status_t test_opaque_mac_sign_finish(
+    test_opaque_mac_operation_t *operation,
+    uint8_t *mac, size_t mac_size, size_t *mac_length );
+
+psa_status_t test_opaque_mac_verify_finish(
+    test_opaque_mac_operation_t *operation,
+    const uint8_t *mac, size_t mac_length );
+
+psa_status_t test_opaque_mac_abort(
+    test_opaque_mac_operation_t *operation );
+
+
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+#endif /* PSA_CRYPTO_TEST_DRIVERS_MAC_H */

--- a/tests/include/test/drivers/test_driver.h
+++ b/tests/include/test/drivers/test_driver.h
@@ -25,6 +25,7 @@
 #include "test/drivers/signature.h"
 #include "test/drivers/key_management.h"
 #include "test/drivers/cipher.h"
+#include "test/drivers/mac.h"
 #include "test/drivers/size.h"
 
 #endif /* PSA_CRYPTO_TEST_DRIVER_H */

--- a/tests/src/drivers/mac.c
+++ b/tests/src/drivers/mac.c
@@ -1,0 +1,170 @@
+/*
+ * Test driver for MAC functions.
+ * Currently not implemented. Present to validate no impact on PSA Crypto core.
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_DRIVERS) && defined(PSA_CRYPTO_DRIVER_TEST)
+#include "psa/crypto.h"
+#include "psa_crypto_core.h"
+
+#include "test/drivers/mac.h"
+#include <string.h>
+
+test_driver_mac_hooks_t test_driver_mac_hooks = TEST_DRIVER_MAC_INIT;
+
+/*
+ * Transparent test driver
+ */
+
+psa_status_t test_transparent_mac_sign_setup(
+    test_transparent_mac_operation_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg )
+{
+    (void) operation;
+    (void) slot;
+    (void) alg;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_mac_verify_setup(
+    test_transparent_mac_operation_t *operation,
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg )
+{
+    (void) operation;
+    (void) slot;
+    (void) alg;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_mac_update(
+    test_transparent_mac_operation_t *operation,
+    const uint8_t *input, size_t input_length )
+{
+    (void) operation;
+    (void) input;
+    (void) input_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_mac_sign_finish(
+    test_transparent_mac_operation_t *operation,
+    uint8_t *mac, size_t mac_size, size_t *mac_length )
+{
+    (void) operation;
+    (void) mac;
+    (void) mac_size;
+    (void) mac_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_mac_verify_finish(
+    test_transparent_mac_operation_t *operation,
+    const uint8_t *mac, size_t mac_length )
+{
+    (void) operation;
+    (void) mac;
+    (void) mac_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_mac_abort(
+    test_transparent_mac_operation_t *operation )
+{
+    (void) operation;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+/*
+ * Opaque test driver
+ */
+
+psa_status_t test_opaque_mac_sign_setup(
+    test_opaque_mac_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg )
+{
+    (void) operation;
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_mac_verify_setup(
+    test_opaque_mac_operation_t *operation,
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg )
+{
+    (void) operation;
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_mac_update(
+    test_opaque_mac_operation_t *operation,
+    const uint8_t *input, size_t input_length )
+{
+    (void) operation;
+    (void) input;
+    (void) input_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_mac_sign_finish(
+    test_opaque_mac_operation_t *operation,
+    uint8_t *mac, size_t mac_size, size_t *mac_length )
+{
+    (void) operation;
+    (void) mac;
+    (void) mac_size;
+    (void) mac_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_mac_verify_finish(
+    test_opaque_mac_operation_t *operation,
+    const uint8_t *mac, size_t mac_length )
+{
+    (void) operation;
+    (void) mac;
+    (void) mac_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_mac_abort(
+    test_opaque_mac_operation_t *operation )
+{
+    (void) operation;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+#endif /* MBEDTLS_PSA_CRYPTO_DRIVERS && PSA_CRYPTO_DRIVER_TEST */

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -240,6 +240,7 @@
     <ClInclude Include="..\..\tests\include\test\random.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\cipher.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\key_management.h" />
+    <ClInclude Include="..\..\tests\include\test\drivers\mac.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\signature.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\size.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\test_driver.h" />


### PR DESCRIPTION
## Description
Add driver delegation as per the already established paradigms and the design document in `docs/proposed/psa-driver-interface.md`.


## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog updated


## Steps to test or reproduce
Test coverage is provided by the existing PSA Crypto test suites. These tests provide confidence that the splicing-in of this driver delegation does not break the software implementation of these MAC algorithms.
Actually implementing a test driver is postponed, pending an architecture for how to test PSA Crypto accelerator drivers.
