### PR TITLE
Use proper formatting macros when using MinGW provided stdio

### DIFF
--- a/ChangeLog.d/fix-mingw-build.txt
+++ b/ChangeLog.d/fix-mingw-build.txt
@@ -1,0 +1,4 @@
+Changes
+   * fix build failure on MinGW toolchain when __USE_MING_ANSI_STDIO is on.
+     When that flag is on, standard GNU C printf format specifiers should be used.
+

--- a/ChangeLog.d/fix-mingw-build.txt
+++ b/ChangeLog.d/fix-mingw-build.txt
@@ -1,4 +1,5 @@
 Changes
    * fix build failure on MinGW toolchain when __USE_MING_ANSI_STDIO is on.
-     When that flag is on, standard GNU C printf format specifiers should be used.
+     When that flag is on, standard GNU C printf format specifiers
+     should be used.
 

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -98,8 +98,13 @@
  */
 #if defined(__has_attribute)
 #if __has_attribute(format)
+#if defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 1
 #define MBEDTLS_PRINTF_ATTRIBUTE(string_index, first_to_check)    \
-    __attribute__((format (printf, string_index, first_to_check)))
+    __attribute__((__format__ (gnu_printf, string_index, first_to_check)))
+#else /* defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 1 */
+#define MBEDTLS_PRINTF_ATTRIBUTE(string_index, first_to_check)    \
+    __attribute__((format(printf, string_index, first_to_check)))
+#endif
 #else /* __has_attribute(format) */
 #define MBEDTLS_PRINTF_ATTRIBUTE(string_index, first_to_check)
 #endif /* __has_attribute(format) */
@@ -119,14 +124,14 @@
  *
  * This module provides debugging functions.
  */
-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800)
+#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800)
    #include <inttypes.h>
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
    #define MBEDTLS_PRINTF_LONGLONG  "I64d"
-#else /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800) */
+#else /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800) */
    #define MBEDTLS_PRINTF_SIZET     "zu"
    #define MBEDTLS_PRINTF_LONGLONG  "lld"
-#endif /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800) */
+#endif /* (defined(__MINGW32__)  && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1800) */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
use proper formatting macros when using MinGW provided stdio


## Status
READY

## Requires Backporting

Yes
development_2.x PR: https://github.com/ARMmbed/mbedtls/pull/4491

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
