### PR TITLE
Conduct secure random generator on macOS

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -127,6 +127,10 @@ if(WIN32)
     set(libs ${libs} ws2_32)
 endif(WIN32)
 
+if(APPLE)
+    list(APPEND libs "-framework Security")
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -159,11 +159,24 @@ static int sysctl_arnd_wrapper( unsigned char *buf, size_t buflen )
 #endif /* KERN_ARND */
 #endif /* __FreeBSD__ || __NetBSD__ */
 
+#if defined(__APPLE__)
+// Use randomization services to generate cryptographically secure random numbers
+#include <Security/SecRandom.h>
+#include <stdlib.h>
+#endif
+
 #include <stdio.h>
 
 int mbedtls_platform_entropy_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen )
 {
+#if defined(__APPLE__)
+    int status = SecRandomCopyBytes(kSecRandomDefault, len, (uint8_t*)output);
+    if (status != errSecSuccess) {
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+    }
+    return( 0 );
+#endif
     FILE *file;
     size_t read_len;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;


### PR DESCRIPTION

## Description

MacOS provides secure random generator which allows us generating random number without calling file descriptor.

For more information see: https://developer.apple.com/documentation/security/1399291-secrandomcopybytes

## Status
**READY/IN DEVELOPMENT/HOLD**


Yes | NO  
Which branch? development

## Migrations
NO

## Additional comments

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
