### PR TITLE
Remove two unused SSL error codes for Mbed TLS 3.0

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -107,7 +107,8 @@
  * SSL       5   2 (Started from 0x5F00)
  * CIPHER    6   8 (Started from 0x6080)
  * SSL       6   24 (Started from top, plus 0x6000)
- * SSL       7   31 (Started from 0x7080, gap at 0x7300)
+ * SSL       7   30 (Started from 0x7080, gaps at
+ *                   0x7300, 0x7800)
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -107,7 +107,7 @@
  * SSL       5   2 (Started from 0x5F00)
  * CIPHER    6   8 (Started from 0x6080)
  * SSL       6   24 (Started from top, plus 0x6000)
- * SSL       7   32
+ * SSL       7   31 (Started from 0x7080, gap at 0x7300)
  *
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -67,7 +67,7 @@
 #define MBEDTLS_ERR_SSL_INVALID_MAC                       -0x7180  /**< Verification of the message MAC failed. */
 #define MBEDTLS_ERR_SSL_INVALID_RECORD                    -0x7200  /**< An invalid SSL record was received. */
 #define MBEDTLS_ERR_SSL_CONN_EOF                          -0x7280  /**< The connection indicated an EOF. */
-#define MBEDTLS_ERR_SSL_UNKNOWN_CIPHER                    -0x7300  /**< An unknown cipher was received. */
+/* NOTE: Error space gap */
 #define MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN                  -0x7380  /**< The server has no ciphersuites in common with the client. */
 #define MBEDTLS_ERR_SSL_NO_RNG                            -0x7400  /**< No RNG was provided to the SSL module. */
 #define MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE             -0x7480  /**< No client certification received from the client, but required by the authentication mode. */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -77,7 +77,7 @@
 #define MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED                 -0x7680  /**< No CA Chain is set, but required to operate. */
 #define MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE                -0x7700  /**< An unexpected message was received from our peer. */
 #define MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE               -0x7780  /**< A fatal alert message was received from our peer. */
-#define MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED                -0x7800  /**< Verification of our peer failed. */
+/* NOTE: Error space gap */
 #define MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY                 -0x7880  /**< The peer notified us that the connection is going to be closed. */
 #define MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO               -0x7900  /**< Processing of the ClientHello handshake message failed. */
 #define MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO               -0x7980  /**< Processing of the ServerHello handshake message failed. */

--- a/library/error.c
+++ b/library/error.c
@@ -374,8 +374,6 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "SSL - An invalid SSL record was received" );
         case -(MBEDTLS_ERR_SSL_CONN_EOF):
             return( "SSL - The connection indicated an EOF" );
-        case -(MBEDTLS_ERR_SSL_UNKNOWN_CIPHER):
-            return( "SSL - An unknown cipher was received" );
         case -(MBEDTLS_ERR_SSL_NO_CIPHER_CHOSEN):
             return( "SSL - The server has no ciphersuites in common with the client" );
         case -(MBEDTLS_ERR_SSL_NO_RNG):

--- a/library/error.c
+++ b/library/error.c
@@ -392,8 +392,6 @@ const char * mbedtls_high_level_strerr( int error_code )
             return( "SSL - An unexpected message was received from our peer" );
         case -(MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE):
             return( "SSL - A fatal alert message was received from our peer" );
-        case -(MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED):
-            return( "SSL - Verification of our peer failed" );
         case -(MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY):
             return( "SSL - The peer notified us that the connection is going to be closed" );
         case -(MBEDTLS_ERR_SSL_BAD_HS_CLIENT_HELLO):


### PR DESCRIPTION
The following SSL error codes are not used anywhere within the library:
* `MBEDTLS_ERR_SSL_UNKNOWN_CIPHER`
* `MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED`

This PR removes them from the public API for Mbed TLS 3.0.

__Note:__ `MBEDTLS_ERR_SSL_PEER_VERIFY_FAILED` being unused comes as a surprise, at is seems to be reasonable to report it to the user upon peer CRT verification failure. However, this study (can potentially re-introduction of the code) can be left for 3.x, while the error code removal can only happen in 3.0.