### PR TITLE
Improve the visibility of some informations

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,16 @@
-Note: This is just a template, so feel free to use/remove the unnecessary things
+_Note:_ this is a template, please remove the parts that are not
+applicable (these initial notes, and the "Bug" section for a Feature request
+and vice-versa).
 
+**Note:** to report a security vulnerability, see `SECURITY.md`. Please do not
+use github issues for vulnerabilities.
+
+_Note:_ To get support, see `SUPPORT.md`. Please do o't use github issues for
+questions.
+
+---------------------------------------------------------------
 ### Description
-- Type: Bug | Enhancement\Feature Request
+- Type: Bug | Enhancement / Feature Request
 - Priority: Blocker | Major | Minor
 
 ---------------------------------------------------------------
@@ -28,14 +37,9 @@ Version:
 **Steps to reproduce**  
 
 ----------------------------------------------------------------
-## Enhancement\Feature Request
-
-**Justification - why does the library need this feature?**  
+## Enhancement / Feature Request
 
 **Suggested enhancement**  
 
------------------------------------------------------------------
+**Justification - why does the library need this feature?**  
 
-## Question
-
-**Please first check for answers in the [Mbed TLS knowledge Base](https://tls.mbed.org/kb). If you can't find the answer you're looking for then please use the [Mbed TLS mailing list](https://lists.trustedfirmware.org/mailman/listinfo/mbed-tls)**

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,11 +2,12 @@ _Note:_ this is a template, please remove the parts that are not
 applicable (these initial notes, and the "Bug" section for a Feature request
 and vice-versa).
 
-**Note:** to report a security vulnerability, see `SECURITY.md`. Please do not
-use github issues for vulnerabilities.
+**Note:** to report a security vulnerability, see
+[SECURITY.md](../SECURITY.md). Please do not use github issues for
+vulnerabilities.
 
-_Note:_ To get support, see `SUPPORT.md`. Please do o't use github issues for
-questions.
+_Note:_ to get support, see [SUPPORT.md](../SUPPORT.md). Please do not use
+github issues for questions.
 
 ---------------------------------------------------------------
 ### Description

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,0 +1,42 @@
+# Maintained branches
+
+At any point in time, we have a number of maintained branches consisting of:
+
+- the development branch: this is where new features lands, as well as bug
+  fixes and security fixes
+- one or more LTS branches: these only get bug fixes and security fixes.
+
+We use [Semantic Versioning](https://semver.org/). In particular, we maintain
+API compatibility in the development branch between major version changes. We
+also maintain ABI compatibility within LTS branches; see the next section for
+details.
+
+## Backwards Compatibility
+
+If you have code that's working and secure with Mbed TLS x.y.z, then you
+should be able to re-compile it without modification with any later release
+x.y'.z' with the same major version number, and your code will still build, be
+secure, and work - unless it was relying on something that became insecure in
+the meantime (for example, crypto that was found to be weak). In case security
+comes in conflict with backwards compatibility, we will put security first,
+but always attempt to provide a compatibility option.
+
+For the LTS branches, additionally we try very hard to also maintain ABI
+compatibility (same definition as API except with re-linking instead of
+re-compiling) and to avoid any increase in code size or RAM usage, or in the
+minimum version of tools needed to build the code. The only exception, as
+before, is in case those goals would conflict with fixing a security issue, we
+will put security first but provide a compatibility option. (So far we never
+had to break ABI compatibility in an LTS branch, but we occasionally had to
+increase code size for a security fix.)
+
+## Currently maintained branches
+
+The following branches are currently maintained:
+
+- development (2.x.y releases)
+- Mbed TLS 2.16, maintained until at least the end of 2021, see
+  <https://tls.mbed.org/tech-updates/blog/announcing-lts-branch-mbedtls-2.16>
+- Mbed TLS 2.7 - end of life in March 2021!
+
+Users are urged to always use the latest version of a maintained branch.

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -2,6 +2,9 @@
 
 At any point in time, we have a number of maintained branches consisting of:
 
+- The [`master`](https://github.com/ARMmbed/mbedtls/tree/master) branch:
+  this always contains the latest release, including all publicly available
+  security fixes.
 - The [`development`](https://github.com/ARMmbed/mbedtls/tree/development) branch:
   this is where new features land,
   as well as bug fixes and security fixes.
@@ -9,7 +12,7 @@ At any point in time, we have a number of maintained branches consisting of:
   these only get bug fixes and security fixes.
 
 We use [Semantic Versioning](https://semver.org/). In particular, we maintain
-API compatibility in the development branch between major version changes. We
+API compatibility in the `master` branch between major version changes. We
 also maintain ABI compatibility within LTS branches; see the next section for
 details.
 
@@ -43,6 +46,7 @@ CONTRIBUTING](CONTRIBUTING.md#cackwords-compatibility).
 
 The following branches are currently maintained:
 
+- [master](https://github.com/ARMmbed/mbedtls/tree/master)
 - [`development`](https://github.com/ARMmbed/mbedtls/)
 - [`mbedtls-2.16`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
  maintained until at least the end of 2021, see

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -2,9 +2,11 @@
 
 At any point in time, we have a number of maintained branches consisting of:
 
-- the development branch: this is where new features lands, as well as bug
-  fixes and security fixes
-- one or more LTS branches: these only get bug fixes and security fixes.
+- The [`development`](https://github.com/ARMmbed/mbedtls/tree/development) branch:
+  this is where new features land,
+  as well as bug fixes and security fixes.
+- One or more long-time support (LTS) branches:
+  these only get bug fixes and security fixes.
 
 We use [Semantic Versioning](https://semver.org/). In particular, we maintain
 API compatibility in the development branch between major version changes. We
@@ -13,13 +15,17 @@ details.
 
 ## Backwards Compatibility
 
-If you have code that's working and secure with Mbed TLS x.y.z, then you
-should be able to re-compile it without modification with any later release
-x.y'.z' with the same major version number, and your code will still build, be
-secure, and work - unless it was relying on something that became insecure in
-the meantime (for example, crypto that was found to be weak). In case security
-comes in conflict with backwards compatibility, we will put security first,
-but always attempt to provide a compatibility option.
+We maintain API compatibility in released versions of Mbed TLS. If you have
+code that's working and secure with Mbed TLS x.y.z and does not rely on
+undocumented features, then you should be able to re-compile it without
+modification with any later release x.y'.z' with the same major version
+number, and your code will still build, be secure, and work.
+
+There are rare exceptions: code that was relying on something that became
+insecure in the meantime (for example, crypto that was found to be weak) may
+need to be changed. In case security comes in conflict with backwards
+compatibility, we will put security first, but always attempt to provide a
+compatibility option.
 
 For the LTS branches, additionally we try very hard to also maintain ABI
 compatibility (same definition as API except with re-linking instead of
@@ -37,8 +43,8 @@ CONTRIBUTING](CONTRIBUTING.md#cackwords-compatibility).
 
 The following branches are currently maintained:
 
-- [development](https://github.com/ARMmbed/mbedtls/)
-- [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
+- [`development`](https://github.com/ARMmbed/mbedtls/)
+- [`mbedtls-2.16`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
  maintained until at least the end of 2021, see
   <https://tls.mbed.org/tech-updates/blog/announcing-lts-branch-mbedtls-2.16>
 - [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7) - end of life in March 2021!

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -30,13 +30,17 @@ will put security first but provide a compatibility option. (So far we never
 had to break ABI compatibility in an LTS branch, but we occasionally had to
 increase code size for a security fix.)
 
-## Currently maintained branches
+For contributors, see the [Backwards Compatibility section of
+CONTRIBUTING](CONTRIBUTING.md#cackwords-compatibility).
+
+## Current Branches
 
 The following branches are currently maintained:
 
-- development (2.x.y releases)
-- Mbed TLS 2.16, maintained until at least the end of 2021, see
+- [development](https://github.com/ARMmbed/mbedtls/)
+- [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
+ maintained until at least the end of 2021, see
   <https://tls.mbed.org/tech-updates/blog/announcing-lts-branch-mbedtls-2.16>
-- Mbed TLS 2.7 - end of life in March 2021!
+- [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7) - end of life in March 2021!
 
 Users are urged to always use the latest version of a maintained branch.

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -51,6 +51,5 @@ The following branches are currently maintained:
 - [`mbedtls-2.16`](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.16)
  maintained until at least the end of 2021, see
   <https://tls.mbed.org/tech-updates/blog/announcing-lts-branch-mbedtls-2.16>
-- [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7) - end of life in March 2021!
 
 Users are urged to always use the latest version of a maintained branch.

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,20 @@
+## Known issues
+
+Known issues in Mbed TLS are [tracked on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+
+## Reporting a bug
+
+If you think you've found a bug in Mbed TLS, please follow these steps:
+
+1. Make sure you're using the latest version of a
+   [maintained branch](BRANCHES.md): `master`, `development`,
+   or a long-time support branch.
+2. Check [GitHub](https://github.com/ARMmbed/mbedtls/issues) to see if
+   your issue has already been reported. If not, …
+3. If the issue is a security risk (for example: buffer overflow,
+   data leak), please report it confidentially as described in
+   [`SECURITY.md`](SECURITY.md). If not, …
+4. Please [create an issue on on GitHub](https://github.com/ARMmbed/mbedtls/issues).
+
+Please do not use GitHub for support questions. If you want to know
+how to do something with Mbed TLS, please see [`SUPPORT.md`](SUPPORT.md) for available documentation and support channels.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,10 @@ Making a Contribution
 1. All new files should include the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) standard license header where possible.
 1. Ensure that each commit has at least one `Signed-off-by:` line from the committer. If anyone else contributes to the commit, they should also add their own `Signed-off-by:` line. By adding this line, contributor(s) certify that the contribution is made under the terms of the [Developer Certificate of Origin](dco.txt). The contribution licensing is described in the [License section of the README](README.md#License).
 
-API/ABI Compatibility
----------------------
-The project aims to minimise the impact on users upgrading to newer versions of the library and it should not be necessary for a user to make any changes to their own code to work with a newer version of the library. Unless the user has made an active decision to use newer features, a newer generation of the library or a change has been necessary due to a security issue or other significant software defect, no modifications to their own code should be necessary. To achieve this, API compatibility is maintained between different versions of Mbed TLS on the main development branch and in LTS (Long Term Support) branches.
+Backwards Compatibility
+-----------------------
+
+The project aims to minimise the impact on users upgrading to newer versions of the library and it should not be necessary for a user to make any changes to their own code to work with a newer version of the library. Unless the user has made an active decision to use newer features, a newer generation of the library or a change has been necessary due to a security issue or other significant software defect, no modifications to their own code should be necessary. To achieve this, API compatibility is maintained between different versions of Mbed TLS on the main development branch and in LTS (Long Term Support) branches, as described in [BRANCHES.md](BRANCHES.md).
 
 To minimise such disruption to users, where a change to the interface is required, all changes to the ABI or API, even on the main development branch where new features are added, need to be justifiable by either being a significant enhancement, new feature or bug fix which is best resolved by an interface change.
 
@@ -47,6 +48,9 @@ When backporting to these branches please observe the following rules:
 1. If a contribution is a new feature or enhancement, no backporting is required. Exceptions to this may be additional test cases or quality improvements such as changes to build or test scripts.
 
 It would be highly appreciated if contributions are backported to LTS branches in addition to the [development branch](https://github.com/ARMmbed/mbedtls/tree/development) by contributors.
+
+The list of maintained branches can be found in the [Current Branches section
+of BRANCHES.md](BRANCHES.md#current-branches).
 
 Currently maintained LTS branches are:
 1. [mbedtls-2.7](https://github.com/ARMmbed/mbedtls/tree/mbedtls-2.7)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To generate a local copy of the library documentation in HTML format, tailored t
 1. Run `make apidoc`.
 1. Browse `apidoc/index.html` or `apidoc/modules.html`.
 
+For other sources of documentation, see the [SUPPORT](SUPPORT.md) document.
+
 Compiling
 ---------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+## Reporting Vulneratibilities
+
+If you think you have found an Mbed TLS security vulnerability, then please
+send an email to the security team at
+<mbed-tls-security@lists.trustedfirmware.org>.
+
+## Security Incident Handling Process
+
+Our security process is detailled in our [security
+center](https://developer.trustedfirmware.org/w/mbed-tls/security-center/).
+
+Its primary goal is to ensure fixes are ready to be deployed when the issue
+goes public.
+
+## Maintained branches
+
+Only the maintained branches, as listed in BRANCHES.md, get security fixes.
+Users are urged to always use the latest version of a maintained branch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ send an email to the security team at
 
 ## Security Incident Handling Process
 
-Our security process is detailled in our [security
+Our security process is detailled in our
+[security
 center](https://developer.trustedfirmware.org/w/mbed-tls/security-center/).
 
 Its primary goal is to ensure fixes are ready to be deployed when the issue
@@ -14,5 +15,6 @@ goes public.
 
 ## Maintained branches
 
-Only the maintained branches, as listed in BRANCHES.md, get security fixes.
+Only the maintained branches, as listed in [`BRANCHES.md`](BRANCHES.md),
+get security fixes.
 Users are urged to always use the latest version of a maintained branch.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,8 @@
 
 Here are some useful sources of information about using Mbed TLS:
 
-- API documentation (see `make apidoc` or directly the header files);
+- API documentation, see the [Documentation section of the
+  README](README.md#License);
 - the `docs` directory in the source tree;
 - the [Mbed TLS knowledge Base](https://tls.mbed.org/kb);
 - the [Mbed TLS mailing-list

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+## Documentation
+
+Here are some useful sources of information about using Mbed TLS:
+
+- API documentation (see `make apidoc` or directly the header files);
+- the `docs` directory in the source tree;
+- the [Mbed TLS knowledge Base](https://tls.mbed.org/kb);
+- the [Mbed TLS mailing-list
+  archives](https://lists.trustedfirmware.org/pipermail/mbed-tls/).
+
+## Asking Questions
+
+If you can't find your answer in the above sources, please use the [Mbed TLS
+mailing list](https://lists.trustedfirmware.org/mailman/listinfo/mbed-tls).


### PR DESCRIPTION
## Description

Currently it's a bit hard for a user or contributor coming to the project on github to discover some basic information such as:

- how to report security bugs (is on the tf.org wiki, which itself was not linked anywhere from the source tree)
- what branches are currently maintained

This PR tries to improve the situation by adding a few files with explicit names (some recognized by github) and cross-referencing with existing documents.

Some of this information is version-independent and arguably should be maintained out-of-tree. However I'm adding them here without waiting for our version-independent docs repo to be ready, in the spirit of incremental improvement: I believe this PR is a strict improvement over the status quo and that it does not make future improvements harder. (When the docs repo is ready we can move the content of most files there and have the in-tree file just point at the appropriate place in the docs repo.)

## Status
**READY**

## Requires Backporting

Debatable. In terms for visibility, I think the default branch is the most important, so we might choose to skip backports until the version-independent docs repo is ready, and add pointers to it from the LTS branches only at this point.
