### PR TITLE
Add missing header to cpp_dummy_build.cpp test

### DIFF
--- a/programs/test/cpp_dummy_build.cpp
+++ b/programs/test/cpp_dummy_build.cpp
@@ -44,6 +44,7 @@
 #include "mbedtls/cipher_internal.h"
 #include "mbedtls/cmac.h"
 #include "mbedtls/compat-1.3.h"
+#include "mbedtls/config_psa.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/debug.h"
 #include "mbedtls/des.h"


### PR DESCRIPTION
## Description
Part of build_default_make_gcc_and_cxx compares the list of headers
included by `programs/test/cpp_dummy_build.cpp` and the actual headers
present.  Add in the missing `mbedtls/psa_config.h` file to this list so
that this test passes.

## Status
**READY**

## Requires Backporting
NO: This is for PSA config support