### PR TITLE
Add const parameters to aria module's API.

### DIFF
--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -347,7 +347,7 @@ int mbedtls_aria_crypt_cfb128( mbedtls_aria_context *ctx,
 int mbedtls_aria_crypt_ctr( mbedtls_aria_context *ctx,
                             size_t length,
                             size_t *nc_off,
-                            unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
+                            const unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
                             unsigned char stream_block[MBEDTLS_ARIA_BLOCKSIZE],
                             const unsigned char *input,
                             unsigned char *output );

--- a/library/aria.c
+++ b/library/aria.c
@@ -738,7 +738,7 @@ int mbedtls_aria_crypt_cfb128( mbedtls_aria_context *ctx,
 int mbedtls_aria_crypt_ctr( mbedtls_aria_context *ctx,
                             size_t length,
                             size_t *nc_off,
-                            unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
+                            const unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
                             unsigned char stream_block[MBEDTLS_ARIA_BLOCKSIZE],
                             const unsigned char *input,
                             unsigned char *output )


### PR DESCRIPTION
## Description
Aria module API functions were missing a const parameter. This PR addresses this issue. Partially implements #4033

## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- **This PR contains changes in the API.** If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | **NO**  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | **NO**

