### PR TITLE
Check storage format tests for regressions

### DIFF
--- a/docs/architecture/testing/psa-storage-format-testing.md
+++ b/docs/architecture/testing/psa-storage-format-testing.md
@@ -34,7 +34,7 @@ Use a similar approach for files other than keys where possible and relevant.
 
 Test cases should normally not be removed from the code base: if something has worked before, it should keep working in future versions, so we should keep testing it.
 
-This cannot be enforced solely by looking at a single version of Mbed TLS, since there would be no indication that more test cases used to exist. It can only be enforced through review of library changes. The review may be assisted by a tool that compares the old and the new version, in the same way that `abi-check.py` compares the library's API and ABI.
+This cannot be enforced solely by looking at a single version of Mbed TLS, since there would be no indication that more test cases used to exist. It can only be enforced through review of library changes. The review is be assisted by a tool that compares the old and the new version, which is implemented in `scripts/abi_check.py`. This tool fails the CI if load-and-check test case disappears (changed test cases are raised as false positives).
 
 If the way certain keys are stored changes, and we don't deliberately decide to stop supporting old keys (which should only be done by retiring a version of the storage format), then we should keep the corresponding test cases in load-only mode: create a file with the expected content, load it and check the data that it contains.
 

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -10,9 +10,9 @@ applying them to compare the header and library files.
 
 For the storage format, this script compares the automatically generated
 storage tests and the manual read tests, and complains if there is a
-reduction in coverage. A change in test data will be signalled as a
+reduction in coverage. A change in test data will be signaled as a
 coverage reduction since the old test data is no longer present. A change in
-how test data is presented will be signalled as well; this would be a false
+how test data is presented will be signaled as well; this would be a false
 positive.
 
 The results of the API/ABI comparison are either formatted as HTML and stored
@@ -65,7 +65,7 @@ class AbiChecker:
         configuration.report_dir: directory for output files
         configuration.keep_all_reports: if false, delete old reports
         configuration.brief: if true, output shorter report to stdout
-        configuration.check_api: if true, compare ABIs
+        configuration.check_abi: if true, compare ABIs
         configuration.check_api: if true, compare APIs
         configuration.check_storage: if true, compare storage format tests
         configuration.skip_file: path to file containing symbols and types to skip

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -249,32 +249,33 @@ class AbiChecker:
         at_paragraph_start = True
         description = None
         full_path = os.path.join(directory, filename)
-        for line_number, line in enumerate(open(full_path), 1):
-            line = line.strip()
-            if not line:
-                at_paragraph_start = True
-                continue
-            if line.startswith('#'):
-                continue
-            if at_paragraph_start:
-                description = line.strip()
-                at_paragraph_start = False
-                continue
-            if line.startswith('depends_on:'):
-                continue
-            # We've reached a test case data line
-            test_case_data = self._normalize_storage_test_case_data(line)
-            if not is_generated:
-                # In manual test data, only look at read tests.
-                function_name = test_case_data.split(':', 1)[0]
-                if 'read' not in function_name.split('_'):
+        with open(full_path) as fd:
+            for line_number, line in enumerate(fd, 1):
+                line = line.strip()
+                if not line:
+                    at_paragraph_start = True
                     continue
-            metadata = SimpleNamespace(
-                filename=filename,
-                line_number=line_number,
-                description=description
-            )
-            storage_tests[test_case_data] = metadata
+                if line.startswith('#'):
+                    continue
+                if at_paragraph_start:
+                    description = line.strip()
+                    at_paragraph_start = False
+                    continue
+                if line.startswith('depends_on:'):
+                    continue
+                # We've reached a test case data line
+                test_case_data = self._normalize_storage_test_case_data(line)
+                if not is_generated:
+                    # In manual test data, only look at read tests.
+                    function_name = test_case_data.split(':', 1)[0]
+                    if 'read' not in function_name.split('_'):
+                        continue
+                metadata = SimpleNamespace(
+                    filename=filename,
+                    line_number=line_number,
+                    description=description
+                )
+                storage_tests[test_case_data] = metadata
 
     @staticmethod
     def _list_generated_test_data_files(git_worktree_path):

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -480,7 +480,8 @@ class AbiChecker:
         """Generate a report of ABI differences
         between self.old_rev and self.new_rev."""
         self.check_repo_path()
-        self.check_abi_tools_are_installed()
+        if self.check_api or self.check_abi:
+            self.check_abi_tools_are_installed()
         self._get_abi_dump_for_ref(self.old_version)
         self._get_abi_dump_for_ref(self.new_version)
         return self.get_abi_compatibility_report()

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 """
-Purpose
-
 This script compares the interfaces of two versions of Mbed TLS, looking
 for backward incompatibilities between two different Git revisions within
 an Mbed TLS repository. It must be run from the root of a Git working tree.
@@ -21,6 +19,8 @@ The results of the API/ABI comparison are either formatted as HTML and stored
 at a configurable location, or are given as a brief list of problems.
 Returns 0 on success, 1 on non-compliance, and 2 if there is an error
 while running the script.
+
+You must run this test from an Mbed TLS root.
 """
 
 # Copyright The Mbed TLS Contributors
@@ -490,17 +490,7 @@ class AbiChecker:
 def run_main():
     try:
         parser = argparse.ArgumentParser(
-            description=(
-                """This script is a small wrapper around the
-                abi-compliance-checker and abi-dumper tools, applying them
-                to compare the ABI and API of the library files from two
-                different Git revisions within an Mbed TLS repository.
-                The results of the comparison are either formatted as HTML and
-                stored at a configurable location, or are given as a brief list
-                of problems. Returns 0 on success, 1 on ABI/API non-compliance,
-                and 2 if there is an error while running the script.
-                Note: must be run from Mbed TLS root."""
-            )
+            description=__doc__
         )
         parser.add_argument(
             "-v", "--verbose", action="store_true",

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -407,14 +407,15 @@ def check_output(generated_output_file, main_input_file, merged_files):
     is also present in an output file. This is not perfect but good enough
     for now.
     """
-    generated_output = set(open(generated_output_file, 'r', encoding='utf-8'))
-    for line in open(main_input_file, 'r', encoding='utf-8'):
-        if line not in generated_output:
-            raise LostContent('original file', line)
-    for merged_file in merged_files:
-        for line in open(merged_file, 'r', encoding='utf-8'):
+    with open(generated_output_file, 'r', encoding='utf-8') as fd:
+        generated_output = set(fd)
+        for line in open(main_input_file, 'r', encoding='utf-8'):
             if line not in generated_output:
-                raise LostContent(merged_file, line)
+                raise LostContent('original file', line)
+        for merged_file in merged_files:
+            for line in open(merged_file, 'r', encoding='utf-8'):
+                if line not in generated_output:
+                    raise LostContent(merged_file, line)
 
 def finish_output(changelog, output_file, input_file, merged_files):
     """Write the changelog to the output file.

--- a/scripts/mbedtls_dev/macro_collector.py
+++ b/scripts/mbedtls_dev/macro_collector.py
@@ -18,7 +18,7 @@
 
 import itertools
 import re
-from typing import Dict, Iterable, Iterator, List, Optional, Pattern, Set, Tuple, Union
+from typing import Dict, IO, Iterable, Iterator, List, Optional, Pattern, Set, Tuple, Union
 
 
 class ReadFileLineException(Exception):
@@ -50,12 +50,13 @@ class read_file_lines:
     """
     def __init__(self, filename: str, binary: bool = False) -> None:
         self.filename = filename
+        self.file = None #type: Optional[IO[str]]
         self.line_number = 'entry' #type: Union[int, str]
         self.generator = None #type: Optional[Iterable[Tuple[int, str]]]
         self.binary = binary
     def __enter__(self) -> 'read_file_lines':
-        self.generator = enumerate(open(self.filename,
-                                        'rb' if self.binary else 'r'))
+        self.file = open(self.filename, 'rb' if self.binary else 'r')
+        self.generator = enumerate(self.file)
         return self
     def __iter__(self) -> Iterator[str]:
         assert self.generator is not None
@@ -64,6 +65,8 @@ class read_file_lines:
             yield content
         self.line_number = 'exit'
     def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        if self.file is not None:
+            self.file.close()
         if exc_type is not None:
             raise ReadFileLineException(self.filename, self.line_number) \
                 from exc_value

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -725,6 +725,8 @@ class TestGenerator:
         filename = self.filename_for(basename)
         test_case.write_data_file(filename, test_cases)
 
+    # Note that targets whose name containns 'test_format' have their content
+    # validated by `abi_check.py`.
     TARGETS = {
         'test_suite_psa_crypto_generate_key.generated':
         lambda info: KeyGenerate(info).test_cases_for_key_generation(),


### PR DESCRIPTION
We validate the stability of the storage format through tests that ensure that a key produced by an older version can still be read by a newer version. Expand `abi_check.py` to complain if such tests are removed. Resolves #4481.

Design: make a list of the test data lines (lines with `function_name:parameter1:parameter2:…`) of generated PSA test cases in the old version and in the new version. Complain about lines in the old version that are missing from the new version.

Known issue: storage format test comparisons are reported in a simple text format, independent of `--brief`. I'm not sure it's worth the effort to align the reporting on the ABI/API comparisong.

Needs backport to 2.28: #5605. It's less critical there because the outputs are in the repository, but still useful because it removes the risk of forgetting to check that the outputs aren't regressing.
