### PR TITLE
Backport 2.16: Make check-names.sh accept any grep

### DIFF
--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -55,11 +55,6 @@ EOF
     exit
 fi
 
-if grep --version|head -n1|grep GNU >/dev/null; then :; else
-    echo "This script requires GNU grep.">&2
-    exit 1
-fi
-
 trace=
 if [ $# -ne 0 ] && [ "$1" = "-v" ]; then
   shift


### PR DESCRIPTION
check-names.sh works fine with GNU and with modern FreeBSD grep
so remove the check for GNU grep.

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>

Backport of #4308.
