### PR TITLE
Fix memsan build with Clang 11

### DIFF
--- a/ChangeLog.d/fix_memsan_build_clang11.txt
+++ b/ChangeLog.d/fix_memsan_build_clang11.txt
@@ -1,0 +1,2 @@
+Changes
+   * Fix memsan build false positive in x509_crt.c with clang 11

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1629,6 +1629,8 @@ cleanup:
     }
 #endif /* MBEDTLS_THREADING_C */
 
+    memset( &sb, 0, sizeof( sb ) );
+
     while( ( entry = readdir( dir ) ) != NULL )
     {
         snp_ret = mbedtls_snprintf( entry_name, sizeof entry_name,


### PR DESCRIPTION
## Description

X509_crt.c, line 1616
```
    struct stat sb;

...

    while( ( entry = readdir( dir ) ) != NULL )
    {
        snp_ret = mbedtls_snprintf( entry_name, sizeof entry_name,
                                    "%s/%s", path, entry->d_name );

        if( snp_ret < 0 || (size_t)snp_ret >= sizeof entry_name )
        {
            ret = MBEDTLS_ERR_X509_BUFFER_TOO_SMALL;
            goto cleanup;
        }
        else if( stat( entry_name, &sb ) == -1 )
        {
            ret = MBEDTLS_ERR_X509_FILE_IO_ERROR;
            goto cleanup;
        }

        if( !S_ISREG( sb.st_mode ) )
            continue;
```
With Clang 11 The above use of S_ISREG is marked as acting on uninitialised data. 

The man page says:

> Unless otherwise specified, the structure members st_mode, st_ino, st_dev, st_uid, st_gid, st_atime, st_ctime, and st_mtime shall have meaningful values for all file types defined in this volume of IEEE Std 1003.1-2001. The value of the member st_nlink shall be set to the number of links to the file.

So according to that the _stat call should definitely be initialising st_mode part of sb, and this is a false positive.

Therefore adding a quick memset to pacify memsan.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Changelog updated

## Steps to test or reproduce
Run the all.sh memsan tests with Clang 11
