### PR TITLE
Add missing const attribute to asn1 api

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -578,7 +578,7 @@ int mbedtls_asn1_get_alg_null( unsigned char **p,
  *
  * \return      NULL if not found, or a pointer to the existing entry.
  */
-mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *list,
+const mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( const mbedtls_asn1_named_data *list,
                                        const char *oid, size_t len );
 
 /**

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -461,7 +461,7 @@ void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head )
     }
 }
 
-mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *list,
+const mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( const mbedtls_asn1_named_data *list,
                                        const char *oid, size_t len )
 {
     while( list != NULL )

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -718,7 +718,7 @@ void find_named_data( data_t *oid0, data_t *oid1, data_t *oid2, data_t *oid3,
     };
     mbedtls_asn1_named_data *pointers[ARRAY_LENGTH( nd ) + 1];
     size_t i;
-    mbedtls_asn1_named_data *found;
+    const mbedtls_asn1_named_data *found;
 
     for( i = 0; i < ARRAY_LENGTH( nd ); i++ )
         pointers[i] = &nd[i];
@@ -726,7 +726,7 @@ void find_named_data( data_t *oid0, data_t *oid1, data_t *oid2, data_t *oid3,
     for( i = 0; i < ARRAY_LENGTH( nd ); i++ )
         nd[i].next = pointers[i+1];
 
-    found = mbedtls_asn1_find_named_data( pointers[from],
+    found = mbedtls_asn1_find_named_data( (const mbedtls_asn1_named_data*) pointers[from],
                                           (const char *) needle->x,
                                           needle->len );
     TEST_ASSERT( found == pointers[position] );


### PR DESCRIPTION
Partially implements #4033, where possible - add const attribute to asn1 api functions' parameters (in scope of 3.0 release).

## Status
**READY**


