### PR TITLE
Fix memory leak in error case in psa_crypto

### DIFF
--- a/ChangeLog.d/fix_psa_crypto_leak.txt
+++ b/ChangeLog.d/fix_psa_crypto_leak.txt
@@ -1,2 +1,2 @@
 Bugfix
-   * Fix memory leak that occured in error case in psa_generate_derived_key_internal()
+   * Fix a memory leak in an error case in psa_generate_derived_key_internal().

--- a/ChangeLog.d/fix_psa_crypto_leak.txt
+++ b/ChangeLog.d/fix_psa_crypto_leak.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix memory leak that occured in error case in psa_generate_derived_key_internal()

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5147,7 +5147,7 @@ static psa_status_t psa_generate_derived_key_internal(
 
     status = psa_allocate_buffer_to_slot( slot, bytes );
     if( status != PSA_SUCCESS )
-        return( status );
+        goto exit;
 
     slot->attr.bits = (psa_key_bits_t) bits;
     psa_key_attributes_t attributes = {


### PR DESCRIPTION
## Description

In psa_generate_derived_key_internal() an error case was returning directly rather than jumping to the exit label, which meant that an allocated buffer would not be free'd.

Found via coverity.

## Status
**READY**

## Requires Backporting
NO  

(New code, bug does not exist in LTS branches)

## Migrations

NO

