### PR TITLE
Backport 2.x: Check if feature macro is defined before define it

### DIFF
--- a/ChangeLog.d/posix-define.txt
+++ b/ChangeLog.d/posix-define.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * In library/net_sockets.c, _POSIX_C_SOURCE and _XOPEN_SOURCE are
+     defined to specific values.  If the code is used in a context
+     where these are already defined, this can result in a compilation
+     error.  Instead, assume that if they are defined, the values will
+     be adequate to build Mbed TLS.

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -20,8 +20,12 @@
 /* Enable definition of getaddrinfo() even when compiling with -std=c99. Must
  * be set before config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600 /* sockaddr_storage */
+#endif
 
 #include "common.h"
 


### PR DESCRIPTION
Backport of #4470