### PR TITLE
Mbed TLS 3.0: Apply X.509 CRT profile to signatures only

### DIFF
--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -161,7 +161,7 @@ typedef struct mbedtls_x509_crt_profile
     uint32_t allowed_mds;       /**< MDs for signatures         */
     uint32_t allowed_pks;       /**< PK algs for signatures     */
     uint32_t allowed_curves;    /**< Elliptic curves for ECDSA  */
-    uint32_t rsa_min_bitlen;    /**< Minimum size for RSA keys  */
+    uint32_t rsa_min_bitlen;    /**< Minimum bit length for RSA signatures */
 }
 mbedtls_x509_crt_profile;
 

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -3103,7 +3103,6 @@ static int x509_crt_verify_restartable_ca_cb( mbedtls_x509_crt *crt,
                      mbedtls_x509_crt_restart_ctx *rs_ctx )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_pk_type_t pk_type;
     mbedtls_x509_crt_verify_chain ver_chain;
     uint32_t ee_flags;
 
@@ -3120,15 +3119,6 @@ static int x509_crt_verify_restartable_ca_cb( mbedtls_x509_crt *crt,
     /* check name if requested */
     if( cn != NULL )
         x509_crt_verify_name( crt, cn, &ee_flags );
-
-    /* Check the type and size of the key */
-    pk_type = mbedtls_pk_get_type( &crt->pk );
-
-    if( x509_profile_check_pk_alg( profile, pk_type ) != 0 )
-        ee_flags |= MBEDTLS_X509_BADCERT_BAD_PK;
-
-    if( x509_profile_check_key( profile, &crt->pk ) != 0 )
-        ee_flags |= MBEDTLS_X509_BADCERT_BAD_KEY;
 
     /* Check the chain */
     ret = x509_crt_verify_chain( crt, trust_ca, ca_crl,


### PR DESCRIPTION
The documentation of X.509 CRT profiles states that the profile applies to _signatures_ in an X.509 CRT chain only. However, the implementation also applies the profile to the end-entity (EE) certificate. This mismatch is the content of #1992.

This PR fixes #1992 by modifying the implementation to not apply the X.509 CRT profile to the EE certificate. It also clarifies that the minimum RSA bit length field in the X.509 CRT profile applies to signatures only.
