### PR TITLE
Changelog entry for mbedtls_mpi_read_string("-0")

### DIFF
--- a/ChangeLog.d/mpi_read_negative_zero.txt
+++ b/ChangeLog.d/mpi_read_negative_zero.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix mbedtls_mpi_read_string on "-0" returning a ``negative zero'' object,
-     which the library does fully consistently treat as equal to zero.
+   * mbedtls_mpi_read_string on "-0" produced an MPI object that was not treated
+     as equal to 0 in all cases. Fix it to produce the same object as "0".

--- a/ChangeLog.d/mpi_read_negative_zero.txt
+++ b/ChangeLog.d/mpi_read_negative_zero.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix mbedtls_mpi_read_string on "-0" returning a ``negative zero'' object,
+     which the library does fully consistently treat as equal to zero.


### PR DESCRIPTION
Since #4297, `mbedtls_mpi_read_string("-0")` no longer produces a "negative zero". I hadn't realize that this edge case had changed. The timeline:

* Mbed TLS releases up to 2.26.0, before https://github.com/ARMmbed/mbedtls/pull/3512: `"-01"` parses as -1, `"-0"` parses as -0 which is not fully supported.
* Between https://github.com/ARMmbed/mbedtls/pull/3512 and https://github.com/ARMmbed/mbedtls/pull/4297 (never released): `"-01"` parses as an invalid MPI which is almost 1 but has the sign bit set to 0 which breaks a few functions.
* After https://github.com/ARMmbed/mbedtls/pull/4297: `"-01"` parses as -1, `"-0"` parses as 0 (same as `"0"`).

Since this is a behavior change, document it in the changelog. It has been backported in https://github.com/ARMmbed/mbedtls/pull/4322.
