### PR TITLE
Fix docs for mbedtls_padlock_has_support

### DIFF
--- a/library/padlock.h
+++ b/library/padlock.h
@@ -71,7 +71,7 @@ extern "C" {
  *
  * \param feature  The feature to detect
  *
- * \return         1 if CPU has support for the feature, 0 otherwise
+ * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
 int mbedtls_padlock_has_support( int feature );
 


### PR DESCRIPTION
Fix a slight inaccuracy in the docs for the return value of
mbedtls_padlock_has_support.

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>

Backports: [2.x](https://github.com/ARMmbed/mbedtls/pull/4537), [2.16](https://github.com/ARMmbed/mbedtls/pull/4540)