### PR TITLE
Add OID for User ID

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -145,6 +145,7 @@
 #define MBEDTLS_OID_AT_DN_QUALIFIER             MBEDTLS_OID_AT "\x2E" /**< id-at-dnQualifier AttributeType:= {id-at 46} */
 #define MBEDTLS_OID_AT_PSEUDONYM                MBEDTLS_OID_AT "\x41" /**< id-at-pseudonym AttributeType:= {id-at 65} */
 
+#define MBEDTLS_OID_UID                         "\x09\x92\x26\x89\x93\xF2\x2C\x64\x01\x01" /** id-domainComponent AttributeType:= {itu-t(0) data(9) pss(2342) ucl(19200300) pilot(100) pilotAttributeType(1) uid(1)} */
 #define MBEDTLS_OID_DOMAIN_COMPONENT            "\x09\x92\x26\x89\x93\xF2\x2C\x64\x01\x19" /** id-domainComponent AttributeType:= {itu-t(0) data(9) pss(2342) ucl(19200300) pilot(100) pilotAttributeType(1) domainComponent(25)} */
 
 /*

--- a/library/oid.c
+++ b/library/oid.c
@@ -238,6 +238,10 @@ static const oid_x520_attr_t oid_x520_attr_type[] =
         "pseudonym",
     },
     {
+        OID_DESCRIPTOR( MBEDTLS_OID_UID,            "id-uid",                         "User Id" ),
+        "uid",
+    },
+    {
         OID_DESCRIPTOR( MBEDTLS_OID_DOMAIN_COMPONENT, "id-domainComponent",           "Domain component" ),
         "DC",
     },


### PR DESCRIPTION
Signed-off-by: Micah N Gorrell <micah.gorrell@venafi.com>

Notes:

## Description
Adds the OID for User ID

## Status
**READY**

## Requires Backporting

NO  

## Migrations

NO

## Additional comments


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
