### PR TITLE
Fix/unused argument warnings

### DIFF
--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -470,6 +470,8 @@ static int ecdsa_sign_det_restartable( mbedtls_ecp_group *grp,
 sign:
 #endif
 #if defined(MBEDTLS_ECDSA_SIGN_ALT)
+    (void) f_rng_blind;
+    (void) p_rng_blind;
     ret = mbedtls_ecdsa_sign( grp, r, s, d, buf, blen,
                               mbedtls_hmac_drbg_random, p_rng );
 #else

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4584,6 +4584,7 @@ psa_status_t psa_aead_encrypt( mbedtls_svc_key_id_t key,
     else
 #endif /* MBEDTLS_CHACHAPOLY_C */
     {
+        (void) tag;
         return( PSA_ERROR_NOT_SUPPORTED );
     }
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5091,6 +5091,7 @@ psa_status_t psa_key_derivation_output_bytes(
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_TLS12_PRF ||
         * MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS */
     {
+        (void) kdf_alg;
         return( PSA_ERROR_BAD_STATE );
     }
 
@@ -5575,6 +5576,9 @@ static psa_status_t psa_key_derivation_input_internal(
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_TLS12_PSK_TO_MS */
     {
         /* This can't happen unless the operation object was not initialized */
+        (void) data;
+        (void) data_length;
+        (void) kdf_alg;
         return( PSA_ERROR_BAD_STATE );
     }
 


### PR DESCRIPTION
## Description
Fixing a few unused variable warning fixes discovered when building with non-default configurations


## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO
