### PR TITLE
Change sha256 and sha512 output type from an array to a pointer

### DIFF
--- a/ChangeLog.d/sha512-output-type.txt
+++ b/ChangeLog.d/sha512-output-type.txt
@@ -1,5 +1,6 @@
 API changes
-   * The output parameter of mbedtls_sha512_finish_ret and mbedtls_sha512_ret
-     now has a pointer type rather than array type. This removes spurious
-     warnings in some compilers when outputting a SHA-384 hash into a
-     48-byte buffer.
+   * The output parameter of mbedtls_sha512_finish_ret, mbedtls_sha512_ret,
+     mbedtls_sha256_finish_ret and mbedtls_sha256_ret now has a pointer type
+     rather than array type. This removes spurious warnings in some compilers
+     when outputting a SHA-384 or SHA-224 hash into a buffer of exactly
+     the hash size.

--- a/ChangeLog.d/sha512-output-type.txt
+++ b/ChangeLog.d/sha512-output-type.txt
@@ -1,0 +1,5 @@
+API changes
+   * The output parameter of mbedtls_sha512_finish_ret and mbedtls_sha512_ret
+     now has a pointer type rather than array type. This removes spurious
+     warnings in some compilers when outputting a SHA-384 hash into a
+     48-byte buffer.

--- a/docs/3.0-migration-guide.d/sha512-output-type.md
+++ b/docs/3.0-migration-guide.d/sha512-output-type.md
@@ -1,8 +1,8 @@
-SHA-512 output type change
+SHA-512 and SHA-256 output type change
 --------------------------
 
-The output parameter of `mbedtls_sha512_finish_ret()` and `mbedtls_sha512_ret()` now has a pointer type rather than array type. This makes no difference in terms of C semantics, but removes spurious warnings in some compilers when outputting a SHA-384 hash into a 48-byte buffer.
+The output parameter of `mbedtls_sha256_finish_ret()`, `mbedtls_sha256_ret()`, `mbedtls_sha512_finish_ret()`, `mbedtls_sha512_ret()` now has a pointer type rather than array type. This makes no difference in terms of C semantics, but removes spurious warnings in some compilers when outputting a SHA-384 hash into a 48-byte buffer or a SHA-224 hash into a 28-byte buffer.
 
 This makes no difference to a vast majority of applications. If your code takes a pointer to one of these functions, you may need to change the type of the pointer.
 
-Alternative implementations of the SHA512 module must adjust their functions' prototype accordingly.
+Alternative implementations of the SHA256 and SHA512 modules must adjust their functions' prototype accordingly.

--- a/docs/3.0-migration-guide.d/sha512-output-type.md
+++ b/docs/3.0-migration-guide.d/sha512-output-type.md
@@ -1,0 +1,8 @@
+SHA-512 output type change
+--------------------------
+
+The output parameter of `mbedtls_sha512_finish_ret()` and `mbedtls_sha512_ret()` now has a pointer type rather than array type. This makes no difference in terms of C semantics, but removes spurious warnings in some compilers when outputting a SHA-384 hash into a 48-byte buffer.
+
+This makes no difference to a vast majority of applications. If your code takes a pointer to one of these functions, you may need to change the type of the pointer.
+
+Alternative implementations of the SHA512 module must adjust their functions' prototype accordingly.

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -127,13 +127,14 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
  * \param ctx      The SHA-256 context. This must be initialized
  *                 and have a hash operation started.
  * \param output   The SHA-224 or SHA-256 checksum result.
- *                 This must be a writable buffer of length \c 32 Bytes.
+ *                 This must be a writable buffer of length \c 32 bytes
+ *                 for SHA-256, 28 bytes for SHA-224.
  *
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
 int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
-                               unsigned char output[32] );
+                               unsigned char *output );
 
 /**
  * \brief          This function processes a single data block within
@@ -163,14 +164,15 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
  * \param input    The buffer holding the data. This must be a readable
  *                 buffer of length \p ilen Bytes.
  * \param ilen     The length of the input data in Bytes.
- * \param output   The SHA-224 or SHA-256 checksum result. This must
- *                 be a writable buffer of length \c 32 Bytes.
+ * \param output   The SHA-224 or SHA-256 checksum result.
+ *                 This must be a writable buffer of length \c 32 bytes
+ *                 for SHA-256, 28 bytes for SHA-224.
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
  */
 int mbedtls_sha256_ret( const unsigned char *input,
                         size_t ilen,
-                        unsigned char output[32],
+                        unsigned char *output,
                         int is224 );
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -128,7 +128,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
  *                 and have a hash operation started.
  * \param output   The SHA-224 or SHA-256 checksum result.
  *                 This must be a writable buffer of length \c 32 bytes
- *                 for SHA-256, 28 bytes for SHA-224.
+ *                 for SHA-256, \c 28 bytes for SHA-224.
  *
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
@@ -166,7 +166,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
  * \param ilen     The length of the input data in Bytes.
  * \param output   The SHA-224 or SHA-256 checksum result.
  *                 This must be a writable buffer of length \c 32 bytes
- *                 for SHA-256, 28 bytes for SHA-224.
+ *                 for SHA-256, \c 28 bytes for SHA-224.
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
  */

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -135,7 +135,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
  *                 and have a hash operation started.
  * \param output   The SHA-384 or SHA-512 checksum result.
  *                 This must be a writable buffer of length \c 64 bytes
- *                 for SHA-512, 48 bytes for SHA-384.
+ *                 for SHA-512, \c 48 bytes for SHA-384.
  *
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
@@ -173,7 +173,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
  * \param ilen     The length of the input data in Bytes.
  * \param output   The SHA-384 or SHA-512 checksum result.
  *                 This must be a writable buffer of length \c 64 bytes
- *                 for SHA-512, 48 bytes for SHA-384.
+ *                 for SHA-512, \c 48 bytes for SHA-384.
  * \param is384    Determines which function to use. This must be either
  *                 \c 0 for SHA-512, or \c 1 for SHA-384.
  *

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -134,13 +134,14 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
  * \param ctx      The SHA-512 context. This must be initialized
  *                 and have a hash operation started.
  * \param output   The SHA-384 or SHA-512 checksum result.
- *                 This must be a writable buffer of length \c 64 Bytes.
+ *                 This must be a writable buffer of length \c 64 bytes
+ *                 for SHA-512, 48 bytes for SHA-384.
  *
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
 int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
-                               unsigned char output[64] );
+                               unsigned char *output );
 
 /**
  * \brief          This function processes a single data block within
@@ -171,7 +172,8 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
  *                 a readable buffer of length \p ilen Bytes.
  * \param ilen     The length of the input data in Bytes.
  * \param output   The SHA-384 or SHA-512 checksum result.
- *                 This must be a writable buffer of length \c 64 Bytes.
+ *                 This must be a writable buffer of length \c 64 bytes
+ *                 for SHA-512, 48 bytes for SHA-384.
  * \param is384    Determines which function to use. This must be either
  *                 \c 0 for SHA-512, or \c 1 for SHA-384.
  *
@@ -184,7 +186,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
  */
 int mbedtls_sha512_ret( const unsigned char *input,
                         size_t ilen,
-                        unsigned char output[64],
+                        unsigned char *output,
                         int is384 );
 
 #if defined(MBEDTLS_SELF_TEST)

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -332,7 +332,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
  * SHA-256 final digest
  */
 int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
-                               unsigned char output[32] )
+                               unsigned char *output )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     uint32_t used;
@@ -401,7 +401,7 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
  */
 int mbedtls_sha256_ret( const unsigned char *input,
                         size_t ilen,
-                        unsigned char output[32],
+                        unsigned char *output,
                         int is224 )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -380,7 +380,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
  * SHA-512 final digest
  */
 int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
-                               unsigned char output[64] )
+                               unsigned char *output )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned used;
@@ -453,7 +453,7 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
  */
 int mbedtls_sha512_ret( const unsigned char *input,
                     size_t ilen,
-                    unsigned char output[64],
+                    unsigned char *output,
                     int is384 )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2897,8 +2897,6 @@ static void ssl_calc_finished_tls_sha256(
 
 #if defined(MBEDTLS_SHA512_C)
 
-typedef int (*finish_sha384_t)(mbedtls_sha512_context*, unsigned char*);
-
 static void ssl_calc_finished_tls_sha384(
                 mbedtls_ssl_context *ssl, unsigned char *buf, int from )
 {
@@ -2957,13 +2955,7 @@ static void ssl_calc_finished_tls_sha384(
     MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha512 state", (unsigned char *)
                    sha512.state, sizeof( sha512.state ) );
 #endif
-    /*
-     * For SHA-384, we can save 16 bytes by keeping padbuf 48 bytes long.
-     * However, to avoid stringop-overflow warning in gcc, we have to cast
-     * mbedtls_sha512_finish_ret().
-     */
-    finish_sha384_t finish = (finish_sha384_t)mbedtls_sha512_finish_ret;
-    finish( &sha512, padbuf );
+    mbedtls_sha512_finish_ret( &sha512, padbuf );
 
     mbedtls_sha512_free( &sha512 );
 #endif


### PR DESCRIPTION
This is the critical part of https://github.com/ARMmbed/mbedtls/issues/4452, fixing https://github.com/ARMmbed/mbedtls/issues/4130 in a clean way.

The SHA512 part is important because the array parameter broke our build with GCC-11. The SHA256 part is less important because SHA-224 is very rarely used and the extra cost is 4 extra bytes, but it could hurt with code that systematically calculates each hash into a tight-sized buffer.

I had a quick look at other functions with array parameters and I didn't spot others where the array size is not always correct. While I think that it is best to avoid array parameters, there would not be much benefit in changing the existing APIs, so I don't think it's worth expending the limited time we have for 3.0 on that.
