### PR TITLE
Fix misuse of MD API in SSL constant-flow HMAC

### DIFF
--- a/ChangeLog.d/fix-ssl-cf-hmac-alt.txt
+++ b/ChangeLog.d/fix-ssl-cf-hmac-alt.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix a regression introduced in 2.24.0 which broke (D)TLS CBC ciphersuites
+     (when the encrypt-then-MAC extension is not in use) with some ALT
+     implementations of the underlying hash (SHA-1, SHA-256, SHA-384), causing
+     the affected side to wrongly reject valid messages. Fixes #4118.

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1164,6 +1164,9 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_ssl_cf_hmac(
             MD_CHK( mbedtls_md_update( ctx, data + offset, 1 ) );
     }
 
+    /* The context needs to finish() before it starts() again */
+    MD_CHK( mbedtls_md_finish( ctx, aux_out ) );
+
     /* Now compute HASH(okey + inner_hash) */
     MD_CHK( mbedtls_md_starts( ctx ) );
     MD_CHK( mbedtls_md_update( ctx, okey, block_size ) );


### PR DESCRIPTION
## Description

Fixes #4118

The sequence of calls starts-update-starts-update-finish is not a
guaranteed valid way to abort an operation and start a new one. Our
software implementation just happens to support it, but alt
implementations may very well not support it.

## Status
**READY**

## Requires Backporting

Yes

- [x] 2.x - #4541 
- [x] 2.16 - #4542 

## Migrations

NO

## Additional comments

See #4524 for how to avoid similar bugs in the future.

## Todos

- [x] Tests - omitted for now, but tracked in #4524
- [x] Documentation
- [x] Changelog updated
- [x] Backported


