### PR TITLE
[Backport 2.x] Fix misuse of MD API in SSL constant-flow HMAC

### DIFF
--- a/ChangeLog.d/fix-ssl-cf-hmac-alt.txt
+++ b/ChangeLog.d/fix-ssl-cf-hmac-alt.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix a regression introduced in 2.24.0 which broke (D)TLS CBC ciphersuites
+     (when the encrypt-then-MAC extension is not in use) with some ALT
+     implementations of the underlying hash (SHA-1, SHA-256, SHA-384), causing
+     the affected side to wrongly reject valid messages. Fixes #4118.

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1241,6 +1241,9 @@ MBEDTLS_STATIC_TESTABLE int mbedtls_ssl_cf_hmac(
             MD_CHK( mbedtls_md_update( ctx, data + offset, 1 ) );
     }
 
+    /* The context needs to finish() before it starts() again */
+    MD_CHK( mbedtls_md_finish( ctx, aux_out ) );
+
     /* Now compute HASH(okey + inner_hash) */
     MD_CHK( mbedtls_md_starts( ctx ) );
     MD_CHK( mbedtls_md_update( ctx, okey, block_size ) );


### PR DESCRIPTION
This is the 2.x backport of #4522 

Note: the backport was trivial, so I think this only needs a single reviewer.
