### PR TITLE
mbed-os: allow storing certificates in filesystem

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -74,7 +74,11 @@
 #if !defined(_WIN32) || defined(EFIX64) || defined(EFI32)
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__MBED__)
+#include <platform/mbed_retarget.h>
+#else
 #include <dirent.h>
+#endif /* __MBED__ */
 #endif /* !_WIN32 || EFIX64 || EFI32 */
 #endif
 


### PR DESCRIPTION
mbed-os doesn't provide `dirent.h`; replace it with `mbed_retarget.h` in case MBEDTLS_FS_IO is defined

Part of https://github.com/ARMmbed/mbed-os/pull/13863.

Fixes https://github.com/ARMmbed/mbed-os/pull/13863/files#r601617986
