### PR TITLE
Fix revert of PSA_AEAD_UPDATE_OUTPUT_SIZE

### DIFF
--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -398,7 +398,7 @@
 #define PSA_AEAD_UPDATE_OUTPUT_SIZE(alg, input_length)                              \
     (PSA_ALG_IS_AEAD_ON_BLOCK_CIPHER(alg) ?                                         \
      PSA_ROUND_UP_TO_MULTIPLE(PSA_BLOCK_CIPHER_BLOCK_MAX_SIZE, (input_length)) :    \
-     (input_length)) :                                                              \
+     (input_length))
 
 /** A sufficient output buffer size for psa_aead_update(), for any of the
  *  supported key types and AEAD algorithms.


### PR DESCRIPTION
## Description
Both the original change, and its incomplete revert were introduced in #3386.

## Status
**READY**

## Requires Backporting
No, PSA only.

## Migrations
No