### PR TITLE
Generate tests python3 make 2.16

### DIFF
--- a/ChangeLog.d/make-generate-tests-python.txt
+++ b/ChangeLog.d/make-generate-tests-python.txt
@@ -1,0 +1,4 @@
+Changes
+   * When building the test suites with GNU make, invoke python3 or python, not
+     python2. The build still works with either Python 2.7 or 3.5+, but we
+     recommend using a version of Python that is supported upstream.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -44,8 +44,7 @@ else
 DLEXT ?= so
 EXEXT=
 SHARED_SUFFIX=
-# python2 for POSIX since FreeBSD has only python2 as default.
-PYTHON ?= python2
+PYTHON ?= $(shell if type python3 >/dev/null 2>/dev/null; then echo python3; else echo python; fi)
 endif
 
 # Zlib shared library extensions:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,7 +62,7 @@ BINARIES := $(addsuffix $(EXEXT),$(APPS))
 
 .SILENT:
 
-.PHONY: all check test clean
+.PHONY: all c_files check test clean
 
 all: $(BINARIES)
 
@@ -70,6 +70,7 @@ $(DEP):
 	$(MAKE) -C ../library
 
 C_FILES := $(addsuffix .c,$(APPS))
+c_files: $(C_FILES)
 
 # Wildcard target for test code generation:
 # A .c file is generated for each .data file in the suites/ directory. Each .c

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -691,6 +691,18 @@ component_check_doxygen_warnings () {
     record_status tests/scripts/doxygen.sh
 }
 
+component_check_python2 () {
+    # Check that what used to work with Python 2 still works with Python 2.
+    msg "check: python2 compatibility"
+    mkdir -p tests/with_python2 tests/with_python3
+    make -C tests PYTHON=python2 c_files
+    mv tests/test_suite_*.c tests/with_python2/
+    make -C tests PYTHON=python3 c_files
+    mv tests/test_suite_*.c tests/with_python3/
+    diff -r tests/with_python2 tests/with_python3
+    rm -rf tests/with_python2 tests/with_python3
+}
+
 
 
 ################################################################

--- a/tests/scripts/generate_test_code.py
+++ b/tests/scripts/generate_test_code.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+# This script should still be compatible with Python 2 in Mbed TLS 2.16.x.
+
 # Test suites code generator.
 #
 # Copyright The Mbed TLS Contributors


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/4393.

Since 2.16 is a long-time support branch, I think that it's ok to change our scripts to default to Python 3, but we should ensure that the code remains compatible with Python 2. So I've added a CI check (which means we need to keep Python 2 on the CI). Compared to 2.x/3.0, I also tweaked the changelog entry to say that Python 2 still works.