### PR TITLE
Fix for memory leak in ssl tests

### DIFF
--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1354,7 +1354,8 @@ static int build_transforms( mbedtls_ssl_transform *t_in,
                     t_in->taglen = 8;
                     break;
                 default:
-                    return( 1 );
+                    ret = 1;
+                    goto cleanup;
             }
             break;
 
@@ -1374,7 +1375,8 @@ static int build_transforms( mbedtls_ssl_transform *t_in,
                     t_in->taglen = 8;
                     break;
                 default:
-                    return( 1 );
+                    ret = 1;
+                    goto cleanup;
             }
             break;
 
@@ -1395,11 +1397,13 @@ static int build_transforms( mbedtls_ssl_transform *t_in,
                     t_in->maclen = 10;
                     break;
                 default:
-                    return( 1 );
+                    ret = 1;
+                    goto cleanup;
             }
             break;
         default:
-            return( 1 );
+            ret = 1;
+            goto cleanup;
             break;
     }
 


### PR DESCRIPTION
## Description

In the error case build_transforms() was returning directly rather than jumping to cleanup, despite having allocated two buffers.

Found via Coverity analysis

## Status
**READY**

## Requires Backporting
NO (Bug does not exist in 2.7 or 2.16 (new code was added)

## Migrations
NO
