### PR TITLE
2.2x only: No longer generate psa_constant_names_generated.c on Windows on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,7 @@ jobs:
 
     - name: Windows
       os: windows
-      before_install:
-        - choco install python --version=3.5.4
-      env:
-        # Add the directory where the Choco package goes
-        - PATH=/c/Python35:/c/Python35/Scripts:$PATH
       script:
-        - type python; python --version
-        - python scripts/generate_psa_constants.py
-        # Logs appear out of sequence on Windows. Give time to catch up.
-        - sleep 5
         - scripts/windows_msbuild.bat v141 # Visual Studio 2017
 
 after_failure:


### PR DESCRIPTION
Since PR #3709, programs/psa/psa_constant_names_generated.c is checked into version control, so it is no longer necessary to generate it.

This pull request is for 2.2x only: in 2.16 we never generated files automatically, and [in 3.0 we will be generating this file and others on the CI](https://github.com/ARMmbed/mbedtls/pull/4395).
