### PR TITLE
Add missing test skip for ALT-implemented GCM (#4010 fix-up)

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -3874,6 +3874,7 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     unsigned char *output_data2 = NULL;
     size_t output_length2 = 0;
     size_t tag_length = PSA_AEAD_TAG_LENGTH( alg );
+    psa_status_t status = PSA_ERROR_GENERIC_ERROR;
     psa_status_t expected_result = expected_result_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
@@ -3894,14 +3895,24 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
                                 &key ) );
 
-    TEST_EQUAL( psa_aead_encrypt( key, alg,
-                                  nonce->x, nonce->len,
-                                  additional_data->x,
-                                  additional_data->len,
-                                  input_data->x, input_data->len,
-                                  output_data, output_size,
-                                  &output_length ),
-                expected_result );
+    status = psa_aead_encrypt( key, alg,
+                               nonce->x, nonce->len,
+                               additional_data->x,
+                               additional_data->len,
+                               input_data->x, input_data->len,
+                               output_data, output_size,
+                               &output_length );
+
+    /* If the operation is not supported, just skip and not fail in case the
+     * encryption involves a common limitation of cryptography hardwares and
+     * an alternative implementation. */
+    if( status == PSA_ERROR_NOT_SUPPORTED )
+    {
+        MBEDTLS_TEST_PSA_SKIP_IF_ALT_AES_192( key_type, key_data->len * 8 );
+        MBEDTLS_TEST_PSA_SKIP_IF_ALT_GCM_NOT_12BYTES_NONCE( alg, nonce->len );
+    }
+
+    TEST_EQUAL( status, expected_result );
 
     if( PSA_SUCCESS == expected_result )
     {


### PR DESCRIPTION
## Description
Test cases `aead_encrypt` and `aead_decrypt` were changed in #4010 to allow ALT-implemented GCM to return `NOT_SUPPORTED` for AES-192 and/or non-12-byte GCM IVs.

There's a third test case (`aead_encrypt_decrypt`) where the same construct should apply, but was forgotten in the PR. This PR is thus a fixup for #4010.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
 NO

