### PR TITLE
Capitalise MPS trace macros

### DIFF
--- a/library/mps_common.h
+++ b/library/mps_common.h
@@ -104,7 +104,7 @@
     {                                                                          \
         if( !(cond) )                                                          \
         {                                                                      \
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_error, string );              \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );         \
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_OPERATION_UNEXPECTED );  \
         }                                                                      \
     } while( 0 )
@@ -126,7 +126,7 @@
     {                                                                   \
         if( !(cond) )                                                   \
         {                                                               \
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_error, string );       \
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR, string );  \
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_INTERNAL_ERROR ); \
         }                                                               \
     } while( 0 )

--- a/library/mps_reader.c
+++ b/library/mps_reader.c
@@ -146,7 +146,7 @@ int mbedtls_mps_reader_init( mbedtls_mps_reader *rd,
                              mbedtls_mps_size_t acc_len )
 {
     MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_init" );
-    MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "* Accumulator size: %u bytes", (unsigned) acc_len );
     mps_reader_zero( rd );
     rd->acc = acc;
@@ -167,7 +167,7 @@ int mbedtls_mps_reader_feed( mbedtls_mps_reader *rd,
 {
     mbedtls_mps_size_t copy_to_acc;
     MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_feed" );
-    MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "* Fragment length: %u bytes", (unsigned) new_frag_len );
 
     if( new_frag == NULL )
@@ -192,7 +192,7 @@ int mbedtls_mps_reader_feed( mbedtls_mps_reader *rd,
         /* Copy new contents to accumulator. */
         memcpy( acc, new_frag, copy_to_acc );
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                 "Copy new data of size %u of %u into accumulator at offset %u",
                 (unsigned) copy_to_acc, (unsigned) new_frag_len, (unsigned) acc_available );
 
@@ -209,7 +209,7 @@ int mbedtls_mps_reader_feed( mbedtls_mps_reader *rd,
 
         /* We have filled the accumulator: Move to consuming mode. */
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "Enough data available to serve user request" );
 
         /* Remember overlap of accumulator and fragment. */
@@ -238,7 +238,7 @@ int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
     unsigned char *frag;
     mbedtls_mps_size_t frag_len, frag_offset, end, frag_fetched, frag_remaining;
     MBEDTLS_MPS_TRACE_INIT( "mbedtls_mps_reader_get" );
-    MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "* Bytes requested: %u", (unsigned) desired );
 
     MBEDTLS_MPS_STATE_VALIDATE_RAW( mps_reader_is_consuming( rd ),
@@ -315,7 +315,7 @@ int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
 
         unsigned char *acc;
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "Serve the request from the accumulator" );
         if( frag_offset - end < desired )
         {
@@ -353,7 +353,7 @@ int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
     }
 
     /* Attempt to serve the request from the current fragment */
-    MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Serve the request from the current fragment." );
 
     frag_len = rd->frag_len;
@@ -365,7 +365,7 @@ int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
     /* Check if we can serve the read request from the fragment. */
     if( frag_remaining < desired )
     {
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "There's not enough data in the current fragment "
                            "to serve the request." );
         /* There's not enough data in the current fragment,
@@ -375,7 +375,7 @@ int mbedtls_mps_reader_get( mbedtls_mps_reader *rd,
             if( frag_remaining > 0 )
             {
                 rd->pending = desired - frag_remaining;
-                MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+                MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Remember to collect %u bytes before re-opening",
                        (unsigned) rd->pending );
             }
@@ -438,13 +438,13 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
 
     if( pending == 0 )
     {
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "No unsatisfied read-request has been logged." );
 
         /* Check if there's data left to be consumed. */
         if( commit < frag_offset || commit - frag_offset < frag_len )
         {
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                                "There is data left to be consumed." );
             rd->end = commit;
             MBEDTLS_MPS_TRACE_RETURN( MBEDTLS_ERR_MPS_READER_DATA_LEFT );
@@ -453,7 +453,7 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
         rd->acc_available = 0;
         rd->acc_share.acc_remaining = 0;
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                            "Fragment has been fully processed and committed." );
     }
     else
@@ -468,13 +468,13 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
         mbedtls_mps_size_t backup_len;
         mbedtls_mps_size_t acc_len_needed;
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                "There has been an unsatisfied read with %u bytes overhead.",
                (unsigned) pending );
 
         if( acc == NULL )
         {
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                                "No accumulator present" );
             MBEDTLS_MPS_TRACE_RETURN(
                 MBEDTLS_ERR_MPS_READER_NEED_ACCUMULATOR );
@@ -514,11 +514,11 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
              * since the last commit. */
             rd->end = commit;
             rd->pending = 0;
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                                "The accumulator is too small to handle the backup." );
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                                "* Size: %u", (unsigned) acc_len );
-            MBEDTLS_MPS_TRACE( mbedtls_mps_trace_error,
+            MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_ERROR,
                                "* Needed: %u (%u + %u)",
                                (unsigned) acc_len_needed,
                                (unsigned) backup_len, (unsigned) pending );
@@ -526,9 +526,9 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
                 MBEDTLS_ERR_MPS_READER_ACCUMULATOR_TOO_SMALL );
         }
 
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                          "Fragment backup: %u", (unsigned) frag_backup_len );
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                          "Accumulator backup: %u", (unsigned) acc_backup_len );
 
         /* Move uncommitted parts from the accumulator to the front
@@ -554,7 +554,7 @@ int mbedtls_mps_reader_reclaim( mbedtls_mps_reader *rd,
     rd->end     = 0;
     rd->pending = 0;
 
-    MBEDTLS_MPS_TRACE( mbedtls_mps_trace_comment,
+    MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_COMMENT,
                        "Final state: aa %u, al %u, ar %u",
                        (unsigned) rd->acc_available, (unsigned) rd->acc_len,
                        (unsigned) rd->acc_share.acc_remaining );

--- a/library/mps_trace.c
+++ b/library/mps_trace.c
@@ -102,19 +102,19 @@ void mbedtls_mps_trace_indent( int level, mbedtls_mps_trace_type ty )
 
     switch( ty )
     {
-        case mbedtls_mps_trace_comment:
+        case MBEDTLS_MPS_TRACE_TYPE_COMMENT:
             mbedtls_printf( "@ " );
             break;
 
-        case mbedtls_mps_trace_call:
+        case MBEDTLS_MPS_TRACE_TYPE_CALL:
             mbedtls_printf( "+--> " );
             break;
 
-        case mbedtls_mps_trace_error:
+        case MBEDTLS_MPS_TRACE_TYPE_ERROR:
             mbedtls_printf( "E " );
             break;
 
-        case mbedtls_mps_trace_return:
+        case MBEDTLS_MPS_TRACE_TYPE_RETURN:
             mbedtls_printf( "< " );
             break;
 

--- a/library/mps_trace.h
+++ b/library/mps_trace.h
@@ -60,10 +60,10 @@
 
 typedef enum
 {
-    mbedtls_mps_trace_comment,
-    mbedtls_mps_trace_call,
-    mbedtls_mps_trace_error,
-    mbedtls_mps_trace_return
+    MBEDTLS_MPS_TRACE_TYPE_COMMENT,
+    MBEDTLS_MPS_TRACE_TYPE_CALL,
+    MBEDTLS_MPS_TRACE_TYPE_ERROR,
+    MBEDTLS_MPS_TRACE_TYPE_RETURN
 } mbedtls_mps_trace_type;
 
 #define MBEDTLS_MPS_TRACE_BIT_LAYER_1 1
@@ -141,7 +141,7 @@ void mbedtls_mps_trace_print_msg( int id, int line, const char *format, ... );
     do {                                                                      \
         if( ! ( MBEDTLS_MPS_TRACE_MASK & ( 1u << mbedtls_mps_trace_id ) ) )   \
             break;                                                            \
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_call, __VA_ARGS__ );             \
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_CALL, __VA_ARGS__ );        \
         mbedtls_mps_trace_inc_depth();                                        \
     } while( 0 )
 
@@ -149,7 +149,7 @@ void mbedtls_mps_trace_print_msg( int id, int line, const char *format, ... );
     do {                                                                    \
         if( ! ( MBEDTLS_MPS_TRACE_MASK & ( 1u << mbedtls_mps_trace_id ) ) ) \
             break;                                                          \
-        MBEDTLS_MPS_TRACE( mbedtls_mps_trace_return, "%d (-%#04x)",         \
+        MBEDTLS_MPS_TRACE( MBEDTLS_MPS_TRACE_TYPE_RETURN, "%d (-%#04x)",    \
                (int) (val), -((unsigned)(val)) );                           \
         mbedtls_mps_trace_dec_depth();                                      \
     } while( 0 )

--- a/tests/scripts/list-enum-consts.pl
+++ b/tests/scripts/list-enum-consts.pl
@@ -26,7 +26,7 @@ use open qw(:std utf8);
 @ARGV = grep { ! /compat-1\.3\.h/ } <include/mbedtls/*.h>;
 push @ARGV, "3rdparty/everest/include/everest/everest.h";
 push @ARGV, "3rdparty/everest/include/everest/x25519.h";
-
+push @ARGV, glob("library/*.h");
 
 my @consts;
 my $state = 'out';


### PR DESCRIPTION
Capitalise the MPS trace macros, as per the coding style (and make a slight
change to naming convention to avoid a name collision).

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>


## Status
**IN DEVELOPMENT**

## Requires Backporting
NO  

## Migrations
NO