### PR TITLE
Make assemble changelog script enforce line length

### DIFF
--- a/ChangeLog.d/make_assemble_changelog_enforce_line_length.txt
+++ b/ChangeLog.d/make_assemble_changelog_enforce_line_length.txt
@@ -1,2 +1,0 @@
-Changes
-   * Make assemble_changelog.py script enforce 80 character line limit

--- a/ChangeLog.d/make_assemble_changelog_enforce_line_length.txt
+++ b/ChangeLog.d/make_assemble_changelog_enforce_line_length.txt
@@ -1,0 +1,2 @@
+Changes
+   * Make assemble_changelog.py script enforce 80 character line limit

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -219,12 +219,14 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
+            line_number = 1
             for line in body_split:
                 if len(line) > MAX_LINE_LENGTH:
                     raise InputFormatError(filename,
-                                           line_offset + category.title_line,
-                                           'Category body line too long: "{} ({})"',
-                                           category.name.decode('utf8'), len(line))
+                                           line_offset + category.title_line + line_number,
+                                           'Line is longer than allowed: Length {} (Max {})',
+                                           len(line), MAX_LINE_LENGTH)
+                line_number += 1
 
             self.categories[category.name] += category.body
 

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -74,6 +74,9 @@ STANDARD_CATEGORIES = (
     b'Changes',
 )
 
+# The maximum line length for an entry
+MAX_LINE_LENGTH = 80
+
 CategoryContent = namedtuple('CategoryContent', [
     'name', 'title_line', # Title text and line number of the title
     'body', 'body_line', # Body text and starting line number of the body
@@ -214,6 +217,15 @@ class ChangeLog:
                                        line_offset + category.title_line,
                                        'Unknown category: "{}"',
                                        category.name.decode('utf8'))
+
+            body_split = category.body.splitlines()
+            for line in body_split:
+                if len(line) > MAX_LINE_LENGTH:
+                    raise InputFormatError(filename,
+                                           line_offset + category.title_line,
+                                           'Category body line too long: "{} ({})"',
+                                           category.name.decode('utf8'), len(line))
+
             self.categories[category.name] += category.body
 
     def __init__(self, input_stream, changelog_format):

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -219,14 +219,12 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
-            line_number = 1
-            for line in body_split:
+            for line_number, line in enumerate(body_split, 1):
                 if len(line) > MAX_LINE_LENGTH:
                     raise InputFormatError(filename,
-                                           line_offset + category.title_line + line_number,
+                                           category.body_line + line_number,
                                            'Line is longer than allowed: Length {} (Max {})',
                                            len(line), MAX_LINE_LENGTH)
-                line_number += 1
 
             self.categories[category.name] += category.body
 


### PR DESCRIPTION
## Description

As I descovered the hard way, a changelog entry with a line length greater than 80 characters would still pass CI, although technically being invalid. This is a quick change to the script to make it detect these descrepancies and fail them.

## Status
**READY**

## Requires Backporting
YES

## Migrations
NO

## Todos
- [x] Tests
- [ ] Backports done

## Steps to test or reproduce
scripts/assemble_changelog.py should now enforce the 80 character line length limit
