### PR TITLE
Add PSA Crypto driver delegation for AEAD functions

### DIFF
--- a/ChangeLog.d/psa-crypto-aead-acceleration.txt
+++ b/ChangeLog.d/psa-crypto-aead-acceleration.txt
@@ -1,0 +1,3 @@
+Features
+    * AEAD operations executed through the PSA API can now be accelerated with
+      a PSA Crypto driver.

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -191,16 +191,18 @@ struct psa_aead_operation_s
     psa_algorithm_t alg;
     unsigned int key_set : 1;
     unsigned int iv_set : 1;
+    unsigned int mbedtls_in_use : 1; /* Indicates mbed TLS is handling the operation. */
     uint8_t iv_size;
     uint8_t block_size;
     union
     {
         unsigned dummy; /* Enable easier initializing of the union. */
         mbedtls_cipher_context_t cipher;
+        psa_operation_driver_context_t driver;
     } ctx;
 };
 
-#define PSA_AEAD_OPERATION_INIT {0, 0, 0, 0, 0, {0}}
+#define PSA_AEAD_OPERATION_INIT {0, 0, 0, 0, 0, 0, {0}}
 static inline struct psa_aead_operation_s psa_aead_operation_init( void )
 {
     const struct psa_aead_operation_s v = PSA_AEAD_OPERATION_INIT;

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -990,4 +990,163 @@ psa_status_t psa_driver_wrapper_cipher_abort(
 #endif /* PSA_CRYPTO_DRIVER_PRESENT */
 }
 
+/*
+ * AEAD functions
+ */
+psa_status_t psa_driver_wrapper_aead_encrypt(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length )
+{
+#if defined(PSA_CRYPTO_DRIVER_PRESENT) && defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
+    psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION(slot->attr.lifetime);
+    psa_key_attributes_t attributes = {
+      .core = slot->attr
+    };
+
+    switch( location )
+    {
+        case PSA_KEY_LOCATION_LOCAL_STORAGE:
+            /* Key is stored in the slot in export representation, so
+             * cycle through all known transparent accelerators */
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+            status = test_transparent_aead_encrypt( &attributes,
+                                                    slot->data.key.data,
+                                                    slot->data.key.bytes,
+                                                    alg,
+                                                    nonce,
+                                                    nonce_length,
+                                                    additional_data,
+                                                    additional_data_length,
+                                                    plaintext,
+                                                    plaintext_length,
+                                                    ciphertext,
+                                                    ciphertext_size,
+                                                    ciphertext_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+            /* Fell through, meaning no accelerator supports this operation */
+            return( PSA_ERROR_NOT_SUPPORTED );
+        /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+        case PSA_CRYPTO_TEST_DRIVER_LIFETIME:
+            return( test_opaque_aead_encrypt( &attributes,
+                                              slot->data.key.data,
+                                              slot->data.key.bytes,
+                                              alg,
+                                              nonce,
+                                              nonce_length,
+                                              additional_data,
+                                              additional_data_length,
+                                              plaintext,
+                                              plaintext_length,
+                                              ciphertext,
+                                              ciphertext_size,
+                                              ciphertext_length ) );
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+        default:
+            /* Key is declared with a lifetime not known to us */
+            return( status );
+    }
+#else /* PSA_CRYPTO_DRIVER_PRESENT */
+    (void) slot;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) plaintext;
+    (void) plaintext_length;
+    (void) ciphertext;
+    (void) ciphertext_size;
+    (void) ciphertext_length;
+
+    return( PSA_ERROR_NOT_SUPPORTED );
+#endif /* PSA_CRYPTO_DRIVER_PRESENT */
+}
+
+psa_status_t psa_driver_wrapper_aead_decrypt(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length )
+{
+#if defined(PSA_CRYPTO_DRIVER_PRESENT) && defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
+    psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION(slot->attr.lifetime);
+    psa_key_attributes_t attributes = {
+      .core = slot->attr
+    };
+
+    switch( location )
+    {
+        case PSA_KEY_LOCATION_LOCAL_STORAGE:
+            /* Key is stored in the slot in export representation, so
+             * cycle through all known transparent accelerators */
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+            status = test_transparent_aead_decrypt( &attributes,
+                                                    slot->data.key.data,
+                                                    slot->data.key.bytes,
+                                                    alg,
+                                                    nonce,
+                                                    nonce_length,
+                                                    additional_data,
+                                                    additional_data_length,
+                                                    ciphertext,
+                                                    ciphertext_length,
+                                                    plaintext,
+                                                    plaintext_size,
+                                                    plaintext_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+            /* Fell through, meaning no accelerator supports this operation */
+            return( PSA_ERROR_NOT_SUPPORTED );
+        /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+        case PSA_CRYPTO_TEST_DRIVER_LIFETIME:
+            return( test_opaque_aead_decrypt( &attributes,
+                                              slot->data.key.data,
+                                              slot->data.key.bytes,
+                                              alg,
+                                              nonce,
+                                              nonce_length,
+                                              additional_data,
+                                              additional_data_length,
+                                              ciphertext,
+                                              ciphertext_length,
+                                              plaintext,
+                                              plaintext_size,
+                                              plaintext_length ) );
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+        default:
+            /* Key is declared with a lifetime not known to us */
+            return( status );
+    }
+#else /* PSA_CRYPTO_DRIVER_PRESENT */
+    (void) slot;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) ciphertext;
+    (void) ciphertext_length;
+    (void) plaintext;
+    (void) plaintext_size;
+    (void) plaintext_length;
+
+    return( PSA_ERROR_NOT_SUPPORTED );
+#endif /* PSA_CRYPTO_DRIVER_PRESENT */
+}
+
 /* End of automatically generated file. */

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -119,6 +119,25 @@ psa_status_t psa_driver_wrapper_cipher_finish(
 psa_status_t psa_driver_wrapper_cipher_abort(
     psa_operation_driver_context_t *operation );
 
+/*
+ * AEAD functions
+ */
+psa_status_t psa_driver_wrapper_aead_encrypt(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length );
+
+psa_status_t psa_driver_wrapper_aead_decrypt(
+    psa_key_slot_t *slot,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length );
+
 #endif /* PSA_CRYPTO_DRIVER_WRAPPERS_H */
 
 /* End of automatically generated file. */

--- a/tests/include/test/drivers/aead.h
+++ b/tests/include/test/drivers/aead.h
@@ -1,0 +1,102 @@
+/*
+ * Test driver for AEAD functions
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_TEST_DRIVERS_AEAD_H
+#define PSA_CRYPTO_TEST_DRIVERS_AEAD_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_TEST)
+#include <psa/crypto_driver_common.h>
+
+typedef struct {
+} test_transparent_aead_operation_t;
+
+typedef struct{
+    unsigned int initialised : 1;
+    test_transparent_aead_operation_t ctx;
+} test_opaque_aead_operation_t;
+
+typedef struct {
+    /* If non-null, on success, copy this to the output. */
+    void *forced_output;
+    size_t forced_output_length;
+    /* If not PSA_SUCCESS, return this error code instead of processing the
+     * function call. */
+    psa_status_t forced_status;
+    /* Count the amount of times one of the cipher driver functions is called. */
+    unsigned long hits;
+} test_driver_aead_hooks_t;
+
+#define TEST_DRIVER_AEAD_INIT { NULL, 0, PSA_SUCCESS, 0 }
+static inline test_driver_aead_hooks_t test_driver_aead_hooks_init( void )
+{
+    const test_driver_aead_hooks_t v = TEST_DRIVER_AEAD_INIT;
+    return( v );
+}
+
+extern test_driver_aead_hooks_t test_driver_aead_hooks;
+
+/*
+ * Transparent
+ */
+psa_status_t test_transparent_aead_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length );
+
+psa_status_t test_transparent_aead_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length );
+
+/*
+ * Opaque
+ */
+psa_status_t test_opaque_aead_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length );
+
+psa_status_t test_opaque_aead_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length );
+#endif /* PSA_CRYPTO_DRIVER_TEST */
+#endif /* PSA_CRYPTO_TEST_DRIVERS_AEAD_H */

--- a/tests/include/test/drivers/test_driver.h
+++ b/tests/include/test/drivers/test_driver.h
@@ -25,6 +25,7 @@
 #include "test/drivers/signature.h"
 #include "test/drivers/key_management.h"
 #include "test/drivers/cipher.h"
+#include "test/drivers/aead.h"
 #include "test/drivers/size.h"
 
 #endif /* PSA_CRYPTO_TEST_DRIVER_H */

--- a/tests/src/drivers/aead.c
+++ b/tests/src/drivers/aead.c
@@ -1,0 +1,140 @@
+/*
+ * Test driver for AEAD functions.
+ * Currently not implemented. Present to validate no impact on PSA Crypto core.
+ */
+/*  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_DRIVERS) && defined(PSA_CRYPTO_DRIVER_TEST)
+#include "psa/crypto.h"
+#include "psa_crypto_core.h"
+
+#include "test/drivers/aead.h"
+
+test_driver_aead_hooks_t test_driver_aead_hooks = TEST_DRIVER_AEAD_INIT;
+
+/*
+ * Transparent
+ */
+psa_status_t test_transparent_aead_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length )
+{
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) plaintext;
+    (void) plaintext_length;
+    (void) ciphertext;
+    (void) ciphertext_size;
+    (void) ciphertext_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_transparent_aead_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length )
+{
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) ciphertext;
+    (void) ciphertext_length;
+    (void) plaintext;
+    (void) plaintext_size;
+    (void) plaintext_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+/*
+ * Opaque
+ */
+psa_status_t test_opaque_aead_encrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *plaintext, size_t plaintext_length,
+    uint8_t *ciphertext, size_t ciphertext_size, size_t *ciphertext_length )
+{
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) plaintext;
+    (void) plaintext_length;
+    (void) ciphertext;
+    (void) ciphertext_size;
+    (void) ciphertext_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+
+psa_status_t test_opaque_aead_decrypt(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key, size_t key_length,
+    psa_algorithm_t alg,
+    const uint8_t *nonce, size_t nonce_length,
+    const uint8_t *additional_data, size_t additional_data_length,
+    const uint8_t *ciphertext, size_t ciphertext_length,
+    uint8_t *plaintext, size_t plaintext_size, size_t *plaintext_length )
+{
+    (void) attributes;
+    (void) key;
+    (void) key_length;
+    (void) alg;
+    (void) nonce;
+    (void) nonce_length;
+    (void) additional_data;
+    (void) additional_data_length;
+    (void) ciphertext;
+    (void) ciphertext_length;
+    (void) plaintext;
+    (void) plaintext_size;
+    (void) plaintext_length;
+    return( PSA_ERROR_NOT_SUPPORTED );
+}
+#endif /* MBEDTLS_PSA_CRYPTO_DRIVERS && PSA_CRYPTO_DRIVER_TEST */

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="..\..\tests\include\test\psa_crypto_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\psa_helpers.h" />
     <ClInclude Include="..\..\tests\include\test\random.h" />
+    <ClInclude Include="..\..\tests\include\test\drivers\aead.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\cipher.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\key_management.h" />
     <ClInclude Include="..\..\tests\include\test\drivers\signature.h" />


### PR DESCRIPTION
## Description
Add driver delegation as per the already established paradigms and the design document in `docs/proposed/psa-driver-interface.md`.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Tests
- [X] Documentation
- [X] Changelog updated

## Steps to test or reproduce
Testing is covered by existing test suites, which verify that the existing implementation still works (the test driver is a stub). For actually testing the driver itself, a generic approach would need to be chosen first.

It is assumed that whoever implements drivers would also need to do their own testing for their specific driver constellation.
