### PR TITLE
Expose flag for critical extensions

### DIFF
--- a/ChangeLog.d/issue4055.txt
+++ b/ChangeLog.d/issue4055.txt
@@ -1,0 +1,3 @@
+API changes
+   * The function mbedtls_x509write_csr_set_extension() has an extra parameter
+     which allows to mark an extension as critical. Fixes #4055.

--- a/docs/3.0-migration-guide.d/csr-add-critical-extension.md
+++ b/docs/3.0-migration-guide.d/csr-add-critical-extension.md
@@ -1,0 +1,9 @@
+Change the API to allow adding critical extensions to CSRs
+------------------------------------------------------------------
+
+This affects applications that call the `mbedtls_x509write_csr_set_extension`
+function.
+
+The API is changed to include the parameter `critical` which allow to mark an
+extension included in a CSR as critical. To get the previous behaviour pass
+`0`.

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -235,6 +235,7 @@ int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
  * \param ctx       CSR context to use
  * \param oid       OID of the extension
  * \param oid_len   length of the OID
+ * \param critical  Set to 1 to mark the extension as critical, 0 otherwise.
  * \param val       value of the extension OCTET STRING
  * \param val_len   length of the value data
  *
@@ -242,6 +243,7 @@ int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
  */
 int mbedtls_x509write_csr_set_extension( mbedtls_x509write_csr *ctx,
                                  const char *oid, size_t oid_len,
+                                 int critical,
                                  const unsigned char *val, size_t val_len );
 
 /**

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -83,10 +83,11 @@ int mbedtls_x509write_csr_set_subject_name( mbedtls_x509write_csr *ctx,
 
 int mbedtls_x509write_csr_set_extension( mbedtls_x509write_csr *ctx,
                                  const char *oid, size_t oid_len,
+                                 int critical,
                                  const unsigned char *val, size_t val_len )
 {
     return mbedtls_x509_set_extension( &ctx->extensions, oid, oid_len,
-                               0, val, val_len );
+                               critical, val, val_len );
 }
 
 int mbedtls_x509write_csr_set_key_usage( mbedtls_x509write_csr *ctx, unsigned char key_usage )
@@ -103,7 +104,7 @@ int mbedtls_x509write_csr_set_key_usage( mbedtls_x509write_csr *ctx, unsigned ch
 
     ret = mbedtls_x509write_csr_set_extension( ctx, MBEDTLS_OID_KEY_USAGE,
                                        MBEDTLS_OID_SIZE( MBEDTLS_OID_KEY_USAGE ),
-                                       c, (size_t)ret );
+                                       0, c, (size_t)ret );
     if( ret != 0 )
         return( ret );
 
@@ -125,7 +126,7 @@ int mbedtls_x509write_csr_set_ns_cert_type( mbedtls_x509write_csr *ctx,
 
     ret = mbedtls_x509write_csr_set_extension( ctx, MBEDTLS_OID_NS_CERT_TYPE,
                                        MBEDTLS_OID_SIZE( MBEDTLS_OID_NS_CERT_TYPE ),
-                                       c, (size_t)ret );
+                                       0, c, (size_t)ret );
     if( ret != 0 )
         return( ret );
 


### PR DESCRIPTION
## Description

Changes the API to enable creating X.509 CSRs with critical extensions. Fixes https://github.com/ARMmbed/mbedtls/issues/4055

## Status
**READY**

## Requires Backporting
NO

## Additional comments

I didn't find any test cases for `mbedtls_x509write_csr_set_extension` so I'm not sure if this is needed.
