### PR TITLE
[2.x only] Remove some remaining uses of deprecated constants

### DIFF
--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -134,7 +134,7 @@ Example 2: the following capability declares that the driver can perform determ
     "entry_points": ["sign_hash"],
     "algorithms": ["PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256)",
                    "PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_384)"],
-    "key_types": ["PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1)"],
+    "key_types": ["PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)"],
     "key_sizes": [256, 384]
 }
 ```
@@ -164,7 +164,7 @@ The name `_` may be used instead of a curve or group to indicate that the capabi
 Valid examples:
 ```
 PSA_KEY_TYPE_AES
-PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1)
+PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1)
 PSA_KEY_TYPE_ECC_KEY_PAIR(_)
 ```
 

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -75,7 +75,7 @@ void external_rng_failure_sign( int key_type, data_t *key_data, int alg,
 
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_set_key_type( &attributes, key_type );
-    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN );
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_HASH );
     psa_set_key_algorithm( &attributes, alg );
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     size_t input_size = input_size_arg;


### PR DESCRIPTION
Deprecated constants should only be used to test them specifically.
Remove a few stragglers.

I used the following command to find problematic occurrences:
```
sed -nE 's/^#define (\w+).*/\1/p' include/psa/crypto_compat.h | grep -vx PSA_KEY_HANDLE_INIT | git grep -wF -f - '*' ':!ChangeLog*' ':!include/psa/crypto_compat.h'
```
The remaining occurrences in `tests/suites/test_suite_psa_crypto.function` are legitimate: they are testing the deprecated constants themselves.
