### PR TITLE
Backport 2.7: ssl-opt.sh: if the server fails, do treat it as a test failure

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -564,8 +564,10 @@ run_test() {
         fi
     fi
 
-    # check server exit code
-    if [ $SRV_RET != 0 ]; then
+    # Check server exit code (only for Mbed TLS: GnuTLS and OpenSSL don't
+    # exit with status 0 when interrupted by a signal, and we don't really
+    # care anyway), in case e.g. the server reports a memory leak.
+    if [ $SRV_RET != 0 ] && is_polar "$SRV_CMD"; then
         fail "Server exited with status $SRV_RET"
         return
     fi

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -530,6 +530,8 @@ run_test() {
         # terminate the server (and the proxy)
         kill $SRV_PID
         wait $SRV_PID
+        SRV_RET=$?
+
         if [ -n "$PXY_CMD" ]; then
             kill $PXY_PID >/dev/null 2>&1
             wait $PXY_PID
@@ -563,8 +565,8 @@ run_test() {
     fi
 
     # check server exit code
-    if [ $? != 0 ]; then
-        fail "server fail"
+    if [ $SRV_RET != 0 ]; then
+        fail "Server exited with status $SRV_RET"
         return
     fi
 


### PR DESCRIPTION
Backport of #4109.