### PR TITLE
Fix build error in host_test.function when int32_t is not int

### DIFF
--- a/ChangeLog.d/host_test-int32.txt
+++ b/ChangeLog.d/host_test-int32.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix test suite code on platforms where int32_t is not int, such as
+     Arm Cortex-M. Fixes #4530.

--- a/tests/suites/host_test.function
+++ b/tests/suites/host_test.function
@@ -33,7 +33,7 @@ int verify_string( char **str )
  *
  * \return      0 if success else 1
  */
-int verify_int( char *str, int *value )
+int verify_int( char *str, int32_t *value )
 {
     size_t i;
     int minus = 0;
@@ -238,7 +238,7 @@ static int parse_arguments( char *buf, size_t len, char **params,
  *
  * \return      0 for success else 1
  */
-static int convert_params( size_t cnt , char ** params , int * int_params_store )
+static int convert_params( size_t cnt , char ** params , int32_t * int_params_store )
 {
     char ** cur = params;
     char ** out = params;
@@ -520,7 +520,7 @@ int execute_tests( int argc , const char ** argv )
     char buf[5000];
     char *params[50];
     /* Store for proccessed integer params. */
-    int int_params[50];
+    int32_t int_params[50];
     void *pointer;
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     int stdout_fd = -1;


### PR DESCRIPTION
Fix https://github.com/ARMmbed/mbedtls/issues/4530.

This is not checked by the CI because we don't build the unit tests on the CI on any platform where `int32_t` and `int` are distinct types. On Arm Cortex-M, `int32_t` is `long int`, so the build fails, although the code would run correctly (I think — there may be bugs due to aliasing, but I haven't checked whether bugs are actually possible). We can't easily build `test_suite_*.o` because it would require more build script changes than I care to do now, and we can't easily build the executables because the only toolchain for Cortex-M we have on the CI is for bare metal and lacks necessary standard library functions.

Backports: #4533, #4534.