### PR TITLE
Add a level of indirection to config file inclusion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ assignees: ''
 
 Mbed TLS version (number or commit id): 
 Operating system and version: 
-Configuration (if not default, please attach `config.h`): 
+Configuration (if not default, please attach `mbedtls_config.h`): 
 Compiler and options (if you used a pre-built binary, please indicate how you obtained it): 
 Additional environment information: 
 

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,4 +1,4 @@
-execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result)
+execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls/mbedtls_config.h get MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED RESULT_VARIABLE result)
 
 if(${result} EQUAL 0)
     add_subdirectory(everest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 if(MBEDTLS_PYTHON_EXECUTABLE)
 
     # If 128-bit keys are configured for CTR_DRBG, display an appropriate warning
-    execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/config.h get MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+    execute_process(COMMAND ${MBEDTLS_PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/config.py -f ${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h get MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
                         RESULT_VARIABLE result)
     if(${result} EQUAL 0)
         message(WARNING ${CTR_DRBG_128_BIT_KEY_WARNING})

--- a/ChangeLog.d/split-config.txt
+++ b/ChangeLog.d/split-config.txt
@@ -1,7 +1,7 @@
 Changes
    * config.h has been split into build_info.h and mbedtls_config.h
      build_info.h is intended to be included from C code directly, while
-     mbedtls_config.h is intended to be edited by end users whishing to
+     mbedtls_config.h is intended to be edited by end users wishing to
      change the build configuration, and should generally only be included from
      build_info.h.
    * The handling of MBEDTLS_CONFIG_FILE has been moved into build_info.h.

--- a/ChangeLog.d/split-config.txt
+++ b/ChangeLog.d/split-config.txt
@@ -5,8 +5,12 @@ Changes
      change the build configuration, and should generally only be included from
      build_info.h.
    * The handling of MBEDTLS_CONFIG_FILE has been moved into build_info.h.
-   * Mandatory version symbols MBEDTLS_CONFIG_VERSION and
-     MBEDTLS_USER_CONFIG_VERSION were introduced for MBEDTLS_CONFIG_FILE and
-     MBEDTLS_USER_CONFIG_FILE respectively. They have to be defined with a
-     value of one in their respective config file for the config to be
-     considered valid.
+   * Config file symbols MBEDTLS_CONFIG_VERSION and MBEDTLS_USER_CONFIG_VERSION
+     were introduced for use in MBEDTLS_CONFIG_FILE and
+     MBEDTLS_USER_CONFIG_FILE respectively.
+     Defining them to a particular value will ensure that mbedtls interprets
+     the config file in a way that's compatible with the config file format
+     indicated by the value.
+     The config file versions are based on the value of MBEDTLS_VERSION_NUMBER
+     of the mbedtls version that first introduced that config file format.
+     The only value currently supported is 0x03000000.

--- a/ChangeLog.d/split-config.txt
+++ b/ChangeLog.d/split-config.txt
@@ -5,12 +5,9 @@ Changes
      change the build configuration, and should generally only be included from
      build_info.h.
    * The handling of MBEDTLS_CONFIG_FILE has been moved into build_info.h.
-   * Config file symbols MBEDTLS_CONFIG_VERSION and MBEDTLS_USER_CONFIG_VERSION
-     were introduced for use in MBEDTLS_CONFIG_FILE and
-     MBEDTLS_USER_CONFIG_FILE respectively.
-     Defining them to a particular value will ensure that mbedtls interprets
+   * A config file version symbol, MBEDTLS_CONFIG_VERSION was introduced.
+     Defining it to a particular value will ensure that mbedtls interprets
      the config file in a way that's compatible with the config file format
-     indicated by the value.
-     The config file versions are based on the value of MBEDTLS_VERSION_NUMBER
-     of the mbedtls version that first introduced that config file format.
-     The only value currently supported is 0x03000000.
+     used by the mbedtls release whose MBEDTLS_VERSION_NUMBER has the same
+     value.
+     The only value supported by mbedtls 3.0.0 is 0x03000000.

--- a/ChangeLog.d/split-config.txt
+++ b/ChangeLog.d/split-config.txt
@@ -1,0 +1,12 @@
+Changes
+   * config.h has been split into build_info.h and mbedtls_config.h
+     build_info.h is intended to be included from C code directly, while
+     mbedtls_config.h is intended to be edited by end users whishing to
+     change the build configuration, and should generally only be included from
+     build_info.h.
+   * The handling of MBEDTLS_CONFIG_FILE has been moved into build_info.h.
+   * Mandatory version symbols MBEDTLS_CONFIG_VERSION and
+     MBEDTLS_USER_CONFIG_VERSION were introduced for MBEDTLS_CONFIG_FILE and
+     MBEDTLS_USER_CONFIG_FILE respectively. They have to be defined with a
+     value of one in their respective config file for the config to be
+     considered valid.

--- a/ChangeLog.d/split-config.txt
+++ b/ChangeLog.d/split-config.txt
@@ -6,8 +6,8 @@ Changes
      build_info.h.
    * The handling of MBEDTLS_CONFIG_FILE has been moved into build_info.h.
    * A config file version symbol, MBEDTLS_CONFIG_VERSION was introduced.
-     Defining it to a particular value will ensure that mbedtls interprets
+     Defining it to a particular value will ensure that Mbed TLS interprets
      the config file in a way that's compatible with the config file format
-     used by the mbedtls release whose MBEDTLS_VERSION_NUMBER has the same
+     used by the Mbed TLS release whose MBEDTLS_VERSION_NUMBER has the same
      value.
-     The only value supported by mbedtls 3.0.0 is 0x03000000.
+     The only value supported by Mbed TLS 3.0.0 is 0x03000000.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Stability
 Configuration
 -------------
 
-Mbed TLS should build out of the box on most systems. Some platform specific options are available in the fully documented configuration file `include/mbedtls/config.h`, which is also the place where features can be selected. This file can be edited manually, or in a more programmatic way using the Python 3 script `scripts/config.py` (use `--help` for usage instructions).
+Mbed TLS should build out of the box on most systems. Some platform specific options are available in the fully documented configuration file `include/mbedtls/mbedtls_config.h`, which is also the place where features can be selected. This file can be edited manually, or in a more programmatic way using the Python 3 script `scripts/config.py` (use `--help` for usage instructions).
 
 Compiler options can be set using conventional environment variables such as `CC` and `CFLAGS` when using the Make and CMake build system (see below).
 
@@ -242,7 +242,7 @@ For machines with a Unix shell and OpenSSL (and optionally GnuTLS) installed, ad
 -   `tests/compat.sh` tests interoperability of every ciphersuite with other implementations.
 -   `tests/scripts/test-ref-configs.pl` test builds in various reduced configurations.
 -   `tests/scripts/key-exchanges.pl` test builds in configurations with a single key exchange enabled
--   `tests/scripts/all.sh` runs a combination of the above tests, plus some more, with various build options (such as ASan, full `config.h`, etc).
+-   `tests/scripts/all.sh` runs a combination of the above tests, plus some more, with various build options (such as ASan, full `mbedtls_config.h`, etc).
 
 Porting Mbed TLS
 ----------------
@@ -281,7 +281,7 @@ A browsable copy of the PSA Cryptography API documents is available on the [PSA 
 Mbed TLS includes a reference implementation of the PSA Cryptography API.
 This implementation is not yet as mature as the rest of the library. Some parts of the code have not been reviewed as thoroughly, and some parts of the PSA implementation are not yet well optimized for code size.
 
-The X.509 and TLS code can use PSA cryptography for a limited subset of operations. To enable this support, activate the compilation option `MBEDTLS_USE_PSA_CRYPTO` in `config.h`.
+The X.509 and TLS code can use PSA cryptography for a limited subset of operations. To enable this support, activate the compilation option `MBEDTLS_USE_PSA_CRYPTO` in `mbedtls_config.h`.
 
 There are currently a few deviations where the library does not yet implement the latest version of the specification. Please refer to the [compliance issues on Github](https://github.com/ARMmbed/mbed-crypto/labels/compliance) for an up-to-date list.
 

--- a/configs/README.txt
+++ b/configs/README.txt
@@ -4,10 +4,10 @@ The examples are generally focused on a particular usage case (eg, support for
 a restricted number of ciphersuites) and aim at minimizing resource usage for
 this target. They can be used as a basis for custom configurations.
 
-These files are complete replacements for the default config.h. To use one of
+These files are complete replacements for the default mbedtls_config.h. To use one of
 them, you can pick one of the following methods:
 
-1. Replace the default file include/mbedtls/config.h with the chosen one.
+1. Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
    (Depending on your compiler, you may need to adjust the line with
    #include "mbedtls/check_config.h" then.)
 

--- a/configs/README.txt
+++ b/configs/README.txt
@@ -8,8 +8,6 @@ These files are complete replacements for the default mbedtls_config.h. To use o
 them, you can pick one of the following methods:
 
 1. Replace the default file include/mbedtls/mbedtls_config.h with the chosen one.
-   (Depending on your compiler, you may need to adjust the line with
-   #include "mbedtls/check_config.h" then.)
 
 2. Define MBEDTLS_CONFIG_FILE and adjust the include path accordingly.
    For example, using make:

--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -29,8 +29,6 @@
  *
  * See README.txt for usage instructions.
  */
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
 
 /* System support */
 //#define MBEDTLS_HAVE_TIME /* Optionally used in Hello messages */
@@ -85,7 +83,3 @@
  */
 #define MBEDTLS_SSL_IN_CONTENT_LEN             1024
 #define MBEDTLS_SSL_OUT_CONTENT_LEN             1024
-
-#include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -30,8 +30,6 @@
  * See README.txt for usage instructions.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
-
 /* System support */
 //#define MBEDTLS_HAVE_TIME /* Optionally used in Hello messages */
 /* Other MBEDTLS_HAVE_XXX flags irrelevant for this configuration */

--- a/configs/config-ccm-psk-tls1_2.h
+++ b/configs/config-ccm-psk-tls1_2.h
@@ -30,6 +30,8 @@
  * See README.txt for usage instructions.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /* System support */
 //#define MBEDTLS_HAVE_TIME /* Optionally used in Hello messages */
 /* Other MBEDTLS_HAVE_XXX flags irrelevant for this configuration */

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -29,6 +29,8 @@
  * See README.txt for usage instructions.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -29,9 +29,6 @@
  * See README.txt for usage instructions.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME
@@ -86,7 +83,3 @@
 
 /* Miscellaneous options */
 #define MBEDTLS_AES_ROM_TABLES
-
-#include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-no-entropy.h
+++ b/configs/config-no-entropy.h
@@ -29,8 +29,6 @@
  * See README.txt for usage instructions.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -33,8 +33,6 @@
  * See README.txt for usage instructions.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -33,6 +33,8 @@
  * See README.txt for usage instructions.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -33,9 +33,6 @@
  * See README.txt for usage instructions.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME
@@ -113,7 +110,3 @@
  */
 #define MBEDTLS_SSL_IN_CONTENT_LEN             1024
 #define MBEDTLS_SSL_OUT_CONTENT_LEN             1024
-
-#include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-symmetric-only.h
+++ b/configs/config-symmetric-only.h
@@ -20,9 +20,6 @@
  *  limitations under the License.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
-
 /* System support */
 //#define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME
@@ -90,9 +87,3 @@
 //#define MBEDTLS_THREADING_C
 #define MBEDTLS_TIMING_C
 #define MBEDTLS_VERSION_C
-
-#include "mbedtls/config_psa.h"
-
-#include "check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-symmetric-only.h
+++ b/configs/config-symmetric-only.h
@@ -20,6 +20,8 @@
  *  limitations under the License.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /* System support */
 //#define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-symmetric-only.h
+++ b/configs/config-symmetric-only.h
@@ -20,8 +20,6 @@
  *  limitations under the License.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
-
 /* System support */
 //#define MBEDTLS_HAVE_ASM
 #define MBEDTLS_HAVE_TIME

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -32,6 +32,8 @@
  * See README.txt for usage instructions.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /* System support */
 #define MBEDTLS_HAVE_ASM
 

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -32,9 +32,6 @@
  * See README.txt for usage instructions.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 
@@ -89,7 +86,3 @@
 
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
-
-#include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -32,8 +32,6 @@
  * See README.txt for usage instructions.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
-
 /* System support */
 #define MBEDTLS_HAVE_ASM
 

--- a/docs/3.0-migration-guide.d/Remove_3DES_ciphersuites.md
+++ b/docs/3.0-migration-guide.d/Remove_3DES_ciphersuites.md
@@ -1,7 +1,7 @@
 Remove 3DES ciphersuites
 --
 
-This change does not affect users using default settings for 3DES in `config.h`
+This change does not affect users using default settings for 3DES in `mbedtls_config.h`
 because the 3DES ciphersuites were disabled by that.
 
 3DES has weaknesses/limitations and there are better alternatives, and more and

--- a/docs/3.0-migration-guide.d/combine_SSL_CID-TLS1_3_PADDING_GRANULARITY_options.md
+++ b/docs/3.0-migration-guide.d/combine_SSL_CID-TLS1_3_PADDING_GRANULARITY_options.md
@@ -1,10 +1,10 @@
 Combine the `MBEDTLS_SSL_CID_PADDING_GRANULARITY` and `MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY` options
 --
 
-This change affects users who modified the default `config.h` padding granularity
+This change affects users who modified the default `mbedtls_config.h` padding granularity
 settings, i.e. enabled at least one of the options.
 
-The `config.h` options `MBEDTLS_SSL_CID_PADDING_GRANULARITY` and
+The `mbedtls_config.h` options `MBEDTLS_SSL_CID_PADDING_GRANULARITY` and
 `MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY` were combined into one option because
 they used exactly the same padding mechanism and hence their respective padding
 granularities can be used in exactly the same way. This change simplifies the

--- a/docs/3.0-migration-guide.d/modify_SHA384_option_behaviour.md
+++ b/docs/3.0-migration-guide.d/modify_SHA384_option_behaviour.md
@@ -1,7 +1,7 @@
 Replaced MBEDTLS_SHA512_NO_SHA384 with MBEDTLS_SHA384_C
 ------------------------------------------------------
 
-This does not affect users who use the default `config.h`.
+This does not affect users who use the default `mbedtls_config.h`.
 MBEDTLS_SHA512_NO_SHA384 was disabled by default, now MBEDTLS_SHA384_C is
 enabled by default.
 

--- a/docs/3.0-migration-guide.d/remove-enable-weak-ciphersuites.md
+++ b/docs/3.0-migration-guide.d/remove-enable-weak-ciphersuites.md
@@ -1,7 +1,7 @@
 Remove the configuration to enable weak ciphersuites in SSL / TLS
 -----------------------------------------------------------------
 
-This does not affect users who use the default `config.h`, as this option was
+This does not affect users who use the default `mbedtls_config.h`, as this option was
 already off by default.
 
 If you were using a weak cipher, please switch to any of the modern,

--- a/docs/3.0-migration-guide.d/remove-null-entropy.md
+++ b/docs/3.0-migration-guide.d/remove-null-entropy.md
@@ -1,7 +1,7 @@
 Remove the option to build the library without any entropy sources
 ------------------------------------------------------------------
 
-This does not affect users who use the default `config.h`, as this option was
+This does not affect users who use the default `mbedtls_config.h`, as this option was
 already off by default.
 
 If you were using the `MBEDTLS_TEST_NULL_ENTROPY` option and your platform

--- a/docs/3.0-migration-guide.d/remove_MBEDTLS_X509_CHECK_x_KEY_USAGE_options.md
+++ b/docs/3.0-migration-guide.d/remove_MBEDTLS_X509_CHECK_x_KEY_USAGE_options.md
@@ -1,4 +1,4 @@
-Remove `MBEDTLS_X509_CHECK_*_KEY_USAGE` options from `config.h`
+Remove `MBEDTLS_X509_CHECK_*_KEY_USAGE` options from `mbedtls_config.h`
 -------------------------------------------------------------------
 
 This change affects users who have chosen the configuration options to disable the

--- a/docs/3.0-migration-guide.d/remove_SSL_DTLS_BADMAC_LIMIT_option.md
+++ b/docs/3.0-migration-guide.d/remove_SSL_DTLS_BADMAC_LIMIT_option.md
@@ -1,7 +1,7 @@
 Remove MBEDTLS_SSL_DTLS_BADMAC_LIMIT option
 -------------------------------------------
 
-This change does not affect users who used the default `config.h`, as the option
+This change does not affect users who used the default `mbedtls_config.h`, as the option
 MBEDTLS_SSL_DTLS_BADMAC_LIMIT was already on by default.
 
 This option was a trade-off between functionality and code size: it allowed

--- a/docs/3.0-migration-guide.d/remove_ssl_record_checking.md
+++ b/docs/3.0-migration-guide.d/remove_ssl_record_checking.md
@@ -1,7 +1,7 @@
 Remove MBEDTLS_SSL_RECORD_CHECKING option and enable its action by default
 --------------------------------------------------------------------------
 
-This change does not affect users who use the default config.h, as the
+This change does not affect users who use the default mbedtls_config.h, as the
 option MBEDTLS_SSL_RECORD_CHECKING was already on by default.
 
 This option was added only to control compilation of one function,

--- a/docs/3.0-migration-guide.d/separate_SHA224_from_SHA256.md
+++ b/docs/3.0-migration-guide.d/separate_SHA224_from_SHA256.md
@@ -1,7 +1,7 @@
 Separated MBEDTLS_SHA224_C and MBEDTLS_SHA256_C
 -----------------------------------------------------------------
 
-This does not affect users who use the default `config.h`. MBEDTLS_SHA256_C
+This does not affect users who use the default `mbedtls_config.h`. MBEDTLS_SHA256_C
 was enabled by default. Now both MBEDTLS_SHA256_C and MBEDTLS_SHA224_C are
 enabled.
 

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -9,7 +9,7 @@ Introduce a level of indirection and versioning in the config files
 
 Also, if you have a custom configuration file:
 
-* Don't include `check_config.h` anymore.
+* Don't include `check_config.h` or `config_psa.h` anymore.
 * Don't define `MBEDTLS_CONFIG_H` anymore.
 
 A config file version symbol, `MBEDTLS_CONFIG_VERSION` was introduced.

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -1,0 +1,16 @@
+Introduce a level of indirection and versioning in the config files
+-------------------------------------------------------------------
+
+`config.h` was split into `build_info.h` and `mbedtls_config.h`.
+`build_info.h` is intended to be included from C code directly, while
+`mbedtls_config.h` is intended to be edited by end users whishing to
+change the build configuration, and should generally only be included from
+`build_info.h`. This is because all the preprocessor logic has been moved
+into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`
+macro.
+
+Mandatory version symbols were introduced for `MBEDTLS_CONFIG_FILE` and
+`MBEDTLS_USER_CONFIG_FILE`, `MBEDTLS_CONFIG_VERSION` and
+`MBEDTLS_USER_CONFIG_VERSION` respectively. Both config files should include
+a definiton of their respective version symbol, with a value of `1` to be
+considered valid.

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -9,8 +9,12 @@ change the build configuration, and should generally only be included from
 into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`
 macro.
 
-Mandatory version symbols were introduced for `MBEDTLS_CONFIG_FILE` and
-`MBEDTLS_USER_CONFIG_FILE`, `MBEDTLS_CONFIG_VERSION` and
-`MBEDTLS_USER_CONFIG_VERSION` respectively. Both config files should include
-a definiton of their respective version symbol, with a value of `1` to be
-considered valid.
+Config file symbols `MBEDTLS_CONFIG_VERSION` and `MBEDTLS_USER_CONFIG_VERSION`
+were introduced for use in `MBEDTLS_CONFIG_FILE` and
+`MBEDTLS_USER_CONFIG_FILE` respectively.
+Defining them to a particular value will ensure that mbedtls interprets
+the config file in a way that's compatible with the config file format
+indicated by the value.
+The config file versions are based on the value of `MBEDTLS_VERSION_NUMBER`
+of the mbedtls version that first introduced that config file format.
+The only value currently supported is `0x03000000`.

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -2,12 +2,15 @@ Introduce a level of indirection and versioning in the config files
 -------------------------------------------------------------------
 
 `config.h` was split into `build_info.h` and `mbedtls_config.h`.
-`build_info.h` is intended to be included from C code directly, while
-`mbedtls_config.h` is intended to be edited by end users wishing to
-change the build configuration, and should generally only be included from
-`build_info.h`. This is because all the preprocessor logic has been moved
-into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`
-macro.
+
+* In code, use `#include <mbedtls/build_info.h>`. Don't include `mbedtls/config.h` and don't refer to `MBEDTLS_CONFIG_FILE`.
+* In build tools, edit `mbedtls_config.h`, or edit `MBEDTLS_CONFIG_FILE` as before.
+* If you had a tool that parsed the library version from `include/mbedtls/version.h`, this has moved to `include/mbedtls/build_info.h`. From C code, both headers now define the `MBEDTLS_VERSION_xxx` macros.
+
+Also, if you have a custom configuration file:
+
+* Don't include `check_config.h` anymore.
+* Don't define `MBEDTLS_CONFIG_H` anymore.
 
 A config file version symbol, `MBEDTLS_CONFIG_VERSION` was introduced.
 Defining it to a particular value will ensure that Mbed TLS interprets

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -3,7 +3,7 @@ Introduce a level of indirection and versioning in the config files
 
 `config.h` was split into `build_info.h` and `mbedtls_config.h`.
 `build_info.h` is intended to be included from C code directly, while
-`mbedtls_config.h` is intended to be edited by end users whishing to
+`mbedtls_config.h` is intended to be edited by end users wishing to
 change the build configuration, and should generally only be included from
 `build_info.h`. This is because all the preprocessor logic has been moved
 into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -10,8 +10,8 @@ into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`
 macro.
 
 A config file version symbol, `MBEDTLS_CONFIG_VERSION` was introduced.
-Defining it to a particular value will ensure that mbedtls interprets
+Defining it to a particular value will ensure that Mbed TLS interprets
 the config file in a way that's compatible with the config file format
-used by the mbedtls release whose `MBEDTLS_VERSION_NUMBER` has the same
+used by the Mbed TLS release whose `MBEDTLS_VERSION_NUMBER` has the same
 value.
-The only value supported by mbedtls 3.0.0 is `0x03000000`.
+The only value supported by Mbed TLS 3.0.0 is `0x03000000`.

--- a/docs/3.0-migration-guide.d/split_config.md
+++ b/docs/3.0-migration-guide.d/split_config.md
@@ -9,12 +9,9 @@ change the build configuration, and should generally only be included from
 into `build_info.h`, including the handling of the `MBEDTLS_CONFIG_FILE`
 macro.
 
-Config file symbols `MBEDTLS_CONFIG_VERSION` and `MBEDTLS_USER_CONFIG_VERSION`
-were introduced for use in `MBEDTLS_CONFIG_FILE` and
-`MBEDTLS_USER_CONFIG_FILE` respectively.
-Defining them to a particular value will ensure that mbedtls interprets
+A config file version symbol, `MBEDTLS_CONFIG_VERSION` was introduced.
+Defining it to a particular value will ensure that mbedtls interprets
 the config file in a way that's compatible with the config file format
-indicated by the value.
-The config file versions are based on the value of `MBEDTLS_VERSION_NUMBER`
-of the mbedtls version that first introduced that config file format.
-The only value currently supported is `0x03000000`.
+used by the mbedtls release whose `MBEDTLS_VERSION_NUMBER` has the same
+value.
+The only value supported by mbedtls 3.0.0 is `0x03000000`.

--- a/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
+++ b/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
@@ -2,7 +2,7 @@ Turn MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE configuration option into a runti
 --
 
 This change affects users who were enabling MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
-option in the `config.h`
+option in the `mbedtls_config.h`
 
 This option has been removed and a new function with similar functionality has
 been introduced into the SSL API.

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -139,7 +139,7 @@ avoid variants of the CRIME and BREACH attacks.
 Remove support for TLS RC4-based ciphersuites
 ---------------------------------------------
 
-This does not affect people who used the default `config.h` and the default
+This does not affect people who used the default `mbedtls_config.h` and the default
 list of ciphersuites, as RC4-based ciphersuites were already not negotiated in
 that case.
 

--- a/docs/architecture/testing/test-framework.md
+++ b/docs/architecture/testing/test-framework.md
@@ -51,7 +51,7 @@ The outcome file is in a CSV format using `;` (semicolon) as the delimiter and n
 The outcome file has 6 fields:
 
 * **Platform**: a description of the platform, e.g. `Linux-x86_64` or `Linux-x86_64-gcc7-msan`.
-* **Configuration**: a unique description of the configuration (`config.h`).
+* **Configuration**: a unique description of the configuration (`mbedtls_config.h`).
 * **Test suite**: `test_suite_xxx` or `ssl-opt`.
 * **Test case**: the description of the test case.
 * **Result**: one of `PASS`, `SKIP` or `FAIL`.

--- a/docs/architecture/tls13-experimental.md
+++ b/docs/architecture/tls13-experimental.md
@@ -15,7 +15,7 @@ MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
 This macro will likely be renamed to `MBEDTLS_SSL_PROTO_TLS1_3` once a minimal viable
 implementation of the TLS 1.3 protocol is available.
 
-See the [documentation of `MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL`](../../include/mbedtls/config.h)
+See the [documentation of `MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL`](../../include/mbedtls/mbedtls_config.h)
 for more information.
 
 Status

--- a/docs/proposed/psa-conditional-inclusion-c.md
+++ b/docs/proposed/psa-conditional-inclusion-c.md
@@ -145,13 +145,13 @@ The following table summarizes where symbols are defined depending on the config
 * (D) indicates a symbol that is deduced from other symbols by code that ships with Mbed TLS.
 * (G) indicates a symbol that is generated from driver descriptions.
 
-| Symbols                   | With `MBEDTLS_PSA_CRYPTO_CONFIG` | Without `MBEDTLS_PSA_CRYPTO_CONFIG` |
-| ------------------------- | -------------------------------- | ----------------------------------- |
-| `MBEDTLS_xxx_C`           | `mbedtls/mbedtls_config.h` (U) or        | `mbedtls/mbedtls_config.h` (U)              |
-|                           | `mbedtls/config_psa.h` (D)       |                                     |
-| `PSA_WANT_xxx`            | `psa/crypto_config.h` (U)        | `mbedtls/config_psa.h` (D)          |
-| `MBEDTLS_PSA_BUILTIN_xxx` | `mbedtls/config_psa.h` (D)       | `mbedtls/config_psa.h` (D)          |
-| `MBEDTLS_PSA_ACCEL_xxx`   | `mbedtls/crypto_drivers.h` (G)   | N/A                                 |
+| Symbols                   | With `MBEDTLS_PSA_CRYPTO_CONFIG`  | Without `MBEDTLS_PSA_CRYPTO_CONFIG` |
+| ------------------------- | --------------------------------- | ----------------------------------- |
+| `MBEDTLS_xxx_C`           | `mbedtls/mbedtls_config.h` (U) or | `mbedtls/mbedtls_config.h` (U)      |
+|                           | `mbedtls/config_psa.h` (D)        |                                     |
+| `PSA_WANT_xxx`            | `psa/crypto_config.h` (U)         | `mbedtls/config_psa.h` (D)          |
+| `MBEDTLS_PSA_BUILTIN_xxx` | `mbedtls/config_psa.h` (D)        | `mbedtls/config_psa.h` (D)          |
+| `MBEDTLS_PSA_ACCEL_xxx`   | `mbedtls/crypto_drivers.h` (G)    | N/A                                 |
 
 #### Visibility of internal symbols
 

--- a/docs/proposed/psa-conditional-inclusion-c.md
+++ b/docs/proposed/psa-conditional-inclusion-c.md
@@ -15,7 +15,7 @@ The present document proposes a way for an application using the PSA cryptograph
 
 ### Conditional inclusion of legacy cryptography modules
 
-Mbed TLS offers a way to select which cryptographic mechanisms are included in a build through its configuration file (`config.h`). This mechanism is based on two main sets of symbols: `MBEDTLS_xxx_C` controls the availability of the mechanism to the application, and `MBEDTLS_xxx_ALT` controls the availability of an alternative implementation, so the software implementation is only included if `MBEDTLS_xxx_C` is defined but not `MBEDTLS_xxx_ALT`.
+Mbed TLS offers a way to select which cryptographic mechanisms are included in a build through its configuration file (`mbedtls_config.h`). This mechanism is based on two main sets of symbols: `MBEDTLS_xxx_C` controls the availability of the mechanism to the application, and `MBEDTLS_xxx_ALT` controls the availability of an alternative implementation, so the software implementation is only included if `MBEDTLS_xxx_C` is defined but not `MBEDTLS_xxx_ALT`.
 
 ### PSA evolution
 
@@ -51,10 +51,10 @@ The current model is difficult to adapt to the PSA interface for several reasons
 
 The PSA Crypto configuration file `psa/crypto_config.h` defines a series of symbols of the form `PSA_WANT_xxx` where `xxx` describes the feature that the symbol enables. The symbols are documented in the section [“PSA Crypto configuration symbols”](#psa-crypto-configuration-symbols) below.
 
-The symbol `MBEDTLS_PSA_CRYPTO_CONFIG` in `mbedtls/config.h` determines whether `psa/crypto_config.h` is used.
+The symbol `MBEDTLS_PSA_CRYPTO_CONFIG` in `mbedtls/mbedtls_config.h` determines whether `psa/crypto_config.h` is used.
 
 * If `MBEDTLS_PSA_CRYPTO_CONFIG` is unset, which is the default at least in Mbed TLS 2.x versions, things are as they are today: the PSA subsystem includes generic code unconditionally, and includes support for specific mechanisms conditionally based on the existing `MBEDTLS_xxx_` symbols.
-* If `MBEDTLS_PSA_CRYPTO_CONFIG` is set, the necessary software implementations of cryptographic algorithms are included based on both the content of the PSA Crypto configuration file and the Mbed TLS configuration file. For example, the code in `aes.c` is enabled if either `mbedtls/config.h` contains `MBEDTLS_AES_C` or `psa/crypto_config.h` contains `PSA_WANT_KEY_TYPE_AES`.
+* If `MBEDTLS_PSA_CRYPTO_CONFIG` is set, the necessary software implementations of cryptographic algorithms are included based on both the content of the PSA Crypto configuration file and the Mbed TLS configuration file. For example, the code in `aes.c` is enabled if either `mbedtls/mbedtls_config.h` contains `MBEDTLS_AES_C` or `psa/crypto_config.h` contains `PSA_WANT_KEY_TYPE_AES`.
 
 ### PSA Crypto configuration symbols
 
@@ -123,17 +123,17 @@ These symbols are not part of the public interface of Mbed TLS towards applicati
 
 #### New-style definition of configuration symbols
 
-When `MBEDTLS_PSA_CRYPTO_CONFIG` is set, the header file `mbedtls/config.h` needs to define all the `MBEDTLS_xxx_C` configuration symbols, including the ones deduced from the PSA Crypto configuration. It does this by including the new header file **`mbedtls/config_psa.h`**, which defines the `MBEDTLS_PSA_BUILTIN_xxx` symbols and deduces the corresponding `MBEDTLS_xxx_C` (and other) symbols.
+When `MBEDTLS_PSA_CRYPTO_CONFIG` is set, the header file `mbedtls/mbedtls_config.h` needs to define all the `MBEDTLS_xxx_C` configuration symbols, including the ones deduced from the PSA Crypto configuration. It does this by including the new header file **`mbedtls/config_psa.h`**, which defines the `MBEDTLS_PSA_BUILTIN_xxx` symbols and deduces the corresponding `MBEDTLS_xxx_C` (and other) symbols.
 
 `mbedtls/config_psa.h` includes `psa/crypto_config.h`, the user-editable file that defines application requirements.
 
 #### Old-style definition of configuration symbols
 
-When `MBEDTLS_PSA_CRYPTO_CONFIG` is not set, the configuration of Mbed TLS works as before, and the inclusion of non-PSA code only depends on `MBEDTLS_xxx` symbols defined (or not) in `mbedtls/config.h`. Furthermore, the new header file **`mbedtls/config_psa.h`** deduces PSA configuration symbols (`PSA_WANT_xxx`, `MBEDTLS_PSA_BUILTIN_xxx`) from classic configuration symbols (`MBEDTLS_xxx`).
+When `MBEDTLS_PSA_CRYPTO_CONFIG` is not set, the configuration of Mbed TLS works as before, and the inclusion of non-PSA code only depends on `MBEDTLS_xxx` symbols defined (or not) in `mbedtls/mbedtls_config.h`. Furthermore, the new header file **`mbedtls/config_psa.h`** deduces PSA configuration symbols (`PSA_WANT_xxx`, `MBEDTLS_PSA_BUILTIN_xxx`) from classic configuration symbols (`MBEDTLS_xxx`).
 
 The `PSA_WANT_xxx` definitions in `mbedtls/config_psa.h` are needed not only to build the PSA parts of the library, but also to build code that uses these parts. This includes structure definitions in `psa/crypto_struct.h`, size calculations in `psa/crypto_sizes.h`, and application code that's specific to a given cryptographic mechanism. In Mbed TLS itself, code under `MBEDTLS_USE_PSA_CRYPTO` and conditional compilation guards in tests and sample programs need `PSA_WANT_xxx`.
 
-Since some existing applications use a handwritten `mbedtls/config.h` or an edited copy of `mbedtls/config.h` from an earlier version of Mbed TLS, `mbedtls/config_psa.h` must be included via an already existing header that is not `mbedtls/config.h`, so it is included via `psa/crypto.h` (for example from `psa/crypto_platform.h`).
+Since some existing applications use a handwritten `mbedtls/mbedtls_config.h` or an edited copy of `mbedtls/mbedtls_config.h` from an earlier version of Mbed TLS, `mbedtls/config_psa.h` must be included via an already existing header that is not `mbedtls/mbedtls_config.h`, so it is included via `psa/crypto.h` (for example from `psa/crypto_platform.h`).
 
 #### Summary of definitions of configuration symbols
 
@@ -147,7 +147,7 @@ The following table summarizes where symbols are defined depending on the config
 
 | Symbols                   | With `MBEDTLS_PSA_CRYPTO_CONFIG` | Without `MBEDTLS_PSA_CRYPTO_CONFIG` |
 | ------------------------- | -------------------------------- | ----------------------------------- |
-| `MBEDTLS_xxx_C`           | `mbedtls/config.h` (U) or        | `mbedtls/config.h` (U)              |
+| `MBEDTLS_xxx_C`           | `mbedtls/mbedtls_config.h` (U) or        | `mbedtls/mbedtls_config.h` (U)              |
 |                           | `mbedtls/config_psa.h` (D)       |                                     |
 | `PSA_WANT_xxx`            | `psa/crypto_config.h` (U)        | `mbedtls/config_psa.h` (D)          |
 | `MBEDTLS_PSA_BUILTIN_xxx` | `mbedtls/config_psa.h` (D)       | `mbedtls/config_psa.h` (D)          |

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -15,7 +15,7 @@ if(INSTALL_MBEDTLS_HEADERS)
 
 endif(INSTALL_MBEDTLS_HEADERS)
 
-# Make config.h available in an out-of-source build. ssl-opt.sh requires it.
+# Make mbedtls_config.h available in an out-of-source build. ssl-opt.sh requires it.
 if (ENABLE_TESTING AND NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     link_to_source(mbedtls)
     link_to_source(psa)

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -41,11 +41,7 @@
 #define MBEDTLS_AES_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -30,11 +30,7 @@
 #define MBEDTLS_ARIA_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_ASN1_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_ASN1_WRITE_H
 #define MBEDTLS_ASN1_WRITE_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/asn1.h"
 

--- a/include/mbedtls/base64.h
+++ b/include/mbedtls/base64.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_BASE64_H
 #define MBEDTLS_BASE64_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_BIGNUM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -1,0 +1,35 @@
+/**
+ * \file build_info.h
+ *
+ * \brief Build-time configuration info
+ *
+ *  Include this file if you need to depend on the
+ *  configuration options defined in config.h
+ */
+ /*
+  *  Copyright The Mbed TLS Contributors
+  *  SPDX-License-Identifier: Apache-2.0
+  *
+  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+  *  not use this file except in compliance with the License.
+  *  You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *  Unless required by applicable law or agreed to in writing, software
+  *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  See the License for the specific language governing permissions and
+  *  limitations under the License.
+  */
+
+#ifndef MBEDTLS_BUILD_INFO_H
+#define MBEDTLS_BUILD_INFO_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#endif /* MBEDTLS_BUILD_INFO_H */

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -26,10 +26,29 @@
 #ifndef MBEDTLS_BUILD_INFO_H
 #define MBEDTLS_BUILD_INFO_H
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
+#define _CRT_SECURE_NO_DEPRECATE 1
+#endif
+
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+
+/* Target and application specific configurations
+ *
+ * Allow user to override any previous default.
+ *
+ */
+#if defined(MBEDTLS_USER_CONFIG_FILE)
+#include MBEDTLS_USER_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
+#include "mbedtls/config_psa.h"
+#endif
+
+#include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_BUILD_INFO_H */

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -49,12 +49,6 @@
 #define MBEDTLS_VERSION_STRING         "2.26.0"
 #define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.26.0"
 
-/**
- * Equal to the #MBEDTLS_VERSION_NUMBER of the mbedtls version that introduced
- * the most recent config version
- */
-#define MBEDTLS_CONFIG_VERSION_LATEST  0x03000000
-
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
@@ -65,8 +59,9 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if defined(MBEDTLS_CONFIG_VERSION) && \
-    MBEDTLS_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION_LATEST
+#if defined(MBEDTLS_CONFIG_VERSION) && ( \
+    MBEDTLS_CONFIG_VERSION < 0x03000000 || \
+    MBEDLTS_CONFIG_VERSION > MBEDTLS_VERSION_NUMBER )
 #error "Invalid config version, defined value of MBEDTLS_CONFIG_VERSION is unsupported"
 #endif
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -26,6 +26,29 @@
 #ifndef MBEDTLS_BUILD_INFO_H
 #define MBEDTLS_BUILD_INFO_H
 
+/*
+ * This set of compile-time defines can be used to determine the version number
+ * of the mbed TLS library used. Run-time variables for the same can be found in
+ * version.h
+ */
+
+/**
+ * The version number x.y.z is split into three parts.
+ * Major, Minor, Patchlevel
+ */
+#define MBEDTLS_VERSION_MAJOR  2
+#define MBEDTLS_VERSION_MINOR  26
+#define MBEDTLS_VERSION_PATCH  0
+
+/**
+ * The single version number has the following structure:
+ *    MMNNPP00
+ *    Major version | Minor version | Patch version
+ */
+#define MBEDTLS_VERSION_NUMBER         0x021A0000
+#define MBEDTLS_VERSION_STRING         "2.26.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.26.0"
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -49,6 +49,8 @@
 #define MBEDTLS_VERSION_STRING         "2.26.0"
 #define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.26.0"
 
+#define MBEDTLS_CONFIG_VERSION_LATEST 1
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
@@ -59,9 +61,10 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if !defined(MBEDTLS_CONFIG_VERSION) || \
-    MBEDTLS_CONFIG_VERSION != 1
-#error "Invalid config version, MBEDTLS_CONFIG_VERSION != 1"
+#if !defined(MBEDTLS_CONFIG_VERSION)
+#define MBEDTLS_CONFIG_VERSION MBEDTLS_CONFIG_VERSION_LATEST
+#elif MBEDTLS_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION_LATEST
+#error "Invalid config version, defined value of MBEDTLS_CONFIG_VERSION is unsupported"
 #endif
 
 #if defined(MBEDTLS_USER_CONFIG_VERSION)
@@ -75,7 +78,7 @@
  */
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
-#if !defined(MBEDTLS_USER_CONFIG_VERSION) || \
+#if defined(MBEDTLS_USER_CONFIG_VERSION) && \
     MBEDTLS_USER_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION
 #error "Version mismatch between config file and MBEDTLS_USER_CONFIG_FILE"
 #endif

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -61,7 +61,7 @@
 
 #if defined(MBEDTLS_CONFIG_VERSION) && ( \
     MBEDTLS_CONFIG_VERSION < 0x03000000 || \
-    MBEDLTS_CONFIG_VERSION > MBEDTLS_VERSION_NUMBER )
+    MBEDTLS_CONFIG_VERSION > MBEDTLS_VERSION_NUMBER )
 #error "Invalid config version, defined value of MBEDTLS_CONFIG_VERSION is unsupported"
 #endif
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -28,7 +28,7 @@
 
 /*
  * This set of compile-time defines can be used to determine the version number
- * of the mbed TLS library used. Run-time variables for the same can be found in
+ * of the Mbed TLS library used. Run-time variables for the same can be found in
  * version.h
  */
 

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -65,14 +65,9 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
-#if !defined(MBEDTLS_CONFIG_VERSION)
-#define MBEDTLS_CONFIG_VERSION MBEDTLS_CONFIG_VERSION_LATEST
-#elif MBEDTLS_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION_LATEST
+#if defined(MBEDTLS_CONFIG_VERSION) && \
+    MBEDTLS_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION_LATEST
 #error "Invalid config version, defined value of MBEDTLS_CONFIG_VERSION is unsupported"
-#endif
-
-#if defined(MBEDTLS_USER_CONFIG_VERSION)
-#error "MBEDTLS_USER_CONFIG_VERSION defined outside MBEDTLS_USER_CONFIG_FILE"
 #endif
 
 /* Target and application specific configurations
@@ -82,10 +77,6 @@
  */
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
-#if defined(MBEDTLS_USER_CONFIG_VERSION) && \
-    MBEDTLS_USER_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION
-#error "Version mismatch between config file and MBEDTLS_USER_CONFIG_FILE"
-#endif
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -4,7 +4,7 @@
  * \brief Build-time configuration info
  *
  *  Include this file if you need to depend on the
- *  configuration options defined in mbedtls_config.h or #MBEDTLS_CONFIG_FILE
+ *  configuration options defined in mbedtls_config.h or MBEDTLS_CONFIG_FILE
  */
  /*
   *  Copyright The Mbed TLS Contributors

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -36,13 +36,26 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#if !defined(MBEDTLS_CONFIG_VERSION) || \
+    MBEDTLS_CONFIG_VERSION != 1
+#error "Invalid config version, MBEDTLS_CONFIG_VERSION != 1"
+#endif
+
 /* Target and application specific configurations
  *
  * Allow user to override any previous default.
  *
  */
+#if defined(MBEDTLS_USER_CONFIG_VERSION)
+#error "MBEDTLS_USER_CONFIG_VERSION defined outside MBEDTLS_USER_CONFIG_FILE"
+#endif
+
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
+#if !defined(MBEDTLS_USER_CONFIG_VERSION) || \
+    MBEDTLS_USER_CONFIG_VERSION != MBEDTLS_CONFIG_VERSION
+#error "Version mismatch between config file and MBEDTLS_USER_CONFIG_FILE"
+#endif
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -4,7 +4,7 @@
  * \brief Build-time configuration info
  *
  *  Include this file if you need to depend on the
- *  configuration options defined in mbedtls_config.h
+ *  configuration options defined in mbedtls_config.h or #MBEDTLS_CONFIG_FILE
  */
  /*
   *  Copyright The Mbed TLS Contributors

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -41,15 +41,15 @@
 #error "Invalid config version, MBEDTLS_CONFIG_VERSION != 1"
 #endif
 
+#if defined(MBEDTLS_USER_CONFIG_VERSION)
+#error "MBEDTLS_USER_CONFIG_VERSION defined outside MBEDTLS_USER_CONFIG_FILE"
+#endif
+
 /* Target and application specific configurations
  *
  * Allow user to override any previous default.
  *
  */
-#if defined(MBEDTLS_USER_CONFIG_VERSION)
-#error "MBEDTLS_USER_CONFIG_VERSION defined outside MBEDTLS_USER_CONFIG_FILE"
-#endif
-
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
 #if !defined(MBEDTLS_USER_CONFIG_VERSION) || \

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -49,7 +49,11 @@
 #define MBEDTLS_VERSION_STRING         "2.26.0"
 #define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.26.0"
 
-#define MBEDTLS_CONFIG_VERSION_LATEST 1
+/**
+ * Equal to the #MBEDTLS_VERSION_NUMBER of the mbedtls version that introduced
+ * the most recent config version
+ */
+#define MBEDTLS_CONFIG_VERSION_LATEST  0x03000000
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1

--- a/include/mbedtls/build_info.h
+++ b/include/mbedtls/build_info.h
@@ -4,7 +4,7 @@
  * \brief Build-time configuration info
  *
  *  Include this file if you need to depend on the
- *  configuration options defined in config.h
+ *  configuration options defined in mbedtls_config.h
  */
  /*
   *  Copyright The Mbed TLS Contributors
@@ -31,7 +31,7 @@
 #endif
 
 #if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
+#include "mbedtls/mbedtls_config.h"
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_CAMELLIA_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -48,11 +48,7 @@
 #define MBEDTLS_CCM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cipher.h"
 

--- a/include/mbedtls/chacha20.h
+++ b/include/mbedtls/chacha20.h
@@ -33,11 +33,7 @@
 #define MBEDTLS_CHACHA20_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdint.h>
 #include <stddef.h>

--- a/include/mbedtls/chachapoly.h
+++ b/include/mbedtls/chachapoly.h
@@ -33,11 +33,7 @@
 #define MBEDTLS_CHACHAPOLY_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /* for shared error codes */
 #include "mbedtls/poly1305.h"

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -20,11 +20,6 @@
  *  limitations under the License.
  */
 
-/*
- * It is recommended to include this file from your mbedtls_config.h
- * in order to catch dependency issues early.
- */
-
 #ifndef MBEDTLS_CHECK_CONFIG_H
 #define MBEDTLS_CHECK_CONFIG_H
 

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -21,7 +21,7 @@
  */
 
 /*
- * It is recommended to include this file from your config.h
+ * It is recommended to include this file from your mbedtls_config.h
  * in order to catch dependency issues early.
  */
 
@@ -42,7 +42,7 @@
 #error "MBEDTLS_PLATFORM_C is required on Windows"
 #endif
 
-/* Fix the config here. Not convenient to put an #ifdef _WIN32 in config.h as
+/* Fix the config here. Not convenient to put an #ifdef _WIN32 in mbedtls_config.h as
  * it would confuse config.py. */
 #if !defined(MBEDTLS_PLATFORM_SNPRINTF_ALT) && \
     !defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -28,11 +28,7 @@
 #define MBEDTLS_CIPHER_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include "mbedtls/platform_util.h"

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -27,11 +27,7 @@
 #define MBEDTLS_CMAC_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cipher.h"
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -24,13 +24,6 @@
  *  limitations under the License.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-#define MBEDTLS_CONFIG_H
-
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
-#define _CRT_SECURE_NO_DEPRECATE 1
-#endif
-
 /**
  * \name SECTION: System support
  *
@@ -3263,20 +3256,3 @@
 //#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
 
 /* \} name SECTION: Customisation configuration options */
-
-/* Target and application specific configurations
- *
- * Allow user to override any previous default.
- *
- */
-#if defined(MBEDTLS_USER_CONFIG_FILE)
-#include MBEDTLS_USER_CONFIG_FILE
-#endif
-
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
-#include "mbedtls/config_psa.h"
-#endif
-
-#include "mbedtls/check_config.h"
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -3,11 +3,11 @@
  * \brief PSA crypto configuration options (set of defines)
  *
  *  This set of compile-time options takes settings defined in
- *  include/mbedtls/config.h and include/psa/crypto_config.h and uses
+ *  include/mbedtls/mbedtls_config.h and include/psa/crypto_config.h and uses
  *  those definitions to define symbols used in the library code.
  *
  *  Users and integrators should not edit this file, please edit
- *  include/mbedtls/config.h for MBETLS_XXX settings or
+ *  include/mbedtls/mbedtls_config.h for MBETLS_XXX settings or
  *  include/psa/crypto_config.h for PSA_WANT_XXX settings.
  */
 /*

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -16,7 +16,7 @@
  * The security strength as defined in NIST SP 800-90A is
  * 128 bits when AES-128 is used (\c MBEDTLS_CTR_DRBG_USE_128_BIT_KEY enabled)
  * and 256 bits otherwise, provided that #MBEDTLS_CTR_DRBG_ENTROPY_LEN is
- * kept at its default value (and not overridden in config.h) and that the
+ * kept at its default value (and not overridden in mbedtls_config.h) and that the
  * DRBG instance is set up with default parameters.
  * See the documentation of mbedtls_ctr_drbg_seed() for more
  * information.
@@ -80,7 +80,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them using the compiler command
+ * Either change them in mbedtls_config.h or define them using the compiler command
  * line.
  * \{
  */

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -42,11 +42,7 @@
 #define MBEDTLS_CTR_DRBG_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/aes.h"
 

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_DEBUG_H
 #define MBEDTLS_DEBUG_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ssl.h"
 

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -28,11 +28,7 @@
 #define MBEDTLS_DES_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -64,11 +64,7 @@
 #define MBEDTLS_DHM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 #include "mbedtls/bignum.h"
 
 /*

--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -33,11 +33,7 @@
 #define MBEDTLS_ECDH_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ecp.h"
 

--- a/include/mbedtls/ecdsa.h
+++ b/include/mbedtls/ecdsa.h
@@ -31,11 +31,7 @@
 #define MBEDTLS_ECDSA_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ecp.h"
 #include "mbedtls/md.h"

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -39,11 +39,7 @@
  * The payloads are serialized in a way suitable for use in TLS, but could
  * also be use outside TLS.
  */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ecp.h"
 #include "mbedtls/md.h"

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -91,7 +91,7 @@ extern "C" {
  * - Increment MBEDTLS_ECP_DP_MAX below if needed.
  * - Update the calculation of MBEDTLS_ECP_MAX_BITS below.
  * - Add the corresponding MBEDTLS_ECP_DP_xxx_ENABLED macro definition to
- *   config.h.
+ *   mbedtls_config.h.
  * - List the curve as a dependency of MBEDTLS_ECP_C and
  *   MBEDTLS_ECDSA_C if supported in check_config.h.
  * - Add the curve to the appropriate curve type macro
@@ -244,7 +244,7 @@ mbedtls_ecp_group;
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h, or define them using the compiler command line.
+ * Either change them in mbedtls_config.h, or define them using the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -35,11 +35,7 @@
 #define MBEDTLS_ECP_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/bignum.h"
 

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -52,7 +52,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_ENTROPY_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_ERROR_H
 #define MBEDTLS_ERROR_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -32,11 +32,7 @@
 #define MBEDTLS_GCM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cipher.h"
 

--- a/include/mbedtls/hkdf.h
+++ b/include/mbedtls/hkdf.h
@@ -25,11 +25,7 @@
 #ifndef MBEDTLS_HKDF_H
 #define MBEDTLS_HKDF_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/md.h"
 

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -27,11 +27,7 @@
 #define MBEDTLS_HMAC_DRBG_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/md.h"
 

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -47,7 +47,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -28,7 +28,7 @@
  * This is an optional version symbol that enables comatibility handling of
  * config files.
  *
- * It is equal to the #MBEDTLS_VERSION_NUMBER of the mbedtls version that
+ * It is equal to the #MBEDTLS_VERSION_NUMBER of the Mbed TLS version that
  * introduced the config format we want to be compatible with.
  */
 //#define MBEDTLS_CONFIG_VERSION 0x03000000

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1,5 +1,5 @@
 /**
- * \file config.h
+ * \file mbedtls_config.h
  *
  * \brief Configuration options (set of defines)
  *
@@ -1736,7 +1736,7 @@
  *
  * If you enable this option and write your own configuration file, you must
  * include mbedtls/config_psa.h in your configuration file. The default
- * provided mbedtls/config.h contains the necessary inclusion.
+ * provided mbedtls/mbedtls_config.h contains the necessary inclusion.
  *
  * This feature is still experimental and is not ready for production since
  * it is not completed.

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1743,10 +1743,6 @@
  * Uncomment this to enable use of PSA Crypto configuration settings which
  * can be found in include/psa/crypto_config.h.
  *
- * If you enable this option and write your own configuration file, you must
- * include mbedtls/config_psa.h in your configuration file. The default
- * provided mbedtls/mbedtls_config.h contains the necessary inclusion.
- *
  * This feature is still experimental and is not ready for production since
  * it is not completed.
  */

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -25,8 +25,6 @@
  */
 
 /**
- * \def MBEDTLS_CONFIG_VERSION
- *
  * This is an optional version symbol that enables comatibility handling of
  * config files.
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -24,6 +24,8 @@
  *  limitations under the License.
  */
 
+#define MBEDTLS_CONFIG_VERSION 1
+
 /**
  * \name SECTION: System support
  *

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -24,7 +24,14 @@
  *  limitations under the License.
  */
 
-#define MBEDTLS_CONFIG_VERSION 1
+/**
+ * This is an optional version symbol that enables comatibility handling of
+ * config files.
+ *
+ * It is equal to the #MBEDTLS_VERSION_NUMBER of the mbedtls version that
+ * introduced the config format we want to be compatible with.
+ */
+#define MBEDTLS_CONFIG_VERSION 0x03000000
 
 /**
  * \name SECTION: System support

--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -25,13 +25,15 @@
  */
 
 /**
+ * \def MBEDTLS_CONFIG_VERSION
+ *
  * This is an optional version symbol that enables comatibility handling of
  * config files.
  *
  * It is equal to the #MBEDTLS_VERSION_NUMBER of the mbedtls version that
  * introduced the config format we want to be compatible with.
  */
-#define MBEDTLS_CONFIG_VERSION 0x03000000
+//#define MBEDTLS_CONFIG_VERSION 0x03000000
 
 /**
  * \name SECTION: System support

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -28,11 +28,7 @@
 
 #include <stddef.h>
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -27,11 +27,7 @@
 #define MBEDTLS_MD5_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/memory_buffer_alloc.h
+++ b/include/mbedtls/memory_buffer_alloc.h
@@ -30,7 +30,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/memory_buffer_alloc.h
+++ b/include/mbedtls/memory_buffer_alloc.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_MEMORY_BUFFER_ALLOC_H
 #define MBEDTLS_MEMORY_BUFFER_ALLOC_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -39,11 +39,7 @@
 #define MBEDTLS_NET_SOCKETS_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ssl.h"
 

--- a/include/mbedtls/nist_kw.h
+++ b/include/mbedtls/nist_kw.h
@@ -36,11 +36,7 @@
 #define MBEDTLS_NIST_KW_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cipher.h"
 

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_OID_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"

--- a/include/mbedtls/pem.h
+++ b/include/mbedtls/pem.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_PEM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -24,11 +24,7 @@
 #define MBEDTLS_PK_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/md.h"
 

--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_PKCS12_H
 #define MBEDTLS_PKCS12_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/md.h"
 #include "mbedtls/cipher.h"

--- a/include/mbedtls/pkcs5.h
+++ b/include/mbedtls/pkcs5.h
@@ -24,11 +24,7 @@
 #ifndef MBEDTLS_PKCS5_H
 #define MBEDTLS_PKCS5_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/md.h"

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -32,11 +32,7 @@
 #define MBEDTLS_PLATFORM_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -46,7 +46,7 @@ extern "C" {
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_PLATFORM_TIME_H
 #define MBEDTLS_PLATFORM_TIME_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -32,7 +32,7 @@ extern "C" {
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -23,11 +23,7 @@
 #ifndef MBEDTLS_PLATFORM_UTIL_H
 #define MBEDTLS_PLATFORM_UTIL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #if defined(MBEDTLS_HAVE_TIME_DATE)

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -33,11 +33,7 @@
 #define MBEDTLS_POLY1305_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdint.h>
 #include <stddef.h>

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -27,11 +27,7 @@
 #define MBEDTLS_PSA_UTIL_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_RIPEMD160_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -29,11 +29,7 @@
 #define MBEDTLS_RSA_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/bignum.h"
 #include "mbedtls/md.h"

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -30,11 +30,7 @@
 #define MBEDTLS_SHA1_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -26,11 +26,7 @@
 #define MBEDTLS_SHA256_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -25,11 +25,7 @@
 #define MBEDTLS_SHA512_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -211,7 +211,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 
@@ -3539,7 +3539,7 @@ int mbedtls_ssl_get_record_expansion( const mbedtls_ssl_context *ssl );
  *
  * \note           The logic to determine the maximum outgoing record payload is
  *                 version-specific. It takes into account various factors, such as
- *                 the config.h setting \c MBEDTLS_SSL_OUT_CONTENT_LEN, extensions
+ *                 the mbedtls_config.h setting \c MBEDTLS_SSL_OUT_CONTENT_LEN, extensions
  *                 such as the max fragment length or record size limit extension if
  *                 used, and for DTLS the path MTU as configured and current
  *                 record expansion.
@@ -3566,7 +3566,7 @@ int mbedtls_ssl_get_max_out_record_payload( const mbedtls_ssl_context *ssl );
  *
  * \note           The logic to determine the maximum outgoing record payload is
  *                 version-specific. It takes into account various factors, such as
- *                 the config.h setting \c MBEDTLS_SSL_IN_CONTENT_LEN, extensions
+ *                 the mbedtls_config.h setting \c MBEDTLS_SSL_IN_CONTENT_LEN, extensions
  *                 such as the max fragment length extension or record size limit
  *                 extension if used, and the current record expansion.
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_SSL_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/bignum.h"
 #include "mbedtls/ecp.h"

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -35,7 +35,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_SSL_CACHE_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ssl.h"
 

--- a/include/mbedtls/ssl_ciphersuites.h
+++ b/include/mbedtls/ssl_ciphersuites.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_SSL_CIPHERSUITES_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/pk.h"
 #include "mbedtls/cipher.h"

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -35,7 +35,7 @@
  * \name SECTION: Module settings
  *
  * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
+ * Either change them in mbedtls_config.h or define them on the compiler command line.
  * \{
  */
 #ifndef MBEDTLS_SSL_COOKIE_TIMEOUT

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_SSL_COOKIE_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ssl.h"
 

--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_SSL_TICKET_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /*
  * This implementation of the session ticket callbacks includes key

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_THREADING_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdlib.h>
 

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_TIMING_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdint.h>
 

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -20,30 +20,14 @@
  *  limitations under the License.
  */
 /*
- * This set of compile-time defines and run-time variables can be used to
- * determine the version number of the mbed TLS library used.
+ * This set of run-time variables can be used to determine the version number of
+ * the mbed TLS library used. Compile-time version defines for the same can be
+ * found in build_info.h
  */
 #ifndef MBEDTLS_VERSION_H
 #define MBEDTLS_VERSION_H
 
 #include "mbedtls/build_info.h"
-
-/**
- * The version number x.y.z is split into three parts.
- * Major, Minor, Patchlevel
- */
-#define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  26
-#define MBEDTLS_VERSION_PATCH  0
-
-/**
- * The single version number has the following structure:
- *    MMNNPP00
- *    Major version | Minor version | Patch version
- */
-#define MBEDTLS_VERSION_NUMBER         0x021A0000
-#define MBEDTLS_VERSION_STRING         "2.26.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.26.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -26,11 +26,7 @@
 #ifndef MBEDTLS_VERSION_H
 #define MBEDTLS_VERSION_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /**
  * The version number x.y.z is split into three parts.

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -21,7 +21,7 @@
  */
 /*
  * This set of run-time variables can be used to determine the version number of
- * the mbed TLS library used. Compile-time version defines for the same can be
+ * the Mbed TLS library used. Compile-time version defines for the same can be
  * found in build_info.h
  */
 #ifndef MBEDTLS_VERSION_H

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -86,7 +86,7 @@ void mbedtls_version_get_string_full( char *string );
  *
  * \note            only checks against defines in the sections "System
  *                  support", "mbed TLS modules" and "mbed TLS feature
- *                  support" in config.h
+ *                  support" in mbedtls_config.h
  *
  * \param feature   The string for the define to check (e.g. "MBEDTLS_AES_C")
  *

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_X509_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_X509_CRL_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/x509.h"
 

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_X509_CRT_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/x509.h"
 #include "mbedtls/x509_crl.h"

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -23,11 +23,7 @@
 #define MBEDTLS_X509_CSR_H
 #include "mbedtls/private_access.h"
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/x509.h"
 

--- a/include/psa/crypto_config.h
+++ b/include/psa/crypto_config.h
@@ -5,7 +5,7 @@
  */
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
 /**
- * When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled in config.h,
+ * When #MBEDTLS_PSA_CRYPTO_CONFIG is enabled in mbedtls_config.h,
  * this file determines which cryptographic mechanisms are enabled
  * through the PSA Cryptography API (\c psa_xxx() functions).
  *
@@ -24,7 +24,7 @@
  */
 #else
 /**
- * When \c MBEDTLS_PSA_CRYPTO_CONFIG is disabled in config.h,
+ * When \c MBEDTLS_PSA_CRYPTO_CONFIG is disabled in mbedtls_config.h,
  * this file is not used, and cryptographic mechanisms are supported
  * through the PSA API if and only if they are supported through the
  * mbedtls_xxx API.

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -40,7 +40,7 @@ extern "C" {
 /* UID for secure storage seed */
 #define PSA_CRYPTO_ITS_RANDOM_SEED_UID 0xFFFFFF52
 
-/* See config.h for definition */
+/* See mbedtls_config.h for definition */
 #if !defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
 #define MBEDTLS_PSA_KEY_SLOT_COUNT 32
 #endif

--- a/include/psa/crypto_platform.h
+++ b/include/psa/crypto_platform.h
@@ -36,11 +36,7 @@
 
 /* Include the Mbed TLS configuration file, the way Mbed TLS does it
  * in each of its header files. */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /* Translate between classic MBEDTLS_xxx feature symbols and PSA_xxx
  * feature symbols. */

--- a/include/psa/crypto_sizes.h
+++ b/include/psa/crypto_sizes.h
@@ -42,11 +42,7 @@
 
 /* Include the Mbed TLS configuration file, the way Mbed TLS does it
  * in each of its header files. */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #define PSA_BITS_TO_BYTES(bits) (((bits) + 7) / 8)
 #define PSA_BYTES_TO_BITS(bytes) ((bytes) * 8)

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -68,11 +68,7 @@ extern "C" {
 
 /* Include the Mbed TLS configuration file, the way Mbed TLS does it
  * in each of its header files. */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cmac.h"
 #include "mbedtls/gcm.h"

--- a/library/Makefile
+++ b/library/Makefile
@@ -1,5 +1,5 @@
 
-# Also see "include/mbedtls/config.h"
+# Also see "include/mbedtls/mbedtls_config.h"
 
 CFLAGS	?= -O2
 WARNING_CFLAGS ?=  -Wall -Wextra -Wformat=2 -Wno-format-nonliteral
@@ -281,12 +281,12 @@ error.c:
 
 version_features.c: ../scripts/generate_features.pl
 version_features.c: ../scripts/data_files/version_features.fmt
-## The generated file only depends on the options that are present in config.h,
+## The generated file only depends on the options that are present in mbedtls_config.h,
 ## not on which options are set. To avoid regenerating this file all the time
-## when switching between configurations, don't declare config.h as a
+## when switching between configurations, don't declare mbedtls_config.h as a
 ## dependency. Remove this file from your working tree if you've just added or
-## removed an option in config.h.
-#version_features.c: ../include/mbedtls/config.h
+## removed an option in mbedtls_config.h.
+#version_features.c: ../include/mbedtls/mbedtls_config.h
 version_features.c:
 	echo "  Gen   $@"
 	$(PERL) ../scripts/generate_features.pl

--- a/library/aesni.h
+++ b/library/aesni.h
@@ -25,11 +25,7 @@
 #ifndef MBEDTLS_AESNI_H
 #define MBEDTLS_AESNI_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/aes.h"
 

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -36,11 +36,7 @@
 #ifndef MBEDTLS_BN_MUL_H
 #define MBEDTLS_BN_MUL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/bignum.h"
 

--- a/library/cipher_wrap.h
+++ b/library/cipher_wrap.h
@@ -24,11 +24,7 @@
 #ifndef MBEDTLS_CIPHER_WRAP_H
 #define MBEDTLS_CIPHER_WRAP_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/cipher.h"
 

--- a/library/common.h
+++ b/library/common.h
@@ -23,11 +23,7 @@
 #ifndef MBEDTLS_LIBRARY_COMMON_H
 #define MBEDTLS_LIBRARY_COMMON_H
 
-#if defined(MBEDTLS_CONFIG_FILE)
-#include MBEDTLS_CONFIG_FILE
-#else
-#include "mbedtls/config.h"
-#endif
+#include "mbedtls/build_info.h"
 
 /** Helper to define a function as static except when building invasive tests.
  *

--- a/library/ecp_internal_alt.h
+++ b/library/ecp_internal_alt.h
@@ -59,11 +59,7 @@
 #ifndef MBEDTLS_ECP_INTERNAL_H
 #define MBEDTLS_ECP_INTERNAL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_ECP_INTERNAL_ALT)
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -44,7 +44,7 @@
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
     !defined(__HAIKU__) && !defined(__midipix__)
-#error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in config.h"
+#error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h"
 #endif
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)

--- a/library/entropy_poll.h
+++ b/library/entropy_poll.h
@@ -51,7 +51,7 @@ int mbedtls_platform_entropy_poll( void *data,
  * \brief           Entropy poll callback for a hardware source
  *
  * \warning         This is not provided by mbed TLS!
- *                  See \c MBEDTLS_ENTROPY_HARDWARE_ALT in config.h.
+ *                  See \c MBEDTLS_ENTROPY_HARDWARE_ALT in mbedtls_config.h.
  *
  * \note            This must accept NULL as its first argument.
  */

--- a/library/entropy_poll.h
+++ b/library/entropy_poll.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_ENTROPY_POLL_H
 #define MBEDTLS_ENTROPY_POLL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/library/md_wrap.h
+++ b/library/md_wrap.h
@@ -26,11 +26,7 @@
 #ifndef MBEDTLS_MD_WRAP_H
 #define MBEDTLS_MD_WRAP_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/md.h"
 

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -18,7 +18,7 @@
  */
 
 /* Enable definition of getaddrinfo() even when compiling with -std=c99. Must
- * be set before config.h, which pulls in glibc's features.h indirectly.
+ * be set before mbedtls_config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
@@ -34,7 +34,7 @@
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
     !defined(__HAIKU__) && !defined(__midipix__)
-#error "This module only works on Unix and Windows, see MBEDTLS_NET_C in config.h"
+#error "This module only works on Unix and Windows, see MBEDTLS_NET_C in mbedtls_config.h"
 #endif
 
 #if defined(MBEDTLS_PLATFORM_C)

--- a/library/padlock.h
+++ b/library/padlock.h
@@ -26,11 +26,7 @@
 #ifndef MBEDTLS_PADLOCK_H
 #define MBEDTLS_PADLOCK_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/aes.h"
 

--- a/library/pk_wrap.h
+++ b/library/pk_wrap.h
@@ -23,11 +23,7 @@
 #ifndef MBEDTLS_PK_WRAP_H
 #define MBEDTLS_PK_WRAP_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/pk.h"
 

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -20,7 +20,7 @@
 
 /*
  * Ensure gmtime_r is available even with -std=c99; must be defined before
- * config.h, which pulls in glibc's features.h. Harmless on other platforms.
+ * mbedtls_config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
 #if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -21,11 +21,7 @@
 #ifndef PSA_CRYPTO_CORE_H
 #define PSA_CRYPTO_CORE_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"

--- a/library/psa_crypto_invasive.h
+++ b/library/psa_crypto_invasive.h
@@ -28,11 +28,7 @@
 #ifndef PSA_CRYPTO_INVASIVE_H
 #define PSA_CRYPTO_INVASIVE_H
 
-#if defined(MBEDTLS_CONFIG_FILE)
-#include MBEDTLS_CONFIG_FILE
-#else
-#include "mbedtls/config.h"
-#endif
+#include "mbedtls/build_info.h"
 
 #include "psa/crypto.h"
 #include "common.h"

--- a/library/psa_crypto_se.h
+++ b/library/psa_crypto_se.h
@@ -21,11 +21,7 @@
 #ifndef PSA_CRYPTO_SE_H
 #define PSA_CRYPTO_SE_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"

--- a/library/rsa_alt_helpers.h
+++ b/library/rsa_alt_helpers.h
@@ -55,11 +55,7 @@
 #ifndef MBEDTLS_RSA_INTERNAL_H
 #define MBEDTLS_RSA_INTERNAL_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/bignum.h"
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_SSL_MISC_H
 #define MBEDTLS_SSL_MISC_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/ssl.h"
 #include "mbedtls/cipher.h"

--- a/library/threading.c
+++ b/library/threading.c
@@ -19,7 +19,7 @@
 
 /*
  * Ensure gmtime_r is available even with -std=c99; must be defined before
- * config.h, which pulls in glibc's features.h. Harmless on other platforms.
+ * mbedtls_config.h, which pulls in glibc's features.h. Harmless on other platforms.
  */
 #if !defined(_POSIX_C_SOURCE)
 #define _POSIX_C_SOURCE 200112L

--- a/library/timing.c
+++ b/library/timing.c
@@ -28,7 +28,7 @@
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
     !defined(__HAIKU__) && !defined(__midipix__)
-#error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in config.h"
+#error "This module only works on Unix and Windows, see MBEDTLS_TIMING_C in mbedtls_config.h"
 #endif
 
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -153,12 +153,12 @@ psa/psa_constant_names_generated.c:
 	$(PYTHON) ../scripts/generate_psa_constants.py
 
 test/query_config.c: ../scripts/generate_query_config.pl
-## The generated file only depends on the options that are present in config.h,
+## The generated file only depends on the options that are present in mbedtls_config.h,
 ## not on which options are set. To avoid regenerating this file all the time
-## when switching between configurations, don't declare config.h as a
+## when switching between configurations, don't declare mbedtls_config.h as a
 ## dependency. Remove this file from your working tree if you've just added or
-## removed an option in config.h.
-#test/query_config.c: ../include/mbedtls/config.h
+## removed an option in mbedtls_config.h.
+#test/query_config.c: ../include/mbedtls/mbedtls_config.h
 test/query_config.c: ../scripts/data_files/query_config.fmt
 test/query_config.c:
 	echo "  Gen   $@"

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -19,7 +19,7 @@
  */
 
 /* Enable definition of fileno() even when compiling with -std=c99. Must be
- * set before config.h, which pulls in glibc's features.h indirectly.
+ * set before mbedtls_config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
 

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -23,11 +23,7 @@
  * Harmless on other platforms. */
 #define _POSIX_C_SOURCE 200112L
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/fuzz/onefile.c
+++ b/programs/fuzz/onefile.c
@@ -5,11 +5,7 @@
 /* This file doesn't use any Mbed TLS function, but grab config.h anyway
  * in case it contains platform-specific #defines related to malloc or
  * stdio functions. */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
 

--- a/programs/fuzz/onefile.c
+++ b/programs/fuzz/onefile.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-/* This file doesn't use any Mbed TLS function, but grab config.h anyway
+/* This file doesn't use any Mbed TLS function, but grab mbedtls_config.h anyway
  * in case it contains platform-specific #defines related to malloc or
  * stdio functions. */
 #include "mbedtls/build_info.h"

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/mpi_demo.c
+++ b/programs/pkey/mpi_demo.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -50,11 +50,7 @@
 /* First include Mbed TLS headers to get the Mbed TLS configuration and
  * platform definitions that we'll use in this program. Also include
  * standard C headers for functions we'll use here. */
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -18,11 +18,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -19,11 +19,7 @@
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -24,11 +24,7 @@
 #define _POSIX_C_SOURCE 200112L
 #define _XOPEN_SOURCE 600
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -18,7 +18,7 @@
  */
 
 /* Enable definition of gethostname() even when compiling with -std=c99. Must
- * be set before config.h, which pulls in glibc's features.h indirectly.
+ * be set before mbedtls_config.h, which pulls in glibc's features.h indirectly.
  * Harmless on other platforms. */
 
 #define _POSIX_C_SOURCE 200112L

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -18,11 +18,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -20,11 +20,7 @@
 #ifndef MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
 #define MBEDTLS_PROGRAMS_SSL_SSL_TEST_LIB_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -19,11 +19,7 @@
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/platform.h"
 #if !defined(MBEDTLS_PLATFORM_C)

--- a/programs/test/cmake_package/cmake_package.c
+++ b/programs/test/cmake_package/cmake_package.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/cmake_package_install/cmake_package_install.c
+++ b/programs/test/cmake_package_install/cmake_package_install.c
@@ -18,11 +18,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/cmake_subproject/cmake_subproject.c
+++ b/programs/test/cmake_subproject/cmake_subproject.c
@@ -18,11 +18,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/cpp_dummy_build.cpp
+++ b/programs/test/cpp_dummy_build.cpp
@@ -18,11 +18,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/aes.h"
 #include "mbedtls/aria.h"

--- a/programs/test/query_compile_time_config.c
+++ b/programs/test/query_compile_time_config.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/query_config.h
+++ b/programs/test/query_config.h
@@ -20,11 +20,7 @@
 #ifndef MBEDTLS_PROGRAMS_TEST_QUERY_CONFIG_H
 #define MBEDTLS_PROGRAMS_TEST_QUERY_CONFIG_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /** Check whether a given configuration symbol is enabled.
  *

--- a/programs/test/query_config.h
+++ b/programs/test/query_config.h
@@ -1,5 +1,5 @@
 /*
- *  Query Mbed TLS compile time configurations from config.h
+ *  Query Mbed TLS compile time configurations from mbedtls_config.h
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
@@ -26,7 +26,7 @@
  *
  * \param config    The symbol to query (e.g. "MBEDTLS_RSA_C").
  * \return          \c 0 if the symbol was defined at compile time
- *                  (in MBEDTLS_CONFIG_FILE or config.h),
+ *                  (in MBEDTLS_CONFIG_FILE or mbedtls_config.h),
  *                  \c 1 otherwise.
  *
  * \note            This function is defined in `programs/test/query_config.c`

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -19,11 +19,7 @@
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "mbedtls/entropy.h"
 #include "mbedtls/hmac_drbg.h"

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -25,11 +25,7 @@
 
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/test/zeroize.c
+++ b/programs/test/zeroize.c
@@ -25,11 +25,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdio.h>
 

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/util/strerror.c
+++ b/programs/util/strerror.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"

--- a/scripts/apidoc_full.sh
+++ b/scripts/apidoc_full.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Generate doxygen documentation with a full config.h (this ensures that every
+# Generate doxygen documentation with a full mbedtls_config.h (this ensures that every
 # available flag is documented, and avoids warnings about documentation
 # without a corresponding #define).
 #
@@ -24,7 +24,7 @@
 
 set -eu
 
-CONFIG_H='include/mbedtls/config.h'
+CONFIG_H='include/mbedtls/mbedtls_config.h'
 
 if [ -r $CONFIG_H ]; then :; else
     echo "$CONFIG_H not found" >&2

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -26,14 +26,14 @@ import os
 import re
 
 class Setting:
-    """Representation of one Mbed TLS config.h setting.
+    """Representation of one Mbed TLS mbedtls_config.h setting.
 
     Fields:
     * name: the symbol name ('MBEDTLS_xxx').
     * value: the value of the macro. The empty string for a plain #define
       with no value.
     * active: True if name is defined, False if a #define for name is
-      present in config.h but commented out.
+      present in mbedtls_config.h but commented out.
     * section: the name of the section that contains this symbol.
     """
     # pylint: disable=too-few-public-methods
@@ -321,7 +321,7 @@ class ConfigFile(Config):
     and modify the configuration.
     """
 
-    _path_in_tree = 'include/mbedtls/config.h'
+    _path_in_tree = 'include/mbedtls/mbedtls_config.h'
     default_path = [_path_in_tree,
                     os.path.join(os.path.dirname(__file__),
                                  os.pardir,
@@ -363,7 +363,7 @@ class ConfigFile(Config):
     _config_line_regexp = re.compile(r'|'.join([_define_line_regexp,
                                                 _section_line_regexp]))
     def _parse_line(self, line):
-        """Parse a line in config.h and return the corresponding template."""
+        """Parse a line in mbedtls_config.h and return the corresponding template."""
         line = line.rstrip('\r\n')
         m = re.match(self._config_line_regexp, line)
         if m is None:
@@ -384,7 +384,7 @@ class ConfigFile(Config):
             return template
 
     def _format_template(self, name, indent, middle):
-        """Build a line for config.h for the given setting.
+        """Build a line for mbedtls_config.h for the given setting.
 
         The line has the form "<indent>#define <name> <value>"
         where <middle> is "#define <name> ".
@@ -428,7 +428,7 @@ class ConfigFile(Config):
 
 if __name__ == '__main__':
     def main():
-        """Command line config.h manipulation tool."""
+        """Command line mbedtls_config.h manipulation tool."""
         parser = argparse.ArgumentParser(description="""
         Mbed TLS and Mbed Crypto configuration file manipulation tool.
         """)

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -17,11 +17,7 @@
  *  limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include "query_config.h"
 

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -1,5 +1,5 @@
 /*
- *  Query Mbed TLS compile time configurations from config.h
+ *  Query Mbed TLS compile time configurations from mbedtls_config.h
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
@@ -30,7 +30,7 @@
 
 /*
  * Include all the headers with public APIs in case they define a macro to its
- * default value when that configuration is not set in the config.h.
+ * default value when that configuration is not set in the mbedtls_config.h.
  */
 #include "mbedtls/aes.h"
 #include "mbedtls/aria.h"

--- a/scripts/ecc-heap.sh
+++ b/scripts/ecc-heap.sh
@@ -24,7 +24,7 @@
 
 set -eu
 
-CONFIG_H='include/mbedtls/config.h'
+CONFIG_H='include/mbedtls/mbedtls_config.h'
 
 if [ -r $CONFIG_H ]; then :; else
     echo "$CONFIG_H not found" >&2
@@ -37,7 +37,7 @@ if grep -i cmake Makefile >/dev/null; then :; else
 fi
 
 if git status | grep -F $CONFIG_H >/dev/null 2>&1; then
-    echo "config.h not clean" >&2
+    echo "mbedtls_config.h not clean" >&2
     exit 1
 fi
 

--- a/scripts/ecc-heap.sh
+++ b/scripts/ecc-heap.sh
@@ -66,8 +66,6 @@ cat << EOF >$CONFIG_H
 #define MBEDTLS_ECP_DP_SECP521R1_ENABLED
 #define MBEDTLS_ECP_DP_CURVE25519_ENABLED
 
-#include "check_config.h"
-
 //#define MBEDTLS_ECP_WINDOW_SIZE            6
 //#define MBEDTLS_ECP_FIXED_POINT_OPTIM      1
 EOF

--- a/scripts/ecp_comb_table.py
+++ b/scripts/ecp_comb_table.py
@@ -126,7 +126,7 @@ int main()
     }
     if ( grp.T == NULL ) {
         fprintf( stderr, "grp.T is not generated. Please make sure"
-                         "MBEDTLS_ECP_FIXED_POINT_OPTIM is enabled in config.h\n" );
+                         "MBEDTLS_ECP_FIXED_POINT_OPTIM is enabled in mbedtls_config.h\n" );
         return 1;
     }
     dump_T( &grp );

--- a/scripts/footprint.sh
+++ b/scripts/footprint.sh
@@ -21,7 +21,7 @@
 # configurations, when built for a Cortex M3/M4 target.
 #
 # Configurations included:
-#   default    include/mbedtls/config.h
+#   default    include/mbedtls/mbedtls_config.h
 #   thread     configs/config-thread.h
 #   suite-b    configs/config-suite-b.h
 #   psk        configs/config-ccm-psk-tls1_2.h
@@ -30,7 +30,7 @@
 #
 set -eu
 
-CONFIG_H='include/mbedtls/config.h'
+CONFIG_H='include/mbedtls/mbedtls_config.h'
 
 if [ -r $CONFIG_H ]; then :; else
     echo "$CONFIG_H not found" >&2
@@ -112,7 +112,7 @@ log "mbed TLS $MBEDTLS_VERSION$GIT_VERSION"
 log "$( arm-none-eabi-gcc --version | head -n1 )"
 log "CFLAGS=$ARMGCC_FLAGS"
 
-doit default    include/mbedtls/config.h
+doit default    include/mbedtls/mbedtls_config.h
 doit thread     configs/config-thread.h
 doit suite-b    configs/config-suite-b.h
 doit psk        configs/config-ccm-psk-tls1_2.h

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -51,7 +51,7 @@ close(FORMAT_FILE);
 
 $/ = $line_separator;
 
-open(CONFIG_H, '<:crlf', "$include_dir/config.h") || die("Failure when opening config.h: $!");
+open(CONFIG_H, '<:crlf', "$include_dir/mbedtls_config.h") || die("Failure when opening mbedtls_config.h: $!");
 
 my $feature_defines = "";
 my $in_section = 0;

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -8,9 +8,9 @@
 # the library, for example, for testing.
 #
 # The query_config.c is generated from the current configuration at
-# include/mbedtls/config.h. The idea is that the config.h contains ALL the
+# include/mbedtls/mbedtls_config.h. The idea is that the mbedtls_config.h contains ALL the
 # compile time configurations available in Mbed TLS (commented or uncommented).
-# This script extracts the configuration macros from the config.h and this
+# This script extracts the configuration macros from the mbedtls_config.h and this
 # information is used to automatically generate the body of the query_config()
 # function by using the template in scripts/data_files/query_config.fmt.
 #
@@ -33,7 +33,7 @@
 
 use strict;
 
-my $config_file = "./include/mbedtls/config.h";
+my $config_file = "./include/mbedtls/mbedtls_config.h";
 
 my $query_config_format_file = "./scripts/data_files/query_config.fmt";
 my $query_config_file = "./programs/test/query_config.c";

--- a/scripts/generate_query_config.pl
+++ b/scripts/generate_query_config.pl
@@ -63,9 +63,6 @@ while (my $line = <CONFIG_FILE>) {
     if ($line =~ /^(\/\/)?\s*#\s*define\s+(MBEDTLS_\w+).*/) {
         my $name = $2;
 
-        # Skip over the macro that prevents multiple inclusion
-        next if "MBEDTLS_CONFIG_H" eq $name;
-
         # Skip over the macro if it is in the ecluded list
         next if $name =~ /$excluded_re/;
 

--- a/scripts/memory.sh
+++ b/scripts/memory.sh
@@ -23,7 +23,7 @@
 
 set -eu
 
-CONFIG_H='include/mbedtls/config.h'
+CONFIG_H='include/mbedtls/mbedtls_config.h'
 
 CLIENT='mini_client'
 
@@ -46,7 +46,7 @@ if [ $( uname ) != Linux ]; then
 fi
 
 if git status | grep -F $CONFIG_H >/dev/null 2>&1; then
-    echo "config.h not clean" >&2
+    echo "mbedtls_config.h not clean" >&2
     exit 1
 fi
 

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -74,7 +74,7 @@ FILTER=""
 # exclude:
 # - NULL: excluded from our default config
 #   avoid plain DES but keep 3DES-EDE-CBC (mbedTLS), DES-CBC3 (OpenSSL)
-# - ARIA: not in default config.h + requires OpenSSL >= 1.1.1
+# - ARIA: not in default mbedtls_config.h + requires OpenSSL >= 1.1.1
 # - ChachaPoly: requires OpenSSL >= 1.1.0
 # - 3DES: not in default config
 EXCLUDE='NULL\|DES\|ARIA\|CHACHA20-POLY1305'

--- a/tests/configs/config-wrapper-malloc-0-null.h
+++ b/tests/configs/config-wrapper-malloc-0-null.h
@@ -18,9 +18,6 @@
  *  limitations under the License.
  */
 
-#ifndef MBEDTLS_CONFIG_H
-/* Don't #define MBEDTLS_CONFIG_H, let config.h do it. */
-
 #include "mbedtls/config.h"
 
 #include <stdlib.h>
@@ -33,5 +30,3 @@ static inline void *custom_calloc( size_t nmemb, size_t size )
 
 #define MBEDTLS_PLATFORM_MEMORY
 #define MBEDTLS_PLATFORM_STD_CALLOC custom_calloc
-
-#endif /* MBEDTLS_CONFIG_H */

--- a/tests/configs/config-wrapper-malloc-0-null.h
+++ b/tests/configs/config-wrapper-malloc-0-null.h
@@ -1,4 +1,4 @@
-/* config.h wrapper that forces calloc(0) to return NULL.
+/* mbedtls_config.h wrapper that forces calloc(0) to return NULL.
  * Used for testing.
  */
 /*
@@ -18,7 +18,7 @@
  *  limitations under the License.
  */
 
-#include "mbedtls/config.h"
+#include "mbedtls/mbedtls_config.h"
 
 #include <stdlib.h>
 static inline void *custom_calloc( size_t nmemb, size_t size )

--- a/tests/include/test/certs.h
+++ b/tests/include/test/certs.h
@@ -22,11 +22,7 @@
 #ifndef MBEDTLS_CERTS_H
 #define MBEDTLS_CERTS_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 

--- a/tests/include/test/constant_flow.h
+++ b/tests/include/test/constant_flow.h
@@ -24,11 +24,7 @@
 #ifndef TEST_CONSTANT_FLOW_H
 #define TEST_CONSTANT_FLOW_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /*
  * This file defines the two macros

--- a/tests/include/test/drivers/aead.h
+++ b/tests/include/test/drivers/aead.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_AEAD_H
 #define PSA_CRYPTO_TEST_DRIVERS_AEAD_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/cipher.h
+++ b/tests/include/test/drivers/cipher.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_CIPHER_H
 #define PSA_CRYPTO_TEST_DRIVERS_CIPHER_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/hash.h
+++ b/tests/include/test/drivers/hash.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_HASH_H
 #define PSA_CRYPTO_TEST_DRIVERS_HASH_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/key_management.h
+++ b/tests/include/test/drivers/key_management.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_KEY_MANAGEMENT_H
 #define PSA_CRYPTO_TEST_DRIVERS_KEY_MANAGEMENT_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/mac.h
+++ b/tests/include/test/drivers/mac.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_MAC_H
 #define PSA_CRYPTO_TEST_DRIVERS_MAC_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/signature.h
+++ b/tests/include/test/drivers/signature.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_SIGNATURE_H
 #define PSA_CRYPTO_TEST_DRIVERS_SIGNATURE_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/drivers/size.h
+++ b/tests/include/test/drivers/size.h
@@ -20,11 +20,7 @@
 #ifndef PSA_CRYPTO_TEST_DRIVERS_SIZE_H
 #define PSA_CRYPTO_TEST_DRIVERS_SIZE_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(PSA_CRYPTO_DRIVER_TEST)
 #include <psa/crypto_driver_common.h>

--- a/tests/include/test/fake_external_rng_for_test.h
+++ b/tests/include/test/fake_external_rng_for_test.h
@@ -22,11 +22,7 @@
 #ifndef FAKE_EXTERNAL_RNG_FOR_TEST_H
 #define FAKE_EXTERNAL_RNG_FOR_TEST_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 /** Enable the insecure implementation of mbedtls_psa_external_get_random().

--- a/tests/include/test/helpers.h
+++ b/tests/include/test/helpers.h
@@ -30,11 +30,7 @@
  * directly (without using the MBEDTLS_PRIVATE wrapper). */
 #define MBEDTLS_ALLOW_PRIVATE_ACCESS
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_THREADING_C) && defined(MBEDTLS_THREADING_PTHREAD) && \
     defined(MBEDTLS_TEST_HOOKS)

--- a/tests/include/test/macros.h
+++ b/tests/include/test/macros.h
@@ -24,11 +24,7 @@
 #ifndef TEST_MACROS_H
 #define TEST_MACROS_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stdlib.h>
 

--- a/tests/include/test/random.h
+++ b/tests/include/test/random.h
@@ -25,11 +25,7 @@
 #ifndef TEST_RANDOM_H
 #define TEST_RANDOM_H
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -85,7 +85,7 @@
 # means that components can assume that the working directory is in a
 # cleaned-up state, and don't need to perform the cleanup themselves.
 # * Run `make clean`.
-# * Restore `include/mbedtks/mbedtls_config.h` from a backup made before running
+# * Restore `include/mbedtls/mbedtls_config.h` from a backup made before running
 #   the component.
 # * Check out `Makefile`, `library/Makefile`, `programs/Makefile`,
 #   `tests/Makefile` and `programs/fuzz/Makefile` from git.

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -34,7 +34,7 @@
 # Warning: the test is destructive. It includes various build modes and
 # configurations, and can and will arbitrarily change the current CMake
 # configuration. The following files must be committed into git:
-#    * include/mbedtls/config.h
+#    * include/mbedtls/mbedtls_config.h
 #    * Makefile, library/Makefile, programs/Makefile, tests/Makefile,
 #      programs/fuzz/Makefile
 # After running this script, the CMake cache will be lost and CMake
@@ -85,7 +85,7 @@
 # means that components can assume that the working directory is in a
 # cleaned-up state, and don't need to perform the cleanup themselves.
 # * Run `make clean`.
-# * Restore `include/mbedtks/config.h` from a backup made before running
+# * Restore `include/mbedtks/mbedtls_config.h` from a backup made before running
 #   the component.
 # * Check out `Makefile`, `library/Makefile`, `programs/Makefile`,
 #   `tests/Makefile` and `programs/fuzz/Makefile` from git.
@@ -125,7 +125,7 @@ pre_check_environment () {
 }
 
 pre_initialize_variables () {
-    CONFIG_H='include/mbedtls/config.h'
+    CONFIG_H='include/mbedtls/mbedtls_config.h'
     CONFIG_BAK="$CONFIG_H.bak"
     CRYPTO_CONFIG_H='include/psa/crypto_config.h'
     CRYPTO_CONFIG_BAK="$CRYPTO_CONFIG_H.bak"
@@ -463,8 +463,8 @@ pre_check_git () {
             exit 1
         fi
 
-        if ! git diff --quiet include/mbedtls/config.h; then
-            err_msg "Warning - the configuration file 'include/mbedtls/config.h' has been edited. "
+        if ! git diff --quiet include/mbedtls/mbedtls_config.h; then
+            err_msg "Warning - the configuration file 'include/mbedtls/mbedtls_config.h' has been edited. "
             echo "You can either delete or preserve your work, or force the test by rerunning the"
             echo "script as: $0 --force"
             exit 1

--- a/tests/scripts/basic-build-test.sh
+++ b/tests/scripts/basic-build-test.sh
@@ -30,7 +30,7 @@
 #
 # The tests focus on functionality and do not consider performance.
 #
-# Note the tests self-adapt due to configurations in include/mbedtls/config.h
+# Note the tests self-adapt due to configurations in include/mbedtls/mbedtls_config.h
 # which can lead to some tests being skipped, and can cause the number of
 # available tests to fluctuate.
 #
@@ -68,7 +68,7 @@ export OPENSSL_CMD="$OPENSSL"
 export GNUTLS_CLI="$GNUTLS_CLI"
 export GNUTLS_SERV="$GNUTLS_SERV"
 
-CONFIG_H='include/mbedtls/config.h'
+CONFIG_H='include/mbedtls/mbedtls_config.h'
 CONFIG_BAK="$CONFIG_H.bak"
 
 # Step 0 - print build environment info

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -102,7 +102,7 @@ cat $HEADERS $LIBRARY \
     | sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
-            | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|^MBEDTLS_USER_CONFIG_VERSION$' || true )
+            | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )
 rm _MBEDTLS_XXX _caps
 if [ "x$TYPOS" = "x" ]; then
     echo "PASS"

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -102,7 +102,7 @@ cat $HEADERS $LIBRARY \
     | sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
-            | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )
+            | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$|^MBEDTLS_USER_CONFIG_VERSION$' || true )
 rm _MBEDTLS_XXX _caps
 if [ "x$TYPOS" = "x" ]; then
     echo "PASS"

--- a/tests/scripts/curves.pl
+++ b/tests/scripts/curves.pl
@@ -36,7 +36,7 @@
 #
 # This script should be executed from the root of the project directory.
 #
-# Only curves that are enabled in config.h will be tested.
+# Only curves that are enabled in mbedtls_config.h will be tested.
 #
 # For best effect, run either with cmake disabled, or cmake enabled in a mode
 # that includes -Werror.
@@ -47,7 +47,7 @@ use strict;
 -d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
 
 my $sed_cmd = 's/^#define \(MBEDTLS_ECP_DP.*_ENABLED\)/\1/p';
-my $config_h = 'include/mbedtls/config.h';
+my $config_h = 'include/mbedtls/mbedtls_config.h';
 my @curves = split( /\s+/, `sed -n -e '$sed_cmd' $config_h` );
 
 # Determine which curves support ECDSA by checking the dependencies of

--- a/tests/scripts/depends-hashes.pl
+++ b/tests/scripts/depends-hashes.pl
@@ -42,7 +42,7 @@ use strict;
 
 -d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
 
-my $config_h = 'include/mbedtls/config.h';
+my $config_h = 'include/mbedtls/mbedtls_config.h';
 
 # as many SSL options depend on specific hashes,
 # and SSL is not in the test suites anyways,

--- a/tests/scripts/depends-pkalgs.pl
+++ b/tests/scripts/depends-pkalgs.pl
@@ -43,7 +43,7 @@ use strict;
 
 -d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
 
-my $config_h = 'include/mbedtls/config.h';
+my $config_h = 'include/mbedtls/mbedtls_config.h';
 
 # Some algorithms can't be disabled on their own as others depend on them, so
 # we list those reverse-dependencies here to keep check_config.h happy.

--- a/tests/scripts/key-exchanges.pl
+++ b/tests/scripts/key-exchanges.pl
@@ -40,7 +40,7 @@ use strict;
 -d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
 
 my $sed_cmd = 's/^#define \(MBEDTLS_KEY_EXCHANGE_.*_ENABLED\)/\1/p';
-my $config_h = 'include/mbedtls/config.h';
+my $config_h = 'include/mbedtls/mbedtls_config.h';
 my @kexes = split( /\s+/, `sed -n -e '$sed_cmd' $config_h` );
 
 system( "cp $config_h $config_h.bak" ) and die;

--- a/tests/scripts/list-symbols.sh
+++ b/tests/scripts/list-symbols.sh
@@ -27,7 +27,7 @@ if grep -i cmake Makefile >/dev/null; then
     exit 1
 fi
 
-cp include/mbedtls/config.h include/mbedtls/config.h.bak
+cp include/mbedtls/mbedtls_config.h include/mbedtls/mbedtls_config.h.bak
 scripts/config.py full
 make clean
 make_ret=
@@ -39,7 +39,7 @@ CFLAGS=-fno-asynchronous-unwind-tables make lib \
     cat list-symbols.make.log >&2
   }
 rm list-symbols.make.log
-mv include/mbedtls/config.h.bak include/mbedtls/config.h
+mv include/mbedtls/mbedtls_config.h.bak include/mbedtls/mbedtls_config.h
 if [ -n "$make_ret" ]; then
     exit "$make_ret"
 fi

--- a/tests/scripts/set_psa_test_dependencies.py
+++ b/tests/scripts/set_psa_test_dependencies.py
@@ -23,7 +23,7 @@ import re
 import sys
 
 CLASSIC_DEPENDENCIES = frozenset([
-    # This list is manually filtered from config.h.
+    # This list is manually filtered from mbedtls_config.h.
 
     # Mbed TLS feature support.
     # Only features that affect what can be done are listed here.

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -60,7 +60,7 @@ if ($#ARGV >= 0) {
 
 -d 'library' && -d 'include' && -d 'tests' or die "Must be run from root\n";
 
-my $config_h = 'include/mbedtls/config.h';
+my $config_h = 'include/mbedtls/mbedtls_config.h';
 
 system( "cp $config_h $config_h.bak" ) and die;
 sub abort {

--- a/tests/scripts/test_config_script.py
+++ b/tests/scripts/test_config_script.py
@@ -8,7 +8,7 @@ This is a harness to help regression testing, not a functional tester.
 Sample usage:
 
     test_config_script.py -d old
-    ## Modify config.py and/or config.h ##
+    ## Modify config.py and/or mbedtls_config.h ##
     test_config_script.py -d new
     diff -ru old new
 """
@@ -170,7 +170,7 @@ def main():
                         dest='output_directory', required=True,
                         help="""Output directory.""")
     parser.add_argument('-f', metavar='FILE',
-                        dest='input_file', default='include/mbedtls/config.h',
+                        dest='input_file', default='include/mbedtls/mbedtls_config.h',
                         help="""Config file (default: %(default)s).""")
     parser.add_argument('-p', metavar='PRESET,...',
                         dest='presets',

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -51,7 +51,7 @@ fi
 : ${PERL:=perl}
 
 guess_config_name() {
-    if git diff --quiet ../include/mbedtls/config.h 2>/dev/null; then
+    if git diff --quiet ../include/mbedtls/mbedtls_config.h 2>/dev/null; then
         echo "default"
     else
         echo "unknown"
@@ -93,7 +93,7 @@ TESTS=0
 FAILS=0
 SKIPS=0
 
-CONFIG_H='../include/mbedtls/config.h'
+CONFIG_H='../include/mbedtls/mbedtls_config.h'
 
 MEMCHECK=0
 FILTER='.*'
@@ -178,7 +178,7 @@ case "$MBEDTLS_TEST_OUTCOME_FILE" in
         ;;
 esac
 
-# Read boolean configuration options from config.h for easy and quick
+# Read boolean configuration options from mbedtls_config.h for easy and quick
 # testing. Skip non-boolean options (with something other than spaces
 # and a comment after "#define SYMBOL"). The variable contains a
 # space-separated list of symbols.
@@ -194,7 +194,7 @@ skip_next_test() {
     SKIP_NEXT="YES"
 }
 
-# skip next test if the flag is not enabled in config.h
+# skip next test if the flag is not enabled in mbedtls_config.h
 requires_config_enabled() {
     case $CONFIGS_ENABLED in
         *" $1 "*) :;;
@@ -202,7 +202,7 @@ requires_config_enabled() {
     esac
 }
 
-# skip next test if the flag is enabled in config.h
+# skip next test if the flag is enabled in mbedtls_config.h
 requires_config_disabled() {
     case $CONFIGS_ENABLED in
         *" $1 "*) SKIP_NEXT="YES";;
@@ -3146,7 +3146,7 @@ run_test    "Renegotiation: server-initiated" \
 
 # Checks that no Signature Algorithm with SHA-1 gets negotiated. Negotiating SHA-1 would mean that
 # the server did not parse the Signature Algorithm extension. This test is valid only if an MD
-# algorithm stronger than SHA-1 is enabled in config.h
+# algorithm stronger than SHA-1 is enabled in mbedtls_config.h
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Renegotiation: Signature Algorithms parsing, client-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 auth_mode=optional" \
@@ -3164,7 +3164,7 @@ run_test    "Renegotiation: Signature Algorithms parsing, client-initiated" \
 
 # Checks that no Signature Algorithm with SHA-1 gets negotiated. Negotiating SHA-1 would mean that
 # the server did not parse the Signature Algorithm extension. This test is valid only if an MD
-# algorithm stronger than SHA-1 is enabled in config.h
+# algorithm stronger than SHA-1 is enabled in mbedtls_config.h
 requires_config_enabled MBEDTLS_SSL_RENEGOTIATION
 run_test    "Renegotiation: Signature Algorithms parsing, server-initiated" \
             "$P_SRV debug_level=3 exchanges=2 renegotiation=1 auth_mode=optional renegotiate=1" \

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -23,11 +23,7 @@
 #endif
 #endif
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include <mbedtls/config.h>
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 /* Test code may use deprecated identifiers only if the preprocessor symbol
  * MBEDTLS_TEST_DEPRECATED is defined. When building tests, set


### PR DESCRIPTION
Split the config files into one that's purely made of `#defines`, intended to be edited by end users, and one that has all the necessary preprocessor logic, extracted from the former config file, and other source files.

Closes #3960

## Status
**Ready**

## Requires Backporting
No

## Migrations
The config file was renamed split and renamed, and a mandatory version symbol was added.

## Todos
- [x] Documentation
- [x] Changelog updated