### PR TITLE
pk.c: Ensure min hash_len in pk_hashlen_helper

### DIFF
--- a/ChangeLog.d/ensure_hash_len_is_valid.txt
+++ b/ChangeLog.d/ensure_hash_len_is_valid.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * Ensure hashlen is suitable for given md_alg in pk verify and sign
+     functions. To avoid buffer over/under reads and writes, a check is made
+     on hashlen to ensure that, if not zero, it is equal to the expected
+     length of the md_alg's digest. If the length is 0 then the hash can be
+     assumed by using the length associated with the md_alg.

--- a/library/pk.c
+++ b/library/pk.c
@@ -235,11 +235,14 @@ static inline int pk_hashlen_helper( mbedtls_md_type_t md_alg, size_t *hash_len 
 {
     const mbedtls_md_info_t *md_info;
 
-    if( *hash_len != 0 )
+    if( *hash_len != 0 && md_alg == MBEDTLS_MD_NONE )
         return( 0 );
 
     if( ( md_info = mbedtls_md_info_from_type( md_alg ) ) == NULL )
         return( -1 );
+
+    if ( *hash_len != 0 && *hash_len != mbedtls_md_get_size( md_info ) )
+        return ( -1 );
 
     *hash_len = mbedtls_md_get_size( md_info );
     return( 0 );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -618,8 +618,9 @@ exit:
 void pk_sign_verify( int type, int parameter, int sign_ret, int verify_ret )
 {
     mbedtls_pk_context pk;
-    size_t sig_len;
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
+    size_t sig_len, hash_len;
+    mbedtls_md_type_t md = MBEDTLS_MD_SHA256;
+    unsigned char *hash = NULL;
     unsigned char sig[MBEDTLS_PK_SIGNATURE_MAX_SIZE];
     void *rs_ctx = NULL;
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
@@ -633,40 +634,43 @@ void pk_sign_verify( int type, int parameter, int sign_ret, int verify_ret )
     mbedtls_ecp_set_max_ops( 42000 );
 #endif
 
+    hash_len = mbedtls_md_get_size( mbedtls_md_info_from_type( md ) );
+    ASSERT_ALLOC( hash, hash_len );
+
     mbedtls_pk_init( &pk );
     USE_PSA_INIT( );
 
-    memset( hash, 0x2a, sizeof hash );
+    memset( hash, 0x2a, hash_len );
     memset( sig, 0, sizeof sig );
 
     TEST_ASSERT( mbedtls_pk_setup( &pk, mbedtls_pk_info_from_type( type ) ) == 0 );
     TEST_ASSERT( pk_genkey( &pk, parameter ) == 0 );
 
-    TEST_ASSERT( mbedtls_pk_sign_restartable( &pk, MBEDTLS_MD_SHA256,
-                 hash, sizeof hash, sig, &sig_len,
+    TEST_ASSERT( mbedtls_pk_sign_restartable( &pk, md,
+                 hash, hash_len, sig, &sig_len,
                  mbedtls_test_rnd_std_rand, NULL, rs_ctx ) == sign_ret );
     if( sign_ret == 0 )
         TEST_ASSERT( sig_len <= MBEDTLS_PK_SIGNATURE_MAX_SIZE );
     else
         sig_len = MBEDTLS_PK_SIGNATURE_MAX_SIZE;
 
-    TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_SHA256,
-                            hash, sizeof hash, sig, sig_len ) == verify_ret );
+    TEST_ASSERT( mbedtls_pk_verify( &pk, md,
+                            hash, hash_len, sig, sig_len ) == verify_ret );
 
     if( verify_ret == 0 )
     {
         hash[0]++;
-        TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_SHA256,
-                                hash, sizeof hash, sig, sig_len ) != 0 );
+        TEST_ASSERT( mbedtls_pk_verify( &pk, md,
+                                hash, hash_len, sig, sig_len ) != 0 );
         hash[0]--;
 
         sig[0]++;
-        TEST_ASSERT( mbedtls_pk_verify( &pk, MBEDTLS_MD_SHA256,
-                                hash, sizeof hash, sig, sig_len ) != 0 );
+        TEST_ASSERT( mbedtls_pk_verify( &pk, md,
+                                hash, hash_len, sig, sig_len ) != 0 );
         sig[0]--;
     }
 
-    TEST_ASSERT( mbedtls_pk_sign( &pk, MBEDTLS_MD_SHA256, hash, sizeof hash,
+    TEST_ASSERT( mbedtls_pk_sign( &pk, md, hash, hash_len,
                                   sig, &sig_len,
                                   mbedtls_test_rnd_std_rand,
                                   NULL ) == sign_ret );
@@ -675,19 +679,19 @@ void pk_sign_verify( int type, int parameter, int sign_ret, int verify_ret )
     else
         sig_len = MBEDTLS_PK_SIGNATURE_MAX_SIZE;
 
-    TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, MBEDTLS_MD_SHA256,
-                 hash, sizeof hash, sig, sig_len, rs_ctx ) == verify_ret );
+    TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, md,
+                 hash, hash_len, sig, sig_len, rs_ctx ) == verify_ret );
 
     if( verify_ret == 0 )
     {
         hash[0]++;
-        TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, MBEDTLS_MD_SHA256,
-                     hash, sizeof hash, sig, sig_len, rs_ctx ) != 0 );
+        TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, md,
+                     hash, hash_len, sig, sig_len, rs_ctx ) != 0 );
         hash[0]--;
 
         sig[0]++;
-        TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, MBEDTLS_MD_SHA256,
-                     hash, sizeof hash, sig, sig_len, rs_ctx ) != 0 );
+        TEST_ASSERT( mbedtls_pk_verify_restartable( &pk, md,
+                     hash, hash_len, sig, sig_len, rs_ctx ) != 0 );
         sig[0]--;
     }
 
@@ -696,6 +700,7 @@ exit:
     mbedtls_pk_restart_free( rs_ctx );
 #endif
     mbedtls_pk_free( &pk );
+    mbedtls_free( hash );
     USE_PSA_DONE( );
 }
 /* END_CASE */


### PR DESCRIPTION
Hello,
This Pull Request is to patch an area of confusion on `pk_sign` and `pk_verify` functions. Both take in an argument `hash_len`, in the API docs, it is noted that:

>  "If hash_len is 0, then the length associated with md_alg is used instead, or an error returned if it is invalid"

I have run into issues where I passed the incorrect value to hash_len and never ran into any "errors". I am sure most users are smarter than I and won't make such foolish mistakes but I do believe that either the documentation or function should be updated to match the other. In this PR,  I have added a commit that makes the `pk_verify/sign` behave as specified by the API docs. 

Currently, the `hash_len` args in these functions are behaving more so like the description in `rsa...verify/sign` documentation. here it lists that `hashlen`: 

>  is only used if md_alg is MBEDTLS_MD_NONE. "

If this is intentional than I think it could be worth updating the documentation of `pk_verify/sign`. If not, then if `hash_len` is passed in as not zero then I believe it should at least be examined to be a valid hash length for the given hash algorithm. In the later called functions, if `md_alg` is not `MD_NONE`, the `hash_len` is overwritten anyway. So, if the user passed in a `hash_len` that is less than the associated md, an error should be returned in order to avoid invalid reads by reaching the end of the buffer. 

I hope this is useful in some way.
I would like to thank @naynajain for bringing this to my attention and helping me out.

Notes:
* This commit throws an error if the user gives a hash_len that is LESS THAN the expected. Test suites will fail for `test_suite_pk` if we throw errors if the `hash_len` is NOT EQUAL to the expected. This is because these test suites allocate and use `MBEDTLS_MD_MAX_SIZE` as their hash lengths. 
* I have looked over the relevant `rsa...verify/sign()` functions called by the `->verify/sign_func()` function pointers, they all seem to overwrite the `hash_len` so it may be worth removing `*hash_len = mbedtls_md_get_size( md_info );` in `pk_hashlen_helper`. I did not remove it in this PR since I do not know the behavior of other functions pointed to by  `->verify/sign_func()` and it is a very unimportant thing to change.

## Description
From commit message:

>    The function `pk_hashlen_helper` exists to ensure a valid hash_len is
>     used in pk_verify and pk_sign functions. This function has been
>     used to adjust to the corrsponding hash_len if the user passes in 0
>     for the hash_len argument based on the md algorithm given. If the user
>     does not pass in 0 as the hash_len, then it is not adjusted. This is
>     problematic if the user gives a hash_len and hash buffer that is less than the
>     associated length of the md algorithm. This error would go unchecked
>     and eventually lead to buffer overread when given to specific pk_sign/verify
>     functions, since they both ignore the hash_len argument if md_alg is not MBEDTLS_MD_NONE.
>     This commit, adds a conditional to `pk_hashlen_helper` so that an
>     error is thrown if the user specifies a hash_length (not 0) and it is
>     less than the expected for the associated message digest algorithm.
>     This aligns better with the api documentation where it states "If
>     hash_len is 0, then the length associated with md_alg is used instead,
>     or an error returned if it is invalid"


## Status
**READY**

## Requires Backporting
Not sure if reading past a buffer can be considered a bug so probably not.
NO  

## Migrations
 NO

## Steps to test or reproduce
Run valgrind on any `mbedtls_pk_verify/read` command where the following conditions for arguments are met:
1. `md_alg` is an actual hash function (not `MBEDTLS_MD_NONE`)
2. `hash_len` is less than `md_alg`s associated length 
3. `hash` is only allocated to have `hash_len` bytes
