### PR TITLE
Remove deliberate fallthrough

### DIFF
--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -92,8 +92,8 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
         case MBEDTLS_MODE_CBC:
             if( taglen == 0 )
                 return( PSA_ALG_CBC_NO_PADDING );
-            /* Intentional fallthrough for taglen != 0 */
-            /* fallthrough */
+            else
+                return( 0 );
         default:
             return( 0 );
     }
@@ -151,7 +151,8 @@ static inline psa_algorithm_t mbedtls_psa_translate_md( mbedtls_md_type_t md_alg
     case MBEDTLS_MD_RIPEMD160:
         return( PSA_ALG_RIPEMD160 );
 #endif
-    case MBEDTLS_MD_NONE:  /* Intentional fallthrough */
+    case MBEDTLS_MD_NONE:
+        return( 0 );
     default:
         return( 0 );
     }


### PR DESCRIPTION
## Description

Clang 11 has stopped using the old comment system (/* fallthrough */ on the line before) to mark deliberate fallthrough, and now demands marking of such with  __attribute(fallthrough). Given not every compiler supports such attributes and these are the only two deliberate fallthrough cases in the project at the minute, take the easy route and just remove the fallthrough.

## Status
**READY**

## Requires Backporting
No: the affected files are not present in any LTS.

## Migrations
NO

## Todos
- [x] Tests
- [ ] Backported


## Steps to test or reproduce
Build PSA enabled build with clang 11
