### PR TITLE
Fix build of 2.7 with MBEDTLS_CERTS_C disabled in config (fixes #4206)

### DIFF
--- a/ChangeLog.d/build-without-certs.txt
+++ b/ChangeLog.d/build-without-certs.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build of sample programs when MBEDTLS_PEM_C is enabled but
+     MBEDTLS_CERTS_C is disabled. Reported by Michael Schuster in #4206.

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1145,8 +1145,8 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "MBEDTLS_CERTS_C not defined." );
 #else
         mbedtls_printf( "All test CRTs loaded via MBEDTLS_CERTS_C are PEM-encoded, but MBEDTLS_PEM_PARSE_C is disabled." );
-    }
 #endif /* MBEDTLS_CERTS_C */
+    }
 #endif /* MBEDTLS_CERTS_C && MBEDTLS_PEM_PARSE_C */
     if( ret < 0 )
     {
@@ -1182,8 +1182,8 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "MBEDTLS_CERTS_C not defined." );
 #else
         mbedtls_printf( "All test CRTs loaded via MBEDTLS_CERTS_C are PEM-encoded, but MBEDTLS_PEM_PARSE_C is disabled." );
-    }
 #endif /* MBEDTLS_CERTS_C */
+    }
 #endif /* MBEDTLS_CERTS_C && MBEDTLS_PEM_PARSE_C */
     if( ret != 0 )
     {
@@ -1209,8 +1209,8 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "MBEDTLS_CERTS_C not defined." );
 #else
         mbedtls_printf( "All test keys loaded via MBEDTLS_CERTS_C are PEM-encoded, but MBEDTLS_PEM_PARSE_C is disabled." );
-    }
 #endif /* MBEDTLS_CERTS_C */
+    }
 #endif /* MBEDTLS_CERTS_C && MBEDTLS_PEM_PARSE_C */
     if( ret != 0 )
     {

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1658,8 +1658,8 @@ int main( int argc, char *argv[] )
         mbedtls_printf( "MBEDTLS_CERTS_C not defined." );
 #else
         mbedtls_printf( "All test CRTs loaded via MBEDTLS_CERTS_C are PEM-encoded, but MBEDTLS_PEM_PARSE_C is disabled." );
-    }
 #endif /* MBEDTLS_CERTS_C */
+    }
 #endif /* MBEDTLS_CERTS_C && MBEDTLS_PEM_PARSE_C */
     if( ret < 0 )
     {


### PR DESCRIPTION
Fixes #4206

## Description

Build of the 2.7 branch fails when MBEDTLS_CERTS_C is disabled.

This only happens with the 2.7 LTS versions. Not affected: 2.16.6 LTS, 2.25.0, development and master, as far as I tested.

Reason: Caused by wrongfully placed closing brackets between #ifdef's, copy & paste hell unleashed ;-)

Origin: The bug was introduced in PR #2498


## Status
**READY**

## Requires Backporting
NO / This problem only applies to the `mbedtls-2.7` branch.

## Migrations
NO
