### PR TITLE
Fix crash in mbedtls_debug_print_mpi

### DIFF
--- a/ChangeLog.d/mbedtls_debug_print_mpi_underflow.txt
+++ b/ChangeLog.d/mbedtls_debug_print_mpi_underflow.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix a crash and potential integer underflow in mbedtls_debug_print_mpi

--- a/library/debug.c
+++ b/library/debug.c
@@ -227,6 +227,8 @@ void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
         NULL == ssl->conf        ||
         NULL == ssl->conf->f_dbg ||
         NULL == X                ||
+        NULL == X->p             ||
+        0    == X->n             ||
         level > debug_threshold )
     {
         return;

--- a/tests/suites/test_suite_debug.data
+++ b/tests/suites/test_suite_debug.data
@@ -62,3 +62,6 @@ mbedtls_debug_print_mpi:16:"0000000000000000000000000000000000000000000000000000
 
 Debug print mbedtls_mpi #6
 mbedtls_debug_print_mpi:16:"0000000000000000000000000000000000000000000000000000000041379d00fed1491fe15df284dfde4a142f68aa8d412023195cee66883e6290ffe703f4ea5963bf212713cee46b107c09182b5edcd955adac418bf4918e2889af48e1099d513830cec85c26ac1e158b52620e33ba8692f893efbb2f958b4424":"MyFile":999:"VALUE":"MyFile(0999)\: value of 'VALUE' (759 bits) is\:\nMyFile(0999)\:  41 37 9d 00 fe d1 49 1f e1 5d f2 84 df de 4a 14\nMyFile(0999)\:  2f 68 aa 8d 41 20 23 19 5c ee 66 88 3e 62 90 ff\nMyFile(0999)\:  e7 03 f4 ea 59 63 bf 21 27 13 ce e4 6b 10 7c 09\nMyFile(0999)\:  18 2b 5e dc d9 55 ad ac 41 8b f4 91 8e 28 89 af\nMyFile(0999)\:  48 e1 09 9d 51 38 30 ce c8 5c 26 ac 1e 15 8b 52\nMyFile(0999)\:  62 0e 33 ba 86 92 f8 93 ef bb 2f 95 8b 44 24\n"
+
+Debug print mbedtls_mpi_sanity #1
+mbedtls_debug_print_mpi_sanity:"MyFile":999:"VALUE"

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -193,3 +193,30 @@ exit:
     mbedtls_ssl_config_free( &conf );
 }
 /* END_CASE */
+
+/* BEGIN_CASE */
+void mbedtls_debug_print_mpi_sanity ( char * file,
+                                      int line, char * prefix )
+{
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    struct buffer_data buffer;
+    mbedtls_mpi val;
+
+    mbedtls_ssl_init( &ssl );
+    mbedtls_ssl_config_init( &conf );
+    mbedtls_mpi_init( &val );
+    memset( buffer.buf, 0, 2000 );
+    buffer.ptr = buffer.buf;
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+
+    mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+    mbedtls_debug_print_mpi( &ssl, 0, file, line, prefix, &val);
+
+exit:
+    mbedtls_mpi_free( &val );
+    mbedtls_ssl_free( &ssl );
+    mbedtls_ssl_config_free( &conf );
+}
+/* END_CASE */


### PR DESCRIPTION
Summary:
When the input of `X` for mbedtls_debug_print_mpi is zero(X->n is 0 or
    X->p is NULL).
There is integer underflow when we subtract 1 from 0
for the unsigned variable [n](https://github.com/ARMmbed/mbedtls/blob/development/library/debug.c#L235).
It also causes crash as it [accesses](https://github.com/ARMmbed/mbedtls/blob/development/library/debug.c#L236) nullptr of X->p. The crash report is the following:

```
(gdb) down
#0  0x0000000000417ec5 in mbedtls_debug_print_mpi (ssl=0x7fffffffcb50, level=3, file=0x48e748 "/home/lhuang04/upstream/library/ssl_tls13_server.c", line=241, text=0x7fffffffb6f0 "ECDH: Qp(Y)", X=0x6c0478)
    at /home/lhuang04/upstream/library/debug.c:235
235	        if( X->p[n] != 0 )
(gdb) down
Bottom (innermost) frame selected; you cannot go down.
(gdb) where
#0  0x0000000000417ec5 in mbedtls_debug_print_mpi (ssl=0x7fffffffcb50, level=3, file=0x48e748 "/home/lhuang04/upstream/library/ssl_tls13_server.c", line=241, text=0x7fffffffb6f0 "ECDH: Qp(Y)", X=0x6c0478)
    at /home/lhuang04/upstream/library/debug.c:235
#1  0x0000000000417dfe in mbedtls_debug_print_ecp (ssl=0x7fffffffcb50, level=3, file=0x48e748 "/home/lhuang04/upstream/library/ssl_tls13_server.c", line=241, text=0x48e89d "ECDH: Qp", X=0x6c0460)
    at /home/lhuang04/upstream/library/debug.c:212
#2  0x000000000042e3cb in check_ecdh_params (ssl=0x7fffffffcb50) at /home/lhuang04/upstream/library/ssl_tls13_server.c:241
#3  0x000000000042e750 in ssl_parse_key_shares_ext (ssl=0x7fffffffcb50, buf=0x6c0a8b "", len=38) at /home/lhuang04/upstream/library/ssl_tls13_server.c:412
#4  0x0000000000431f4a in ssl_client_hello_parse (ssl=0x7fffffffcb50, buf=0x6c0a44 "", buflen=184) at /home/lhuang04/upstream/library/ssl_tls13_server.c:2738
#5  0x0000000000430f35 in ssl_client_hello_process (ssl=0x7fffffffcb50) at /home/lhuang04/upstream/library/ssl_tls13_server.c:2110
#6  0x000000000043444d in mbedtls_ssl_handshake_server_step (ssl=0x7fffffffcb50) at /home/lhuang04/upstream/library/ssl_tls13_server.c:4314
#7  0x000000000041f327 in mbedtls_ssl_handshake_step (ssl=0x7fffffffcb50) at /home/lhuang04/upstream/library/ssl_tls.c:6835
#8  0x000000000041f3c2 in mbedtls_ssl_handshake (ssl=0x7fffffffcb50) at /home/lhuang04/upstream/library/ssl_tls.c:6890
#9  0x0000000000414f9c in main (argc=8, argv=0x7fffffffdc98) at /home/lhuang04/upstream/programs/ssl/ssl_server2.c:4230
(gdb) p X->n
$1 = 0
(gdb) p n
$2 = 18446744073709551615
(gdb) p X->p
$3 = (mbedtls_mpi_uint *) 0x0
(gdb) 

```

Test Plan:
* Check out [tls13-prototype](https://github.com/hannestschofenig/mbedtls/tree/tls13-prototype)
```
git clone https://github.com/hannestschofenig/mbedtls
```
* Apply the following to enable X25519
```
diff --git a/library/ssl_tls.c b/library/ssl_tls.c
index 14d9e8678..d1bf6bdb8 100644
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8135,6 +8135,9 @@ static int ssl_preset_suiteb_signature_algorithms_tls13[] = {

 #if defined(MBEDTLS_ECP_C)
 static mbedtls_ecp_group_id ssl_preset_suiteb_curves[] = {
+#if defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+    MBEDTLS_ECP_DP_CURVE25519,
+#endif /* MBEDTLS_ECP_DP_CURVE25519_ENABLED */
 #if defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
     MBEDTLS_ECP_DP_SECP256R1,
 #endif /* MBEDTLS_ECP_DP_SECP256R1_ENABLED */
```
* Run test
```
tests/ssl-opt.sh -s -p -f "default suite, ECDHE-ECDSA, SRV auth"
```

or
```
tests/ssl-opt.sh
```

Reviewers:
@hanno-arm 

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
Fix crash and potential integer underflow in `mbedtls_debug_print_mpi`


## Status
*READY

## Requires Backporting


Yes | NO  
Which branch?
development

## Migrations

If there is any API change, what's the incentive and logic for it.
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
See above.
