### PR TITLE
Remove MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME

### DIFF
--- a/configs/config-psa-crypto.h
+++ b/configs/config-psa-crypto.h
@@ -3225,7 +3225,6 @@
  */
 //#define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768
 
-//#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 //#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
 //#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3806,7 +3806,6 @@
  */
 //#define MBEDTLS_SSL_DTLS_MAX_BUFFERING             32768
 
-//#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 //#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
 //#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -237,10 +237,6 @@
  * \{
  */
 
-#if !defined(MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME)
-#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
-#endif
-
 /*
  * Maximum fragment length in bytes,
  * determines the size of each of the two internal I/O buffers.

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -2708,14 +2708,6 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_SSL_DTLS_MAX_BUFFERING */
 
-#if defined(MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME)
-    if( strcmp( "MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME", config ) == 0 )
-    {
-        MACRO_EXPANSION_TO_STR( MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME );
-        return( 0 );
-    }
-#endif /* MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME */
-
 #if defined(MBEDTLS_PSK_MAX_LEN)
     if( strcmp( "MBEDTLS_PSK_MAX_LEN", config ) == 0 )
     {


### PR DESCRIPTION
## Description
Removes a long unused config option.

Fixes #4321.


## Status
**READY**

## Requires Backporting

NO  
This change is for Mbed TLS 3.0 and contains API changes.