### PR TITLE
Add session ID as an explicit parameter to SSL session cache API

### DIFF
--- a/ChangeLog.d/session-cache-api.txt
+++ b/ChangeLog.d/session-cache-api.txt
@@ -1,4 +1,4 @@
-API Changes
+API changes
     * The getter and setter API of the SSL session cache (used for
       session-ID based session resumption) has changed to that of
       a key-value store with keys being session IDs and values

--- a/ChangeLog.d/session-cache-api.txt
+++ b/ChangeLog.d/session-cache-api.txt
@@ -1,0 +1,5 @@
+API Changes
+    * The getter and setter API of the SSL session cache (used for
+      session-ID based session resumption) has changed to that of
+      a key-value store with keys being session IDs and values
+      being opaque instances of `mbedtls_ssl_session`.

--- a/docs/3.0-migration-guide.d/session-cache-api.md
+++ b/docs/3.0-migration-guide.d/session-cache-api.md
@@ -1,0 +1,28 @@
+Session Cache API Change
+-----------------------------------------------------------------
+
+This affects users who use `mbedtls_ssl_conf_session_cache()`
+to configure a custom session cache implementation different
+from the one Mbed TLS implements in `library/ssl_cache.c`.
+
+Those users will need to modify the API of their session cache
+implementation to that of a key-value store with keys being
+session IDs and values being instances of `mbedtls_ssl_session`:
+
+```
+typedef int mbedtls_ssl_cache_get_t( void *data,
+                                     unsigned char const *session_id,
+                                     size_t session_id_len,
+                                     mbedtls_ssl_session *session );
+typedef int mbedtls_ssl_cache_set_t( void *data,
+                                     unsigned char const *session_id,
+                                     size_t session_id_len,
+                                     const mbedtls_ssl_session *session );
+```
+
+Since the structure of `mbedtls_ssl_session` is no longer public from 3.0
+onwards, portable session cache implementations must not access fields of
+`mbedtls_ssl_session`. See the corresponding migration guide. Users that
+find themselves unable to migrate their session cache functionality without
+accessing fields of `mbedtls_ssl_session` should describe their usecase
+on the Mbed TLS mailing list.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -501,6 +501,7 @@ typedef enum
    MBEDTLS_SSL_TLS_PRF_SHA256
 }
 mbedtls_tls_prf_types;
+
 /**
  * \brief          Callback type: send data on the network.
  *
@@ -625,6 +626,11 @@ typedef struct mbedtls_ssl_key_cert mbedtls_ssl_key_cert;
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
+
+/* TODO: Document */
+typedef int mbedtls_ssl_cache_get_t( void *data, mbedtls_ssl_session *session );
+/* TODO: Document */
+typedef int mbedtls_ssl_cache_set_t( void *data, const mbedtls_ssl_session *session );
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -968,9 +974,9 @@ struct mbedtls_ssl_config
     void *p_rng;                    /*!< context for the RNG function       */
 
     /** Callback to retrieve a session from the cache                       */
-    int (*f_get_cache)(void *, mbedtls_ssl_session *);
+    mbedtls_ssl_cache_get_t *f_get_cache;
     /** Callback to store a session into the cache                          */
-    int (*f_set_cache)(void *, const mbedtls_ssl_session *);
+    mbedtls_ssl_cache_set_t *f_set_cache;
     void *p_cache;                  /*!< context for cache callbacks        */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
@@ -2428,9 +2434,9 @@ void mbedtls_ssl_conf_handshake_timeout( mbedtls_ssl_config *conf, uint32_t min,
  * \param f_set_cache    session set callback
  */
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
-        void *p_cache,
-        int (*f_get_cache)(void *, mbedtls_ssl_session *),
-        int (*f_set_cache)(void *, const mbedtls_ssl_session *) );
+                                     void *p_cache,
+                                     mbedtls_ssl_cache_get_t *f_get_cache,
+                                     mbedtls_ssl_cache_set_t *f_set_cache );
 #endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_CLI_C)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -627,12 +627,46 @@ typedef struct mbedtls_ssl_key_cert mbedtls_ssl_key_cert;
 typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
 
-/* TODO: Document */
+/**
+ * \brief          Callback type: server-side session cache getter
+ *
+ *                 The session cache is logically a key value store, with
+ *                 keys being session IDs and values being instances of
+ *                 mbedtls_ssl_session.
+ *
+ *                 This callback retrieves an entry in this key-value store.
+ *
+ * \param data            The address of the session cache structure to query.
+ * \param session_id      The buffer holding the session ID to query.
+ * \param session_id_len  The length of \p session_id in Bytes.
+ * \param session         The address at which to store the session found
+ *                        in the cache.
+ *
+ * \return                \c 0 on success
+ * \return                A non-zero return value on failure.
+ */
 typedef int mbedtls_ssl_cache_get_t( void *data,
                                      unsigned char const *session_id,
                                      size_t session_id_len,
                                      mbedtls_ssl_session *session );
-/* TODO: Document */
+/**
+ * \brief          Callback type: server-side session cache setter
+ *
+ *                 The session cache is logically a key value store, with
+ *                 keys being session IDs and values being instances of
+ *                 mbedtls_ssl_session.
+ *
+ *                 This callback sets an entry in this key-value store.
+ *
+ * \param data            The address of the session cache structure to modify.
+ * \param session_id      The buffer holding the session ID to query.
+ * \param session_id_len  The length of \p session_id in Bytes.
+ * \param session         The address of the session to be stored in the
+ *                        session cache.
+ *
+ * \return                \c 0 on success
+ * \return                A non-zero return value on failure.
+ */
 typedef int mbedtls_ssl_cache_set_t( void *data,
                                      unsigned char const *session_id,
                                      size_t session_id_len,

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -639,11 +639,16 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
  * \param data            The address of the session cache structure to query.
  * \param session_id      The buffer holding the session ID to query.
  * \param session_id_len  The length of \p session_id in Bytes.
- * \param session         The address at which to store the session found
- *                        in the cache.
+ * \param session         The address of the session structure to populate.
+ *                        It is initialized with mbdtls_ssl_session_init(),
+ *                        and the callback must always leave it in a state
+ *                        where it can savely be freed via
+ *                        mbedtls_ssl_session_free() independent of the
+ *                        return code of this function.
  *
  * \return                \c 0 on success
  * \return                A non-zero return value on failure.
+ *
  */
 typedef int mbedtls_ssl_cache_get_t( void *data,
                                      unsigned char const *session_id,

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -642,7 +642,7 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
  * \param session         The address of the session structure to populate.
  *                        It is initialized with mbdtls_ssl_session_init(),
  *                        and the callback must always leave it in a state
- *                        where it can savely be freed via
+ *                        where it can safely be freed via
  *                        mbedtls_ssl_session_free() independent of the
  *                        return code of this function.
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -628,9 +628,15 @@ typedef struct mbedtls_ssl_flight_item mbedtls_ssl_flight_item;
 #endif
 
 /* TODO: Document */
-typedef int mbedtls_ssl_cache_get_t( void *data, mbedtls_ssl_session *session );
+typedef int mbedtls_ssl_cache_get_t( void *data,
+                                     unsigned char const *session_id,
+                                     size_t session_id_len,
+                                     mbedtls_ssl_session *session );
 /* TODO: Document */
-typedef int mbedtls_ssl_cache_set_t( void *data, const mbedtls_ssl_session *session );
+typedef int mbedtls_ssl_cache_set_t( void *data,
+                                     unsigned char const *session_id,
+                                     size_t session_id_len,
+                                     const mbedtls_ssl_session *session );
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
 #if defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -67,11 +67,13 @@ struct mbedtls_ssl_cache_entry
 #if defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t timestamp;           /*!< entry timestamp    */
 #endif
-    mbedtls_ssl_session session;        /*!< entry session      */
-#if defined(MBEDTLS_X509_CRT_PARSE_C) && \
-    defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-    mbedtls_x509_buf peer_cert;         /*!< entry peer_cert    */
-#endif
+
+    unsigned char session_id[32];       /*!< session ID         */
+    size_t session_id_len;
+
+    unsigned char *session;             /*!< serialized session */
+    size_t session_len;
+
     mbedtls_ssl_cache_entry *next;      /*!< chain pointer      */
 };
 

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -99,19 +99,32 @@ void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache );
  * \brief          Cache get callback implementation
  *                 (Thread-safe if MBEDTLS_THREADING_C is enabled)
  *
- * \param data     SSL cache context
- * \param session  session to retrieve entry for
+ * \param data            The SSL cache context to use.
+ * \param session_id      The pointer to the buffer holding the session ID
+ *                        for the session to load.
+ * \param session_id_len  The length of \p session_id in bytes.
+ * \param session         The address at which to store the session
+ *                        associated with \p session_id, if present.
  */
-int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session );
+int mbedtls_ssl_cache_get( void *data,
+                           unsigned char const *session_id,
+                           size_t session_id_len,
+                           mbedtls_ssl_session *session );
 
 /**
  * \brief          Cache set callback implementation
  *                 (Thread-safe if MBEDTLS_THREADING_C is enabled)
  *
- * \param data     SSL cache context
- * \param session  session to store entry for
+ * \param data            The SSL cache context to use.
+ * \param session_id      The pointer to the buffer holding the session ID
+ *                        associated to \p session.
+ * \param session_id_len  The length of \p session_id in bytes.
+ * \param session         The session to store.
  */
-int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session );
+int mbedtls_ssl_cache_set( void *data,
+                           unsigned char const *session_id,
+                           size_t session_id_len,
+                           const mbedtls_ssl_session *session );
 
 #if defined(MBEDTLS_HAVE_TIME)
 /**

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -78,14 +78,12 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
             continue;
 #endif
 
-        if( session->ciphersuite != entry->session.ciphersuite ||
-            session->compression != entry->session.compression ||
-            session->id_len != entry->session.id_len )
-            continue;
-
-        if( memcmp( session->id, entry->session.id,
+        if( session->id_len != entry->session.id_len ||
+            memcmp( session->id, entry->session.id,
                     entry->session.id_len ) != 0 )
+        {
             continue;
+        }
 
         ret = mbedtls_ssl_session_copy( session, &entry->session );
         if( ret != 0 )

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -50,7 +50,10 @@ void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 #endif
 }
 
-int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
+int mbedtls_ssl_cache_get( void *data,
+                           unsigned char const *session_id,
+                           size_t session_id_len,
+                           mbedtls_ssl_session *session )
 {
     int ret = 1;
 #if defined(MBEDTLS_HAVE_TIME)
@@ -78,8 +81,8 @@ int mbedtls_ssl_cache_get( void *data, mbedtls_ssl_session *session )
             continue;
 #endif
 
-        if( session->id_len != entry->session.id_len ||
-            memcmp( session->id, entry->session.id,
+        if( session_id_len != entry->session.id_len ||
+            memcmp( session_id, entry->session.id,
                     entry->session.id_len ) != 0 )
         {
             continue;
@@ -135,7 +138,10 @@ exit:
     return( ret );
 }
 
-int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
+int mbedtls_ssl_cache_set( void *data,
+                           unsigned char const *session_id,
+                           size_t session_id_len,
+                           const mbedtls_ssl_session *session )
 {
     int ret = 1;
 #if defined(MBEDTLS_HAVE_TIME)
@@ -167,8 +173,11 @@ int mbedtls_ssl_cache_set( void *data, const mbedtls_ssl_session *session )
         }
 #endif
 
-        if( memcmp( session->id, cur->session.id, cur->session.id_len ) == 0 )
+        if( session_id_len == cur->session.id_len &&
+            memcmp( session_id, cur->session.id, cur->session.id_len ) == 0 )
+        {
             break; /* client reconnected, keep timestamp for session id */
+        }
 
 #if defined(MBEDTLS_HAVE_TIME)
         if( oldest == 0 || cur->timestamp < oldest )

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -50,84 +50,98 @@ void mbedtls_ssl_cache_init( mbedtls_ssl_cache_context *cache )
 #endif
 }
 
+static int ssl_cache_find_entry( mbedtls_ssl_cache_context *cache,
+                                 unsigned char const *session_id,
+                                 size_t session_id_len,
+                                 mbedtls_ssl_cache_entry **dst )
+{
+    int ret = 1;
+#if defined(MBEDTLS_HAVE_TIME)
+    mbedtls_time_t t = mbedtls_time( NULL );
+#endif
+    mbedtls_ssl_cache_entry *cur;
+
+    for( cur = cache->chain; cur != NULL; cur = cur->next )
+    {
+#if defined(MBEDTLS_HAVE_TIME)
+        if( cache->timeout != 0 &&
+            (int) ( t - cur->timestamp ) > cache->timeout )
+            continue;
+#endif
+
+        if( session_id_len != cur->session.id_len ||
+            memcmp( session_id, cur->session.id,
+                    cur->session.id_len ) != 0 )
+        {
+            continue;
+        }
+
+        break;
+    }
+
+    if( cur != NULL )
+    {
+        *dst = cur;
+        ret = 0;
+    }
+
+    return( ret );
+}
+
+
 int mbedtls_ssl_cache_get( void *data,
                            unsigned char const *session_id,
                            size_t session_id_len,
                            mbedtls_ssl_session *session )
 {
     int ret = 1;
-#if defined(MBEDTLS_HAVE_TIME)
-    mbedtls_time_t t = mbedtls_time( NULL );
-#endif
     mbedtls_ssl_cache_context *cache = (mbedtls_ssl_cache_context *) data;
-    mbedtls_ssl_cache_entry *cur, *entry;
+    mbedtls_ssl_cache_entry *entry;
 
 #if defined(MBEDTLS_THREADING_C)
     if( mbedtls_mutex_lock( &cache->mutex ) != 0 )
         return( 1 );
 #endif
 
-    cur = cache->chain;
-    entry = NULL;
+    ret = ssl_cache_find_entry( cache, session_id, session_id_len, &entry );
+    if( ret != 0 )
+        goto exit;
 
-    while( cur != NULL )
+    ret = mbedtls_ssl_session_copy( session, &entry->session );
+    if( ret != 0 )
+        goto exit;
+
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && \
+    defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
+    /*
+     * Restore peer certificate (without rest of the original chain)
+     */
+    if( entry->peer_cert.p != NULL )
     {
-        entry = cur;
-        cur = cur->next;
+        /* `session->peer_cert` is NULL after the call to
+         * mbedtls_ssl_session_copy(), because cache entries
+         * have the `peer_cert` field set to NULL. */
 
-#if defined(MBEDTLS_HAVE_TIME)
-        if( cache->timeout != 0 &&
-            (int) ( t - entry->timestamp ) > cache->timeout )
-            continue;
-#endif
-
-        if( session_id_len != entry->session.id_len ||
-            memcmp( session_id, entry->session.id,
-                    entry->session.id_len ) != 0 )
-        {
-            continue;
-        }
-
-        ret = mbedtls_ssl_session_copy( session, &entry->session );
-        if( ret != 0 )
+        if( ( session->peer_cert = mbedtls_calloc( 1,
+                             sizeof(mbedtls_x509_crt) ) ) == NULL )
         {
             ret = 1;
             goto exit;
         }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C) && \
-    defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
-        /*
-         * Restore peer certificate (without rest of the original chain)
-         */
-        if( entry->peer_cert.p != NULL )
+        mbedtls_x509_crt_init( session->peer_cert );
+        if( mbedtls_x509_crt_parse( session->peer_cert, entry->peer_cert.p,
+                            entry->peer_cert.len ) != 0 )
         {
-            /* `session->peer_cert` is NULL after the call to
-             * mbedtls_ssl_session_copy(), because cache entries
-             * have the `peer_cert` field set to NULL. */
-
-            if( ( session->peer_cert = mbedtls_calloc( 1,
-                                 sizeof(mbedtls_x509_crt) ) ) == NULL )
-            {
-                ret = 1;
-                goto exit;
-            }
-
-            mbedtls_x509_crt_init( session->peer_cert );
-            if( mbedtls_x509_crt_parse( session->peer_cert, entry->peer_cert.p,
-                                entry->peer_cert.len ) != 0 )
-            {
-                mbedtls_free( session->peer_cert );
-                session->peer_cert = NULL;
-                ret = 1;
-                goto exit;
-            }
+            mbedtls_free( session->peer_cert );
+            session->peer_cert = NULL;
+            ret = 1;
+            goto exit;
         }
+    }
 #endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
 
-        ret = 0;
-        goto exit;
-    }
+    ret = 0;
 
 exit:
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -135,17 +135,17 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
 
     mbedtls_ssl_cache_entry *old = NULL;
     int count = 0;
-    mbedtls_ssl_cache_entry *cur, *prv;
+    mbedtls_ssl_cache_entry *cur, *last;
 
     cur = cache->chain;
-    prv = NULL;
+    last = NULL;
 
     /* Check 1: Is there already an entry with the given session ID?
      *
      * If yes, overwrite it.
      *
      * If not, `count` will hold the size of the session cache
-     * at the end of this loop, and `prv` will point to the last
+     * at the end of this loop, and `last` will point to the last
      * entry, both of which will be used later. */
 
     while( cur != NULL )
@@ -158,7 +158,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
             goto found;
         }
 
-        prv = cur;
+        last = cur;
         cur = cur->next;
     }
 
@@ -184,7 +184,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
             old = cur;
         }
 
-        prv = cur;
+        last = cur;
         cur = cur->next;
     }
 #endif /* MBEDTLS_HAVE_TIME */
@@ -199,10 +199,10 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
             return( 1 );
 
         /* Append to the end of the linked list. */
-        if( prv == NULL )
+        if( last == NULL )
             cache->chain = cur;
         else
-            prv->next = cur;
+            last->next = cur;
 
         goto found;
     }
@@ -226,7 +226,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
     old = cache->chain;
     cache->chain = old->next;
     old->next = NULL;
-    prv->next = old;
+    last->next = old;
 #endif /* MBEDTLS_HAVE_TIME */
 
     /* Now `old` points to the oldest entry to be overwritten. */

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -131,8 +131,9 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
 {
 #if defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t t = mbedtls_time( NULL ), oldest = 0;
+#endif /* MBEDTLS_HAVE_TIME */
+
     mbedtls_ssl_cache_entry *old = NULL;
-#endif
     int count = 0;
     mbedtls_ssl_cache_entry *cur, *prv;
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -300,7 +300,7 @@ int mbedtls_ssl_cache_set( void *data,
     if( ret != 0 )
         goto exit;
 
-    if( session_id_len > 32 )
+    if( session_id_len > sizeof( cur->session_id ) )
     {
         ret = 1;
         goto exit;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -124,10 +124,10 @@ exit:
     return( ret );
 }
 
-static int ssl_cache_find_fresh_entry( mbedtls_ssl_cache_context *cache,
-                                       unsigned char const *session_id,
-                                       size_t session_id_len,
-                                       mbedtls_ssl_cache_entry **dst )
+static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
+                                        unsigned char const *session_id,
+                                        size_t session_id_len,
+                                        mbedtls_ssl_cache_entry **dst )
 {
     int ret = 1;
 #if defined(MBEDTLS_HAVE_TIME)
@@ -270,9 +270,9 @@ int mbedtls_ssl_cache_set( void *data,
         return( ret );
 #endif
 
-    ret = ssl_cache_find_fresh_entry( cache,
-                                      session_id, session_id_len,
-                                      &cur );
+    ret = ssl_cache_pick_writing_slot( cache,
+                                       session_id, session_id_len,
+                                       &cur );
     if( ret != 0 )
         goto exit;
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -151,14 +151,11 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
     while( cur != NULL )
     {
         count++;
-
         if( session_id_len == cur->session_id_len &&
             memcmp( session_id, cur->session_id, cur->session_id_len ) == 0 )
         {
             goto found;
         }
-
-        last = cur;
         cur = cur->next;
     }
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -137,9 +137,6 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
     int count = 0;
     mbedtls_ssl_cache_entry *cur, *last;
 
-    cur = cache->chain;
-    last = NULL;
-
     /* Check 1: Is there already an entry with the given session ID?
      *
      * If yes, overwrite it.
@@ -148,7 +145,8 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
      * at the end of this loop, and `last` will point to the last
      * entry, both of which will be used later. */
 
-    while( cur != NULL )
+    last = NULL;
+    for( cur = cache->chain; cur != NULL; cur = cur->next )
     {
         count++;
         if( session_id_len == cur->session_id_len &&
@@ -156,7 +154,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
         {
             goto found;
         }
-        cur = cur->next;
+        last = cur;
     }
 
     /* Check 2: Is there an outdated entry in the cache?
@@ -167,7 +165,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
      */
 
 #if defined(MBEDTLS_HAVE_TIME)
-    while( cur != NULL )
+    for( cur = cache->chain; cur != NULL; cur = cur->next )
     {
         if( cache->timeout != 0 &&
             (int) ( t - cur->timestamp ) > cache->timeout )
@@ -180,9 +178,6 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
             oldest = cur->timestamp;
             old = cur;
         }
-
-        last = cur;
-        cur = cur->next;
     }
 #endif /* MBEDTLS_HAVE_TIME */
 

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -225,7 +225,7 @@ static int ssl_cache_pick_writing_slot( mbedtls_ssl_cache_context *cache,
 
     old = cache->chain;
     cache->chain = old->next;
-    cur->next = NULL;
+    old->next = NULL;
     prv->next = old;
 #endif /* MBEDTLS_HAVE_TIME */
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2810,7 +2810,7 @@ static void ssl_handle_id_based_session_resumption( mbedtls_ssl_context *ssl )
 
 exit:
 
-    mbedtls_platform_zeroize( &session_tmp, sizeof( session_tmp ) );
+    mbedtls_ssl_session_free( &session_tmp );
 }
 
 static int ssl_write_server_hello( mbedtls_ssl_context *ssl )

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2765,7 +2765,7 @@ static int ssl_write_hello_verify_request( mbedtls_ssl_context *ssl )
 }
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
-static void ssl_check_id_based_session_resumption( mbedtls_ssl_context *ssl )
+static void ssl_handle_id_based_session_resumption( mbedtls_ssl_context *ssl )
 {
     int ret;
     mbedtls_ssl_session session_tmp;
@@ -2883,7 +2883,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "server hello, random bytes", buf + 6, 32 );
 
-    ssl_check_id_based_session_resumption( ssl );
+    ssl_handle_id_based_session_resumption( ssl );
 
     if( ssl->handshake->resume == 0 )
     {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2765,6 +2765,53 @@ static int ssl_write_hello_verify_request( mbedtls_ssl_context *ssl )
 }
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY */
 
+static void ssl_check_id_based_session_resumption( mbedtls_ssl_context *ssl )
+{
+    int ret;
+    mbedtls_ssl_session session_tmp = { 0 };
+    mbedtls_ssl_session * const session = ssl->session_negotiate;
+
+    /* Resume is 0  by default, see ssl_handshake_init().
+     * It may be already set to 1 by ssl_parse_session_ticket_ext(). */
+    if( ssl->handshake->resume == 1 )
+        return;
+    if( ssl->session_negotiate->id_len == 0 )
+        return;
+    if( ssl->conf->f_get_cache == NULL )
+        return;
+#if defined(MBEDTLS_SSL_RENEGOTIATION)
+    if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
+        return;
+#endif
+
+    session_tmp.id_len = session->id_len;
+    memcpy( session_tmp.id, session->id, session->id_len );
+
+    ret = ssl->conf->f_get_cache( ssl->conf->p_cache,
+                                  &session_tmp );
+    if( ret != 0 )
+        goto exit;
+
+    if( session->ciphersuite != session_tmp.ciphersuite ||
+        session->compression != session_tmp.compression )
+    {
+        /* Mismatch between cached and negotiated session */
+        goto exit;
+    }
+
+    /* Move semantics */
+    /* Zeroization of session_tmp happens at the end of the function. */
+    mbedtls_ssl_session_free( session );
+    *session = session_tmp;
+
+    MBEDTLS_SSL_DEBUG_MSG( 3, ( "session successfully restored from cache" ) );
+    ssl->handshake->resume = 1;
+
+exit:
+
+    mbedtls_platform_zeroize( &session_tmp, sizeof( session_tmp ) );
+}
+
 static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_HAVE_TIME)
@@ -2835,22 +2882,7 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_BUF( 3, "server hello, random bytes", buf + 6, 32 );
 
-    /*
-     * Resume is 0  by default, see ssl_handshake_init().
-     * It may be already set to 1 by ssl_parse_session_ticket_ext().
-     * If not, try looking up session ID in our cache.
-     */
-    if( ssl->handshake->resume == 0 &&
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-        ssl->renego_status == MBEDTLS_SSL_INITIAL_HANDSHAKE &&
-#endif
-        ssl->session_negotiate->id_len != 0 &&
-        ssl->conf->f_get_cache != NULL &&
-        ssl->conf->f_get_cache( ssl->conf->p_cache, ssl->session_negotiate ) == 0 )
-    {
-        MBEDTLS_SSL_DEBUG_MSG( 3, ( "session successfully restored from cache" ) );
-        ssl->handshake->resume = 1;
-    }
+    ssl_check_id_based_session_resumption( ssl );
 
     if( ssl->handshake->resume == 0 )
     {

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2784,10 +2784,9 @@ static void ssl_check_id_based_session_resumption( mbedtls_ssl_context *ssl )
         return;
 #endif
 
-    session_tmp.id_len = session->id_len;
-    memcpy( session_tmp.id, session->id, session->id_len );
-
     ret = ssl->conf->f_get_cache( ssl->conf->p_cache,
+                                  session->id,
+                                  session->id_len,
                                   &session_tmp );
     if( ret != 0 )
         goto exit;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2768,7 +2768,7 @@ static int ssl_write_hello_verify_request( mbedtls_ssl_context *ssl )
 static void ssl_check_id_based_session_resumption( mbedtls_ssl_context *ssl )
 {
     int ret;
-    mbedtls_ssl_session session_tmp = { 0 };
+    mbedtls_ssl_session session_tmp;
     mbedtls_ssl_session * const session = ssl->session_negotiate;
 
     /* Resume is 0  by default, see ssl_handshake_init().
@@ -2783,6 +2783,8 @@ static void ssl_check_id_based_session_resumption( mbedtls_ssl_context *ssl )
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
         return;
 #endif
+
+    mbedtls_ssl_session_init( &session_tmp );
 
     ret = ssl->conf->f_get_cache( ssl->conf->p_cache,
                                   session->id,

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2803,7 +2803,7 @@ static void ssl_handle_id_based_session_resumption( mbedtls_ssl_context *ssl )
     /* Move semantics */
     mbedtls_ssl_session_free( session );
     *session = session_tmp;
-    memset( &session_tmp, 0, sizeof( mbedtls_ssl_session ) );
+    memset( &session_tmp, 0, sizeof( session_tmp ) );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "session successfully restored from cache" ) );
     ssl->handshake->resume = 1;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2775,7 +2775,7 @@ static void ssl_handle_id_based_session_resumption( mbedtls_ssl_context *ssl )
      * It may be already set to 1 by ssl_parse_session_ticket_ext(). */
     if( ssl->handshake->resume == 1 )
         return;
-    if( ssl->session_negotiate->id_len == 0 )
+    if( session->id_len == 0 )
         return;
     if( ssl->conf->f_get_cache == NULL )
         return;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2801,9 +2801,9 @@ static void ssl_handle_id_based_session_resumption( mbedtls_ssl_context *ssl )
     }
 
     /* Move semantics */
-    /* Zeroization of session_tmp happens at the end of the function. */
     mbedtls_ssl_session_free( session );
     *session = session_tmp;
+    memset( &session_tmp, 0, sizeof( mbedtls_ssl_session ) );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "session successfully restored from cache" ) );
     ssl->handshake->resume = 1;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4167,9 +4167,9 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_SRV_C)
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
-        void *p_cache,
-        int (*f_get_cache)(void *, mbedtls_ssl_session *),
-        int (*f_set_cache)(void *, const mbedtls_ssl_session *) )
+                                     void *p_cache,
+                                     mbedtls_ssl_cache_get_t *f_get_cache,
+                                     mbedtls_ssl_cache_set_t *f_set_cache )
 {
     conf->p_cache = p_cache;
     conf->f_get_cache = f_get_cache;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3411,7 +3411,10 @@ void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl )
         ssl->session->id_len != 0 &&
         resume == 0 )
     {
-        if( ssl->conf->f_set_cache( ssl->conf->p_cache, ssl->session ) != 0 )
+        if( ssl->conf->f_set_cache( ssl->conf->p_cache,
+                                    ssl->session->id,
+                                    ssl->session->id_len,
+                                    ssl->session ) != 0 )
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "cache did not store session" ) );
     }
 


### PR DESCRIPTION
__Context:__ This PR aims to address #4333 - see there for a problem description.

__Changes:__ 
* Move consistency check for ciphersuite and compression outside of the session cache implementation. In particular, session cache implementations need not access those fields anymore, which is a step towards making `mbedtls_ssl_session` opaque.
* Add the session ID as an explicit parameter to the SSL session cache API (API break). In particular, session cache implementation need not access the session ID field anymore, which is another step towards making `mbedtls_ssl_session` opaque.
* Simplify SSL session cache reference implementation by using session serialization.

__Backports:__ (partial)
- 2.x #4529 
- ~2.16 #4539~
