### PR TITLE
Disable debugging features in baremetal

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -231,11 +231,15 @@ def full_adapter(name, active, section):
 
 # The baremetal configuration excludes options that require a library or
 # operating system feature that is typically not present on bare metal
-# systems. Features that are excluded from "full" won't be in "baremetal"
-# either (unless explicitly turned on in baremetal_adapter) so they don't
-# need to be repeated here.
+# systems. It also excludes debugging features that would typically be omitted
+# where code size is at a premium and that do not have a module of their own,
+# in order to make `size library/*.o` informative.
+# Features that are excluded from "full" won't be in "baremetal" either
+# (unless explicitly turned on in baremetal_adapter) so they don't need to
+# be repeated here.
 EXCLUDE_FROM_BAREMETAL = frozenset([
     #pylint: disable=line-too-long
+    'MBEDTLS_DEBUG_C', # large code size increase in TLS
     'MBEDTLS_ENTROPY_NV_SEED', # requires a filesystem and FS_IO or alternate NV seed hooks
     'MBEDTLS_FS_IO', # requires a filesystem
     'MBEDTLS_HAVE_TIME', # requires a clock
@@ -247,6 +251,7 @@ EXCLUDE_FROM_BAREMETAL = frozenset([
     'MBEDTLS_PSA_CRYPTO_SE_C', # requires a filesystem and PSA_CRYPTO_STORAGE_C
     'MBEDTLS_PSA_CRYPTO_STORAGE_C', # requires a filesystem
     'MBEDTLS_PSA_ITS_FILE_C', # requires a filesystem
+    'MBEDTLS_TEST_HOOKS', # only useful with the hosted test framework, increases code size
     'MBEDTLS_THREADING_C', # requires a threading interface
     'MBEDTLS_THREADING_PTHREAD', # requires pthread
     'MBEDTLS_TIMING_C', # requires a clock

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -231,9 +231,11 @@ def full_adapter(name, active, section):
 
 # The baremetal configuration excludes options that require a library or
 # operating system feature that is typically not present on bare metal
-# systems. It also excludes debugging features that would typically be omitted
-# where code size is at a premium and that do not have a module of their own,
-# in order to make `size library/*.o` informative.
+# systems.
+# It also excludes debugging features that increase the code size of other
+# modules since they would typically be disabled in production in environments
+# where code size is at a premium, in order to make `size library/*.o`
+# informative.
 # Features that are excluded from "full" won't be in "baremetal" either
 # (unless explicitly turned on in baremetal_adapter) so they don't need to
 # be repeated here.


### PR DESCRIPTION
The baremetal configuration is, among other things, our default reference point for code size measurements. So disable debugging features that would not be enabled in production where code size is limited. In particular, this shrinks the core SSL modules by about half. Keep debugging features that are solely in their own modules (MBEDTLS_ERROR_C, MBEDTLS_VERSION_FEATURES) since it's easy to filter them out.

Named configurations are not documented interfaces, so we don't announce this in the changelog and we do it in LTS branches as well.

Backports:
* 2.16: https://github.com/ARMmbed/mbedtls/pull/4359
* 2.x: https://github.com/ARMmbed/mbedtls/pull/4358