### PR TITLE
Backport 2.16: Allow changelog entries to have URLs exceeding 80 char limit.

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -228,6 +228,8 @@ class ChangeLog:
     # a version that is not yet released. Something like "3.1a" is accepted.
     _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
     _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
+    _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
+    _has_url_re = re.compile(br'.*://.*')
 
     def add_categories_from_text(self, filename, line_offset,
                                  text, allow_unknown_category):
@@ -246,12 +248,18 @@ class ChangeLog:
                                        category.name.decode('utf8'))
 
             body_split = category.body.splitlines()
+
             for line_number, line in enumerate(body_split, 1):
-                if len(line) > MAX_LINE_LENGTH:
+                if not self._only_url_re.match(line) and \
+                   len(line) > MAX_LINE_LENGTH:
+                    long_url_msg = '. URL exceeding length limit must be alone in its line.' \
+                        if self._has_url_re.match(line) else ""
                     raise InputFormatError(filename,
                                            category.body_line + line_number,
-                                           'Line is longer than allowed: Length {} (Max {})',
-                                           len(line), MAX_LINE_LENGTH)
+                                           'Line is longer than allowed: '
+                                           'Length {} (Max {}){}',
+                                           len(line), MAX_LINE_LENGTH,
+                                           long_url_msg)
 
             self.categories[category.name] += category.body
 


### PR DESCRIPTION
Backport from #4253 