### PR TITLE
Add support of 128 bit keys to 3DES CMAC

### DIFF
--- a/library/cmac.c
+++ b/library/cmac.c
@@ -204,6 +204,7 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
         case MBEDTLS_CIPHER_AES_192_ECB:
         case MBEDTLS_CIPHER_AES_256_ECB:
         case MBEDTLS_CIPHER_DES_EDE3_ECB:
+        case MBEDTLS_CIPHER_DES_EDE_ECB:
             break;
         default:
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );


### PR DESCRIPTION
I asked this question awhile ago
https://github.com/ARMmbed/mbedtls/issues/4195

I checked the handling of 128 bit keys in mbedTLS part of OP-TEE and it turned out that the fix is actually trivial.
I'm about to add the same (almost) code to OP-TEE and I think that it might also make sense to add it to the original mbedTLS.

With this tiny change one can use 
```
cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_DES_EDE_ECB);
ret = mbedtls_cipher_cmac_starts(&ctx, mac_des3_cmac_vect6_key_128, 128);
```
with 128 bit key and get the same result as with
```
cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_DES_EDE3_ECB);
ret = mbedtls_cipher_cmac_starts(&ctx, mac_des3_cmac_vect6_key_192, 192);
```
without having to copy K1 to K3 (extending 128 bit key to 192 bits)

Simple test run 

```
====================================
3DES CMAC test using 128 bit key and MBEDTLS_CIPHER_DES_EDE_ECB:
====================================
Key (128 bits):
61 c4 ec 20 70 e9 bf 2a 
ec 02 d0 b0 e9 9e 8f 01 

Input data:
ff bd 75 61 93 91 88 bc 
Output:
55 a0 4c 23 d5 b4 3e 49 
====================================
3DES CMAC test using 192 bit key and MBEDTLS_CIPHER_DES_EDE3_ECB:
====================================
Key (192 bits):
61 c4 ec 20 70 e9 bf 2a 
ec 02 d0 b0 e9 9e 8f 01 
61 c4 ec 20 70 e9 bf 2a 

Input data:
ff bd 75 61 93 91 88 bc 
Output:
55 a0 4c 23 d5 b4 3e 49 
```
