### PR TITLE
[Backport 2.x] Allow CMAC_ALT implementations to not support 3DES

### DIFF
--- a/ChangeLog.d/allow_alt_cmac_without_des.txt
+++ b/ChangeLog.d/allow_alt_cmac_without_des.txt
@@ -1,0 +1,3 @@
+Changes
+   * Alternative implementations of CMAC may now opt to not support 3DES as a
+     CMAC block cipher, and still pass the CMAC self test.

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -198,6 +198,13 @@ int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_len,
 /**
  * \brief          The CMAC checkup routine.
  *
+ * \note           In case the CMAC routines are provided by an alternative
+ *                 implementation (i.e. #MBEDTLS_CMAC_ALT is defined), the
+ *                 checkup routine will succeed even if the implementation does
+ *                 not support the less widely used AES-192 or 3DES primitives.
+ *                 The self-test requires at least AES-128 and AES-256 to be
+ *                 supported by the underlying implementation.
+ *
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -77,6 +77,12 @@ struct mbedtls_cmac_context_t
  *                      the input data.
  *                      Must be called with an initialized cipher context.
  *
+ * \note                When the CMAC implementation is supplied by an alternate
+ *                      implementation (through #MBEDTLS_CMAC_ALT), some ciphers
+ *                      may not be supported by that implementation, and thus
+ *                      return an error. Alternate implementations must support
+ *                      AES-128 and AES-256, and may support AES-192 and 3DES.
+ *
  * \param ctx           The cipher context used for the CMAC operation, initialized
  *                      as one of the following types: MBEDTLS_CIPHER_AES_128_ECB,
  *                      MBEDTLS_CIPHER_AES_192_ECB, MBEDTLS_CIPHER_AES_256_ECB,
@@ -154,6 +160,11 @@ int mbedtls_cipher_cmac_reset( mbedtls_cipher_context_t *ctx );
  *                      The CMAC result is calculated as
  *                      output = generic CMAC(cmac key, input buffer).
  *
+ * \note                When the CMAC implementation is supplied by an alternate
+ *                      implementation (through #MBEDTLS_CMAC_ALT), some ciphers
+ *                      may not be supported by that implementation, and thus
+ *                      return an error. Alternate implementations must support
+ *                      AES-128 and AES-256, and may support AES-192 and 3DES.
  *
  * \param cipher_info   The cipher information.
  * \param key           The CMAC key.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -2631,6 +2631,11 @@
  * Enable the CMAC (Cipher-based Message Authentication Code) mode for block
  * ciphers.
  *
+ * \note When #MBEDTLS_CMAC_ALT is active, meaning that the underlying
+ *       implementation of the CMAC algorithm is provided by an alternate
+ *       implementation, that alternate implementation may opt to not support
+ *       AES-192 or 3DES as underlying block ciphers for the CMAC operation.
+ *
  * Module:  library/cmac.c
  *
  * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -867,11 +867,12 @@ static int cmac_test_wth_cipher( int verbose,
         {
             /* When CMAC is implemented by an alternative implementation, or
              * the underlying primitive itself is implemented alternatively,
-             * AES-192 may be unavailable. This should not cause the selftest
-             * function to fail. */
+             * AES-192 and/or 3DES may be unavailable. This should not cause
+             * the selftest function to fail. */
             if( ( ret == MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED ||
                   ret == MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE ) &&
-                  cipher_type == MBEDTLS_CIPHER_AES_192_ECB ) {
+                ( cipher_type == MBEDTLS_CIPHER_AES_192_ECB ||
+                  cipher_type == MBEDTLS_CIPHER_DES_EDE3_ECB ) ) {
                 if( verbose != 0 )
                     mbedtls_printf( "skipped\n" );
                 continue;


### PR DESCRIPTION
## Description
Backport of #4146, which was approved by @gilles-peskine-arm and @ronald-cron-arm 

## Status
**READY**

## Migrations
NO

## Additional comments
Clean rebase of #4146 on top of development_2.x
