### PR TITLE
Backport 2.x: Fix ARIA_ALT header and self-test and CAMELLIA_ALT self-test

### DIFF
--- a/ChangeLog.d/aria-alt.txt
+++ b/ChangeLog.d/aria-alt.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix some issues affecting MBEDTLS_ARIA_ALT implementations: a misplaced
+     directive in a header and a missing initialization in the self-test.
+   * Fix a missing initialization in the Camellia self-test, affecting
+     MBEDTLS_CAMELLIA_ALT implementations.

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -61,13 +61,13 @@
 /* MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED is deprecated and should not be used. */
 #define MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED      -0x0058  /**< ARIA hardware accelerator failed. */
 
-#if !defined(MBEDTLS_ARIA_ALT)
-// Regular implementation
-//
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if !defined(MBEDTLS_ARIA_ALT)
+// Regular implementation
+//
 
 /**
  * \brief The ARIA context-type definition.

--- a/library/aria.c
+++ b/library/aria.c
@@ -921,7 +921,7 @@ static const uint8_t aria_test2_ctr_ct[3][48] =         // CTR ciphertext
         {                                   \
             if( verbose )                   \
                 mbedtls_printf( "failed\n" );       \
-            return( 1 );                    \
+            goto exit;                              \
         } else {                            \
             if( verbose )                   \
                 mbedtls_printf( "passed\n" );       \
@@ -935,6 +935,7 @@ int mbedtls_aria_self_test( int verbose )
     int i;
     uint8_t blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
+    int ret = 1;
 
 #if (defined(MBEDTLS_CIPHER_MODE_CFB) || defined(MBEDTLS_CIPHER_MODE_CTR))
     size_t j;
@@ -945,6 +946,8 @@ int mbedtls_aria_self_test( int verbose )
      defined(MBEDTLS_CIPHER_MODE_CTR))
     uint8_t buf[48], iv[MBEDTLS_ARIA_BLOCKSIZE];
 #endif
+
+    mbedtls_aria_init( &ctx );
 
     /*
      * Test set 1
@@ -1065,7 +1068,11 @@ int mbedtls_aria_self_test( int verbose )
         mbedtls_printf( "\n" );
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-    return( 0 );
+    ret = 0;
+
+exit:
+    mbedtls_aria_free( &ctx );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -942,9 +942,11 @@ int mbedtls_camellia_self_test( int verbose )
     unsigned char nonce_counter[16];
     unsigned char stream_block[16];
 #endif
+    int ret = 1;
 
     mbedtls_camellia_context ctx;
 
+    mbedtls_camellia_init( &ctx );
     memset( key, 0, 32 );
 
     for( j = 0; j < 6; j++ ) {
@@ -974,8 +976,7 @@ int mbedtls_camellia_self_test( int verbose )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
-
-            return( 1 );
+            goto exit;
         }
     }
 
@@ -1027,8 +1028,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
 
@@ -1071,8 +1071,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
         else
@@ -1087,8 +1086,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
 
@@ -1100,7 +1098,11 @@ int mbedtls_camellia_self_test( int verbose )
         mbedtls_printf( "\n" );
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-    return( 0 );
+    ret = 0;
+
+exit:
+    mbedtls_camellia_free( &ctx );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */


### PR DESCRIPTION
Trivial backport of #4553