### PR TITLE
Baremetal aes masking speedup

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -1421,9 +1421,9 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     uint8_t round_ctrl_table[( 14 + AES_SCA_CM_ROUNDS + 2 )];
 
 #if defined MBEDTLS_AES_128_BIT_MASKED
-    uint32_t rk_masked[MBEDTLS_AES_128_EXPANDED_KEY_SIZE_IN_WORDS] = {0};
-    uint8_t sbox_masked[256] = {0};
-    uint32_t mask[10] = {0};
+    uint32_t rk_masked[MBEDTLS_AES_128_EXPANDED_KEY_SIZE_IN_WORDS];
+    uint8_t sbox_masked[256];
+    uint32_t mask[10];
 #endif
 
 #if defined(MBEDTLS_VALIDATE_AES_KEYS_INTEGRITY)

--- a/library/aes.c
+++ b/library/aes.c
@@ -1560,8 +1560,6 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
         {
             flow_control++;
         }
-        //Cleanup the masked key
-        mbedtls_platform_memset( rk_masked, 0, sizeof(rk_masked) );
 #else
         aes_fround_final( aes_data_ptr->rk_ptr,
             &aes_data_ptr->xy_values[0],


### PR DESCRIPTION
## Description
MBEDTLS_AES_128_BIT_MASKED configuration  improvements 
1. Skip local variables initialization to improve performance on restricted targets
2. Remove unneeded buffer cleanup in a loop 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
