### PR TITLE
Fix SSL tests scripts with recent OpenSSL server with Diffie-Hellman

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -871,9 +871,22 @@ setup_arguments()
     fi
 
     M_SERVER_ARGS="server_port=$PORT server_addr=0.0.0.0 force_version=$MODE"
-    O_SERVER_ARGS="-accept $PORT -cipher NULL,ALL -$MODE -dhparam data_files/dhparams.pem"
+    O_SERVER_ARGS="-accept $PORT -cipher NULL,ALL -$MODE"
     G_SERVER_ARGS="-p $PORT --http $G_MODE"
     G_SERVER_PRIO="NORMAL:${G_PRIO_CCM}+NULL:+MD5:+PSK:+DHE-PSK:+ECDHE-PSK:+SHA256:+SHA384:+RSA-PSK:-VERS-TLS-ALL:$G_PRIO_MODE"
+
+    # The default prime for `openssl s_server` depends on the version:
+    # * OpenSSL <= 1.0.2a: 512-bit
+    # * OpenSSL 1.0.2b to 1.1.1b: 1024-bit
+    # * OpenSSL >= 1.1.1c: 2048-bit
+    # Mbed TLS wants >=1024, so force that for older versions. Don't force
+    # it for newer versions, which reject a 1024-bit prime. Indifferently
+    # force it or not for intermediate versions.
+    case $($OPENSSL_CMD version) in
+        "OpenSSL 1.0"*)
+            O_SERVER_ARGS="$O_SERVER_ARGS -dhparam data_files/dhparams.pem"
+            ;;
+    esac
 
     # with OpenSSL 1.0.1h, -www, -WWW and -HTTP break DTLS handshakes
     if is_dtls "$MODE"; then

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1197,7 +1197,7 @@ SRV_DELAY_SECONDS=0
 P_SRV="$P_SRV server_addr=127.0.0.1 server_port=$SRV_PORT"
 P_CLI="$P_CLI server_addr=127.0.0.1 server_port=+SRV_PORT"
 P_PXY="$P_PXY server_addr=127.0.0.1 server_port=$SRV_PORT listen_addr=127.0.0.1 listen_port=$PXY_PORT ${SEED:+"seed=$SEED"}"
-O_SRV="$O_SRV -accept $SRV_PORT -dhparam data_files/dhparams.pem"
+O_SRV="$O_SRV -accept $SRV_PORT"
 O_CLI="$O_CLI -connect localhost:+SRV_PORT"
 G_SRV="$G_SRV -p $SRV_PORT"
 G_CLI="$G_CLI -p +SRV_PORT"


### PR DESCRIPTION
`compat.sh` and `ssl-opt.sh` don't work with a modern OpenSSL (e.g. the system one on Ubuntu 20.04) because they force the use of a small DH prime. We do this for compatibility with ancient versions of OpenSSL which we still use for legacy features. Only do it for those ancient versions, not for modern versions. This way you can run the SSL test scripts with the system version of OpenSSL on a modern system (barring other issues which I haven't checked).

This may turn out not to be needed in 3.0 if we remove everything that requires legacy OpenSSL for interoperability testing. If so we can either revert the patch or keep it for similarity with LTS branches.

Backports:
* 2.x: https://github.com/ARMmbed/mbedtls/pull/4289
* 2.16: https://github.com/ARMmbed/mbedtls/pull/4326
