### PR TITLE
Add missing const attribute to asn1write api

### DIFF
--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -55,7 +55,7 @@ extern "C" {
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_len( unsigned char **p, const unsigned char *start,
                             size_t len );
 /**
  * \brief           Write an ASN.1 tag in ASN.1 format.
@@ -69,7 +69,7 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_tag( unsigned char **p, const unsigned char *start,
                             unsigned char tag );
 
 /**
@@ -85,7 +85,7 @@ int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_raw_buffer( unsigned char **p, const unsigned char *start,
                                    const unsigned char *buf, size_t size );
 
 #if defined(MBEDTLS_BIGNUM_C)
@@ -103,7 +103,7 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_mpi( unsigned char **p, const unsigned char *start,
                             const mbedtls_mpi *X );
 #endif /* MBEDTLS_BIGNUM_C */
 
@@ -119,7 +119,7 @@ int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
+int mbedtls_asn1_write_null( unsigned char **p, const unsigned char *start );
 
 /**
  * \brief           Write an OID tag (#MBEDTLS_ASN1_OID) and data
@@ -135,7 +135,7 @@ int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_oid( unsigned char **p, const unsigned char *start,
                             const char *oid, size_t oid_len );
 
 /**
@@ -154,7 +154,7 @@ int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
 int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
-                                             unsigned char *start,
+                                             const unsigned char *start,
                                              const char *oid, size_t oid_len,
                                              size_t par_len );
 
@@ -171,7 +171,7 @@ int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_bool( unsigned char **p, const unsigned char *start,
                              int boolean );
 
 /**
@@ -188,7 +188,7 @@ int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
+int mbedtls_asn1_write_int( unsigned char **p, const unsigned char *start, int val );
 
 /**
  * \brief           Write an enum tag (#MBEDTLS_ASN1_ENUMERATED) and value
@@ -203,7 +203,7 @@ int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val );
+int mbedtls_asn1_write_enum( unsigned char **p, const unsigned char *start, int val );
 
 /**
  * \brief           Write a string in ASN.1 format using a specific
@@ -222,7 +222,7 @@ int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_tagged_string( unsigned char **p, const unsigned char *start,
                                       int tag, const char *text,
                                       size_t text_len );
 
@@ -242,7 +242,7 @@ int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
  * \return          A negative error code on failure.
  */
 int mbedtls_asn1_write_printable_string( unsigned char **p,
-                                         unsigned char *start,
+                                         const unsigned char *start,
                                          const char *text, size_t text_len );
 
 /**
@@ -260,7 +260,7 @@ int mbedtls_asn1_write_printable_string( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_utf8_string( unsigned char **p, const unsigned char *start,
                                     const char *text, size_t text_len );
 
 /**
@@ -278,7 +278,7 @@ int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_ia5_string( unsigned char **p, const unsigned char *start,
                                    const char *text, size_t text_len );
 
 /**
@@ -295,7 +295,7 @@ int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_bitstring( unsigned char **p, const unsigned char *start,
                                   const unsigned char *buf, size_t bits );
 
 /**
@@ -316,7 +316,7 @@ int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
  * \return          A negative error code on failure.
  */
 int mbedtls_asn1_write_named_bitstring( unsigned char **p,
-                                        unsigned char *start,
+                                        const unsigned char *start,
                                         const unsigned char *buf,
                                         size_t bits );
 
@@ -334,7 +334,7 @@ int mbedtls_asn1_write_named_bitstring( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_octet_string( unsigned char **p, const unsigned char *start,
                                      const unsigned char *buf, size_t size );
 
 /**

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -34,7 +34,7 @@
 #define mbedtls_free       free
 #endif
 
-int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len )
+int mbedtls_asn1_write_len( unsigned char **p, const unsigned char *start, size_t len )
 {
     if( len < 0x80 )
     {
@@ -98,7 +98,7 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
 #endif
 }
 
-int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start, unsigned char tag )
+int mbedtls_asn1_write_tag( unsigned char **p, const unsigned char *start, unsigned char tag )
 {
     if( *p - start < 1 )
         return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
@@ -108,7 +108,7 @@ int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start, unsigned ch
     return( 1 );
 }
 
-int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_raw_buffer( unsigned char **p, const unsigned char *start,
                            const unsigned char *buf, size_t size )
 {
     size_t len = 0;
@@ -124,7 +124,7 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
 }
 
 #if defined(MBEDTLS_BIGNUM_C)
-int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start, const mbedtls_mpi *X )
+int mbedtls_asn1_write_mpi( unsigned char **p, const unsigned char *start, const mbedtls_mpi *X )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -161,7 +161,7 @@ cleanup:
 }
 #endif /* MBEDTLS_BIGNUM_C */
 
-int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start )
+int mbedtls_asn1_write_null( unsigned char **p, const unsigned char *start )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -174,7 +174,7 @@ int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start )
     return( (int) len );
 }
 
-int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_oid( unsigned char **p, const unsigned char *start,
                     const char *oid, size_t oid_len )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -188,7 +188,7 @@ int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
     return( (int) len );
 }
 
-int mbedtls_asn1_write_algorithm_identifier( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_algorithm_identifier( unsigned char **p, const unsigned char *start,
                                      const char *oid, size_t oid_len,
                                      size_t par_len )
 {
@@ -209,7 +209,7 @@ int mbedtls_asn1_write_algorithm_identifier( unsigned char **p, unsigned char *s
     return( (int) len );
 }
 
-int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start, int boolean )
+int mbedtls_asn1_write_bool( unsigned char **p, const unsigned char *start, int boolean )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -226,7 +226,7 @@ int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start, int boolea
     return( (int) len );
 }
 
-static int asn1_write_tagged_int( unsigned char **p, unsigned char *start, int val, int tag )
+static int asn1_write_tagged_int( unsigned char **p, const unsigned char *start, int val, int tag )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -255,17 +255,17 @@ static int asn1_write_tagged_int( unsigned char **p, unsigned char *start, int v
     return( (int) len );
 }
 
-int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val )
+int mbedtls_asn1_write_int( unsigned char **p, const unsigned char *start, int val )
 {
     return( asn1_write_tagged_int( p, start, val, MBEDTLS_ASN1_INTEGER ) );
 }
 
-int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val )
+int mbedtls_asn1_write_enum( unsigned char **p, const unsigned char *start, int val )
 {
     return( asn1_write_tagged_int( p, start, val, MBEDTLS_ASN1_ENUMERATED ) );
 }
 
-int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start, int tag,
+int mbedtls_asn1_write_tagged_string( unsigned char **p, const unsigned char *start, int tag,
     const char *text, size_t text_len )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -280,26 +280,26 @@ int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start, i
     return( (int) len );
 }
 
-int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_utf8_string( unsigned char **p, const unsigned char *start,
     const char *text, size_t text_len )
 {
     return( mbedtls_asn1_write_tagged_string(p, start, MBEDTLS_ASN1_UTF8_STRING, text, text_len) );
 }
 
-int mbedtls_asn1_write_printable_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_printable_string( unsigned char **p, const unsigned char *start,
                                  const char *text, size_t text_len )
 {
     return( mbedtls_asn1_write_tagged_string(p, start, MBEDTLS_ASN1_PRINTABLE_STRING, text, text_len) );
 }
 
-int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_ia5_string( unsigned char **p, const unsigned char *start,
                            const char *text, size_t text_len )
 {
     return( mbedtls_asn1_write_tagged_string(p, start, MBEDTLS_ASN1_IA5_STRING, text, text_len) );
 }
 
 int mbedtls_asn1_write_named_bitstring( unsigned char **p,
-                                        unsigned char *start,
+                                        const unsigned char *start,
                                         const unsigned char *buf,
                                         size_t bits )
 {
@@ -341,7 +341,7 @@ int mbedtls_asn1_write_named_bitstring( unsigned char **p,
     return( mbedtls_asn1_write_bitstring( p, start, buf, bits ) );
 }
 
-int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_bitstring( unsigned char **p, const unsigned char *start,
                           const unsigned char *buf, size_t bits )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -374,7 +374,7 @@ int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
     return( (int) len );
 }
 
-int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
+int mbedtls_asn1_write_octet_string( unsigned char **p, const unsigned char *start,
                              const unsigned char *buf, size_t size )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;

--- a/tests/suites/test_suite_asn1write.function
+++ b/tests/suites/test_suite_asn1write.function
@@ -304,7 +304,7 @@ void test_asn1_write_bitstrings( data_t *bitstring, int bits,
 {
     generic_write_data_t data = { NULL, NULL, NULL, NULL, 0 };
     int ret;
-    int ( *func )( unsigned char **p, unsigned char *start,
+    int ( *func )( unsigned char **p, const unsigned char *start,
                    const unsigned char *buf, size_t bits ) =
         ( is_named ? mbedtls_asn1_write_named_bitstring :
           mbedtls_asn1_write_bitstring );


### PR DESCRIPTION
Partially implements #4033, where possible - add const attribute to asn1write api functions' parameters (in scope of 3.0 release).

## Status
**READY**

