### PR TITLE
Backport 2.7: Fix an incorrect error code if RSA private operation glitched

### DIFF
--- a/ChangeLog.d/rsa_private-ret.txt
+++ b/ChangeLog.d/rsa_private-ret.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix an incorrect error code if an RSA private operation glitched.

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1045,10 +1045,10 @@ cleanup:
     mbedtls_mpi_free( &C );
     mbedtls_mpi_free( &I );
 
-    if( ret != 0 )
+    if( ret != 0 && ret >= -0x007f )
         return( MBEDTLS_ERR_RSA_PRIVATE_FAILED + ret );
 
-    return( 0 );
+    return( ret );
 }
 
 #if defined(MBEDTLS_PKCS1_V21)


### PR DESCRIPTION
mbedtls_rsa_private() could return the sum of two RSA error codes
instead of a valid error code in some rare circumstances:

* If rsa_prepare_blinding() returned  MBEDTLS_ERR_RSA_RNG_FAILED
  (indicating a misbehaving or misconfigured RNG).
* If the comparison with the public value failed (typically indicating
  a glitch attack).

Make sure not to add two high-level error codes.

Signed-off-by: Gilles Peskine <Gilles.Peskine@arm.com>

This is a backport of #3988