### PR TITLE
Add macro to mark deliberate case fallthrough

### DIFF
--- a/ChangeLog.d/add_fallthrough_macro.txt
+++ b/ChangeLog.d/add_fallthrough_macro.txt
@@ -1,3 +1,2 @@
-Features
-   * Add a macro to mark deliberate fallthrough in a case statement, to stop
-   warnings being generated with newer compilers.
+Changes
+      * Fix the build with Clang ≥10 and -Wimplicit-fallthrough when MBEDTLS_USE_PSA_CRYPTO is enabled.

--- a/ChangeLog.d/add_fallthrough_macro.txt
+++ b/ChangeLog.d/add_fallthrough_macro.txt
@@ -1,0 +1,3 @@
+Features
+   * Add a macro to mark deliberate fallthrough in a case statement, to stop
+   warnings being generated with newer compilers.

--- a/ChangeLog.d/add_fallthrough_macro.txt
+++ b/ChangeLog.d/add_fallthrough_macro.txt
@@ -1,2 +1,3 @@
 Changes
-      * Fix the build with Clang ≥10 and -Wimplicit-fallthrough when MBEDTLS_USE_PSA_CRYPTO is enabled.
+      * Fix the build with Clang ≥10 and -Wimplicit-fallthrough when
+        MBEDTLS_USE_PSA_CRYPTO is enabled.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -206,15 +206,15 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
  * line before the deliberate fallthrough for backward compatibility with
  * compilers that do not support the attribute.
  */
-#if ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ )
+#if defined (__has_attribute)
 #if __has_attribute(fallthrough)
 #define MBEDTLS_FALLTHROUGH __attribute__((fallthrough))
 #else /* __has_attribute(fallthrough) */
 #define MBEDTLS_FALLTHROUGH
 #endif /* __has_attribute(fallthrough) */
-#else /* ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ ) */
+#else /* (__has_attribute) */
 #define MBEDTLS_FALLTHROUGH
-#endif /* ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ ) */
+#endif /* (__has_attribute) */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -187,6 +187,35 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf );
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
+/** Helper to mark a deliberate fallthrough in a case statement.
+ *
+ * Note this will only be defined for compilers that support it,
+ * however with newer versions of GCC and Clang not using this
+ * generates warnings.
+ *
+ * Usage:
+ *
+ * ```
+ *   case MBEDTLS_MD_NONE:
+ *        MBEDTLS_FALLTHROUGH;
+ *        // fallthrough
+ *   default:
+ *       return( 0 );
+ * ```
+ * Note that the 'fallthrough' comment should still be on its own on the
+ * line before the deliberate fallthrough for backward compatibility with
+ * compilers that do not support the attribute.
+ */
+#if ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ )
+#if __has_attribute(fallthrough)
+#define MBEDTLS_FALLTHROUGH __attribute__((fallthrough))
+#else /* __has_attribute(fallthrough) */
+#define MBEDTLS_FALLTHROUGH
+#endif /* __has_attribute(fallthrough) */
+#else /* ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ ) */
+#define MBEDTLS_FALLTHROUGH
+#endif /* ( defined(__GNUC__) && __GNUC__ >= 7 ) || ( defined __clang__ ) */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -34,6 +34,8 @@
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 
+#include "mbedtls/platform_util.h"
+
 #include "psa/crypto.h"
 
 #include "mbedtls/ecp.h"
@@ -93,8 +95,8 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
             if( taglen == 0 )
                 return( PSA_ALG_CBC_NO_PADDING );
             /* Intentional fallthrough for taglen != 0 */
-            /* fallthrough */
             MBEDTLS_FALLTHROUGH;
+            /* fallthrough */
         default:
             return( 0 );
     }
@@ -152,8 +154,9 @@ static inline psa_algorithm_t mbedtls_psa_translate_md( mbedtls_md_type_t md_alg
     case MBEDTLS_MD_RIPEMD160:
         return( PSA_ALG_RIPEMD160 );
 #endif
-    case MBEDTLS_MD_NONE:  /* Intentional fallthrough */
+        case MBEDTLS_MD_NONE:  /* Intentional fallthrough */
         MBEDTLS_FALLTHROUGH;
+        /* fallthrough */
     default:
         return( 0 );
     }

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -94,6 +94,7 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
                 return( PSA_ALG_CBC_NO_PADDING );
             /* Intentional fallthrough for taglen != 0 */
             /* fallthrough */
+            MBEDTLS_FALLTHROUGH;
         default:
             return( 0 );
     }
@@ -152,6 +153,7 @@ static inline psa_algorithm_t mbedtls_psa_translate_md( mbedtls_md_type_t md_alg
         return( PSA_ALG_RIPEMD160 );
 #endif
     case MBEDTLS_MD_NONE:  /* Intentional fallthrough */
+        MBEDTLS_FALLTHROUGH;
     default:
         return( 0 );
     }

--- a/library/common.h
+++ b/library/common.h
@@ -50,4 +50,25 @@
 #define MBEDTLS_STATIC_TESTABLE static
 #endif
 
+/** Helper to mark a deliberate fallthrough in a case statement.
+ *
+ * Note this will only be defined for compilers that support it,
+ * however with newer versions of GCC and Clang not using this
+ * generates warnings.
+ *
+ * Usage:
+ *
+ * ```
+ *   case MBEDTLS_MD_NONE:  // Intentional fallthrough
+ *        MBEDTLS_FALLTHROUGH;
+ *   default:
+ *       return( 0 );
+ * ```
+ */
+#if __has_attribute(fallthrough)
+#define MBEDTLS_FALLTHROUGH __attribute(fallthrough)
+#else
+#define MBEDTLS_FALLTHROUGH
+#endif
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -50,25 +50,4 @@
 #define MBEDTLS_STATIC_TESTABLE static
 #endif
 
-/** Helper to mark a deliberate fallthrough in a case statement.
- *
- * Note this will only be defined for compilers that support it,
- * however with newer versions of GCC and Clang not using this
- * generates warnings.
- *
- * Usage:
- *
- * ```
- *   case MBEDTLS_MD_NONE:  // Intentional fallthrough
- *        MBEDTLS_FALLTHROUGH;
- *   default:
- *       return( 0 );
- * ```
- */
-#if __has_attribute(fallthrough)
-#define MBEDTLS_FALLTHROUGH __attribute(fallthrough)
-#else
-#define MBEDTLS_FALLTHROUGH
-#endif
-
 #endif /* MBEDTLS_LIBRARY_COMMON_H */


### PR DESCRIPTION
## Description
Whilst attempting to run the CF tests via all.sh I was getting compilation failures due to warnings about case dropthrough (Memsan build, clang 11.0.01) so added this PR in order to fix them. The -Wimplicit-fallthrough and -Werror flags have been a part of this build for some time, however this code is new. This is a generally good thing to do anyway.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Changelog updated


## Steps to test or reproduce
Run the CF tests with a newish compiler.
