### PR TITLE
Adding m == 0 shortcut to mbedtls_ecp_mul_shortcuts()

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2795,7 +2795,7 @@ cleanup:
 
 #if defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED)
 /*
- * R = m * P with shortcuts for m == 1 and m == -1
+ * R = m * P with shortcuts for m == 0, m == 1 and m == -1
  * NOT constant-time - ONLY for short Weierstrass!
  */
 static int mbedtls_ecp_mul_shortcuts( mbedtls_ecp_group *grp,
@@ -2806,7 +2806,11 @@ static int mbedtls_ecp_mul_shortcuts( mbedtls_ecp_group *grp,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    if( mbedtls_mpi_cmp_int( m, 1 ) == 0 )
+    if ( mbedtls_mpi_cmp_int( m, 0 ) == 0 )
+    {
+        MBEDTLS_MPI_CHK( mbedtls_ecp_set_zero( R ) );
+    }
+    else if( mbedtls_mpi_cmp_int( m, 1 ) == 0 )
     {
         MBEDTLS_MPI_CHK( mbedtls_ecp_copy( R, P ) );
     }


### PR DESCRIPTION
## Description
Resolves: #1792 

Short issue #1792 description: 
"ECDSA verification (mbedtls_ecdsa_verify or mbedtls_ecdsa_read_signature) returns MBEDTLS_ERR_ECP_INVALID_KEY when the payload (which should be a hash) is all-bits zero. The curve is a short Weierstrass curve."

root cause: `ecp_mul_restartable()` function is very strict and don't handle situation like that.

Fix: There was a new shortcut added to the `mbedtls_ecp_mul_shortcuts()` It is a shortcut for a situation when `m == 0`.

## Status
**READY**

## Requires Backporting
Rather NO

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated

## Steps to test or reproduce
Please check: #1792 