### PR TITLE
Define CCM multi-part API

### DIFF
--- a/ChangeLog.d/m-ccm-api.txt
+++ b/ChangeLog.d/m-ccm-api.txt
@@ -1,0 +1,5 @@
+Features
+   * The CCM API now supports multi-part operations. Alternative
+     implementations can add multipart support according to the new multi-part
+     interface functions. The implementation of these functions in Mbed TLS
+     will be added in a future release.

--- a/ChangeLog.d/m-ccm-api.txt
+++ b/ChangeLog.d/m-ccm-api.txt
@@ -1,5 +1,0 @@
-Features
-   * The CCM API now supports multi-part operations. Alternative
-     implementations can add multipart support according to the new multi-part
-     interface functions. The implementation of these functions in Mbed TLS
-     will be added in a future release.

--- a/docs/3.0-migration-guide.d/ccm-alt.md
+++ b/docs/3.0-migration-guide.d/ccm-alt.md
@@ -1,0 +1,9 @@
+CCM interface changes: impact for alternative implementations
+-------------------------------------------------------------
+
+The CCM interface has changed with the addition of support for
+multi-part operations. Five new API functions have been defined:
+mbedtls_ccm_starts(), mbedtls_ccm_set_lengths(),
+mbedtls_ccm_update_ad(), mbedtls_ccm_update() and mbedtls_ccm_finish().
+Alternative implementations of CCM (`MBEDTLS_CCM_ALT`) have now to
+implement those additional five API functions.

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -297,6 +297,8 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \brief           This function starts a CCM encryption or decryption
  *                  operation.
  *
+ * \note            This function is not implemented in Mbed TLS yet.
+ *
  * \param ctx       The CCM context. This must be initialized.
  * \param mode      The operation to perform: #MBEDTLS_CCM_ENCRYPT or
  *                  #MBEDTLS_CCM_DECRYPT or #MBEDTLS_CCM_STAR_ENCRYPT or
@@ -332,6 +334,8 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  *                  up exactly to the total length of additional data
  *                  \c total_ad_len passed to mbedtls_ccm_starts(). You may not
  *                  call this function after calling mbedtls_ccm_update().
+ *
+ * \note            This function is not implemented in Mbed TLS yet.
  *
  * \param ctx       The CCM context. This must have been started with
  *                  mbedtls_ccm_starts() and must not have yet received
@@ -386,6 +390,8 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                    the last one) then it is correct to use \p output_size
  *                    =\p input_length.
  *
+ * \note            This function is not implemented in Mbed TLS yet.
+ *
  * \note            For decryption, the output buffer cannot be the same as
  *                  the input buffer. If the buffers overlap, the output buffer
  *                  must trail at least 8 Bytes behind the input buffer.
@@ -422,6 +428,8 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *
  *                  It wraps up the CCM stream, and generates the
  *                  tag. The tag can have a maximum length of 16 Bytes.
+ *
+ * \note            This function is not implemented in Mbed TLS yet.
  *
  * \param ctx       The CCM context. This must be initialized.
  * \param tag       The buffer for holding the tag. If \p tag_len is greater

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -366,15 +366,17 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  ways:
  *                  - Immediate output: the output length is always equal
  *                    to the input length.
- *                  - Buffered output: but for the last chunck of input data,
+ *                  - Buffered output: but for the last part of input data,
  *                    the output consists of a whole number of 16-byte blocks.
  *                    If the total input length so far (not including
  *                    associated data) is 16 \* *B* + *A* with *A* < 16 then
  *                    the total output length is 16 \* *B*.
- *                    For the last chunck of input data, the output length is
- *                    equal to the input length. The function uses the length
- *                    in bytes of the body data passed in mbedtls_ccm_starts()
- *                    to detect the last chunck of data to encrypt or decrypt.
+ *                    For the last part of input data, the output length is
+ *                    equal to the input length plus the number of bytes (*A*)
+ *                    buffered in the previous call to the function (if any).
+ *                    The function uses the total length of input data
+ *                    \c total_input_len passed to mbedtls_ccm_starts()
+ *                    to detect the last part of input data.
  *
  *                  In particular:
  *                  - It is always correct to call this function with

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -326,13 +326,12 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  *                  (authenticated but not encrypted data) in a CCM
  *                  encryption or decryption operation.
  *
- *                  Call this function after mbedtls_ccm_starts() to pass
- *                  the associated data. If the associated data is empty,
- *                  you do not need to call this function. You may not
+ *                  You may call this function zero, one or more times
+ *                  to pass successive parts of the additional data. The
+ *                  lengths \p add_len of the data parts should eventually add
+ *                  up exactly to the total length of additional data
+ *                  \c total_ad_len passed to mbedtls_ccm_starts(). You may not
  *                  call this function after calling mbedtls_ccm_update().
- *
- * \note            This function may be called several times per operation,
- *                  passing the associated data in chunks.
  *
  * \param ctx       The CCM context. This must have been started with
  *                  mbedtls_ccm_starts() and must not have yet received
@@ -358,7 +357,10 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  to pass successive parts of the input: the plaintext to
  *                  encrypt, or the ciphertext (not including the tag) to
  *                  decrypt. After the last part of the input, call
- *                  mbedtls_ccm_finish().
+ *                  mbedtls_ccm_finish(). The lengths \p input_length of the
+ *                  data parts should eventually add up exactly to the total
+ *                  length of input data \c total_input_len passed to
+ *                  mbedtls_ccm_starts().
  *
  *                  This function may produce output in one of the following
  *                  ways:

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -306,9 +306,10 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \param iv        The initialization vector. This must be a readable buffer
  *                  of at least \p iv_len Bytes.
  * \param iv_len    The length of the IV in bytes.
- * \param total_add_len    The total length of additional data in bytes.
- * \param total_input_len  The total length of input data to encrypt or decrypt
- *                         in bytes.
+ * \param total_add_len  The total length of additional data in bytes.
+ * \param plaintext_len  The length in bytes of the plaintext to encrypt or
+ *                       result of the decryption (thus not encompassing the
+ *                       additional data that are not encrypted).
  *
  * \return          \c 0 on success.
  * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
@@ -321,7 +322,7 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
                         const unsigned char *iv,
                         size_t iv_len,
                         size_t total_add_len,
-                        size_t total_input_len );
+                        size_t plaintext_len );
 
 /**
  * \brief           This function feeds an input buffer as associated data
@@ -362,8 +363,8 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  encrypt, or the ciphertext (not including the tag) to
  *                  decrypt. After the last part of the input, call
  *                  mbedtls_ccm_finish(). The lengths \p input_len of the
- *                  data parts should eventually add up exactly to the total
- *                  length of input data \c total_input_len passed to
+ *                  data parts should eventually add up exactly to the
+ *                  plaintext length \c plaintext_len passed to
  *                  mbedtls_ccm_starts().
  *
  *                  This function may produce output in one of the following
@@ -378,8 +379,8 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                    For the last part of input data, the output length is
  *                    equal to the input length plus the number of bytes (*A*)
  *                    buffered in the previous call to the function (if any).
- *                    The function uses the total length of input data
- *                    \c total_input_len passed to mbedtls_ccm_starts()
+ *                    The function uses the plaintext length
+ *                    \c plaintext_len passed to mbedtls_ccm_starts()
  *                    to detect the last part of input data.
  *
  *                  In particular:
@@ -446,9 +447,8 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *                  additional data \c total_add_len passed to
  *                  mbedtls_ccm_starts(),
  *                  the total amount of input data passed to
- *                  mbedtls_ccm_update() was lower than the total length of
- *                  input data \c total_input_len passed to
- *                  mbedtls_ccm_starts().
+ *                  mbedtls_ccm_update() was lower than the plaintext length
+ *                  \c plaintext_len passed to mbedtls_ccm_starts().
  */
 int mbedtls_ccm_finish( mbedtls_ccm_context *ctx,
                         unsigned char *tag, size_t tag_len );

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -396,10 +396,6 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *
  * \note            This function is not implemented in Mbed TLS yet.
  *
- * \note            For decryption, the output buffer cannot be the same as
- *                  the input buffer. If the buffers overlap, the output buffer
- *                  must trail at least 8 Bytes behind the input buffer.
- *
  * \param ctx           The CCM context. This must have been started with
  *                      mbedtls_ccm_starts().
  * \param input         The buffer holding the input data. If \p input_len
@@ -419,7 +415,6 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
  *                 total input length too long,
- *                 unsupported input/output buffer overlap detected,
  *                 or \p output_size too small.
  */
 int mbedtls_ccm_update( mbedtls_ccm_context *ctx,

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -315,7 +315,8 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  *                  15 - \p iv_len.
  *
  * \return          \c 0 on success.
- * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p ctx is in an invalid state,
  *                  \p mode is invalid,
  *                  \p iv_len is invalid (lower than \c 7 or greater than
  *                  \c 13).
@@ -345,7 +346,8 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  *                       additional data that are not encrypted).
  *
  * \return          \c 0 on success.
- * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p ctx is in an invalid state,
  *                  \p total_ad_len is greater than \c 0xFF00.
  */
 int mbedtls_ccm_set_lengths( mbedtls_ccm_context *ctx,
@@ -378,7 +380,8 @@ int mbedtls_ccm_set_lengths( mbedtls_ccm_context *ctx,
  *                  \p ad may be \c NULL.
  *
  * \return          \c 0 on success.
- * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p ctx is in an invalid state,
  *                  total input length too long.
  */
 int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
@@ -444,6 +447,7 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                 \p ctx is in an invalid state,
  *                 total input length too long,
  *                 or \p output_size too small.
  */
@@ -474,6 +478,7 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p ctx is in an invalid state,
  *                  invalid value of \p tag_len,
  *                  the total amount of additional data passed to
  *                  mbedtls_ccm_update_ad() was lower than the total length of

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -138,10 +138,10 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
  *                  or 13. The length L of the message length field is
  *                  15 - \p iv_len.
- * \param add       The additional data field. If \p add_len is greater than
- *                  zero, \p add must be a readable buffer of at least that
+ * \param ad        The additional data field. If \p ad_len is greater than
+ *                  zero, \p ad must be a readable buffer of at least that
  *                  length.
- * \param add_len   The length of additional data in Bytes.
+ * \param ad_len    The length of additional data in Bytes.
  *                  This must be less than `2^16 - 2^8`.
  * \param input     The buffer holding the input data. If \p length is greater
  *                  than zero, \p input must be a readable buffer of at least
@@ -159,7 +159,7 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
  */
 int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                          const unsigned char *iv, size_t iv_len,
-                         const unsigned char *add, size_t add_len,
+                         const unsigned char *ad, size_t ad_len,
                          const unsigned char *input, unsigned char *output,
                          unsigned char *tag, size_t tag_len );
 
@@ -184,9 +184,9 @@ int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
  *                  or 13. The length L of the message length field is
  *                  15 - \p iv_len.
- * \param add       The additional data field. This must be a readable buffer of
- *                  at least \p add_len Bytes.
- * \param add_len   The length of additional data in Bytes.
+ * \param ad        The additional data field. This must be a readable buffer of
+ *                  at least \p ad_len Bytes.
+ * \param ad_len    The length of additional data in Bytes.
  *                  This must be less than 2^16 - 2^8.
  * \param input     The buffer holding the input data. If \p length is greater
  *                  than zero, \p input must be a readable buffer of at least
@@ -207,7 +207,7 @@ int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  */
 int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                          const unsigned char *iv, size_t iv_len,
-                         const unsigned char *add, size_t add_len,
+                         const unsigned char *ad, size_t ad_len,
                          const unsigned char *input, unsigned char *output,
                          unsigned char *tag, size_t tag_len );
 
@@ -223,9 +223,9 @@ int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
  *                  or 13. The length L of the message length field is
  *                  15 - \p iv_len.
- * \param add       The additional data field. This must be a readable buffer
- *                  of at least that \p add_len Bytes..
- * \param add_len   The length of additional data in Bytes.
+ * \param ad        The additional data field. This must be a readable buffer
+ *                  of at least that \p ad_len Bytes..
+ * \param ad_len    The length of additional data in Bytes.
  *                  This must be less than 2^16 - 2^8.
  * \param input     The buffer holding the input data. If \p length is greater
  *                  than zero, \p input must be a readable buffer of at least
@@ -244,7 +244,7 @@ int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  */
 int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
                       const unsigned char *iv, size_t iv_len,
-                      const unsigned char *add, size_t add_len,
+                      const unsigned char *ad, size_t ad_len,
                       const unsigned char *input, unsigned char *output,
                       const unsigned char *tag, size_t tag_len );
 
@@ -265,9 +265,9 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
  *                  or 13. The length L of the message length field is
  *                  15 - \p iv_len.
- * \param add       The additional data field. This must be a readable buffer of
- *                  at least that \p add_len Bytes.
- * \param add_len   The length of additional data in Bytes.
+ * \param ad        The additional data field. This must be a readable buffer of
+ *                  at least that \p ad_len Bytes.
+ * \param ad_len    The length of additional data in Bytes.
  *                  This must be less than 2^16 - 2^8.
  * \param input     The buffer holding the input data. If \p length is greater
  *                  than zero, \p input must be a readable buffer of at least
@@ -289,7 +289,7 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  */
 int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
                       const unsigned char *iv, size_t iv_len,
-                      const unsigned char *add, size_t add_len,
+                      const unsigned char *ad, size_t ad_len,
                       const unsigned char *input, unsigned char *output,
                       const unsigned char *tag, size_t tag_len );
 
@@ -308,7 +308,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
  *                  or 13. The length L of the message length field is
  *                  15 - \p iv_len.
- * \param total_add_len  The total length of additional data in bytes.
+ * \param total_ad_len   The total length of additional data in bytes.
  *                       This must be less than `2^16 - 2^8`.
  * \param plaintext_len  The length in bytes of the plaintext to encrypt or
  *                       result of the decryption (thus not encompassing the
@@ -319,13 +319,13 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  *                  \p mode is invalid,
  *                  \p iv_len is invalid (lower than \c 7 or greater than
  *                  \c 13),
- *                  \p total_add_len is greater than \c 0xFF00.
+ *                  \p total_ad_len is greater than \c 0xFF00.
  */
 int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
                         int mode,
                         const unsigned char *iv,
                         size_t iv_len,
-                        size_t total_add_len,
+                        size_t total_ad_len,
                         size_t plaintext_len );
 
 /**
@@ -335,9 +335,9 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  *
  *                  You may call this function zero, one or more times
  *                  to pass successive parts of the additional data. The
- *                  lengths \p add_len of the data parts should eventually add
+ *                  lengths \p ad_len of the data parts should eventually add
  *                  up exactly to the total length of additional data
- *                  \c total_add_len passed to mbedtls_ccm_starts(). You may
+ *                  \c total_ad_len passed to mbedtls_ccm_starts(). You may
  *                  not call this function after calling mbedtls_ccm_update().
  *
  * \note            This function is not implemented in Mbed TLS yet.
@@ -345,18 +345,18 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  * \param ctx       The CCM context. This must have been started with
  *                  mbedtls_ccm_starts() and must not have yet received
  *                  any input with mbedtls_ccm_update().
- * \param add       The buffer holding the additional data, or \c NULL
- *                  if \p add_len is \c 0.
- * \param add_len   The length of the additional data. If \c 0,
- *                  \p add may be \c NULL.
+ * \param ad        The buffer holding the additional data, or \c NULL
+ *                  if \p ad_len is \c 0.
+ * \param ad_len    The length of the additional data. If \c 0,
+ *                  \p ad may be \c NULL.
  *
  * \return          \c 0 on success.
  * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
  *                  total input length too long.
  */
 int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
-                           const unsigned char *add,
-                           size_t add_len );
+                           const unsigned char *ad,
+                           size_t ad_len );
 
 /**
  * \brief           This function feeds an input buffer into an ongoing CCM
@@ -446,7 +446,7 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *                  invalid value of \p tag_len,
  *                  the total amount of additional data passed to
  *                  mbedtls_ccm_update_ad() was lower than the total length of
- *                  additional data \c total_add_len passed to
+ *                  additional data \c total_ad_len passed to
  *                  mbedtls_ccm_starts(),
  *                  the total amount of input data passed to
  *                  mbedtls_ccm_update() was lower than the plaintext length

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -306,7 +306,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \param iv        The initialization vector. This must be a readable buffer
  *                  of at least \p iv_len Bytes.
  * \param iv_len    The length of the IV in bytes.
- * \param total_ad_len     The total length of additional data in bytes.
+ * \param total_add_len    The total length of additional data in bytes.
  * \param total_input_len  The total length of input data to encrypt or decrypt
  *                         in bytes.
  *
@@ -314,13 +314,13 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
  *                  \p iv_len is invalid (lower than \c 7 or greater than
  *                  \c 13),
- *                  \p total_ad_len is greater than \c 0xFF00.
+ *                  \p total_add_len is greater than \c 0xFF00.
  */
 int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
                         int mode,
                         const unsigned char *iv,
                         size_t iv_len,
-                        size_t total_ad_len,
+                        size_t total_add_len,
                         size_t total_input_len );
 
 /**
@@ -332,8 +332,8 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  *                  to pass successive parts of the additional data. The
  *                  lengths \p add_len of the data parts should eventually add
  *                  up exactly to the total length of additional data
- *                  \c total_ad_len passed to mbedtls_ccm_starts(). You may not
- *                  call this function after calling mbedtls_ccm_update().
+ *                  \c total_add_len passed to mbedtls_ccm_starts(). You may
+ *                  not call this function after calling mbedtls_ccm_update().
  *
  * \note            This function is not implemented in Mbed TLS yet.
  *
@@ -361,7 +361,7 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  to pass successive parts of the input: the plaintext to
  *                  encrypt, or the ciphertext (not including the tag) to
  *                  decrypt. After the last part of the input, call
- *                  mbedtls_ccm_finish(). The lengths \p input_length of the
+ *                  mbedtls_ccm_finish(). The lengths \p input_len of the
  *                  data parts should eventually add up exactly to the total
  *                  length of input data \c total_input_len passed to
  *                  mbedtls_ccm_starts().
@@ -384,11 +384,11 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *
  *                  In particular:
  *                  - It is always correct to call this function with
- *                    \p output_size >= \p input_length + 15.
- *                  - If \p input_length is a multiple of 16 for all the calls
+ *                    \p output_size >= \p input_len + 15.
+ *                  - If \p input_len is a multiple of 16 for all the calls
  *                    to this function during an operation (not necessary for
  *                    the last one) then it is correct to use \p output_size
- *                    =\p input_length.
+ *                    =\p input_len.
  *
  * \note            This function is not implemented in Mbed TLS yet.
  *
@@ -397,18 +397,18 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  must trail at least 8 Bytes behind the input buffer.
  *
  * \param ctx           The CCM context. This must be initialized.
- * \param input         The buffer holding the input data. If \p input_length
+ * \param input         The buffer holding the input data. If \p input_len
  *                      is greater than zero, this must be a readable buffer
- *                      of at least \p input_length bytes.
- * \param input_length  The length of the input data in bytes.
+ *                      of at least \p input_len bytes.
+ * \param input_len     The length of the input data in bytes.
  * \param output        The buffer for the output data. If \p output_size
  *                      is greater than zero, this must be a writable buffer of
  *                      at least \p output_size bytes.
  * \param output_size   The size of the output buffer in bytes.
  *                      See the function description regarding the output size.
- * \param output_length On success, \p *output_length contains the actual
+ * \param output_len    On success, \p *output_len contains the actual
  *                      length of the output written in \p output.
- *                      On failure, the content of \p *output_length is
+ *                      On failure, the content of \p *output_len is
  *                      unspecified.
  *
  * \return         \c 0 on success.
@@ -418,9 +418,9 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                 or \p output_size too small.
  */
 int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
-                        const unsigned char *input, size_t input_length,
+                        const unsigned char *input, size_t input_len,
                         unsigned char *output, size_t output_size,
-                        size_t *output_length );
+                        size_t *output_len );
 
 /**
  * \brief           This function finishes the CCM operation and generates
@@ -443,7 +443,7 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *                  invalid value of \p tag_len,
  *                  the total amount of additional data passed to
  *                  mbedtls_ccm_update_ad() was lower than the total length of
- *                  additional data \c total_ad_len passed to
+ *                  additional data \c total_add_len passed to
  *                  mbedtls_ccm_starts(),
  *                  the total amount of input data passed to
  *                  mbedtls_ccm_update() was lower than the total length of

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -375,7 +375,7 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  ways:
  *                  - Immediate output: the output length is always equal
  *                    to the input length.
- *                  - Buffered output: but for the last part of input data,
+ *                  - Buffered output: except for the last part of input data,
  *                    the output consists of a whole number of 16-byte blocks.
  *                    If the total input length so far (not including
  *                    associated data) is 16 \* *B* + *A* with *A* < 16 then

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -316,6 +316,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  *
  * \return          \c 0 on success.
  * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p mode is invalid,
  *                  \p iv_len is invalid (lower than \c 7 or greater than
  *                  \c 13),
  *                  \p total_add_len is greater than \c 0xFF00.

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -432,7 +432,15 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:
- *                  invalid value of \p tag_len.
+ *                  invalid value of \p tag_len,
+ *                  the total amount of additional data passed to
+ *                  mbedtls_ccm_update_ad() was lower than the total length of
+ *                  additional data \c total_ad_len passed to
+ *                  mbedtls_ccm_starts(),
+ *                  the total amount of input data passed to
+ *                  mbedtls_ccm_update() was lower than the total length of
+ *                  input data \c total_input_len passed to
+ *                  mbedtls_ccm_starts().
  */
 int mbedtls_ccm_finish( mbedtls_ccm_context *ctx,
                         unsigned char *tag, size_t tag_len );

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -301,20 +301,25 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \param mode      The operation to perform: #MBEDTLS_CCM_ENCRYPT or
  *                  #MBEDTLS_CCM_DECRYPT or #MBEDTLS_CCM_STAR_ENCRYPT or
  *                  #MBEDTLS_CCM_STAR_DECRYPT.
- * \param iv        The initialization vector. This must be a readable buffer of
- *                  at least \p iv_len Bytes.
- * \param iv_len    The length of the IV.
- * \param ad_len    The length of the additional data in bytes.
- * \param body_len  The length of the data to encrypt or decrypt in bytes.
+ * \param iv        The initialization vector. This must be a readable buffer
+ *                  of at least \p iv_len Bytes.
+ * \param iv_len    The length of the IV in bytes.
+ * \param total_ad_len     The total length of additional data in bytes.
+ * \param total_input_len  The total length of input data to encrypt or decrypt
+ *                         in bytes.
  *
  * \return          \c 0 on success.
+ * \return          \#MBEDTLS_ERR_CCM_BAD_INPUT on failure:
+ *                  \p iv_len is invalid (lower than \c 7 or greater than
+ *                  \c 13),
+ *                  \p total_ad_len is greater than \c 0xFF00.
  */
 int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
                         int mode,
                         const unsigned char *iv,
                         size_t iv_len,
-                        size_t ad_len,
-                        size_t body_len );
+                        size_t total_ad_len,
+                        size_t total_input_len );
 
 /**
  * \brief           This function feeds an input buffer as associated data

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -400,7 +400,8 @@ int mbedtls_ccm_update_ad( mbedtls_ccm_context *ctx,
  *                  the input buffer. If the buffers overlap, the output buffer
  *                  must trail at least 8 Bytes behind the input buffer.
  *
- * \param ctx           The CCM context. This must be initialized.
+ * \param ctx           The CCM context. This must have been started with
+ *                      mbedtls_ccm_starts().
  * \param input         The buffer holding the input data. If \p input_len
  *                      is greater than zero, this must be a readable buffer
  *                      of at least \p input_len bytes.
@@ -435,7 +436,8 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  *
  * \note            This function is not implemented in Mbed TLS yet.
  *
- * \param ctx       The CCM context. This must be initialized.
+ * \param ctx       The CCM context. This must have been started with
+ *                  mbedtls_ccm_starts().
  * \param tag       The buffer for holding the tag. If \p tag_len is greater
  *                  than zero, this must be a writable buffer of at least \p
  *                  tag_len Bytes.

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -297,6 +297,11 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \brief           This function starts a CCM encryption or decryption
  *                  operation.
  *
+ *                  This function and mbedtls_ccm_set_lengths() must be called
+ *                  before calling mbedtls_ccm_update_ad() or
+ *                  mbedtls_ccm_update(). This function can be called before
+ *                  or after mbedtls_ccm_set_lengths().
+ *
  * \note            This function is not implemented in Mbed TLS yet.
  *
  * \param ctx       The CCM context. This must be initialized.
@@ -324,6 +329,11 @@ int mbedtls_ccm_starts( mbedtls_ccm_context *ctx,
  * \brief           This function declares the lengths of the message
  *                  and additional data for a CCM encryption or decryption
  *                  operation.
+ *
+ *                  This function and mbedtls_ccm_starts() must be called
+ *                  before calling mbedtls_ccm_update_ad() or
+ *                  mbedtls_ccm_update(). This function can be called before
+ *                  or after mbedtls_ccm_starts().
  *
  * \note            This function is not implemented in Mbed TLS yet.
  *

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -305,8 +305,11 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  *                  #MBEDTLS_CCM_STAR_DECRYPT.
  * \param iv        The initialization vector. This must be a readable buffer
  *                  of at least \p iv_len Bytes.
- * \param iv_len    The length of the IV in bytes.
+ * \param iv_len    The length of the nonce in Bytes: 7, 8, 9, 10, 11, 12,
+ *                  or 13. The length L of the message length field is
+ *                  15 - \p iv_len.
  * \param total_add_len  The total length of additional data in bytes.
+ *                       This must be less than `2^16 - 2^8`.
  * \param plaintext_len  The length in bytes of the plaintext to encrypt or
  *                       result of the decryption (thus not encompassing the
  *                       additional data that are not encrypted).
@@ -436,8 +439,9 @@ int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
  * \param tag       The buffer for holding the tag. If \p tag_len is greater
  *                  than zero, this must be a writable buffer of at least \p
  *                  tag_len Bytes.
- * \param tag_len   The length of the tag to generate. This must be at least
- *                  four for CCM but can be equal to \c 0 for CCM*.
+ * \param tag_len   The length of the tag to generate in Bytes:
+ *                  4, 6, 8, 10, 12, 14 or 16.
+ *                  For CCM*, zero is also valid.
  *
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_CCM_BAD_INPUT on failure:


### PR DESCRIPTION
## Description
Define CCM multi-part API along the lines of the GCM multi-part API. The two APIs are not exactly the same as, contrary to GCM, CCM needs the size of the additional data and plaintext/ciphertext from the start.

Fixes #4352

## Status
READY

## Requires Backporting
NO

## Todos
- [x] Documentation
- [x] Changelog updated
