### PR TITLE
Implement one-shot MAC

### DIFF
--- a/ChangeLog.d/one-shot-mac.txt
+++ b/ChangeLog.d/one-shot-mac.txt
@@ -1,0 +1,3 @@
+Features
+   * Implement psa_mac_compute() and psa_mac_verify() as defined in the
+     PSA Cryptograpy API 1.0.0 specification.

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2444,7 +2444,68 @@ cleanup:
     return( status == PSA_SUCCESS ? abort_status : status );
 }
 
+psa_status_t psa_mac_compute( mbedtls_svc_key_id_t key,
+                              psa_algorithm_t alg,
+                              const uint8_t *input,
+                              size_t input_length,
+                              uint8_t *mac,
+                              size_t mac_size,
+                              size_t *mac_length)
+{
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
 
+    status = psa_mac_sign_setup( &operation, key, alg );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+    status = psa_mac_update( &operation, input, input_length );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+    status = psa_mac_sign_finish( &operation, mac, mac_size, mac_length );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+exit:
+    if ( status == PSA_SUCCESS )
+        status = psa_mac_abort( &operation );
+    else
+        psa_mac_abort( &operation );
+
+    return ( status );
+}
+
+psa_status_t psa_mac_verify( mbedtls_svc_key_id_t key,
+                             psa_algorithm_t alg,
+                             const uint8_t *input,
+                             size_t input_length,
+                             const uint8_t *mac,
+                             size_t mac_length)
+{
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+
+    status = psa_mac_verify_setup( &operation, key, alg );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+    status = psa_mac_update( &operation, input, input_length );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+    status = psa_mac_verify_finish( &operation, mac, mac_length );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+exit:
+    if ( status == PSA_SUCCESS )
+        status = psa_mac_abort( &operation );
+    else
+        psa_mac_abort( &operation );
+
+    return ( status );
+}
 
 /****************************************************************/
 /* Asymmetric cryptography */

--- a/library/psa_crypto_mac.c
+++ b/library/psa_crypto_mac.c
@@ -359,30 +359,6 @@ static psa_status_t mac_setup( mbedtls_psa_mac_operation_t *operation,
     return( status );
 }
 
-static psa_status_t mac_compute(
-    const psa_key_attributes_t *attributes,
-    const uint8_t *key_buffer,
-    size_t key_buffer_size,
-    psa_algorithm_t alg,
-    const uint8_t *input,
-    size_t input_length,
-    uint8_t *mac,
-    size_t mac_size,
-    size_t *mac_length )
-{
-    /* One-shot MAC has not been implemented in this PSA implementation yet. */
-    (void) attributes;
-    (void) key_buffer;
-    (void) key_buffer_size;
-    (void) alg;
-    (void) input;
-    (void) input_length;
-    (void) mac;
-    (void) mac_size;
-    (void) mac_length;
-    return( PSA_ERROR_NOT_SUPPORTED );
-}
-
 static psa_status_t mac_update(
     mbedtls_psa_mac_operation_t *operation,
     const uint8_t *input,
@@ -497,6 +473,44 @@ cleanup:
 
     return( status );
 }
+
+static psa_status_t mac_compute(
+    const psa_key_attributes_t *attributes,
+    const uint8_t *key_buffer,
+    size_t key_buffer_size,
+    psa_algorithm_t alg,
+    const uint8_t *input,
+    size_t input_length,
+    uint8_t *mac,
+    size_t mac_size,
+    size_t *mac_length )
+{
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    mbedtls_psa_mac_operation_t operation = MBEDTLS_PSA_MAC_OPERATION_INIT;
+
+    status = mac_setup( &operation,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+    if( status != PSA_SUCCESS )
+        goto exit;
+
+    if( input_length > 0 )
+    {
+        status = mac_update( &operation, input, input_length );
+        if( status != PSA_SUCCESS )
+            goto exit;
+    }
+
+    status = mac_finish_internal( &operation, mac, mac_size );
+    if( status == PSA_SUCCESS )
+        *mac_length = mac_size;
+
+exit:
+    mac_abort( &operation );
+
+    return( status );
+}
+
 #endif /* BUILTIN_ALG_HMAC || BUILTIN_ALG_CMAC */
 
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1984,7 +1984,21 @@ void mac_sign( int key_type_arg,
         mbedtls_test_set_step( output_size );
         ASSERT_ALLOC( actual_mac, output_size );
 
-        /* Calculate the MAC. */
+        /* Calculate the MAC, one-shot case. */
+        TEST_EQUAL( psa_mac_compute( key, alg,
+                                     input->x, input->len,
+                                     actual_mac, output_size, &mac_length ),
+                    expected_status );
+        if( expected_status == PSA_SUCCESS )
+        {
+            ASSERT_COMPARE( expected_mac->x, expected_mac->len,
+                            actual_mac, mac_length );
+        }
+
+        if( output_size > 0 )
+            memset( actual_mac, 0, output_size );
+
+        /* Calculate the MAC, multi-part case. */
         PSA_ASSERT( psa_mac_sign_setup( &operation, key, alg ) );
         PSA_ASSERT( psa_mac_update( &operation,
                                     input->x, input->len ) );
@@ -2036,7 +2050,11 @@ void mac_verify( int key_type_arg,
     PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
                                 &key ) );
 
-    /* Test the correct MAC. */
+    /* Verify correct MAC, one-shot case. */
+    PSA_ASSERT( psa_mac_verify( key, alg, input->x, input->len,
+                                expected_mac->x, expected_mac->len ) );
+
+    /* Verify correct MAC, multi-part case. */
     PSA_ASSERT( psa_mac_verify_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_mac_update( &operation,
                                 input->x, input->len ) );
@@ -2044,7 +2062,14 @@ void mac_verify( int key_type_arg,
                                        expected_mac->x,
                                        expected_mac->len ) );
 
-    /* Test a MAC that's too short. */
+    /* Test a MAC that's too short, one-shot case. */
+    TEST_EQUAL( psa_mac_verify( key, alg,
+                                input->x, input->len,
+                                expected_mac->x,
+                                expected_mac->len - 1 ),
+                PSA_ERROR_INVALID_SIGNATURE );
+
+    /* Test a MAC that's too short, multi-part case. */
     PSA_ASSERT( psa_mac_verify_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_mac_update( &operation,
                                 input->x, input->len ) );
@@ -2053,9 +2078,15 @@ void mac_verify( int key_type_arg,
                                        expected_mac->len - 1 ),
                 PSA_ERROR_INVALID_SIGNATURE );
 
-    /* Test a MAC that's too long. */
+    /* Test a MAC that's too long, one-shot case. */
     ASSERT_ALLOC( perturbed_mac, expected_mac->len + 1 );
     memcpy( perturbed_mac, expected_mac->x, expected_mac->len );
+    TEST_EQUAL( psa_mac_verify( key, alg,
+                                input->x, input->len,
+                                 perturbed_mac, expected_mac->len + 1 ),
+                PSA_ERROR_INVALID_SIGNATURE );
+
+    /* Test a MAC that's too long, multi-part case. */
     PSA_ASSERT( psa_mac_verify_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_mac_update( &operation,
                                 input->x, input->len ) );
@@ -2069,6 +2100,12 @@ void mac_verify( int key_type_arg,
     {
         mbedtls_test_set_step( i );
         perturbed_mac[i] ^= 1;
+
+        TEST_EQUAL( psa_mac_verify( key, alg,
+                                    input->x, input->len,
+                                    perturbed_mac, expected_mac->len ),
+                    PSA_ERROR_INVALID_SIGNATURE );
+
         PSA_ASSERT( psa_mac_verify_setup( &operation, key, alg ) );
         PSA_ASSERT( psa_mac_update( &operation,
                                     input->x, input->len ) );

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1238,7 +1238,27 @@ void mac_verify( int key_type_arg,
 
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
-    /* Test the correct MAC. */
+    /*
+     * Verify the MAC, one-shot case.
+     */
+    status = psa_mac_verify( key, alg,
+                             input->x, input->len,
+                             expected_mac->x, expected_mac->len );
+    TEST_EQUAL( mbedtls_test_driver_mac_hooks.hits, 1 );
+    if( forced_status == PSA_SUCCESS ||
+        forced_status == PSA_ERROR_NOT_SUPPORTED )
+    {
+        PSA_ASSERT( status );
+    }
+    else
+        TEST_EQUAL( forced_status, status );
+
+    mbedtls_test_driver_mac_hooks = mbedtls_test_driver_mac_hooks_init();
+    mbedtls_test_driver_mac_hooks.forced_status = forced_status;
+
+    /*
+     * Verify the MAC, multi-part case.
+     */
     status = psa_mac_verify_setup( &operation, key, alg );
     TEST_EQUAL( mbedtls_test_driver_mac_hooks.hits, 1 );
 

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -1118,7 +1118,31 @@ void mac_sign( int key_type_arg,
     ASSERT_ALLOC( actual_mac, mac_buffer_size );
     mbedtls_test_driver_mac_hooks.forced_status = forced_status;
 
-    /* Calculate the MAC. */
+    /*
+     * Calculate the MAC, one-shot case.
+     */
+    status = psa_mac_compute( key, alg,
+                              input->x, input->len,
+                              actual_mac, mac_buffer_size,
+                              &mac_length );
+
+    TEST_EQUAL( mbedtls_test_driver_mac_hooks.hits, 1 );
+    if( forced_status == PSA_SUCCESS ||
+        forced_status == PSA_ERROR_NOT_SUPPORTED )
+    {
+        PSA_ASSERT( status );
+    }
+    else
+        TEST_EQUAL( forced_status, status );
+
+    if( mac_buffer_size > 0 )
+        memset( actual_mac, 0, mac_buffer_size );
+    mbedtls_test_driver_mac_hooks = mbedtls_test_driver_mac_hooks_init();
+    mbedtls_test_driver_mac_hooks.forced_status = forced_status;
+
+    /*
+     * Calculate the MAC, multipart case.
+     */
     status = psa_mac_sign_setup( &operation, key, alg );
     TEST_EQUAL( mbedtls_test_driver_mac_hooks.hits, 1 );
 


### PR DESCRIPTION
## Description

Implement one-shot MAC APIs introduced in PSA Crypto API 1.0 beta1 (ARMmbed/mbed-crypto#17).

Resolves #3258

This PR is depends on the MAC driver rework (#4247)

## Todos
- [x] Tests
- [x] Changelog updated
