### PR TITLE
2.x backport: Fix docs for mbedtls_padlock_has_support

### DIFF
--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -71,7 +71,7 @@ extern "C" {
  *
  * \param feature  The feature to detect
  *
- * \return         1 if CPU has support for the feature, 0 otherwise
+ * \return         non-zero if CPU has support for the feature, 0 otherwise
  */
 int mbedtls_padlock_has_support( int feature );
 


### PR DESCRIPTION
Backport of #4536 