### PR TITLE
Combine error codes with bitwise or, not addition

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -164,7 +164,7 @@ static inline int mbedtls_error_add_ext( int high, int low,
     (void)file;
     (void)line;
 
-    return( high + low );
+    return( -( -high | -low ) );
 }
 
 /**


### PR DESCRIPTION
Use bitwise or on the absolute values, rather than addition, to combine a high-level error code with a low-level error code (or an error code of either kind with 0). This gives the same result when combining error codes of different levels, since those use disjoint bit positions.

An advantage of using bitwise or is that it is more robust to mistakes. For example, combining an error code with itself is now a no-op. Combining two error codes from the same module is more likely to result in an error code from that module. We detect such errors dynamically in tests when MBEDTLS_TEST_HOOKS is enabled, but that doesn't help for rare cases which are not covered by our tests.

Another advantage is that it guarantees that the result cannot be 0 if either input is nonzero. This sometimes helps optimizers and static analyzers.

A downside is that the generated code tends to be slightly larger. When combining a high-level constant with a low-level value, which is a common idiom, the typical cost with Arm Thumb seems to be 1 extra instruction, e.g. dhm_read_bignum before:

    30:   4b04            ldr     r3, [pc, #16]   ; (44 <dhm_read_bignum+0x44>)
    32:   18c0            adds    r0, r0, r3
    44:   ffffcf00        .word   0xffffcf00

After:

    30:   23c4            movs    r3, #196        ; 0xc4
    32:   4240            negs    r0, r0
    34:   019b            lsls    r3, r3, #6
    36:   4318            orrs    r0, r3
    38:   4240            negs    r0, r0

### Status

For discussion: do we want to do this?

This is a follow-up to #4006. I don't want to hold up #4006 with this discussion, hence I'm making it a separate PR. This PR will be re-targeted against `development` once #4006 is merged, and eventually merged both into the 2.x and 3.0 branches.

Not to be backported since this changes error codes in buggy cases that we can't identify.
