### PR TITLE
Allow changelog entries to have URLs exceeding 80 char limit.

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -201,8 +201,6 @@ class ChangeLog:
     # a version that is not yet released. Something like "3.1a" is accepted.
     _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
     _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
-    _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
-    _has_url_re = re.compile(br'.*://.*')
 
     def add_categories_from_text(self, filename, line_offset,
                                  text, allow_unknown_category):
@@ -221,12 +219,14 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
+            _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
+            _has_url_re = re.compile(br'.*://.*')
             for line_number, line in enumerate(body_split, 1):
-                if not self.__class__._only_url_re.match(line) and \
+                if not _only_url_re.match(line) and \
                    len(line) > MAX_LINE_LENGTH:
                     long_url_msg = '. URL exceeding length limit must be ' \
-                        'alone in it\'s line.' if \
-                        self.__class__._has_url_re.match(line) else ""
+                        'alone in it\'s line.' if _has_url_re.match(line)  \
+                        else ""
                     raise InputFormatError(filename,
                                            category.body_line + line_number,
                                            'Line is longer than allowed: '

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -225,9 +225,8 @@ class ChangeLog:
             for line_number, line in enumerate(body_split, 1):
                 if not self._only_url_re.match(line) and \
                    len(line) > MAX_LINE_LENGTH:
-                    long_url_msg = '. URL exceeding length limit must be ' \
-                        'alone in it\'s line.' if self._has_url_re.match(line)  \
-                        else ""
+                    long_url_msg = '. URL exceeding length limit must be alone in its line.' \
+                        if self._has_url_re.match(line) else ""
                     raise InputFormatError(filename,
                                            category.body_line + line_number,
                                            'Line is longer than allowed: '

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -201,6 +201,8 @@ class ChangeLog:
     # a version that is not yet released. Something like "3.1a" is accepted.
     _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
     _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
+    _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
+    _has_url_re = re.compile(br'.*://.*')
 
     def add_categories_from_text(self, filename, line_offset,
                                  text, allow_unknown_category):
@@ -219,13 +221,12 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
-            _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
-            _has_url_re = re.compile(br'.*://.*')
+
             for line_number, line in enumerate(body_split, 1):
-                if not _only_url_re.match(line) and \
+                if not self._only_url_re.match(line) and \
                    len(line) > MAX_LINE_LENGTH:
                     long_url_msg = '. URL exceeding length limit must be ' \
-                        'alone in it\'s line.' if _has_url_re.match(line)  \
+                        'alone in it\'s line.' if self._has_url_re.match(line)  \
                         else ""
                     raise InputFormatError(filename,
                                            category.body_line + line_number,

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -219,8 +219,9 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
+            re_has_url = re.compile('.*http[s]?://.*')
             for line_number, line in enumerate(body_split, 1):
-                if not re.match('.*http[s]?://.*', line.decode('utf-8')) and \
+                if not re_has_url.match(line.decode('utf-8')) and \
                    len(line) > MAX_LINE_LENGTH:
                     raise InputFormatError(filename,
                                            category.body_line + line_number,

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -220,7 +220,8 @@ class ChangeLog:
 
             body_split = category.body.splitlines()
             for line_number, line in enumerate(body_split, 1):
-                if len(line) > MAX_LINE_LENGTH:
+                if not re.match('.*http[s]?://.*', line.decode('utf-8')) and \
+                   len(line) > MAX_LINE_LENGTH:
                     raise InputFormatError(filename,
                                            category.body_line + line_number,
                                            'Line is longer than allowed: Length {} (Max {})',

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -201,6 +201,8 @@ class ChangeLog:
     # a version that is not yet released. Something like "3.1a" is accepted.
     _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
     _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
+    _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
+    _has_url_re = re.compile(br'.*://.*')
 
     def add_categories_from_text(self, filename, line_offset,
                                  text, allow_unknown_category):
@@ -219,14 +221,18 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
-            re_has_url = re.compile('.*http[s]?://.*')
             for line_number, line in enumerate(body_split, 1):
-                if not re_has_url.match(line.decode('utf-8')) and \
+                if not self.__class__._only_url_re.match(line) and \
                    len(line) > MAX_LINE_LENGTH:
+                    long_url_msg = '. URL exceeding length limit must be ' \
+                        'alone in it\'s line.' if \
+                        self.__class__._has_url_re.match(line) else ""
                     raise InputFormatError(filename,
                                            category.body_line + line_number,
-                                           'Line is longer than allowed: Length {} (Max {})',
-                                           len(line), MAX_LINE_LENGTH)
+                                           'Line is longer than allowed: '
+                                           'Length {} (Max {}){}',
+                                           len(line), MAX_LINE_LENGTH,
+                                           long_url_msg)
 
             self.categories[category.name] += category.body
 


### PR DESCRIPTION
Sometimes it's useful to use a URL in the changelog entry. However - splitting the URL into multiple lines would force
the user to "recreate" the URL instead of simply following the hyper-link.
It is common for the URL to be longer the 80 characters.

This PR adds an exception from the 80 char limit for URLs.