### PR TITLE
Actually use the READ_TIMEOUT_MS in the example DTLS client and server

### DIFF
--- a/ChangeLog.d/dtls_sample_use_read_timeout.txt
+++ b/ChangeLog.d/dtls_sample_use_read_timeout.txt
@@ -1,0 +1,2 @@
+Changes
+   * Fix the setting of the read timeout in the DTLS sample programs.

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -191,6 +191,7 @@ int main( int argc, char *argv[] )
     mbedtls_ssl_conf_ca_chain( &conf, &cacert, NULL );
     mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );
+    mbedtls_ssl_conf_read_timeout( &conf, READ_TIMEOUT_MS );
 
     if( ( ret = mbedtls_ssl_setup( &ssl, &conf ) ) != 0 )
     {

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -223,6 +223,7 @@ int main( void )
 
     mbedtls_ssl_conf_rng( &conf, mbedtls_ctr_drbg_random, &ctr_drbg );
     mbedtls_ssl_conf_dbg( &conf, my_debug, stdout );
+    mbedtls_ssl_conf_read_timeout( &conf, READ_TIMEOUT_MS );
 
 #if defined(MBEDTLS_SSL_CACHE_C)
     mbedtls_ssl_conf_session_cache( &conf, &cache,

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -87,7 +87,7 @@ int main( void )
 #include "mbedtls/ssl_cache.h"
 #endif
 
-#define READ_TIMEOUT_MS 10000   /* 5 seconds */
+#define READ_TIMEOUT_MS 10000   /* 10 seconds */
 #define DEBUG_LEVEL 0
 
 


### PR DESCRIPTION
## Description
`programs/ssl/dtls_client.c` and `programs/ssl/dtls_server.c` each contain a `#define READ_TIMEOUT_MS` that was previously used to specify the read timeout. Since 97fd52c529e293f98674f313fb2da9a9f8b85fbc, those defines have been useless / not serving their intended purpose. This PR makes those defines serve their purpose again.

## Status
**READY**

## Requires Backporting
~I don't know~ Yes

## Migrations
NO

## Todos
- [ ] Changelog updated
- [ ] Backported
