### PR TITLE
Error on removed options

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -839,6 +839,40 @@
 #error "MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH defined, but not all prerequisites"
 #endif
 
+
+
+/* Reject attempts to enable options that have been removed and that could
+ * cause a build to succeed but with features removed. */
+
+#if defined(MBEDTLS_HAVEGE_C) //no-check-names
+#error "MBEDTLS_HAVEGE_C was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/2599"
+#endif
+
+#if defined(MBEDTLS_SSL_HW_RECORD_ACCEL) //no-check-names
+#error "MBEDTLS_SSL_HW_RECORD_ACCEL was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_SSL3) //no-check-names
+#error "MBEDTLS_SSL_PROTO_SSL3 (SSL v3.0 support) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#endif
+
+#if defined(MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO) //no-check-names
+#error "MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO (SSL v2 ClientHello support) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#endif
+
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) //no-check-names
+#error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT (compatibility with the buggy implementation of truncated HMAC in Mbed TLS up to 2.7) was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#endif
+
+#if defined(MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES) //no-check-names
+#error "MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES was removed in Mbed TLS 3.0. See the ChangeLog for entry if you really need SHA-1-signed certificates."
+#endif
+
+#if defined(MBEDTLS_ZLIB_SUPPORT) //no-check-names
+#error "MBEDTLS_ZLIB_SUPPORT was removed in Mbed TLS 3.0. See https://github.com/ARMmbed/mbedtls/issues/4031"
+#endif
+
+
 /*
  * Avoid warning from -pedantic. This is a convenient place for this
  * workaround since this is included by every single file before the

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -865,7 +865,7 @@
 #endif
 
 #if defined(MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES) //no-check-names
-#error "MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES was removed in Mbed TLS 3.0. See the ChangeLog for entry if you really need SHA-1-signed certificates."
+#error "MBEDTLS_TLS_DEFAULT_ALLOW_SHA1_IN_CERTIFICATES was removed in Mbed TLS 3.0. See the ChangeLog entry if you really need SHA-1-signed certificates."
 #endif
 
 #if defined(MBEDTLS_ZLIB_SUPPORT) //no-check-names

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -97,8 +97,9 @@ LIBRARY="$( ls library/*.c )"
 LIBRARY="$LIBRARY 3rdparty/everest/library/everest.c 3rdparty/everest/library/x25519.c"
 NL='
 '
-sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
-    $HEADERS $LIBRARY \
+cat $HEADERS $LIBRARY \
+    | grep -v -e '//no-check-names' -e '#error' \
+    | sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
             | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )


### PR DESCRIPTION
If the compile-time configuration enables an option that was removed in Mbed TLS 3.0, and the effect of removing the option would likely not be detected at build time, `#error` out in `check_config.h`.

I didn't add `#error` clauses if the use of the feature would be detected at compile time. For example, if an application uses the test certificates that were formerly enabled by `MBEDTLS_CERTS_C`, it will fail to link, so no extra error detection is necessary.
