### PR TITLE
Apply 4334 to development-3.0

### DIFF
--- a/ChangeLog.d/issue4280.txt
+++ b/ChangeLog.d/issue4280.txt
@@ -1,0 +1,2 @@
+Removals
+   * Removed deprecated functions from hashing modules. Fixes #4280.

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -38,6 +38,8 @@
 #define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */
 #define MBEDTLS_ERR_MD_FILE_IO_ERROR                      -0x5200  /**< Opening or reading of file failed. */
 
+// TODO [TR] for #4029: can't remove it because it's still used in the code.
+// see the other TODOs
 /* MBEDTLS_ERR_MD_HW_ACCEL_FAILED is deprecated and should not be used. */
 #define MBEDTLS_ERR_MD_HW_ACCEL_FAILED                    -0x5280  /**< MD hardware accelerator failed. */
 
@@ -158,33 +160,6 @@ void mbedtls_md_init( mbedtls_md_context_t *ctx );
  */
 void mbedtls_md_free( mbedtls_md_context_t *ctx );
 
-#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED    __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief           This function selects the message digest algorithm to use,
- *                  and allocates internal structures.
- *
- *                  It should be called after mbedtls_md_init() or mbedtls_md_free().
- *                  Makes it necessary to call mbedtls_md_free() later.
- *
- * \deprecated      Superseded by mbedtls_md_setup() in 2.0.0
- *
- * \param ctx       The context to set up.
- * \param md_info   The information structure of the message-digest algorithm
- *                  to use.
- *
- * \return          \c 0 on success.
- * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
- *                  failure.
- * \return          #MBEDTLS_ERR_MD_ALLOC_FAILED on memory-allocation failure.
- */
-int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
-#undef MBEDTLS_DEPRECATED
-#endif /* MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief           This function selects the message digest algorithm to use,

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -35,9 +35,6 @@
 
 #include <stddef.h>
 
-/* MBEDTLS_ERR_MD2_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_MD2_HW_ACCEL_FAILED                   -0x002B  /**< MD2 hardware accelerator failed */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -167,77 +164,6 @@ int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
  */
 int mbedtls_internal_md2_process( mbedtls_md2_context *ctx );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          MD2 context setup
- *
- * \deprecated     Superseded by mbedtls_md2_starts_ret() in 2.7.0
- *
- * \param ctx      context to be initialized
- *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md2_starts( mbedtls_md2_context *ctx );
-
-/**
- * \brief          MD2 process buffer
- *
- * \deprecated     Superseded by mbedtls_md2_update_ret() in 2.7.0
- *
- * \param ctx      MD2 context
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md2_update( mbedtls_md2_context *ctx,
-                                            const unsigned char *input,
-                                            size_t ilen );
-
-/**
- * \brief          MD2 final digest
- *
- * \deprecated     Superseded by mbedtls_md2_finish_ret() in 2.7.0
- *
- * \param ctx      MD2 context
- * \param output   MD2 checksum result
- *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md2_finish( mbedtls_md2_context *ctx,
-                                            unsigned char output[16] );
-
-/**
- * \brief          MD2 process data block (internal use only)
- *
- * \deprecated     Superseded by mbedtls_internal_md2_process() in 2.7.0
- *
- * \param ctx      MD2 context
- *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md2_process( mbedtls_md2_context *ctx );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          Output = MD2( input buffer )
  *
@@ -253,33 +179,6 @@ MBEDTLS_DEPRECATED void mbedtls_md2_process( mbedtls_md2_context *ctx );
 int mbedtls_md2_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          Output = MD2( input buffer )
- *
- * \deprecated     Superseded by mbedtls_md2_ret() in 2.7.0
- *
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- * \param output   MD2 checksum result
- *
- * \warning        MD2 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md2( const unsigned char *input,
-                                     size_t ilen,
-                                     unsigned char output[16] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -36,9 +36,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_MD4_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_MD4_HW_ACCEL_FAILED                   -0x002D  /**< MD4 hardware accelerator failed */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -168,79 +165,6 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
 int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
                                   const unsigned char data[64] );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          MD4 context setup
- *
- * \deprecated     Superseded by mbedtls_md4_starts_ret() in 2.7.0
- *
- * \param ctx      context to be initialized
- *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md4_starts( mbedtls_md4_context *ctx );
-
-/**
- * \brief          MD4 process buffer
- *
- * \deprecated     Superseded by mbedtls_md4_update_ret() in 2.7.0
- *
- * \param ctx      MD4 context
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md4_update( mbedtls_md4_context *ctx,
-                                            const unsigned char *input,
-                                            size_t ilen );
-
-/**
- * \brief          MD4 final digest
- *
- * \deprecated     Superseded by mbedtls_md4_finish_ret() in 2.7.0
- *
- * \param ctx      MD4 context
- * \param output   MD4 checksum result
- *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md4_finish( mbedtls_md4_context *ctx,
-                                            unsigned char output[16] );
-
-/**
- * \brief          MD4 process data block (internal use only)
- *
- * \deprecated     Superseded by mbedtls_internal_md4_process() in 2.7.0
- *
- * \param ctx      MD4 context
- * \param data     buffer holding one block of data
- *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md4_process( mbedtls_md4_context *ctx,
-                                             const unsigned char data[64] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          Output = MD4( input buffer )
  *
@@ -258,33 +182,6 @@ MBEDTLS_DEPRECATED void mbedtls_md4_process( mbedtls_md4_context *ctx,
 int mbedtls_md4_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          Output = MD4( input buffer )
- *
- * \deprecated     Superseded by mbedtls_md4_ret() in 2.7.0
- *
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- * \param output   MD4 checksum result
- *
- * \warning        MD4 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md4( const unsigned char *input,
-                                     size_t ilen,
-                                     unsigned char output[16] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -35,9 +35,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_MD5_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_MD5_HW_ACCEL_FAILED                   -0x002F  /**< MD5 hardware accelerator failed */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -168,79 +165,6 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
 int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
                                   const unsigned char data[64] );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          MD5 context setup
- *
- * \deprecated     Superseded by mbedtls_md5_starts_ret() in 2.7.0
- *
- * \param ctx      context to be initialized
- *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md5_starts( mbedtls_md5_context *ctx );
-
-/**
- * \brief          MD5 process buffer
- *
- * \deprecated     Superseded by mbedtls_md5_update_ret() in 2.7.0
- *
- * \param ctx      MD5 context
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md5_update( mbedtls_md5_context *ctx,
-                                            const unsigned char *input,
-                                            size_t ilen );
-
-/**
- * \brief          MD5 final digest
- *
- * \deprecated     Superseded by mbedtls_md5_finish_ret() in 2.7.0
- *
- * \param ctx      MD5 context
- * \param output   MD5 checksum result
- *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md5_finish( mbedtls_md5_context *ctx,
-                                            unsigned char output[16] );
-
-/**
- * \brief          MD5 process data block (internal use only)
- *
- * \deprecated     Superseded by mbedtls_internal_md5_process() in 2.7.0
- *
- * \param ctx      MD5 context
- * \param data     buffer holding one block of data
- *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md5_process( mbedtls_md5_context *ctx,
-                                             const unsigned char data[64] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          Output = MD5( input buffer )
  *
@@ -258,33 +182,6 @@ MBEDTLS_DEPRECATED void mbedtls_md5_process( mbedtls_md5_context *ctx,
 int mbedtls_md5_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          Output = MD5( input buffer )
- *
- * \deprecated     Superseded by mbedtls_md5_ret() in 2.7.0
- *
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- * \param output   MD5 checksum result
- *
- * \warning        MD5 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_md5( const unsigned char *input,
-                                     size_t ilen,
-                                     unsigned char output[16] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -31,10 +31,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED is deprecated and should not be used.
- */
-#define MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED             -0x0031  /**< RIPEMD160 hardware accelerator failed */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -125,63 +121,6 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
 int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
                                         const unsigned char data[64] );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          RIPEMD-160 context setup
- *
- * \deprecated     Superseded by mbedtls_ripemd160_starts_ret() in 2.7.0
- *
- * \param ctx      context to be initialized
- */
-MBEDTLS_DEPRECATED void mbedtls_ripemd160_starts(
-                                            mbedtls_ripemd160_context *ctx );
-
-/**
- * \brief          RIPEMD-160 process buffer
- *
- * \deprecated     Superseded by mbedtls_ripemd160_update_ret() in 2.7.0
- *
- * \param ctx      RIPEMD-160 context
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- */
-MBEDTLS_DEPRECATED void mbedtls_ripemd160_update(
-                                                mbedtls_ripemd160_context *ctx,
-                                                const unsigned char *input,
-                                                size_t ilen );
-
-/**
- * \brief          RIPEMD-160 final digest
- *
- * \deprecated     Superseded by mbedtls_ripemd160_finish_ret() in 2.7.0
- *
- * \param ctx      RIPEMD-160 context
- * \param output   RIPEMD-160 checksum result
- */
-MBEDTLS_DEPRECATED void mbedtls_ripemd160_finish(
-                                                mbedtls_ripemd160_context *ctx,
-                                                unsigned char output[20] );
-
-/**
- * \brief          RIPEMD-160 process data block (internal use only)
- *
- * \deprecated     Superseded by mbedtls_internal_ripemd160_process() in 2.7.0
- *
- * \param ctx      RIPEMD-160 context
- * \param data     buffer holding one block of data
- */
-MBEDTLS_DEPRECATED void mbedtls_ripemd160_process(
-                                            mbedtls_ripemd160_context *ctx,
-                                            const unsigned char data[64] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          Output = RIPEMD-160( input buffer )
  *
@@ -194,28 +133,6 @@ MBEDTLS_DEPRECATED void mbedtls_ripemd160_process(
 int mbedtls_ripemd160_ret( const unsigned char *input,
                            size_t ilen,
                            unsigned char output[20] );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          Output = RIPEMD-160( input buffer )
- *
- * \deprecated     Superseded by mbedtls_ripemd160_ret() in 2.7.0
- *
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- * \param output   RIPEMD-160 checksum result
- */
-MBEDTLS_DEPRECATED void mbedtls_ripemd160( const unsigned char *input,
-                                           size_t ilen,
-                                           unsigned char output[20] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -38,8 +38,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED                  -0x0035  /**< SHA-1 hardware accelerator failed */
 #define MBEDTLS_ERR_SHA1_BAD_INPUT_DATA                   -0x0073  /**< SHA-1 input data was malformed. */
 
 #ifdef __cplusplus
@@ -185,85 +183,6 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
 int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
                                    const unsigned char data[64] );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          This function starts a SHA-1 checksum calculation.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- * \deprecated     Superseded by mbedtls_sha1_starts_ret() in 2.7.0.
- *
- * \param ctx      The SHA-1 context to initialize. This must be initialized.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
-
-/**
- * \brief          This function feeds an input buffer into an ongoing SHA-1
- *                 checksum calculation.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- * \deprecated     Superseded by mbedtls_sha1_update_ret() in 2.7.0.
- *
- * \param ctx      The SHA-1 context. This must be initialized and
- *                 have a hash operation started.
- * \param input    The buffer holding the input data.
- *                 This must be a readable buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data \p input in Bytes.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_sha1_update( mbedtls_sha1_context *ctx,
-                                             const unsigned char *input,
-                                             size_t ilen );
-
-/**
- * \brief          This function finishes the SHA-1 operation, and writes
- *                 the result to the output buffer.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- * \deprecated     Superseded by mbedtls_sha1_finish_ret() in 2.7.0.
- *
- * \param ctx      The SHA-1 context. This must be initialized and
- *                 have a hash operation started.
- * \param output   The SHA-1 checksum result.
- *                 This must be a writable buffer of length \c 20 Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
-                                             unsigned char output[20] );
-
-/**
- * \brief          SHA-1 process data block (internal use only).
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- * \deprecated     Superseded by mbedtls_internal_sha1_process() in 2.7.0.
- *
- * \param ctx      The SHA-1 context. This must be initialized.
- * \param data     The data block being processed.
- *                 This must be a readable buffer of length \c 64 bytes.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
-                                              const unsigned char data[64] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          This function calculates the SHA-1 checksum of a buffer.
  *
@@ -290,41 +209,6 @@ MBEDTLS_DEPRECATED void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
 int mbedtls_sha1_ret( const unsigned char *input,
                       size_t ilen,
                       unsigned char output[20] );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          This function calculates the SHA-1 checksum of a buffer.
- *
- *                 The function allocates the context, performs the
- *                 calculation, and frees the context.
- *
- *                 The SHA-1 result is calculated as
- *                 output = SHA-1(input buffer).
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- * \deprecated     Superseded by mbedtls_sha1_ret() in 2.7.0
- *
- * \param input    The buffer holding the input data.
- *                 This must be a readable buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data \p input in Bytes.
- * \param output   The SHA-1 checksum result. This must be a writable
- *                 buffer of size \c 20 Bytes.
- *
- */
-MBEDTLS_DEPRECATED void mbedtls_sha1( const unsigned char *input,
-                                      size_t ilen,
-                                      unsigned char output[20] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -34,8 +34,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED                -0x0037  /**< SHA-256 hardware accelerator failed */
 #define MBEDTLS_ERR_SHA256_BAD_INPUT_DATA                 -0x0074  /**< SHA-256 input data was malformed. */
 
 #ifdef __cplusplus
@@ -152,72 +150,6 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
 int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                      const unsigned char data[64] );
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          This function starts a SHA-224 or SHA-256 checksum
- *                 calculation.
- *
- * \deprecated     Superseded by mbedtls_sha256_starts_ret() in 2.7.0.
- *
- * \param ctx      The context to use. This must be initialized.
- * \param is224    Determines which function to use. This must be
- *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha256_starts( mbedtls_sha256_context *ctx,
-                                               int is224 );
-
-/**
- * \brief          This function feeds an input buffer into an ongoing
- *                 SHA-256 checksum calculation.
- *
- * \deprecated     Superseded by mbedtls_sha256_update_ret() in 2.7.0.
- *
- * \param ctx      The SHA-256 context to use. This must be
- *                 initialized and have a hash operation started.
- * \param input    The buffer holding the data. This must be a readable
- *                 buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data in Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha256_update( mbedtls_sha256_context *ctx,
-                                               const unsigned char *input,
-                                               size_t ilen );
-
-/**
- * \brief          This function finishes the SHA-256 operation, and writes
- *                 the result to the output buffer.
- *
- * \deprecated     Superseded by mbedtls_sha256_finish_ret() in 2.7.0.
- *
- * \param ctx      The SHA-256 context. This must be initialized and
- *                 have a hash operation started.
- * \param output   The SHA-224 or SHA-256 checksum result. This must be
- *                 a writable buffer of length \c 32 Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
-                                               unsigned char output[32] );
-
-/**
- * \brief          This function processes a single data block within
- *                 the ongoing SHA-256 computation. This function is for
- *                 internal use only.
- *
- * \deprecated     Superseded by mbedtls_internal_sha256_process() in 2.7.0.
- *
- * \param ctx      The SHA-256 context. This must be initialized.
- * \param data     The buffer holding one block of data. This must be
- *                 a readable buffer of size \c 64 Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
-                                                const unsigned char data[64] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
-
 /**
  * \brief          This function calculates the SHA-224 or SHA-256
  *                 checksum of a buffer.
@@ -240,41 +172,6 @@ int mbedtls_sha256_ret( const unsigned char *input,
                         size_t ilen,
                         unsigned char output[32],
                         int is224 );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-
-/**
- * \brief          This function calculates the SHA-224 or SHA-256 checksum
- *                 of a buffer.
- *
- *                 The function allocates the context, performs the
- *                 calculation, and frees the context.
- *
- *                 The SHA-256 result is calculated as
- *                 output = SHA-256(input buffer).
- *
- * \deprecated     Superseded by mbedtls_sha256_ret() in 2.7.0.
- *
- * \param input    The buffer holding the data. This must be a readable
- *                 buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data in Bytes.
- * \param output   The SHA-224 or SHA-256 checksum result. This must be
- *                 a writable buffer of length \c 32 Bytes.
- * \param is224    Determines which function to use. This must be either
- *                 \c 0 for SHA-256, or \c 1 for SHA-224.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
-                                        size_t ilen,
-                                        unsigned char output[32],
-                                        int is224 );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -33,8 +33,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED is deprecated and should not be used. */
-#define MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED                -0x0039  /**< SHA-512 hardware accelerator failed */
 #define MBEDTLS_ERR_SHA512_BAD_INPUT_DATA                 -0x0075  /**< SHA-512 input data was malformed. */
 
 #ifdef __cplusplus
@@ -158,75 +156,6 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
  */
 int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
                                      const unsigned char data[128] );
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-/**
- * \brief          This function starts a SHA-384 or SHA-512 checksum
- *                 calculation.
- *
- * \deprecated     Superseded by mbedtls_sha512_starts_ret() in 2.7.0
- *
- * \param ctx      The SHA-512 context to use. This must be initialized.
- * \param is384    Determines which function to use. This must be either
- *                 \c 0 for SHA-512 or \c 1 for SHA-384.
- *
- * \note           When \c MBEDTLS_SHA512_NO_SHA384 is defined, \p is384 must
- *                 be \c 0, or the function will fail to work.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha512_starts( mbedtls_sha512_context *ctx,
-                                               int is384 );
-
-/**
- * \brief          This function feeds an input buffer into an ongoing
- *                 SHA-512 checksum calculation.
- *
- * \deprecated     Superseded by mbedtls_sha512_update_ret() in 2.7.0.
- *
- * \param ctx      The SHA-512 context. This must be initialized
- *                 and have a hash operation started.
- * \param input    The buffer holding the data. This must be a readable
- *                 buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data in Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha512_update( mbedtls_sha512_context *ctx,
-                                               const unsigned char *input,
-                                               size_t ilen );
-
-/**
- * \brief          This function finishes the SHA-512 operation, and writes
- *                 the result to the output buffer.
- *
- * \deprecated     Superseded by mbedtls_sha512_finish_ret() in 2.7.0.
- *
- * \param ctx      The SHA-512 context. This must be initialized
- *                 and have a hash operation started.
- * \param output   The SHA-384 or SHA-512 checksum result. This must
- *                 be a writable buffer of size \c 64 Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
-                                               unsigned char output[64] );
-
-/**
- * \brief          This function processes a single data block within
- *                 the ongoing SHA-512 computation. This function is for
- *                 internal use only.
- *
- * \deprecated     Superseded by mbedtls_internal_sha512_process() in 2.7.0.
- *
- * \param ctx      The SHA-512 context. This must be initialized.
- * \param data     The buffer holding one block of data. This must be
- *                 a readable buffer of length \c 128 Bytes.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha512_process(
-                                            mbedtls_sha512_context *ctx,
-                                            const unsigned char data[128] );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 /**
  * \brief          This function calculates the SHA-512 or SHA-384
@@ -257,44 +186,6 @@ int mbedtls_sha512_ret( const unsigned char *input,
                         size_t ilen,
                         unsigned char output[64],
                         int is384 );
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-#if defined(MBEDTLS_DEPRECATED_WARNING)
-#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
-#else
-#define MBEDTLS_DEPRECATED
-#endif
-
-/**
- * \brief          This function calculates the SHA-512 or SHA-384
- *                 checksum of a buffer.
- *
- *                 The function allocates the context, performs the
- *                 calculation, and frees the context.
- *
- *                 The SHA-512 result is calculated as
- *                 output = SHA-512(input buffer).
- *
- * \deprecated     Superseded by mbedtls_sha512_ret() in 2.7.0
- *
- * \param input    The buffer holding the data. This must be a
- *                 readable buffer of length \p ilen Bytes.
- * \param ilen     The length of the input data in Bytes.
- * \param output   The SHA-384 or SHA-512 checksum result. This must
- *                 be a writable buffer of length \c 64 Bytes.
- * \param is384    Determines which function to use. This must be either
- *                 \c 0 for SHA-512, or \c 1 for SHA-384.
- *
- * \note           When \c MBEDTLS_SHA512_NO_SHA384 is defined, \p is384 must
- *                 be \c 0, or the function will fail to work.
- */
-MBEDTLS_DEPRECATED void mbedtls_sha512( const unsigned char *input,
-                                        size_t ilen,
-                                        unsigned char output[64],
-                                        int is384 );
-
-#undef MBEDTLS_DEPRECATED
-#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/error.c
+++ b/library/error.c
@@ -126,18 +126,6 @@
 #include "mbedtls/md.h"
 #endif
 
-#if defined(MBEDTLS_MD2_C)
-#include "mbedtls/md2.h"
-#endif
-
-#if defined(MBEDTLS_MD4_C)
-#include "mbedtls/md4.h"
-#endif
-
-#if defined(MBEDTLS_MD5_C)
-#include "mbedtls/md5.h"
-#endif
-
 #if defined(MBEDTLS_NET_C)
 #include "mbedtls/net_sockets.h"
 #endif
@@ -172,10 +160,6 @@
 
 #if defined(MBEDTLS_POLY1305_C)
 #include "mbedtls/poly1305.h"
-#endif
-
-#if defined(MBEDTLS_RIPEMD160_C)
-#include "mbedtls/ripemd160.h"
 #endif
 
 #if defined(MBEDTLS_RSA_C)
@@ -771,21 +755,6 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "HMAC_DRBG - The entropy source failed" );
 #endif /* MBEDTLS_HMAC_DRBG_C */
 
-#if defined(MBEDTLS_MD2_C)
-        case -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED):
-            return( "MD2 - MD2 hardware accelerator failed" );
-#endif /* MBEDTLS_MD2_C */
-
-#if defined(MBEDTLS_MD4_C)
-        case -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED):
-            return( "MD4 - MD4 hardware accelerator failed" );
-#endif /* MBEDTLS_MD4_C */
-
-#if defined(MBEDTLS_MD5_C)
-        case -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED):
-            return( "MD5 - MD5 hardware accelerator failed" );
-#endif /* MBEDTLS_MD5_C */
-
 #if defined(MBEDTLS_NET_C)
         case -(MBEDTLS_ERR_NET_SOCKET_FAILED):
             return( "NET - Failed to open a socket" );
@@ -843,28 +812,17 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "POLY1305 - Poly1305 hardware accelerator failed" );
 #endif /* MBEDTLS_POLY1305_C */
 
-#if defined(MBEDTLS_RIPEMD160_C)
-        case -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED):
-            return( "RIPEMD160 - RIPEMD160 hardware accelerator failed" );
-#endif /* MBEDTLS_RIPEMD160_C */
-
 #if defined(MBEDTLS_SHA1_C)
-        case -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED):
-            return( "SHA1 - SHA-1 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA):
             return( "SHA1 - SHA-1 input data was malformed" );
 #endif /* MBEDTLS_SHA1_C */
 
 #if defined(MBEDTLS_SHA256_C)
-        case -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED):
-            return( "SHA256 - SHA-256 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA):
             return( "SHA256 - SHA-256 input data was malformed" );
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
-        case -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED):
-            return( "SHA512 - SHA-512 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA):
             return( "SHA512 - SHA-512 input data was malformed" );
 #endif /* MBEDTLS_SHA512_C */

--- a/library/error.c
+++ b/library/error.c
@@ -239,6 +239,8 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "CIPHER - Authentication failed (for AEAD modes)" );
         case -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT):
             return( "CIPHER - The context is invalid. For example, because it was freed" );
+        case -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED):
+            return( "CIPHER - Cipher hardware accelerator failed" );
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_DHM_C)
@@ -298,6 +300,8 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "MD - Failed to allocate memory" );
         case -(MBEDTLS_ERR_MD_FILE_IO_ERROR):
             return( "MD - Opening or reading of file failed" );
+        case -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED):
+            return( "MD - MD hardware accelerator failed" );
 #endif /* MBEDTLS_MD_C */
 
 #if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
@@ -395,6 +399,10 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "RSA - The output buffer for decryption is not large enough" );
         case -(MBEDTLS_ERR_RSA_RNG_FAILED):
             return( "RSA - The random generator failed to generate non-zeros" );
+        case -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION):
+            return( "RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality" );
+        case -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED):
+            return( "RSA - RSA hardware accelerator failed" );
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_SSL_TLS_C)
@@ -593,6 +601,11 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "AES - AES hardware accelerator failed" );
 #endif /* MBEDTLS_AES_C */
 
+#if defined(MBEDTLS_ARC4_C)
+        case -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED):
+            return( "ARC4 - ARC4 hardware accelerator failed" );
+#endif /* MBEDTLS_ARC4_C */
+
 #if defined(MBEDTLS_ARIA_C)
         case -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA):
             return( "ARIA - Bad input data" );
@@ -758,6 +771,21 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "HMAC_DRBG - The entropy source failed" );
 #endif /* MBEDTLS_HMAC_DRBG_C */
 
+#if defined(MBEDTLS_MD2_C)
+        case -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED):
+            return( "MD2 - MD2 hardware accelerator failed" );
+#endif /* MBEDTLS_MD2_C */
+
+#if defined(MBEDTLS_MD4_C)
+        case -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED):
+            return( "MD4 - MD4 hardware accelerator failed" );
+#endif /* MBEDTLS_MD4_C */
+
+#if defined(MBEDTLS_MD5_C)
+        case -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED):
+            return( "MD5 - MD5 hardware accelerator failed" );
+#endif /* MBEDTLS_MD5_C */
+
 #if defined(MBEDTLS_NET_C)
         case -(MBEDTLS_ERR_NET_SOCKET_FAILED):
             return( "NET - Failed to open a socket" );
@@ -815,17 +843,28 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "POLY1305 - Poly1305 hardware accelerator failed" );
 #endif /* MBEDTLS_POLY1305_C */
 
+#if defined(MBEDTLS_RIPEMD160_C)
+        case -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED):
+            return( "RIPEMD160 - RIPEMD160 hardware accelerator failed" );
+#endif /* MBEDTLS_RIPEMD160_C */
+
 #if defined(MBEDTLS_SHA1_C)
+        case -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED):
+            return( "SHA1 - SHA-1 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA):
             return( "SHA1 - SHA-1 input data was malformed" );
 #endif /* MBEDTLS_SHA1_C */
 
 #if defined(MBEDTLS_SHA256_C)
+        case -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED):
+            return( "SHA256 - SHA-256 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA):
             return( "SHA256 - SHA-256 input data was malformed" );
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
+        case -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED):
+            return( "SHA512 - SHA-512 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA):
             return( "SHA512 - SHA-512 input data was malformed" );
 #endif /* MBEDTLS_SHA512_C */

--- a/library/error.c
+++ b/library/error.c
@@ -239,8 +239,6 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "CIPHER - Authentication failed (for AEAD modes)" );
         case -(MBEDTLS_ERR_CIPHER_INVALID_CONTEXT):
             return( "CIPHER - The context is invalid. For example, because it was freed" );
-        case -(MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED):
-            return( "CIPHER - Cipher hardware accelerator failed" );
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_DHM_C)
@@ -300,8 +298,6 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "MD - Failed to allocate memory" );
         case -(MBEDTLS_ERR_MD_FILE_IO_ERROR):
             return( "MD - Opening or reading of file failed" );
-        case -(MBEDTLS_ERR_MD_HW_ACCEL_FAILED):
-            return( "MD - MD hardware accelerator failed" );
 #endif /* MBEDTLS_MD_C */
 
 #if defined(MBEDTLS_PEM_PARSE_C) || defined(MBEDTLS_PEM_WRITE_C)
@@ -399,10 +395,6 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "RSA - The output buffer for decryption is not large enough" );
         case -(MBEDTLS_ERR_RSA_RNG_FAILED):
             return( "RSA - The random generator failed to generate non-zeros" );
-        case -(MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION):
-            return( "RSA - The implementation does not offer the requested operation, for example, because of security violations or lack of functionality" );
-        case -(MBEDTLS_ERR_RSA_HW_ACCEL_FAILED):
-            return( "RSA - RSA hardware accelerator failed" );
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_SSL_TLS_C)
@@ -601,11 +593,6 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "AES - AES hardware accelerator failed" );
 #endif /* MBEDTLS_AES_C */
 
-#if defined(MBEDTLS_ARC4_C)
-        case -(MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED):
-            return( "ARC4 - ARC4 hardware accelerator failed" );
-#endif /* MBEDTLS_ARC4_C */
-
 #if defined(MBEDTLS_ARIA_C)
         case -(MBEDTLS_ERR_ARIA_BAD_INPUT_DATA):
             return( "ARIA - Bad input data" );
@@ -771,21 +758,6 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "HMAC_DRBG - The entropy source failed" );
 #endif /* MBEDTLS_HMAC_DRBG_C */
 
-#if defined(MBEDTLS_MD2_C)
-        case -(MBEDTLS_ERR_MD2_HW_ACCEL_FAILED):
-            return( "MD2 - MD2 hardware accelerator failed" );
-#endif /* MBEDTLS_MD2_C */
-
-#if defined(MBEDTLS_MD4_C)
-        case -(MBEDTLS_ERR_MD4_HW_ACCEL_FAILED):
-            return( "MD4 - MD4 hardware accelerator failed" );
-#endif /* MBEDTLS_MD4_C */
-
-#if defined(MBEDTLS_MD5_C)
-        case -(MBEDTLS_ERR_MD5_HW_ACCEL_FAILED):
-            return( "MD5 - MD5 hardware accelerator failed" );
-#endif /* MBEDTLS_MD5_C */
-
 #if defined(MBEDTLS_NET_C)
         case -(MBEDTLS_ERR_NET_SOCKET_FAILED):
             return( "NET - Failed to open a socket" );
@@ -843,28 +815,17 @@ const char * mbedtls_low_level_strerr( int error_code )
             return( "POLY1305 - Poly1305 hardware accelerator failed" );
 #endif /* MBEDTLS_POLY1305_C */
 
-#if defined(MBEDTLS_RIPEMD160_C)
-        case -(MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED):
-            return( "RIPEMD160 - RIPEMD160 hardware accelerator failed" );
-#endif /* MBEDTLS_RIPEMD160_C */
-
 #if defined(MBEDTLS_SHA1_C)
-        case -(MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED):
-            return( "SHA1 - SHA-1 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA1_BAD_INPUT_DATA):
             return( "SHA1 - SHA-1 input data was malformed" );
 #endif /* MBEDTLS_SHA1_C */
 
 #if defined(MBEDTLS_SHA256_C)
-        case -(MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED):
-            return( "SHA256 - SHA-256 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA256_BAD_INPUT_DATA):
             return( "SHA256 - SHA-256 input data was malformed" );
 #endif /* MBEDTLS_SHA256_C */
 
 #if defined(MBEDTLS_SHA512_C)
-        case -(MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED):
-            return( "SHA512 - SHA-512 hardware accelerator failed" );
         case -(MBEDTLS_ERR_SHA512_BAD_INPUT_DATA):
             return( "SHA512 - SHA-512 input data was malformed" );
 #endif /* MBEDTLS_SHA512_C */

--- a/library/md.c
+++ b/library/md.c
@@ -390,13 +390,6 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
     return( 0 );
 }
 
-#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
-int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info )
-{
-    return mbedtls_md_setup( ctx, md_info, 1 );
-}
-#endif
-
 #define ALLOC( type )                                                   \
     do {                                                                \
         ctx->md_ctx = mbedtls_calloc( 1, sizeof( mbedtls_##type##_context ) ); \

--- a/library/md2.c
+++ b/library/md2.c
@@ -106,13 +106,6 @@ int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md2_starts( mbedtls_md2_context *ctx )
-{
-    mbedtls_md2_starts_ret( ctx );
-}
-#endif
-
 #if !defined(MBEDTLS_MD2_PROCESS_ALT)
 int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
 {
@@ -153,12 +146,6 @@ int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md2_process( mbedtls_md2_context *ctx )
-{
-    mbedtls_internal_md2_process( ctx );
-}
-#endif
 #endif /* !MBEDTLS_MD2_PROCESS_ALT */
 
 /*
@@ -195,15 +182,6 @@ int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md2_update( mbedtls_md2_context *ctx,
-                         const unsigned char *input,
-                         size_t ilen )
-{
-    mbedtls_md2_update_ret( ctx, input, ilen );
-}
-#endif
-
 /*
  * MD2 final digest
  */
@@ -230,14 +208,6 @@ int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
 
     return( 0 );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md2_finish( mbedtls_md2_context *ctx,
-                         unsigned char output[16] )
-{
-    mbedtls_md2_finish_ret( ctx, output );
-}
-#endif
 
 #endif /* !MBEDTLS_MD2_ALT */
 
@@ -267,15 +237,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md2( const unsigned char *input,
-                  size_t ilen,
-                  unsigned char output[16] )
-{
-    mbedtls_md2_ret( input, ilen, output );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/md4.c
+++ b/library/md4.c
@@ -102,13 +102,6 @@ int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md4_starts( mbedtls_md4_context *ctx )
-{
-    mbedtls_md4_starts_ret( ctx );
-}
-#endif
-
 #if !defined(MBEDTLS_MD4_PROCESS_ALT)
 int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
                                   const unsigned char data[64] )
@@ -238,13 +231,6 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md4_process( mbedtls_md4_context *ctx,
-                          const unsigned char data[64] )
-{
-    mbedtls_internal_md4_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_MD4_PROCESS_ALT */
 
 /*
@@ -301,15 +287,6 @@ int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md4_update( mbedtls_md4_context *ctx,
-                         const unsigned char *input,
-                         size_t ilen )
-{
-    mbedtls_md4_update_ret( ctx, input, ilen );
-}
-#endif
-
 static const unsigned char md4_padding[64] =
 {
  0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -355,14 +332,6 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md4_finish( mbedtls_md4_context *ctx,
-                         unsigned char output[16] )
-{
-    mbedtls_md4_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* !MBEDTLS_MD4_ALT */
 
 /*
@@ -391,15 +360,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md4( const unsigned char *input,
-                  size_t ilen,
-                  unsigned char output[16] )
-{
-    mbedtls_md4_ret( input, ilen, output );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -101,13 +101,6 @@ int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md5_starts( mbedtls_md5_context *ctx )
-{
-    mbedtls_md5_starts_ret( ctx );
-}
-#endif
-
 #if !defined(MBEDTLS_MD5_PROCESS_ALT)
 int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
                                   const unsigned char data[64] )
@@ -244,13 +237,6 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md5_process( mbedtls_md5_context *ctx,
-                          const unsigned char data[64] )
-{
-    mbedtls_internal_md5_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_MD5_PROCESS_ALT */
 
 /*
@@ -303,15 +289,6 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
 
     return( 0 );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md5_update( mbedtls_md5_context *ctx,
-                         const unsigned char *input,
-                         size_t ilen )
-{
-    mbedtls_md5_update_ret( ctx, input, ilen );
-}
-#endif
 
 /*
  * MD5 final digest
@@ -370,14 +347,6 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md5_finish( mbedtls_md5_context *ctx,
-                         unsigned char output[16] )
-{
-    mbedtls_md5_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* !MBEDTLS_MD5_ALT */
 
 /*
@@ -406,15 +375,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_md5( const unsigned char *input,
-                  size_t ilen,
-                  unsigned char output[16] )
-{
-    mbedtls_md5_ret( input, ilen, output );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 /*

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -151,9 +151,6 @@ psa_status_t mbedtls_to_psa_error( int ret )
         case MBEDTLS_ERR_AES_HW_ACCEL_FAILED:
             return( PSA_ERROR_HARDWARE_FAILURE );
 
-        case MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED:
-            return( PSA_ERROR_HARDWARE_FAILURE );
-
         case MBEDTLS_ERR_ASN1_OUT_OF_DATA:
         case MBEDTLS_ERR_ASN1_UNEXPECTED_TAG:
         case MBEDTLS_ERR_ASN1_INVALID_LENGTH:
@@ -263,11 +260,6 @@ psa_status_t mbedtls_to_psa_error( int ret )
             return( PSA_ERROR_INSUFFICIENT_ENTROPY );
 #endif
 
-        case MBEDTLS_ERR_MD2_HW_ACCEL_FAILED:
-        case MBEDTLS_ERR_MD4_HW_ACCEL_FAILED:
-        case MBEDTLS_ERR_MD5_HW_ACCEL_FAILED:
-            return( PSA_ERROR_HARDWARE_FAILURE );
-
         case MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE:
             return( PSA_ERROR_NOT_SUPPORTED );
         case MBEDTLS_ERR_MD_BAD_INPUT_DATA:
@@ -276,8 +268,6 @@ psa_status_t mbedtls_to_psa_error( int ret )
             return( PSA_ERROR_INSUFFICIENT_MEMORY );
         case MBEDTLS_ERR_MD_FILE_IO_ERROR:
             return( PSA_ERROR_STORAGE_FAILURE );
-        case MBEDTLS_ERR_MD_HW_ACCEL_FAILED:
-            return( PSA_ERROR_HARDWARE_FAILURE );
 
         case MBEDTLS_ERR_MPI_FILE_IO_ERROR:
             return( PSA_ERROR_STORAGE_FAILURE );
@@ -327,9 +317,6 @@ psa_status_t mbedtls_to_psa_error( int ret )
         case MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED:
             return( PSA_ERROR_NOT_SUPPORTED );
 
-        case MBEDTLS_ERR_RIPEMD160_HW_ACCEL_FAILED:
-            return( PSA_ERROR_HARDWARE_FAILURE );
-
         case MBEDTLS_ERR_RSA_BAD_INPUT_DATA:
             return( PSA_ERROR_INVALID_ARGUMENT );
         case MBEDTLS_ERR_RSA_INVALID_PADDING:
@@ -350,11 +337,6 @@ psa_status_t mbedtls_to_psa_error( int ret )
         case MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION:
             return( PSA_ERROR_NOT_SUPPORTED );
         case MBEDTLS_ERR_RSA_HW_ACCEL_FAILED:
-            return( PSA_ERROR_HARDWARE_FAILURE );
-
-        case MBEDTLS_ERR_SHA1_HW_ACCEL_FAILED:
-        case MBEDTLS_ERR_SHA256_HW_ACCEL_FAILED:
-        case MBEDTLS_ERR_SHA512_HW_ACCEL_FAILED:
             return( PSA_ERROR_HARDWARE_FAILURE );
 
         case MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH:

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -103,13 +103,6 @@ int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx )
-{
-    mbedtls_ripemd160_starts_ret( ctx );
-}
-#endif
-
 #if !defined(MBEDTLS_RIPEMD160_PROCESS_ALT)
 /*
  * Process one block
@@ -307,13 +300,6 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_ripemd160_process( mbedtls_ripemd160_context *ctx,
-                                const unsigned char data[64] )
-{
-    mbedtls_internal_ripemd160_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_RIPEMD160_PROCESS_ALT */
 
 /*
@@ -368,15 +354,6 @@ int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
-                               const unsigned char *input,
-                               size_t ilen )
-{
-    mbedtls_ripemd160_update_ret( ctx, input, ilen );
-}
-#endif
-
 static const unsigned char ripemd160_padding[64] =
 {
  0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -423,14 +400,6 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx,
-                               unsigned char output[20] )
-{
-    mbedtls_ripemd160_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* ! MBEDTLS_RIPEMD160_ALT */
 
 /*
@@ -459,15 +428,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_ripemd160( const unsigned char *input,
-                        size_t ilen,
-                        unsigned char output[20] )
-{
-    mbedtls_ripemd160_ret( input, ilen, output );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 /*

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -114,13 +114,6 @@ int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
-{
-    mbedtls_sha1_starts_ret( ctx );
-}
-#endif
-
 #if !defined(MBEDTLS_SHA1_PROCESS_ALT)
 int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
                                    const unsigned char data[64] )
@@ -294,13 +287,6 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
-                           const unsigned char data[64] )
-{
-    mbedtls_internal_sha1_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 /*
@@ -355,15 +341,6 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
 
     return( 0 );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha1_update( mbedtls_sha1_context *ctx,
-                          const unsigned char *input,
-                          size_t ilen )
-{
-    mbedtls_sha1_update_ret( ctx, input, ilen );
-}
-#endif
 
 /*
  * SHA-1 final digest
@@ -426,14 +403,6 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
-                          unsigned char output[20] )
-{
-    mbedtls_sha1_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* !MBEDTLS_SHA1_ALT */
 
 /*
@@ -465,15 +434,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha1( const unsigned char *input,
-                   size_t ilen,
-                   unsigned char output[20] )
-{
-    mbedtls_sha1_ret( input, ilen, output );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 /*

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -138,14 +138,6 @@ int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha256_starts( mbedtls_sha256_context *ctx,
-                            int is224 )
-{
-    mbedtls_sha256_starts_ret( ctx, is224 );
-}
-#endif
-
 #if !defined(MBEDTLS_SHA256_PROCESS_ALT)
 static const uint32_t K[] =
 {
@@ -281,13 +273,6 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
-                             const unsigned char data[64] )
-{
-    mbedtls_internal_sha256_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 /*
@@ -342,15 +327,6 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
 
     return( 0 );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha256_update( mbedtls_sha256_context *ctx,
-                            const unsigned char *input,
-                            size_t ilen )
-{
-    mbedtls_sha256_update_ret( ctx, input, ilen );
-}
-#endif
 
 /*
  * SHA-256 final digest
@@ -418,14 +394,6 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
-                            unsigned char output[32] )
-{
-    mbedtls_sha256_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* !MBEDTLS_SHA256_ALT */
 
 /*
@@ -459,16 +427,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha256( const unsigned char *input,
-                     size_t ilen,
-                     unsigned char output[32],
-                     int is224 )
-{
-    mbedtls_sha256_ret( input, ilen, output, is224 );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 /*

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -171,14 +171,6 @@ int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 )
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha512_starts( mbedtls_sha512_context *ctx,
-                            int is384 )
-{
-    mbedtls_sha512_starts_ret( ctx, is384 );
-}
-#endif
-
 #if !defined(MBEDTLS_SHA512_PROCESS_ALT)
 
 /*
@@ -330,13 +322,6 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha512_process( mbedtls_sha512_context *ctx,
-                             const unsigned char data[128] )
-{
-    mbedtls_internal_sha512_process( ctx, data );
-}
-#endif
 #endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 /*
@@ -390,15 +375,6 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
 
     return( 0 );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha512_update( mbedtls_sha512_context *ctx,
-                            const unsigned char *input,
-                            size_t ilen )
-{
-    mbedtls_sha512_update_ret( ctx, input, ilen );
-}
-#endif
 
 /*
  * SHA-512 final digest
@@ -470,14 +446,6 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
     return( 0 );
 }
 
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
-                            unsigned char output[64] )
-{
-    mbedtls_sha512_finish_ret( ctx, output );
-}
-#endif
-
 #endif /* !MBEDTLS_SHA512_ALT */
 
 /*
@@ -515,16 +483,6 @@ exit:
 
     return( ret );
 }
-
-#if !defined(MBEDTLS_DEPRECATED_REMOVED)
-void mbedtls_sha512( const unsigned char *input,
-                     size_t ilen,
-                     unsigned char output[64],
-                     int is384 )
-{
-    mbedtls_sha512_ret( input, ilen, output, is384 );
-}
-#endif
 
 #if defined(MBEDTLS_SELF_TEST)
 


### PR DESCRIPTION
#4334 was merged in development instead of development_3.0 by mistake, this is a revival of it now targeting the correct branch :)

I rebased the over development_3.0 but kept the same commit structure, in order to make it easy to check that this indeed equivalent to the original using something like `git range-diff development..public/pr/4334 development_3.0..public/pr/4349` (after checking that the command is correct and adapting names to your local setup).

Fixes #4280