### PR TITLE
Backport 2.x: Fix missing compilation guard around psa_crypto_driver_wrappers.c

### DIFF
--- a/ChangeLog.d/undefined_reference_without_psa.txt
+++ b/ChangeLog.d/undefined_reference_without_psa.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * With MBEDTLS_PSA_CRYPTO_C disabled, some functions were getting built
+     nonetheless, resulting in undefined reference errors when building a
+     shared library. Reported by Guillermo Garcia M. in #4411.

--- a/library/psa_crypto_driver_wrappers.c
+++ b/library/psa_crypto_driver_wrappers.c
@@ -28,6 +28,8 @@
 
 #include "mbedtls/platform.h"
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+
 #if defined(MBEDTLS_PSA_CRYPTO_DRIVERS)
 
 /* Include test driver definition when running tests */
@@ -1777,4 +1779,5 @@ psa_status_t psa_driver_wrapper_mac_abort(
             return( PSA_ERROR_INVALID_ARGUMENT );
     }
 }
-/* End of automatically generated file. */
+
+#endif /* MBEDTLS_PSA_CRYPTO_C */


### PR DESCRIPTION
Fix #4411.

No non-regression because I'd like a discussion on how to do it. Replace some/most static builds by shared builds? Do both a static and a shared build? I filed the wish for testing at https://github.com/ARMmbed/mbedtls/issues/4545.

[3.0 version](https://github.com/ARMmbed/mbedtls/pull/4543)