### PR TITLE
Use Python 3 instead of Python 2 to generate test files

### DIFF
--- a/ChangeLog.d/make-generate-tests-python.txt
+++ b/ChangeLog.d/make-generate-tests-python.txt
@@ -1,0 +1,3 @@
+Changes
+   * When building the test suites with GNU make, invoke python3 or python, not
+     python2, which is no longer supported upstream.

--- a/programs/fuzz/Makefile
+++ b/programs/fuzz/Makefile
@@ -20,8 +20,6 @@ endif
 DLEXT ?= so
 EXEXT=
 SHARED_SUFFIX=
-# python2 for POSIX since FreeBSD has only python2 as default.
-PYTHON ?= python2
 
 # Zlib shared library extensions:
 ifdef ZLIB

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -54,8 +54,7 @@ else
 DLEXT ?= so
 EXEXT=
 SHARED_SUFFIX=
-# python2 for POSIX since FreeBSD has only python2 as default.
-PYTHON ?= python2
+PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; else echo python; fi)
 endif
 
 # Zlib shared library extensions:


### PR DESCRIPTION
Python 2 is no longer officially supported, but we were still using it to generate test suite .c files from .function files when using GNU make. Switch to looking for Python 3.

This change was done for CMake a long time ago.

Backports: [2.x](https://github.com/ARMmbed/mbedtls/pull/4460), [2.16](https://github.com/ARMmbed/mbedtls/pull/4461)