### PR TITLE
TLS 1.3 Key schedule: Second level secret generation

### DIFF
--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -628,6 +628,11 @@ int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
     mbedtls_md_info_t const *md_info = mbedtls_md_info_from_type( md_type );
     size_t const md_size = mbedtls_md_get_size( md_info );
 
+#if !defined(MBEDTLS_DEBUG_C)
+    ssl = NULL; /* make sure we don't use it except for debug */
+    ((void) ssl);
+#endif
+
     /* We should never call this function with an unknown hash,
      * but add an assertion anyway. */
     if( md_info == 0 )

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -368,9 +368,6 @@ int mbedtls_ssl_tls1_3_derive_early_secrets(
      *            v
      *  PSK ->  HKDF-Extract = Early Secret
      *            |
-     *            +-----> Derive-Secret(., "ext binder" | "res binder", "")
-     *            |                     = binder_key
-     *            |
      *            +-----> Derive-Secret(., "c e traffic", ClientHello)
      *            |                     = client_early_traffic_secret
      *            |

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -465,4 +465,37 @@ int mbedtls_ssl_tls1_3_evolve_secret(
                    const unsigned char *input, size_t input_len,
                    unsigned char *secret_new );
 
+#define MBEDTLS_SSL_TLS1_3_PSK_EXTERNAL   0
+#define MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION 1
+
+/**
+ * \brief             Calculate a TLS 1.3 PSK binder.
+ *
+ * \param ssl         The SSL context. This is used for debugging only and may
+ *                    be \c NULL if MBEDTLS_DEBUG_C is disabled.
+ * \param md_type     The hash algorithm associated to the PSK \p psk.
+ * \param psk         The buffer holding the PSK for which to create a binder.
+ * \param psk_len     The size of \p psk in bytes.
+ * \param is_external This indicates whether the PSK \p psk is externally
+ *                    provisioned (#MBEDTLS_SSL_TLS1_3_PSK_EXTERNAL) or a
+ *                    resumption PSK (#MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION).
+ * \param transcript  The handshake transcript up to the point where the
+ *                    PSK binder calculation happens. This must be readable,
+ *                    and its size must be equal to the digest size of
+ *                    the hash algorithm represented by \p md_type.
+ * \param result      The address at which to store the PSK binder on success.
+ *                    This must be writable, and its size must be equal to the
+ *                    digest size of  the hash algorithm represented by
+ *                    \p md_type.
+ *
+ * \returns           \c 0 on success.
+ * \returns           A negative error code on failure.
+ */
+int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
+                               const mbedtls_md_type_t md_type,
+                               unsigned char const *psk, size_t psk_len,
+                               int psk_type,
+                               unsigned char const *transcript,
+                               unsigned char *result );
+
 #endif /* MBEDTLS_SSL_TLS1_3_KEYS_H */

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -70,6 +70,27 @@ extern const struct mbedtls_ssl_tls1_3_labels_struct mbedtls_ssl_tls1_3_labels;
 #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_CONTEXT_LEN  \
     MBEDTLS_MD_MAX_SIZE
 
+typedef struct
+{
+    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
+} mbedtls_ssl_tls1_3_early_secrets;
+
+typedef struct
+{
+    unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
+} mbedtls_ssl_tls1_3_handshake_secrets;
+
+typedef struct
+{
+    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
+    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
+} mbedtls_ssl_tls1_3_application_secrets;
+
 /* Maximum desired length for expanded key material generated
  * by HKDF-Expand-Label.
  *
@@ -197,6 +218,179 @@ int mbedtls_ssl_tls1_3_derive_secret(
                    const unsigned char *ctx, size_t clen,
                    int ctx_hashed,
                    unsigned char *dstbuf, size_t buflen );
+
+/**
+ * \brief Derive TLS 1.3 early data key material from early secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels.
+ *
+ * <tt>
+ *        Early Secret
+ *             |
+ *             +-----> Derive-Secret(., "c e traffic", ClientHello)
+ *             |                      = client_early_traffic_secret
+ *             |
+ *             +-----> Derive-Secret(., "e exp master", ClientHello)
+ *             .                      = early_exporter_master_secret
+ *             .
+ *             .
+ * </tt>
+ *
+ * \note  To obtain the actual key and IV for the early data traffic,
+ *        the client secret derived by this function need to be
+ *        further processed by mbedtls_ssl_tls1_3_make_traffic_keys().
+ *
+ * \note  The binder key, which is also generated from the early secret,
+ *        is omitted here. Its calculation is part of the separate routine
+ *        mbedtls_ssl_tls1_3_create_psk_binder().
+ *
+ * \param md_type      The hash algorithm associated with the PSK for which
+ *                     early data key material is being derived.
+ * \param early_secret The early secret from which the early data key material
+ *                     should be derived. This must be a readable buffer whose
+ *                     length is the digest size of the hash algorithm
+ *                     represented by \p md_size.
+ * \param transcript   The transcript of the handshake so far, calculated with
+ *                     respect to \p md_type. This must be a readable buffer
+ *                     whose length is the digest size of the hash algorithm
+ *                     represented by \p md_size.
+ * \param derived      The address of the structure in which to store
+ *                     the early data key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
+int mbedtls_ssl_tls1_3_derive_early_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *early_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_early_secrets *derived );
+
+/**
+ * \brief Derive TLS 1.3 handshake key material from the handshake secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels from the standard.
+ *
+ * <tt>
+ *        Handshake Secret
+ *              |
+ *              +-----> Derive-Secret( ., "c hs traffic",
+ *              |                      ClientHello...ServerHello )
+ *              |                      = client_handshake_traffic_secret
+ *              |
+ *              +-----> Derive-Secret( ., "s hs traffic",
+ *              .                      ClientHello...ServerHello )
+ *              .                      = server_handshake_traffic_secret
+ *              .
+ * </tt>
+ *
+ * \note  To obtain the actual key and IV for the encrypted handshake traffic,
+ *        the client and server secret derived by this function need to be
+ *        further processed by mbedtls_ssl_tls1_3_make_traffic_keys().
+ *
+ * \param md_type           The hash algorithm associated with the ciphersuite
+ *                          that's being used for the connection.
+ * \param handshake_secret  The handshake secret from which the handshake key
+ *                          material should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the handshake so far, calculated
+ *                          with respect to \p md_type. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param derived           The address of the structure in which to
+ *                          store the handshake key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
+int mbedtls_ssl_tls1_3_derive_handshake_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *handshake_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_handshake_secrets *derived );
+
+/**
+ * \brief Derive TLS 1.3 application key material from the master secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels from the standard.
+ *
+ * <tt>
+ *        Master Secret
+ *              |
+ *              +-----> Derive-Secret( ., "c ap traffic",
+ *              |                      ClientHello...server Finished )
+ *              |                      = client_application_traffic_secret_0
+ *              |
+ *              +-----> Derive-Secret( ., "s ap traffic",
+ *              |                      ClientHello...Server Finished )
+ *              |                      = server_application_traffic_secret_0
+ *              |
+ *              +-----> Derive-Secret( ., "exp master",
+ *              .                      ClientHello...server Finished)
+ *              .                      = exporter_master_secret
+ *              .
+ * </tt>
+ *
+ * \note  To obtain the actual key and IV for the (0-th) application traffic,
+ *        the client and server secret derived by this function need to be
+ *        further processed by mbedtls_ssl_tls1_3_make_traffic_keys().
+ *
+ * \param md_type           The hash algorithm associated with the ciphersuite
+ *                          that's being used for the connection.
+ * \param master_secret     The master secret from which the application key
+ *                          material should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the handshake up to and including
+ *                          the ServerFinished message, calculated with respect
+ *                          to \p md_type. This must be a readable buffer whose
+ *                          length is the digest size of the hash algorithm
+ *                          represented by \p md_type.
+ * \param derived           The address of the structure in which to
+ *                          store the application key material.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
+int mbedtls_ssl_tls1_3_derive_application_secrets(
+          mbedtls_md_type_t md_type,
+          unsigned char const *master_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived );
+
+/**
+ * \brief Derive TLS 1.3 resumption master secret from the master secret.
+ *
+ *        This is a small wrapper invoking mbedtls_ssl_tls1_3_derive_secret()
+ *        with the appropriate labels from the standard.
+ *
+ * \param md_type           The hash algorithm used in the application for which
+ *                          key material is being derived.
+ * \param application_secret The application secret from which the resumption master
+ *                          secret should be derived. This must be a readable
+ *                          buffer whose length is the digest size of the hash
+ *                          algorithm represented by \p md_size.
+ * \param transcript        The transcript of the handshake up to and including
+ *                          the ClientFinished message, calculated with respect
+ *                          to \p md_type. This must be a readable buffer whose
+ *                          length is the digest size of the hash algorithm
+ *                          represented by \p md_type.
+ * \param transcript_len    The length of \p transcript in Bytes.
+ * \param derived           The address of the structure in which to
+ *                          store the resumption master secret.
+ *
+ * \returns        \c 0 on success.
+ * \returns        A negative error code on failure.
+ */
+int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
+          mbedtls_md_type_t md_type,
+          unsigned char const *application_secret,
+          unsigned char const *transcript, size_t transcript_len,
+          mbedtls_ssl_tls1_3_application_secrets *derived );
 
 /**
  * \brief Compute the next secret in the TLS 1.3 key schedule

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -476,7 +476,7 @@ int mbedtls_ssl_tls1_3_evolve_secret(
  * \param md_type     The hash algorithm associated to the PSK \p psk.
  * \param psk         The buffer holding the PSK for which to create a binder.
  * \param psk_len     The size of \p psk in bytes.
- * \param is_external This indicates whether the PSK \p psk is externally
+ * \param psk_type    This indicates whether the PSK \p psk is externally
  *                    provisioned (#MBEDTLS_SSL_TLS1_3_PSK_EXTERNAL) or a
  *                    resumption PSK (#MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION).
  * \param transcript  The handshake transcript up to the point where the

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -9257,6 +9257,12 @@ SSL TLS 1.3 Key schedule: Resumption secrets derivation helper
 # Vector from RFC 8448
 ssl_tls1_3_derive_resumption_secrets:MBEDTLS_MD_SHA256:"e2d32d4ed66dd37897a0e80c84107503ce58bf8aad4cb55a5002d77ecb890ece":"c3c122e0bd907a4a3ff6112d8fd53dbf89c773d9552e8b6b9d56d361b3a97bf6":"5e95bdf1f89005ea2e9aa0ba85e728e3c19c5fe0c699e3f5bee59faebd0b5406"
 
+SSL TLS 1.3 Key schedule: PSK binder
+# Vector from RFC 8448
+# For the resumption PSK, see Section 3, 'generate resumption secret "tls13 resumption"'
+# For all other data, see Section 4, 'construct a ClientHello handshake message:'
+ssl_tls1_3_create_psk_binder:MBEDTLS_MD_SHA256:"4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3":MBEDTLS_SSL_TLS1_3_PSK_RESUMPTION:"63224b2e4573f2d3454ca84b9d009a04f6be9e05711a8396473aefa01e924a14":"3add4fb2d8fdf822a0ca3cf7678ef5e88dae990141c5924d57bb6fa31b9e5f9d"
+
 SSL TLS_PRF MBEDTLS_SSL_TLS_PRF_NONE
 ssl_tls_prf:MBEDTLS_SSL_TLS_PRF_NONE:"":"":"test tls_prf label":"":MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE
 

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -9241,6 +9241,22 @@ SSL TLS 1.3 Key schedule: Derive-Secret( ., "res master", hash)
 # Vector from RFC 8448
 ssl_tls1_3_derive_secret:MBEDTLS_MD_SHA256:"e2d32d4ed66dd37897a0e80c84107503ce58bf8aad4cb55a5002d77ecb890ece":tls1_3_label_res_master:"c3c122e0bd907a4a3ff6112d8fd53dbf89c773d9552e8b6b9d56d361b3a97bf6":32:MBEDTLS_SSL_TLS1_3_CONTEXT_HASHED:"5e95bdf1f89005ea2e9aa0ba85e728e3c19c5fe0c699e3f5bee59faebd0b5406"
 
+SSL TLS 1.3 Key schedule: Early secrets derivation helper
+# Vector from RFC 8448
+ssl_tls1_3_derive_early_secrets:MBEDTLS_MD_SHA256:"9b2188e9b2fc6d64d71dc329900e20bb41915000f678aa839cbb797cb7d8332c":"08ad0fa05d7c7233b1775ba2ff9f4c5b8b59276b7f227f13a976245f5d960913":"3fbbe6a60deb66c30a32795aba0eff7eaa10105586e7be5c09678d63b6caab62":"b2026866610937d7423e5be90862ccf24c0e6091186d34f812089ff5be2ef7df"
+
+SSL TLS 1.3 Key schedule: Handshake secrets derivation helper
+# Vector from RFC 8448
+ssl_tls1_3_derive_handshake_secrets:MBEDTLS_MD_SHA256:"005cb112fd8eb4ccc623bb88a07c64b3ede1605363fc7d0df8c7ce4ff0fb4ae6":"f736cb34fe25e701551bee6fd24c1cc7102a7daf9405cb15d97aafe16f757d03":"2faac08f851d35fea3604fcb4de82dc62c9b164a70974d0462e27f1ab278700f":"fe927ae271312e8bf0275b581c54eef020450dc4ecffaa05a1a35d27518e7803"
+
+SSL TLS 1.3 Key schedule: Application secrets derivation helper
+# Vector from RFC 8448
+ssl_tls1_3_derive_application_secrets:MBEDTLS_MD_SHA256:"e2d32d4ed66dd37897a0e80c84107503ce58bf8aad4cb55a5002d77ecb890ece":"b0aeffc46a2cfe33114e6fd7d51f9f04b1ca3c497dab08934a774a9d9ad7dbf3":"2abbf2b8e381d23dbebe1dd2a7d16a8bf484cb4950d23fb7fb7fa8547062d9a1":"cc21f1bf8feb7dd5fa505bd9c4b468a9984d554a993dc49e6d285598fb672691":"3fd93d4ffddc98e64b14dd107aedf8ee4add23f4510f58a4592d0b201bee56b4"
+
+SSL TLS 1.3 Key schedule: Resumption secrets derivation helper
+# Vector from RFC 8448
+ssl_tls1_3_derive_resumption_secrets:MBEDTLS_MD_SHA256:"e2d32d4ed66dd37897a0e80c84107503ce58bf8aad4cb55a5002d77ecb890ece":"c3c122e0bd907a4a3ff6112d8fd53dbf89c773d9552e8b6b9d56d361b3a97bf6":"5e95bdf1f89005ea2e9aa0ba85e728e3c19c5fe0c699e3f5bee59faebd0b5406"
+
 SSL TLS_PRF MBEDTLS_SSL_TLS_PRF_NONE
 ssl_tls_prf:MBEDTLS_SSL_TLS_PRF_NONE:"":"":"test tls_prf label":"":MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3914,6 +3914,36 @@ void ssl_tls1_3_derive_resumption_secrets( int hash_alg,
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+void ssl_tls1_3_create_psk_binder( int hash_alg,
+                                   data_t *psk,
+                                   int psk_type,
+                                   data_t *transcript,
+                                   data_t *binder_expected )
+{
+    unsigned char binder[ MBEDTLS_MD_MAX_SIZE ];
+
+    /* Double-check that we've passed sane parameters. */
+    mbedtls_md_type_t md_type = (mbedtls_md_type_t) hash_alg;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+    TEST_ASSERT( md_info != 0                    &&
+                 transcript->len == md_size      &&
+                 binder_expected->len == md_size );
+
+    TEST_ASSERT( mbedtls_ssl_tls1_3_create_psk_binder(
+                     NULL, /* SSL context for debugging only */
+                     md_type,
+                     psk->x, psk->len,
+                     psk_type,
+                     transcript->x,
+                     binder ) == 0 );
+
+    ASSERT_COMPARE( binder, md_size,
+                    binder_expected->x, binder_expected->len );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 void ssl_tls1_3_key_evolution( int hash_alg,
                                data_t *secret,
                                data_t *input,

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3794,6 +3794,126 @@ MBEDTLS_SSL_TLS1_3_LABEL_LIST
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+void ssl_tls1_3_derive_early_secrets( int hash_alg,
+                                      data_t *secret,
+                                      data_t *transcript,
+                                      data_t *traffic_expected,
+                                      data_t *exporter_expected )
+{
+    mbedtls_ssl_tls1_3_early_secrets secrets;
+
+    /* Double-check that we've passed sane parameters. */
+    mbedtls_md_type_t md_type = (mbedtls_md_type_t) hash_alg;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+    TEST_ASSERT( md_info != 0                      &&
+                 secret->len == md_size            &&
+                 transcript->len == md_size        &&
+                 traffic_expected->len == md_size  &&
+                 exporter_expected->len == md_size );
+
+    TEST_ASSERT( mbedtls_ssl_tls1_3_derive_early_secrets(
+                     md_type, secret->x, transcript->x, transcript->len,
+                     &secrets ) == 0 );
+
+    ASSERT_COMPARE( secrets.client_early_traffic_secret, md_size,
+                    traffic_expected->x, traffic_expected->len );
+    ASSERT_COMPARE( secrets.early_exporter_master_secret, md_size,
+                    exporter_expected->x, exporter_expected->len );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+void ssl_tls1_3_derive_handshake_secrets( int hash_alg,
+                                          data_t *secret,
+                                          data_t *transcript,
+                                          data_t *client_expected,
+                                          data_t *server_expected )
+{
+    mbedtls_ssl_tls1_3_handshake_secrets secrets;
+
+    /* Double-check that we've passed sane parameters. */
+    mbedtls_md_type_t md_type = (mbedtls_md_type_t) hash_alg;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+    TEST_ASSERT( md_info != 0                      &&
+                 secret->len == md_size            &&
+                 transcript->len == md_size        &&
+                 client_expected->len == md_size   &&
+                 server_expected->len == md_size );
+
+    TEST_ASSERT( mbedtls_ssl_tls1_3_derive_handshake_secrets(
+                     md_type, secret->x, transcript->x, transcript->len,
+                     &secrets ) == 0 );
+
+    ASSERT_COMPARE( secrets.client_handshake_traffic_secret, md_size,
+                    client_expected->x, client_expected->len );
+    ASSERT_COMPARE( secrets.server_handshake_traffic_secret, md_size,
+                    server_expected->x, server_expected->len );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+void ssl_tls1_3_derive_application_secrets( int hash_alg,
+                                          data_t *secret,
+                                          data_t *transcript,
+                                          data_t *client_expected,
+                                          data_t *server_expected,
+                                          data_t *exporter_expected )
+{
+    mbedtls_ssl_tls1_3_application_secrets secrets;
+
+    /* Double-check that we've passed sane parameters. */
+    mbedtls_md_type_t md_type = (mbedtls_md_type_t) hash_alg;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+    TEST_ASSERT( md_info != 0                      &&
+                 secret->len == md_size            &&
+                 transcript->len == md_size        &&
+                 client_expected->len == md_size   &&
+                 server_expected->len == md_size   &&
+                 exporter_expected->len == md_size );
+
+    TEST_ASSERT( mbedtls_ssl_tls1_3_derive_application_secrets(
+                     md_type, secret->x, transcript->x, transcript->len,
+                     &secrets ) == 0 );
+
+    ASSERT_COMPARE( secrets.client_application_traffic_secret_N, md_size,
+                    client_expected->x, client_expected->len );
+    ASSERT_COMPARE( secrets.server_application_traffic_secret_N, md_size,
+                    server_expected->x, server_expected->len );
+    ASSERT_COMPARE( secrets.exporter_master_secret, md_size,
+                    exporter_expected->x, exporter_expected->len );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+void ssl_tls1_3_derive_resumption_secrets( int hash_alg,
+                                           data_t *secret,
+                                           data_t *transcript,
+                                           data_t *resumption_expected )
+{
+    mbedtls_ssl_tls1_3_application_secrets secrets;
+
+    /* Double-check that we've passed sane parameters. */
+    mbedtls_md_type_t md_type = (mbedtls_md_type_t) hash_alg;
+    mbedtls_md_info_t const * const md_info = mbedtls_md_info_from_type( md_type );
+    size_t const md_size = mbedtls_md_get_size( md_info );
+    TEST_ASSERT( md_info != 0                        &&
+                 secret->len == md_size              &&
+                 transcript->len == md_size          &&
+                 resumption_expected->len == md_size );
+
+    TEST_ASSERT( mbedtls_ssl_tls1_3_derive_resumption_master_secret(
+                     md_type, secret->x, transcript->x, transcript->len,
+                     &secrets ) == 0 );
+
+    ASSERT_COMPARE( secrets.resumption_master_secret, md_size,
+                    resumption_expected->x, resumption_expected->len );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
 void ssl_tls1_3_key_evolution( int hash_alg,
                                data_t *secret,
                                data_t *input,


### PR DESCRIPTION
__Context:__ This PR is part of the upstreaming of the TLS 1.3 prototype from https://github.com/hannestschofenig/mbedtls/, Specifically, it continues the upstreaming of the TLS 1.3 key schedule functionality, started in https://github.com/ARMmbed/mbedtls/pull/3568.

__Details:__ Recall the TLS 1.3 key schedule form RFC 8448:
```

             0
             |
             v
   PSK ->  HKDF-Extract = Early Secret
             |
             +-----> Derive-Secret(., "ext binder" | "res binder", "")
             |                     = binder_key
             |
             +-----> Derive-Secret(., "c e traffic", ClientHello)
             |                     = client_early_traffic_secret
             |
             +-----> Derive-Secret(., "e exp master", ClientHello)
             |                     = early_exporter_master_secret
             v
       Derive-Secret(., "derived", "")
             |
             v
   (EC)DHE -> HKDF-Extract = Handshake Secret
             |
             +-----> Derive-Secret(., "c hs traffic",
             |                     ClientHello...ServerHello)
             |                     = client_handshake_traffic_secret
             |
             +-----> Derive-Secret(., "s hs traffic",
             |                     ClientHello...ServerHello)
             |                     = server_handshake_traffic_secret
             v
       Derive-Secret(., "derived", "")
             |
             v
   0 -> HKDF-Extract = Master Secret
             |
             +-----> Derive-Secret(., "c ap traffic",
             |                     ClientHello...server Finished)
             |                     = client_application_traffic_secret_0
             |
             +-----> Derive-Secret(., "s ap traffic",
             |                     ClientHello...server Finished)
             |                     = server_application_traffic_secret_0
             |
             +-----> Derive-Secret(., "exp master",
             |                     ClientHello...server Finished)
             |                     = exporter_master_secret
             |
             +-----> Derive-Secret(., "res master",
                                   ClientHello...client Finished)
                                   = resumption_master_secret
```

The vertical secret evolution is already upstreamed as `mbedtls_ssl_tls1_3_evolve_secret()`, and the primitive `Derive-Secret()` for the horizontal "second level" key evolution is upstreamed as `mbedtls_ssl_tls1_3_derive_secret()`. 

However, we have not yet upstreamed any code that would invoke `mbedtls_ssl_tls1_3_derive_secret()` with the specific TLS 1.3 labels, to generate the set of "second level" secrets specific to each handshake stage (early/handshake/application). This is what this PR does: It adds convenience structures
```c
typedef struct
{
    unsigned char binder_key                  [ MBEDTLS_MD_MAX_SIZE ];
    unsigned char client_early_traffic_secret [ MBEDTLS_MD_MAX_SIZE ];
    unsigned char early_exporter_master_secret[ MBEDTLS_MD_MAX_SIZE ];
} mbedtls_ssl_tls1_3_early_secrets;

typedef struct
{
    unsigned char client_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
    unsigned char server_handshake_traffic_secret[ MBEDTLS_MD_MAX_SIZE ];
} mbedtls_ssl_tls1_3_handshake_secrets;

typedef struct
{
    unsigned char client_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
    unsigned char server_application_traffic_secret_N[ MBEDTLS_MD_MAX_SIZE ];
    unsigned char exporter_master_secret             [ MBEDTLS_MD_MAX_SIZE ];
    unsigned char resumption_master_secret           [ MBEDTLS_MD_MAX_SIZE ];
} mbedtls_ssl_tls1_3_application_secrets;
```

as well as helper functions
```c
int mbedtls_ssl_tls1_3_derive_early_secrets(
          mbedtls_md_type_t md_type,
          unsigned char const *early_secret,
          unsigned char const *transcript, size_t transcript_len,
          mbedtls_ssl_tls1_3_early_secrets *derived );
int mbedtls_ssl_tls1_3_derive_handshake_secrets(
          mbedtls_md_type_t md_type,
          unsigned char const *handshake_secret,
          unsigned char const *transcript, size_t transcript_len,
          mbedtls_ssl_tls1_3_handshake_secrets *derived );
int mbedtls_ssl_tls1_3_derive_application_secrets(
          mbedtls_md_type_t md_type,
          unsigned char const *master_secret,
          unsigned char const *transcript, size_t transcript_len,
          mbedtls_ssl_tls1_3_application_secrets *derived );
int mbedtls_ssl_tls1_3_derive_resumption_master_secret(
          mbedtls_md_type_t md_type,
          unsigned char const *application_secret,
          unsigned char const *transcript, size_t transcript_len,
          mbedtls_ssl_tls1_3_application_secrets *derived );
```
implementing the second level key evolution.

It also upstreams a helper function
```c
int mbedtls_ssl_tls1_3_create_psk_binder( mbedtls_ssl_context *ssl,
                               const mbedtls_md_type_t md_type,
                               unsigned char const *psk, size_t psk_len,
                               int psk_type,
                               unsigned char const *transcript,
                               unsigned char *result );
```
for the calculation of PSK binders.

Please see the corresponding commits, and esp. the documentation within `mbedtls_ssl_tls1_3_keys.h`, for more information.