### PR TITLE
[backport 2.x] Add missing parenthesis when MBEDTLS_ECP_NORMALIZE_MXZ_ALT is declared

### DIFF
--- a/ChangeLog.d/add-missing-parenthesis.txt
+++ b/ChangeLog.d/add-missing-parenthesis.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Add a parenthesis that was missing from ecp.c when
+     MBEDTLS_ECP_RANDOMIZE_MXZ_ALT is defined. Found and reported by
+     mbeniamino in #4217.

--- a/ChangeLog.d/add-missing-parenthesis.txt
+++ b/ChangeLog.d/add-missing-parenthesis.txt
@@ -1,4 +1,3 @@
 Bugfix
-   * Add a parenthesis that was missing from ecp.c when
-     MBEDTLS_ECP_RANDOMIZE_MXZ_ALT is defined. Found and reported by
-     mbeniamino in #4217.
+   * Fix a compilation error when MBEDTLS_ECP_RANDOMIZE_MXZ_ALT is
+     defined. Fixes #4217.

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2477,7 +2477,7 @@ static int ecp_randomize_mxz( const mbedtls_ecp_group *grp, mbedtls_ecp_point *P
 {
 #if defined(MBEDTLS_ECP_RANDOMIZE_MXZ_ALT)
     if( mbedtls_internal_ecp_grp_capable( grp ) )
-        return( mbedtls_internal_ecp_randomize_mxz( grp, P, f_rng, p_rng );
+        return( mbedtls_internal_ecp_randomize_mxz( grp, P, f_rng, p_rng ) );
 #endif /* MBEDTLS_ECP_RANDOMIZE_MXZ_ALT */
 
 #if defined(MBEDTLS_ECP_NO_FALLBACK) && defined(MBEDTLS_ECP_RANDOMIZE_MXZ_ALT)


### PR DESCRIPTION
Backport of #4219 to 2.x