### PR TITLE
Remove per-version ciphersuite configuration API for Mbed TLS 3.0

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2491,17 +2491,6 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
 void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
                                    const int *ciphersuites );
 
-/**
- * \brief               Get ciphersuite for given protocol's minor version.
- *
- * \param conf          The SSL configuration.
- * \param prot_version  Protocol version. One of MBEDTLS_SSL_MINOR_VERSION_x macros.
- * \return              Ciphersuites pointer if successful.
- * \return              \c NULL if no ciphersuites where found.
- */
-const int *mbedtls_ssl_get_protocol_version_ciphersuites(
-    const mbedtls_ssl_config *conf, int prot_version );
-
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 #define MBEDTLS_SSL_UNEXPECTED_CID_IGNORE 0
 #define MBEDTLS_SSL_UNEXPECTED_CID_FAIL   1
@@ -2540,29 +2529,6 @@ const int *mbedtls_ssl_get_protocol_version_ciphersuites(
 int mbedtls_ssl_conf_cid( mbedtls_ssl_config *conf, size_t len,
                           int ignore_other_cids );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-
-/**
- * \brief               Set the list of allowed ciphersuites and the
- *                      preference order for a specific version of the protocol.
- *                      (Only useful on the server side)
- *
- *                      The ciphersuites array is not copied, and must remain
- *                      valid for the lifetime of the ssl_config.
- *
- * \param conf          SSL configuration
- * \param ciphersuites  0-terminated list of allowed ciphersuites
- * \param major         Major version number (only MBEDTLS_SSL_MAJOR_VERSION_3
- *                      supported)
- * \param minor         Minor version number (MBEDTLS_SSL_MINOR_VERSION_1,
- *                      MBEDTLS_SSL_MINOR_VERSION_2,
- *                      MBEDTLS_SSL_MINOR_VERSION_3 supported)
- *
- * \note                With DTLS, use MBEDTLS_SSL_MINOR_VERSION_2 for DTLS 1.0
- *                      and MBEDTLS_SSL_MINOR_VERSION_3 for DTLS 1.2
- */
-void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
-                                       const int *ciphersuites,
-                                       int major, int minor );
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3837,36 +3837,6 @@ void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
         ciphersuites);
 }
 
-const int *mbedtls_ssl_get_protocol_version_ciphersuites(
-    const mbedtls_ssl_config *conf, int prot_version )
-{
-    int ciphersuite_list_index =
-        protocol_version_to_ciphersuites_list_index(prot_version);
-    if ( ciphersuite_list_index >= 0 &&
-         (unsigned int)ciphersuite_list_index <
-         sizeof(conf->ciphersuite_list)/sizeof(conf->ciphersuite_list[0]) )
-    {
-        return conf->ciphersuite_list[ciphersuite_list_index];
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
-                                       const int *ciphersuites,
-                                       int major, int minor )
-{
-    if( major != MBEDTLS_SSL_MAJOR_VERSION_3 )
-        return;
-
-    if( minor < MBEDTLS_SSL_MINOR_VERSION_1 || minor > MBEDTLS_SSL_MINOR_VERSION_3 )
-        return;
-
-    set_protocol_version_ciphersuites(conf, minor, ciphersuites);
-}
-
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
                                     const mbedtls_x509_crt_profile *profile )

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -93,7 +93,6 @@ int main( void )
 #define DFL_ECJPAKE_PW          NULL
 #define DFL_PSK_LIST            NULL
 #define DFL_FORCE_CIPHER        0
-#define DFL_VERSION_SUITES      NULL
 #define DFL_RENEGOTIATION       MBEDTLS_SSL_RENEGOTIATION_DISABLED
 #define DFL_ALLOW_LEGACY        -2
 #define DFL_RENEGOTIATE         0
@@ -505,9 +504,6 @@ int main( void )
     "    force_version=%%s    default: \"\" (none)\n"       \
     "                        options: tls1, tls1_1, tls1_2, dtls1, dtls1_2\n" \
     "\n"                                                                \
-    "    version_suites=a,b,c        per-version ciphersuites\n"        \
-    "                                in order from tls1 to tls1_2\n"    \
-    "                                default: all enabled\n"            \
     "    force_ciphersuite=<name>    default: all enabled\n"            \
     "    query_config=<name>         return 0 if the specified\n"       \
     "                                configuration macro is defined and 1\n"  \
@@ -569,7 +565,6 @@ struct options
     char *psk_list;             /* list of PSK id/key pairs for callback    */
     const char *ecjpake_pw;     /* the EC J-PAKE password                   */
     int force_ciphersuite[2];   /* protocol/ciphersuite to use, or all      */
-    const char *version_suites; /* per-version ciphersuites                 */
     int renegotiation;          /* enable / disable renegotiation           */
     int allow_legacy;           /* allow legacy renegotiation               */
     int renegotiate;            /* attempt renegotiation?                   */
@@ -1257,7 +1252,6 @@ int main( int argc, char *argv[] )
 {
     int ret = 0, len, written, frags, exchanges_left;
     int query_config_ret = 0;
-    int version_suites[3][2];
     io_ctx_t io_ctx;
     unsigned char* buf = 0;
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
@@ -1485,7 +1479,6 @@ int main( int argc, char *argv[] )
     opt.psk_list            = DFL_PSK_LIST;
     opt.ecjpake_pw          = DFL_ECJPAKE_PW;
     opt.force_ciphersuite[0]= DFL_FORCE_CIPHER;
-    opt.version_suites      = DFL_VERSION_SUITES;
     opt.renegotiation       = DFL_RENEGOTIATION;
     opt.allow_legacy        = DFL_ALLOW_LEGACY;
     opt.renegotiate         = DFL_RENEGOTIATE;
@@ -1673,8 +1666,6 @@ int main( int argc, char *argv[] )
         }
         else if( strcmp( p, "curves" ) == 0 )
             opt.curves = q;
-        else if( strcmp( p, "version_suites" ) == 0 )
-            opt.version_suites = q;
         else if( strcmp( p, "renegotiation" ) == 0 )
         {
             opt.renegotiation = (atoi( q )) ?
@@ -2095,47 +2086,6 @@ int main( int argc, char *argv[] )
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
         }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-    }
-
-    if( opt.version_suites != NULL )
-    {
-        const char *name[3] = { 0 };
-
-        /* Parse 4-element coma-separated list */
-        for( i = 0, p = (char *) opt.version_suites;
-             i < 3 && *p != '\0';
-             i++ )
-        {
-            name[i] = p;
-
-            /* Terminate the current string and move on to next one */
-            while( *p != ',' && *p != '\0' )
-                p++;
-            if( *p == ',' )
-                *p++ = '\0';
-        }
-
-        if( i != 3 )
-        {
-            mbedtls_printf( "too few values for version_suites\n" );
-            ret = 1;
-            goto exit;
-        }
-
-        memset( version_suites, 0, sizeof( version_suites ) );
-
-        /* Get the suites identifiers from their name */
-        for( i = 0; i < 3; i++ )
-        {
-            version_suites[i][0] = mbedtls_ssl_get_ciphersuite_id( name[i] );
-
-            if( version_suites[i][0] == 0 )
-            {
-                mbedtls_printf( "unknown ciphersuite: '%s'\n", name[i] );
-                ret = 2;
-                goto usage;
-            }
-        }
     }
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -2720,19 +2670,6 @@ int main( int argc, char *argv[] )
 
     if( opt.force_ciphersuite[0] != DFL_FORCE_CIPHER )
         mbedtls_ssl_conf_ciphersuites( &conf, opt.force_ciphersuite );
-
-    if( opt.version_suites != NULL )
-    {
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[0],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_1 );
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[1],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_2 );
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[2],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_3 );
-    }
 
     if( opt.allow_legacy != DFL_ALLOW_LEGACY )
         mbedtls_ssl_conf_legacy_renegotiation( &conf, opt.allow_legacy );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -5877,35 +5877,6 @@ run_test    "ECJPAKE: working, DTLS, nolog" \
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
             0
 
-# Tests for ciphersuites per version
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1
-requires_config_enabled MBEDTLS_CAMELLIA_C
-requires_config_enabled MBEDTLS_AES_C
-run_test    "Per-version suites: TLS 1.0" \
-            "$P_SRV version_suites=TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
-            "$P_CLI force_version=tls1" \
-            0 \
-            -c "Ciphersuite is TLS-RSA-WITH-AES-256-CBC-SHA"
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_1
-requires_config_enabled MBEDTLS_CAMELLIA_C
-requires_config_enabled MBEDTLS_AES_C
-run_test    "Per-version suites: TLS 1.1" \
-            "$P_SRV version_suites=TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
-            "$P_CLI force_version=tls1_1" \
-            0 \
-            -c "Ciphersuite is TLS-RSA-WITH-AES-128-CBC-SHA"
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_enabled MBEDTLS_CAMELLIA_C
-requires_config_enabled MBEDTLS_AES_C
-run_test    "Per-version suites: TLS 1.2" \
-            "$P_SRV version_suites=TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
-            "$P_CLI force_version=tls1_2" \
-            0 \
-            -c "Ciphersuite is TLS-RSA-WITH-AES-128-GCM-SHA256"
-
 # Test for ClientHello without extensions
 
 requires_gnutls


### PR DESCRIPTION
__Dependency:__ This PR should only be merged as part of or after removal of support for TLS 1.0 and 1.1.

__Summary:__ This PR removes the APIs

```
    mbedtls_ssl_conf_ciphersuites_for_version()
    mbedtls_ssl_get_protocol_version_ciphersuites()
```

which allow to configure/retrieve lists of acceptable ciphersuites for each supported version of TLS.

__Rationale:__ With Mbed TLS 3.0, support for SSL3, TLS 1.0 and TLS 1.1 is dropped. Moreover, upcoming TLS 1.3 support has a different notion of cipher suite and will require a different API.

This means that it's only for TLS 1.2 that we require a ciphersuite configuration API, and

```
   mbedtls_ssl_conf_ciphersuites()
```

can be used for that. The version-specific ciphersuite configuration API `mbedtls_ssl_conf_ciphersuites_for_version()`, in turn, is no longer needed. For the same reason, a per-version getter `mbedtls_ssl_get_protocol_version_ciphersuites()` is no longer needed.

@mstarzyk-mobica What was the reason to introduce `mbedtls_ssl_get_protocol_version_ciphersuites()`? The user needs to maintain the configured ciphersuite lists for the duration of the SSL config anyway, so why would one need a getter for it?