### PR TITLE
Implement 3.0-API for SSL session resumption

### DIFF
--- a/docs/3.0-migration-guide.d/remove-ssl-get-session_pointer.md
+++ b/docs/3.0-migration-guide.d/remove-ssl-get-session_pointer.md
@@ -1,0 +1,23 @@
+Remove the SSL API mbedtls_ssl_get_session_pointer()
+-----------------------------------------------------------------
+
+This affects two classes of users:
+
+1. Users who manually inspect parts of the current session through
+   direct structure field access.
+
+2. Users of session resumption who query the current session
+   via `mbedtls_ssl_get_session_pointer()` prior to saving or exporting
+   it via `mbedtls_ssl_session_copy()` or `mbedtls_ssl_session_save()`,
+   respectively.
+
+Migration paths:
+
+1. Mbed TLS 3.0 does not offer a migration path for the usecase 1: Like many
+   other Mbed TLS structures, the structure of `mbedtls_ssl_session` is no
+   longer part of the public API in Mbed TLS 3.0, and direct structure field
+   access is no longer supported. Please see the corresponding migration guide.
+
+2. Users should replace calls to `mbedtls_ssl_get_session_pointer()` by
+   calls to `mbedtls_ssl_get_session()` as demonstrated in the example
+   program `programs/ssl/ssl_client2.c`.

--- a/docs/3.0-migration-guide.d/ssl-ticket-api.md
+++ b/docs/3.0-migration-guide.d/ssl-ticket-api.md
@@ -2,7 +2,7 @@ Modified semantics of mbedtls_ssl_{get,set}_session()
 -----------------------------------------------------------------
 
 This affects users who call `mbedtls_ssl_get_session()` or
-`mbedtls_ssl_session_set()` multiple times on the same SSL context
+`mbedtls_ssl_set_session()` multiple times on the same SSL context
 representing an established TLS 1.2 connection.
 Those users will now observe the second call to fail with
 `MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE`.

--- a/docs/3.0-migration-guide.d/ssl-ticket-api.md
+++ b/docs/3.0-migration-guide.d/ssl-ticket-api.md
@@ -1,0 +1,30 @@
+Modified semantics of mbedtls_ssl_{get,set}_session()
+-----------------------------------------------------------------
+
+This affects users who call `mbedtls_ssl_get_session()` or
+`mbedtls_ssl_session_set()` multiple times on the same SSL context
+representing an established TLS 1.2 connection.
+Those users will now observe the second call to fail with
+`MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE`.
+
+Migration path:
+- Exporting the same TLS 1.2 connection multiple times via
+  `mbedtls_ssl_get_session()` leads to multiple copies of
+  the same session. This use of `mbedtls_ssl_get_session()`
+  is discouraged, and the following should be considered:
+  * If the various session copies are later loaded into
+    fresh SSL contexts via `mbedtls_ssl_set_session()`,
+    export via `mbedtls_ssl_get_session()` only once and
+    load the same session into different contexts via
+    `mbedtls_ssl_set_session()`. Since `mbedtls_ssl_set_session()`
+    makes a copy of the session that's being loaded, this
+    is functionally equivalent.
+  * If the various session copies are later serialized
+    via `mbedtls_ssl_session_save()`, export and serialize
+    the session only once via `mbedtls_ssl_get_session()` and
+    `mbedtls_ssl_session_save()` and make copies of the raw
+    data instead.
+- Calling `mbedtls_ssl_set_session()` multiple times in Mbed TLS 2.x
+  is not useful since subsequent calls overwrite the effect of previous
+  calls. Applications achieve equivalent functional behaviour by
+  issuing only the very last call to `mbedtls_ssl_set_session()`.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2433,7 +2433,6 @@ int mbedtls_ssl_session_load( mbedtls_ssl_session *session,
  *                 of session cache or session tickets.
  *
  * \see            mbedtls_ssl_session_load()
- * \see            mbedtls_ssl_get_session_pointer()
  *
  * \param session  The session structure to be saved.
  * \param buf      The buffer to write the serialized data to. It must be a
@@ -2455,23 +2454,6 @@ int mbedtls_ssl_session_save( const mbedtls_ssl_session *session,
                               unsigned char *buf,
                               size_t buf_len,
                               size_t *olen );
-
-/**
- * \brief          Get a pointer to the current session structure, for example
- *                 to serialize it.
- *
- * \warning        Ownership of the session remains with the SSL context, and
- *                 the returned pointer is only guaranteed to be valid until
- *                 the next API call operating on the same \p ssl context.
- *
- * \see            mbedtls_ssl_session_save()
- *
- * \param ssl      The SSL context.
- *
- * \return         A pointer to the current session if successful.
- * \return         \c NULL if no session is active.
- */
-const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl );
 
 /**
  * \brief               Set the list of allowed ciphersuites and the preference

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2386,8 +2386,8 @@ void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
  *                 to reject any attempt for resumption and fall back to
  *                 a full handshake.
  *
- * \note           The mechanism of session resumption is opaque to this
- *                 call: For TLS 1.2, both session ID-based resumption and
+ * \note           This function can handle a variety of mechanisms for session
+ *                 resumption: For TLS 1.2, both session ID-based resumption and
  *                 ticket-based resumption will be considered. For TLS 1.3,
  *                 once implemented, sessions equate to tickets, and loading
  *                 one or more sessions via this call will lead to their
@@ -3718,8 +3718,8 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 This must have been initialized with mbedtls_ssl_init_session()
  *                 but otherwise be unused.
  *
- * \note           The mechanism of session resumption is opaque to this
- *                 call: For TLS 1.2, both session ID-based resumption and
+ * \note           This function can handle a variety of mechanism for session
+ *                 resumption: For TLS 1.2, both session ID-based resumption and
  *                 ticket-based resumption will be considered. For TLS 1.3,
  *                 once implemented, sessions equate to tickets, and calling
  *                 this function multiple times will export the available

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3718,7 +3718,7 @@ const mbedtls_x509_crt *mbedtls_ssl_get_peer_cert( const mbedtls_ssl_context *ss
  *                 This must have been initialized with mbedtls_ssl_init_session()
  *                 but otherwise be unused.
  *
- * \note           This function can handle a variety of mechanism for session
+ * \note           This function can handle a variety of mechanisms for session
  *                 resumption: For TLS 1.2, both session ID-based resumption and
  *                 ticket-based resumption will be considered. For TLS 1.3,
  *                 once implemented, sessions equate to tickets, and calling

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4801,14 +4801,6 @@ int mbedtls_ssl_get_session( const mbedtls_ssl_context *ssl,
 }
 #endif /* MBEDTLS_SSL_CLI_C */
 
-const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_context *ssl )
-{
-    if( ssl == NULL )
-        return( NULL );
-
-    return( ssl->session );
-}
-
 /*
  * Define ticket header determining Mbed TLS version
  * and structure of the ticket.

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -2224,6 +2224,8 @@ int main( int argc, char *argv[] )
 
         if( opt.reco_mode == 1 )
         {
+            mbedtls_ssl_session exported_session;
+
             /* free any previously saved data */
             if( session_data != NULL )
             {
@@ -2232,27 +2234,40 @@ int main( int argc, char *argv[] )
                 session_data = NULL;
             }
 
+            mbedtls_ssl_session_init( &exported_session );
+            ret = mbedtls_ssl_get_session( &ssl, &exported_session );
+            if( ret != 0 )
+            {
+                mbedtls_printf(
+                    "failed\n  ! mbedtls_ssl_get_session() returned -%#02x\n",
+                    (unsigned) -ret );
+                goto exit;
+            }
+
             /* get size of the buffer needed */
-            mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
-                                      NULL, 0, &session_data_len );
+            mbedtls_ssl_session_save( &exported_session, NULL, 0, &session_data_len );
             session_data = mbedtls_calloc( 1, session_data_len );
             if( session_data == NULL )
             {
                 mbedtls_printf( " failed\n  ! alloc %u bytes for session data\n",
                                 (unsigned) session_data_len );
+                mbedtls_ssl_session_free( &exported_session );
                 ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
                 goto exit;
             }
 
             /* actually save session data */
-            if( ( ret = mbedtls_ssl_session_save( mbedtls_ssl_get_session_pointer( &ssl ),
+            if( ( ret = mbedtls_ssl_session_save( &exported_session,
                                                   session_data, session_data_len,
                                                   &session_data_len ) ) != 0 )
             {
                 mbedtls_printf( " failed\n  ! mbedtls_ssl_session_saved returned -0x%04x\n\n",
                                 (unsigned int) -ret );
+                mbedtls_ssl_session_free( &exported_session );
                 goto exit;
             }
+
+            mbedtls_ssl_session_free( &exported_session );
         }
         else
         {


### PR DESCRIPTION
This PR fixes #4184, removing `mbedtls_ssl_get_session_pointer()` and modifying the semantics of `mbedtls_ssl_{set,get}_session()` in preparation for the forthcoming support of TLS 1.3.

See #4184, https://lists.trustedfirmware.org/pipermail/mbed-tls/2020-April/000049.html and the commit messages for details.