### PR TITLE
Backport 2.16: Fix stack corruption in mbedtls_net_poll with large file descriptor

### DIFF
--- a/ChangeLog.d/net_poll-fd_setsize.txt
+++ b/ChangeLog.d/net_poll-fd_setsize.txt
@@ -1,0 +1,4 @@
+Security
+   * Fix a stack buffer overflow with mbedtls_net_poll() and
+     mbedtls_net_recv_timeout() when given a file descriptor that is
+     beyond FD_SETSIZE. Reported by FigBug in #4169.

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -182,6 +182,10 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
 /**
  * \brief          Check and wait for the context to be ready for read/write
  *
+ * \note           The current implementation of this function uses
+ *                 select() and returns an error if the file descriptor
+ *                 is beyond \c FD_SETSIZE.
+ *
  * \param ctx      Socket to check
  * \param rw       Bitflag composed of MBEDTLS_NET_POLL_READ and
  *                 MBEDTLS_NET_POLL_WRITE specifying the events
@@ -262,6 +266,10 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  * \brief          Read at most 'len' characters, blocking for at most
  *                 'timeout' seconds. If no error occurs, the actual amount
  *                 read is returned.
+ *
+ * \note           The current implementation of this function uses
+ *                 select() and returns an error if the file descriptor
+ *                 is beyond \c FD_SETSIZE.
  *
  * \param ctx      Socket
  * \param buf      The buffer to write to

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -151,6 +151,7 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  *
  * \return         0 if successful, or one of:
  *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                      MBEDTLS_ERR_NET_UNKNOWN_HOST,
  *                      MBEDTLS_ERR_NET_BIND_FAILED,
  *                      MBEDTLS_ERR_NET_LISTEN_FAILED
  *
@@ -170,6 +171,8 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *                  can be NULL if client_ip is null
  *
  * \return          0 if successful, or
+ *                  MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                  MBEDTLS_ERR_NET_BIND_FAILED,
  *                  MBEDTLS_ERR_NET_ACCEPT_FAILED, or
  *                  MBEDTLS_ERR_NET_BUFFER_TOO_SMALL if buf_size is too small,
  *                  MBEDTLS_ERR_SSL_WANT_READ if bind_fd was set to
@@ -277,10 +280,11 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  * \param timeout  Maximum number of milliseconds to wait for data
  *                 0 means no timeout (wait forever)
  *
- * \return         the number of bytes received,
- *                 or a non-zero error code:
- *                 MBEDTLS_ERR_SSL_TIMEOUT if the operation timed out,
+ * \return         The number of bytes received if successful.
+ *                 MBEDTLS_ERR_SSL_TIMEOUT if the operation timed out.
  *                 MBEDTLS_ERR_SSL_WANT_READ if interrupted by a signal.
+ *                 Another negative error code (MBEDTLS_ERR_NET_xxx)
+ *                 for other failures.
  *
  * \note           This function will block (until data becomes available or
  *                 timeout is reached) even if the socket is set to

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -184,7 +184,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
  *
  * \note           The current implementation of this function uses
  *                 select() and returns an error if the file descriptor
- *                 is beyond \c FD_SETSIZE.
+ *                 is \c FD_SETSIZE or greater.
  *
  * \param ctx      Socket to check
  * \param rw       Bitflag composed of MBEDTLS_NET_POLL_READ and
@@ -269,7 +269,7 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  *
  * \note           The current implementation of this function uses
  *                 select() and returns an error if the file descriptor
- *                 is beyond \c FD_SETSIZE.
+ *                 is \c FD_SETSIZE or greater.
  *
  * \param ctx      Socket
  * \param buf      The buffer to write to

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -497,9 +497,9 @@ int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
     /* A limitation of select() is that it only works with file descriptors
-     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
-     * early, because attempting to call FD_SET on a large file descriptor
-     * is a buffer overflow on typical platforms. */
+     * that are strictly less than FD_SETSIZE. This is a limitation of the
+     * fd_set type. Error out early, because attempting to call FD_SET on a
+     * large file descriptor is a buffer overflow on typical platforms. */
     if( fd >= FD_SETSIZE )
         return( MBEDTLS_ERR_NET_POLL_FAILED );
 
@@ -623,9 +623,9 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf,
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
     /* A limitation of select() is that it only works with file descriptors
-     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
-     * early, because attempting to call FD_SET on a large file descriptor
-     * is a buffer overflow on typical platforms. */
+     * that are strictly less than FD_SETSIZE. This is a limitation of the
+     * fd_set type. Error out early, because attempting to call FD_SET on a
+     * large file descriptor is a buffer overflow on typical platforms. */
     if( fd >= FD_SETSIZE )
         return( MBEDTLS_ERR_NET_POLL_FAILED );
 

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -496,6 +496,13 @@ int mbedtls_net_poll( mbedtls_net_context *ctx, uint32_t rw, uint32_t timeout )
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
+    /* A limitation of select() is that it only works with file descriptors
+     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
+     * early, because attempting to call FD_SET on a large file descriptor
+     * is a buffer overflow on typical platforms. */
+    if( fd >= FD_SETSIZE )
+        return( MBEDTLS_ERR_NET_POLL_FAILED );
+
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
     /* Ensure that memory sanitizers consider read_fds and write_fds as
@@ -614,6 +621,13 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf,
 
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
+
+    /* A limitation of select() is that it only works with file descriptors
+     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
+     * early, because attempting to call FD_SET on a large file descriptor
+     * is a buffer overflow on typical platforms. */
+    if( fd >= FD_SETSIZE )
+        return( MBEDTLS_ERR_NET_POLL_FAILED );
 
     FD_ZERO( &read_fds );
     FD_SET( fd, &read_fds );


### PR DESCRIPTION
Straightforward backport of the bug fix in #4173. I didn't backport the new tests because they're in a new test suite and there's a mild but nonzero concern about the test code's portability.