### PR TITLE
Add changelog entry for #4510

### DIFF
--- a/ChangeLog.d/psa_sign_message.txt
+++ b/ChangeLog.d/psa_sign_message.txt
@@ -1,0 +1,2 @@
+Features
+   * Implement psa_sign_message() and psa_verify_message().


### PR DESCRIPTION
We forgot a changelog entry in #4510 (`psa_sign_message`). Forward-port of #4525.