### PR TITLE
ssl-opt.sh: if the server fails, do treat it as a test failure

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -804,8 +804,10 @@ run_test() {
         fi
     fi
 
-    # check server exit code
-    if [ $SRV_RET != 0 ]; then
+    # Check server exit code (only for Mbed TLS: GnuTLS and OpenSSL don't
+    # exit with status 0 when interrupted by a signal, and we don't really
+    # care anyway), in case e.g. the server reports a memory leak.
+    if [ $SRV_RET != 0 ] && is_polar "$SRV_CMD"; then
         fail "Server exited with status $SRV_RET"
         return
     fi

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -770,6 +770,7 @@ run_test() {
         # terminate the server (and the proxy)
         kill $SRV_PID
         wait $SRV_PID
+        SRV_RET=$?
 
         if [ -n "$PXY_CMD" ]; then
             kill $PXY_PID >/dev/null 2>&1
@@ -804,8 +805,8 @@ run_test() {
     fi
 
     # check server exit code
-    if [ $? != 0 ]; then
-        fail "server fail"
+    if [ $SRV_RET != 0 ]; then
+        fail "Server exited with status $SRV_RET"
         return
     fi
 


### PR DESCRIPTION
This used to be the case a long time ago but was accidentally broken.

After investigation (see PR comments), openssl and gnutls servers don't report success if we kill them after one connection. But `ssl_server2` does, and that's the important case where we want to detect errors. So this PR checks the return code of `ssl_server2` only.

Fix, for `ssl-opt.sh` only, #4103. Useful for https://github.com/ARMmbed/mbedtls/pull/4104.

Backports: #4134 #4135