### PR TITLE
Backport 2.16: Fix ARIA_ALT header and self-test and CAMELLIA_ALT self-test

### DIFF
--- a/ChangeLog.d/aria-alt.txt
+++ b/ChangeLog.d/aria-alt.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix some issues affecting MBEDTLS_ARIA_ALT implementations: a misplaced
+     directive in a header and a missing initialization in the self-test.
+   * Fix a missing initialization in the Camellia self-test, affecting
+     MBEDTLS_CAMELLIA_ALT implementations.

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -88,13 +88,13 @@
 /* MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED is deprecated and should not be used. */
 #define MBEDTLS_ERR_ARIA_HW_ACCEL_FAILED      -0x0058  /**< ARIA hardware accelerator failed. */
 
-#if !defined(MBEDTLS_ARIA_ALT)
-// Regular implementation
-//
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if !defined(MBEDTLS_ARIA_ALT)
+// Regular implementation
+//
 
 /**
  * \brief The ARIA context-type definition.

--- a/library/aria.c
+++ b/library/aria.c
@@ -952,7 +952,7 @@ static const uint8_t aria_test2_ctr_ct[3][48] =         // CTR ciphertext
         {                                   \
             if( verbose )                   \
                 mbedtls_printf( "failed\n" );       \
-            return( 1 );                    \
+            goto exit;                              \
         } else {                            \
             if( verbose )                   \
                 mbedtls_printf( "passed\n" );       \
@@ -966,6 +966,7 @@ int mbedtls_aria_self_test( int verbose )
     int i;
     uint8_t blk[MBEDTLS_ARIA_BLOCKSIZE];
     mbedtls_aria_context ctx;
+    int ret = 1;
 
 #if (defined(MBEDTLS_CIPHER_MODE_CFB) || defined(MBEDTLS_CIPHER_MODE_CTR))
     size_t j;
@@ -976,6 +977,8 @@ int mbedtls_aria_self_test( int verbose )
      defined(MBEDTLS_CIPHER_MODE_CTR))
     uint8_t buf[48], iv[MBEDTLS_ARIA_BLOCKSIZE];
 #endif
+
+    mbedtls_aria_init( &ctx );
 
     /*
      * Test set 1
@@ -1096,7 +1099,11 @@ int mbedtls_aria_self_test( int verbose )
         mbedtls_printf( "\n" );
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-    return( 0 );
+    ret = 0;
+
+exit:
+    mbedtls_aria_free( &ctx );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -973,9 +973,11 @@ int mbedtls_camellia_self_test( int verbose )
     unsigned char nonce_counter[16];
     unsigned char stream_block[16];
 #endif
+    int ret = 1;
 
     mbedtls_camellia_context ctx;
 
+    mbedtls_camellia_init( &ctx );
     memset( key, 0, 32 );
 
     for( j = 0; j < 6; j++ ) {
@@ -1005,8 +1007,7 @@ int mbedtls_camellia_self_test( int verbose )
         {
             if( verbose != 0 )
                 mbedtls_printf( "failed\n" );
-
-            return( 1 );
+            goto exit;
         }
     }
 
@@ -1058,8 +1059,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
 
@@ -1102,8 +1102,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
         else
@@ -1118,8 +1117,7 @@ int mbedtls_camellia_self_test( int verbose )
             {
                 if( verbose != 0 )
                     mbedtls_printf( "failed\n" );
-
-                return( 1 );
+                goto exit;
             }
         }
 
@@ -1131,7 +1129,11 @@ int mbedtls_camellia_self_test( int verbose )
         mbedtls_printf( "\n" );
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
-    return( 0 );
+    ret = 0;
+
+exit:
+    mbedtls_camellia_free( &ctx );
+    return( ret );
 }
 
 #endif /* MBEDTLS_SELF_TEST */


### PR DESCRIPTION
Trivial backport of #4553