### PR TITLE
ssl-opt.sh: add --priority=normal to gnutls-serv

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -634,6 +634,21 @@ detect_dtls() {
     fi
 }
 
+# check if the given command uses gnutls and sets global variable CMD_IS_GNUTLS
+is_gnutls() {
+    case "$1" in
+    *gnutls-cli*)
+        CMD_IS_GNUTLS=1
+        ;;
+    *gnutls-serv*)
+        CMD_IS_GNUTLS=1
+        ;;
+    *)
+        CMD_IS_GNUTLS=0
+        ;;
+    esac
+}
+
 # Compare file content
 # Usage: find_in_both pattern file1 file2
 # extract from file1 the first line matching the pattern
@@ -723,6 +738,30 @@ run_test() {
         case " $SRV_CMD " in
             *' server_addr=::1 '*)
                 PXY_CMD="$PXY_CMD server_addr=::1 listen_addr=::1";;
+        esac
+    fi
+
+    # update CMD_IS_GNUTLS variable
+    is_gnutls "$SRV_CMD"
+
+    # if the server uses gnutls but doesn't set priority, explicitly
+    # set the default priority
+    if [ "$CMD_IS_GNUTLS" -eq 1 ]; then
+        case "$SRV_CMD" in
+              *--priority*) :;;
+              *) SRV_CMD="$SRV_CMD --priority=NORMAL";;
+        esac
+    fi
+
+    # update CMD_IS_GNUTLS variable
+    is_gnutls "$CLI_CMD"
+
+    # if the client uses gnutls but doesn't set priority, explicitly
+    # set the default priority
+    if [ "$CMD_IS_GNUTLS" -eq 1 ]; then
+        case "$CLI_CMD" in
+              *--priority*) :;;
+              *) CLI_CMD="$CLI_CMD --priority=NORMAL";;
         esac
     fi
 


### PR DESCRIPTION
For calls to gnutls-serv where --priority is not specified, explicitly
add the default value: --priority=normal. This is needed for some tests
on Ubuntu 20.04 (gnutls-serv 3.6.13).

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>

## Steps to test or reproduce
./ssl-opt.sh -f "DTLS fragmenting: gnutls server, DTLS 1.0"
