### PR TITLE
Fix a malformed define guard

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5707,7 +5707,7 @@ void persistent_key_load_key_from_storage( data_t *data,
             break;
 
         case DERIVE_KEY:
-#if PSA_WANT_ALG_HKDF && PSA_WANT_ALG_SHA_256
+#if defined(PSA_WANT_ALG_HKDF) && defined(PSA_WANT_ALG_SHA_256)
             {
                 /* Create base key */
                 psa_algorithm_t derive_alg = PSA_ALG_HKDF( PSA_ALG_SHA_256 );


### PR DESCRIPTION
## Description
All compile-time switches on `PSA_WANT_` are constructed with `defined(...)`. There's one exception that was introduced in `test_suite_psa_crypto.function`, and it triggers a compiler error/warning when the symbol in question isn't defined (expands to `#if &&` which obviously isn't a valid preprocessor statement).

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO
