### PR TITLE
Check if feature macro is defined before define it

### DIFF
--- a/ChangeLog.d/posix-define.txt
+++ b/ChangeLog.d/posix-define.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * In library/net_sockets.c, _POSIX_C_SOURCE and _XOPEN_SOURCE are
+     defined to specific values.  If the code is used in a context
+     where these are already defined, this can result in a compilation
+     error.  Instead, assume that if they are defined, the values will
+     be adequate to build Mbed TLS.

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -20,8 +20,12 @@
 /* Enable definition of getaddrinfo() even when compiling with -std=c99. Must
  * be set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600 /* sockaddr_storage */
+#endif
 
 #include "common.h"
 


### PR DESCRIPTION
Zephyr's native posix port define _POSIX_C_SOURCE with a higher value
during the build, so when mbedTLS defines it with a different value
breaks the build.

As Zephyr is already defining a higher value is guaranteed that mbedTLS
required features will be available. So, just define it in case it was
not defined before.

[taken from Zephyr mbedtls module:
https://github.com/zephyrproject-rtos/mbedtls/commit/76dcd6eecae4c1b556a52b1b9ef66e75fc538bc5]

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>
Signed-off-by: David Brown <david.brown@linaro.org>

## Status
**READY**

## Requires Backporting
Yes: 2.16, 2.26

## Migrations
If there is any API change, what's the incentive and logic for it.

NO