### PR TITLE
Update return code for various key operations

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1363,7 +1363,7 @@ static psa_status_t psa_validate_key_attributes(
     if( status != PSA_SUCCESS )
         return( status );
 
-    status = psa_validate_key_persistence( lifetime );
+    status = psa_validate_key_persistence( lifetime, key );
     if( status != PSA_SUCCESS )
         return( status );
 
@@ -1907,6 +1907,11 @@ psa_status_t psa_copy_key( mbedtls_svc_key_id_t source_key,
 exit:
     if( status != PSA_SUCCESS )
         psa_fail_key_creation( target_slot, driver );
+
+    /* Return invalid handle as per PSA API 1.0.0 if trying to copy persistent
+     * key which do not exist. */
+    if( status == PSA_ERROR_DOES_NOT_EXIST )
+        status = PSA_ERROR_INVALID_HANDLE;
 
     unlock_status = psa_unlock_key_slot( source_slot );
 
@@ -3364,6 +3369,11 @@ psa_status_t psa_sign_hash( mbedtls_svc_key_id_t key,
     status = psa_get_and_lock_key_slot_with_policy( key, &slot,
                                                     PSA_KEY_USAGE_SIGN_HASH,
                                                     alg );
+    /* Return invalid handle as per PSA API 1.0.0 if trying to copy persistent
+     * key which do not exist. */
+    if( status == PSA_ERROR_DOES_NOT_EXIST )
+        status = PSA_ERROR_INVALID_HANDLE;
+
     if( status != PSA_SUCCESS )
         goto exit;
     if( ! PSA_KEY_TYPE_IS_KEY_PAIR( slot->attr.type ) )

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -371,7 +371,8 @@ psa_status_t psa_validate_key_location( psa_key_lifetime_t lifetime,
         return( PSA_SUCCESS );
 }
 
-psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime )
+psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime,
+                                           mbedtls_svc_key_id_t key_id )
 {
     if ( PSA_KEY_LIFETIME_IS_VOLATILE( lifetime ) )
     {
@@ -382,8 +383,13 @@ psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime )
     {
         /* Persistent keys require storage support */
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
-        return( PSA_SUCCESS );
+        if( PSA_SUCCESS == psa_validate_key_id( key_id,
+                                 psa_key_lifetime_is_external( lifetime ) ) )
+            return( PSA_SUCCESS );
+        else
+            return( PSA_ERROR_INVALID_ARGUMENT );
 #else /* MBEDTLS_PSA_CRYPTO_STORAGE_C */
+        (void) key_id;
         return( PSA_ERROR_NOT_SUPPORTED );
 #endif /* !MBEDTLS_PSA_CRYPTO_STORAGE_C */
     }

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -203,12 +203,16 @@ psa_status_t psa_validate_key_location( psa_key_lifetime_t lifetime,
 /** Validate the persistence of a key.
  *
  * \param[in] lifetime  The key lifetime attribute.
+ * \param[in] key_id    The key identifier.
  *
  * \retval #PSA_SUCCESS
+ * \retval #PSA_ERROR_INVALID_HANDLE
+ *         \p key_id is not a valid key identifier.
  * \retval #PSA_ERROR_INVALID_ARGUMENT The key is persistent but persistent
  *         keys are not supported.
  */
-psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime );
+psa_status_t psa_validate_key_persistence( psa_key_lifetime_t lifetime,
+                                           mbedtls_svc_key_id_t key_id );
 
 /** Validate a key identifier.
  *


### PR DESCRIPTION
Update psa_destroy_key and other key operations to return
PSA_ERROR_INVALID_HANDLE where appropriate, rather than
PSA_ERROR_DOES_NOT_EXIST.

Fixes #4162 

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>
