### PR TITLE
Backport 2.16: Add macro to check error code additions/combinations

### DIFF
--- a/ChangeLog.d/fix-pk-parse-key-error-code.txt
+++ b/ChangeLog.d/fix-pk-parse-key-error-code.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix an incorrect error code when parsing a PKCS#8 private key.

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1070,7 +1070,7 @@ static int pk_parse_key_pkcs8_unencrypted_der(
         return( MBEDTLS_ERR_PK_KEY_INVALID_VERSION + ret );
 
     if( ( ret = pk_get_pk_alg( &p, end, &pk_alg, &params ) ) != 0 )
-        return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT + ret );
+        return( ret );
 
     if( ( ret = mbedtls_asn1_get_tag( &p, end, &len, MBEDTLS_ASN1_OCTET_STRING ) ) != 0 )
         return( MBEDTLS_ERR_PK_KEY_INVALID_FORMAT + ret );


### PR DESCRIPTION
Just a minor bug fix which was discovered and fixed in #4006.
