### PR TITLE
Backport 2.7: Fix stack corruption in mbedtls_net_poll with large file descriptor

### DIFF
--- a/ChangeLog.d/net_poll-fd_setsize.txt
+++ b/ChangeLog.d/net_poll-fd_setsize.txt
@@ -1,0 +1,3 @@
+Security
+   * Fix a stack buffer overflow with mbedtls_net_recv_timeout() when given a
+     file descriptor that is beyond FD_SETSIZE. Reported by FigBug in #4169.

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -130,6 +130,7 @@ int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char 
  *
  * \return         0 if successful, or one of:
  *                      MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                      MBEDTLS_ERR_NET_UNKNOWN_HOST,
  *                      MBEDTLS_ERR_NET_BIND_FAILED,
  *                      MBEDTLS_ERR_NET_LISTEN_FAILED
  *
@@ -149,6 +150,8 @@ int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char 
  *                  can be NULL if client_ip is null
  *
  * \return          0 if successful, or
+ *                  MBEDTLS_ERR_NET_SOCKET_FAILED,
+ *                  MBEDTLS_ERR_NET_BIND_FAILED,
  *                  MBEDTLS_ERR_NET_ACCEPT_FAILED, or
  *                  MBEDTLS_ERR_NET_BUFFER_TOO_SMALL if buf_size is too small,
  *                  MBEDTLS_ERR_SSL_WANT_READ if bind_fd was set to
@@ -229,10 +232,11 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  * \param timeout  Maximum number of milliseconds to wait for data
  *                 0 means no timeout (wait forever)
  *
- * \return         the number of bytes received,
- *                 or a non-zero error code:
- *                 MBEDTLS_ERR_SSL_TIMEOUT if the operation timed out,
+ * \return         The number of bytes received if successful.
+ *                 MBEDTLS_ERR_SSL_TIMEOUT if the operation timed out.
  *                 MBEDTLS_ERR_SSL_WANT_READ if interrupted by a signal.
+ *                 Another negative error code (MBEDTLS_ERR_NET_xxx)
+ *                 for other failures.
  *
  * \note           This function will block (until data becomes available or
  *                 timeout is reached) even if the socket is set to

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -219,6 +219,10 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  *                 'timeout' seconds. If no error occurs, the actual amount
  *                 read is returned.
  *
+ * \note           The current implementation of this function uses
+ *                 select() and returns an error if the file descriptor
+ *                 is beyond \c FD_SETSIZE.
+ *
  * \param ctx      Socket
  * \param buf      The buffer to write to
  * \param len      Maximum length of the buffer

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -221,7 +221,7 @@ int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len );
  *
  * \note           The current implementation of this function uses
  *                 select() and returns an error if the file descriptor
- *                 is beyond \c FD_SETSIZE.
+ *                 is \c FD_SETSIZE or greater.
  *
  * \param ctx      Socket
  * \param buf      The buffer to write to

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -535,6 +535,13 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
+    /* A limitation of select() is that it only works with file descriptors
+     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
+     * early, because attempting to call FD_SET on a large file descriptor
+     * is a buffer overflow on typical platforms. */
+    if( fd >= FD_SETSIZE )
+        return( MBEDTLS_ERR_NET_RECV_FAILED );
+
     FD_ZERO( &read_fds );
     FD_SET( fd, &read_fds );
 

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -536,9 +536,9 @@ int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
     /* A limitation of select() is that it only works with file descriptors
-     * up to FD_SETSIZE. This is a limitation of the fd_set type. Error out
-     * early, because attempting to call FD_SET on a large file descriptor
-     * is a buffer overflow on typical platforms. */
+     * that are strictly less than FD_SETSIZE. This is a limitation of the
+     * fd_set type. Error out early, because attempting to call FD_SET on a
+     * large file descriptor is a buffer overflow on typical platforms. */
     if( fd >= FD_SETSIZE )
         return( MBEDTLS_ERR_NET_RECV_FAILED );
 


### PR DESCRIPTION
Partial backport of the bug fix in #4173: 2.7 doesn't have `mbedtls_net_poll`, but it has `mbedtls_net_recv_timeout` which has the same bug. As with 2.16, I didn't backport the new tests because they're in a new test suite and there's a mild but nonzero concern about the test code's portability.