### PR TITLE
Forwardport 3.0: Make check-names.sh accept FreeBSD grep

### DIFF
--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -28,11 +28,6 @@ EOF
     exit
 fi
 
-if grep --version|head -n1|grep GNU >/dev/null; then :; else
-    echo "This script requires GNU grep.">&2
-    exit 1
-fi
-
 trace=
 if [ $# -ne 0 ] && [ "$1" = "-v" ]; then
   shift


### PR DESCRIPTION
check-names.sh works fine with the version of FreeBSD grep used on OS X,
so permit this to be used.

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>