### PR TITLE
Lighten and test constraints on context types in alternative implementations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ API changes
      Various helpers and definitions available for use in alt implementations
      have been moved out of the include/ directory and into the library/
      directory. The files concerned are ecp_internal.h and rsa_internal.h
-     which have also been renamed to ecp_alt.h and rsa_alt_helpers.h
+     which have also been renamed to ecp_internal_alt.h and rsa_alt_helpers.h
      respectively.
    * Move internal headers.
      Header files that were only meant for the library's internal use and

--- a/ChangeLog.d/alt-context-relaxation.txt
+++ b/ChangeLog.d/alt-context-relaxation.txt
@@ -1,0 +1,6 @@
+Features
+   * Alternative implementations of the AES, DHM, ECJPAKE, ECP, RSA and timing
+     modules had undocumented constraints on their context types. These
+     constraints have been relaxed.
+     See docs/architecture/alternative-implementations.md for the remaining
+     constraints.

--- a/ChangeLog.d/dhm-fields.txt
+++ b/ChangeLog.d/dhm-fields.txt
@@ -1,6 +1,8 @@
 Features
    * The new functions mbedtls_dhm_get_len() and mbedtls_dhm_get_bitlen()
      query the size of the modulus in a Diffie-Hellman context.
+   * The new function mbedtls_dhm_get_value() copy a field out of a
+     Diffie-Hellman context.
 
 API changes
    * Instead of accessing the len field of a DHM context, which is no longer

--- a/ChangeLog.d/dhm-fields.txt
+++ b/ChangeLog.d/dhm-fields.txt
@@ -1,0 +1,7 @@
+Features
+   * The new functions mbedtls_dhm_get_len() and mbedtls_dhm_get_bitlen()
+     query the size of the modulus in a Diffie-Hellman context.
+
+API changes
+   * Instead of accessing the len field of a DHM context, which is no longer
+     supported, use the new function mbedtls_dhm_get_len() .

--- a/ChangeLog.d/ecjpake-point_format.txt
+++ b/ChangeLog.d/ecjpake-point_format.txt
@@ -1,0 +1,4 @@
+Features
+   * Use the new function mbedtls_ecjpake_set_point_format() to select the
+     point format for ECJPAKE instead of accessing the point_format field
+     directly, which is no longer supported.

--- a/ChangeLog.d/ecp_max_bits.txt
+++ b/ChangeLog.d/ecp_max_bits.txt
@@ -1,0 +1,3 @@
+Removals
+   * MBEDTLS_ECP_MAX_BITS is no longer a configuration option because it is
+     now determined automatically based on supported curves.

--- a/configs/config-suite-b.h
+++ b/configs/config-suite-b.h
@@ -84,8 +84,7 @@
 #define MBEDTLS_AES_ROM_TABLES
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS   384
-#define MBEDTLS_MPI_MAX_SIZE    48 // 384 bits is 48 bytes
+#define MBEDTLS_MPI_MAX_SIZE    48 // 384-bit EC curve = 48 bytes
 
 /* Save RAM at the expense of speed, see ecp.h */
 #define MBEDTLS_ECP_WINDOW_SIZE        2

--- a/configs/config-thread.h
+++ b/configs/config-thread.h
@@ -85,8 +85,7 @@
 #define MBEDTLS_AES_ROM_TABLES
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             256
-#define MBEDTLS_MPI_MAX_SIZE              32 // 256 bits is 32 bytes
+#define MBEDTLS_MPI_MAX_SIZE              32 // 256-bit EC curve = 32 bytes
 
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8

--- a/docs/3.0-migration-guide.md
+++ b/docs/3.0-migration-guide.md
@@ -59,7 +59,7 @@ were documented as internal, despite being in the public include directory.
 If you're providing alt implementations of ECP or RSA, you'll need to add our
 `library` directory to your include path when building your alt
 implementations, and note that `ecp_internal.h` and `rsa_internal.h` have been
-renamed to `ecp_alt.h` and `rsa_alt_helpers.h` respectively.
+renamed to `ecp_internal_alt.h` and `rsa_alt_helpers.h` respectively.
 
 If you're a library user and used to rely on having access to a structure or
 function that's now in a private header, please reach out on the mailing list

--- a/docs/architecture/alternative-implementations.md
+++ b/docs/architecture/alternative-implementations.md
@@ -51,6 +51,18 @@ Where a context type needs to have a certain field, the field must have the same
 * ECP: `mbedtls_ecp_group` must have the fields `id`, `P`, `A`, `B`, `G`, `N`, `pbits` and `nbits`.
     * If `MBEDTLS_PK_PARSE_EC_EXTENDED` is enabled, those fields must be writable, and `mbedtls_ecp_point_read_binary()` must support a group structure where only `P`, `pbits`, `A` and `B` are set.
 
+It must be possible to move a context object in memory (except during the execution of a library function that takes this context as an argument). (This is necessary, for example, to support applications that populate a context on the stack of an inner function and then copy the context upwards through the call chain, or applications written in a language with automatic memory management that can move objects on the heap.) That is, call sequences like the following must work:
+```
+mbedtls_xxx_context ctx1, ctx2;
+mbedtls_xxx_init(&ctx1);
+mbedtls_xxx_setup(&ctx1, …);
+ctx2 = ctx1;
+memset(&ctx1, 0, sizeof(ctx1));
+mbedtls_xxx_do_stuff(&ctx2, …);
+mbedtls_xxx_free(&ctx2);
+```
+In practice, this means that a pointer to a context or to a part of a context does not remain valid across function calls. Alternative implementations do not need to support copying of contexts: contexts can only be cloned through explicit `clone()` functions.
+
 ## Function alternative implementations
 
 In some cases, it is possible to replace a single function or a small set of functions instead of [providing an alternative implementation of the whole module](#module-alternative-implementations).

--- a/docs/architecture/alternative-implementations.md
+++ b/docs/architecture/alternative-implementations.md
@@ -40,6 +40,17 @@ The general principle of an alternative implementation is:
 
 See https://tls.mbed.org/kb/development/hw_acc_guidelines for a more detailed guide.
 
+### Constraints on context types
+
+Generally, alternative implementations can define their context types to any C type except incomplete and array types (although they would normally be `struct` types). This section lists some known limitations where the context type needs to be a structure with certain fields.
+
+Where a context type needs to have a certain field, the field must have the same type and semantics as in the built-in implementation, but does not need to be at the same position in the structure. Furthermore, unless otherwise indicated, only read access is necessary: the field can be `const`, and modifications to it do not need to be supported. For example, if an alternative implementation of asymmetric cryptography uses a different representation of large integers, it is sufficient to provide a read-only copy of the fields listed here of type `mbedtls_mpi`.
+
+* AES: if `MBEDTLS_AESNI_C` or `MBEDTLS_PADLOCK_C` is enabled, `mbedtls_aes_context` must have the fields `nr` and `rk`.
+* DHM: if `MBEDTLS_DEBUG_C` is enabled, `mbedtls_dhm_context` must have the fields `P`, `Q`, `G`, `GX`, `GY` and `K`.
+* ECP: `mbedtls_ecp_group` must have the fields `id`, `P`, `A`, `B`, `G`, `N`, `pbits` and `nbits`.
+    * If `MBEDTLS_PK_PARSE_EC_EXTENDED` is enabled, those fields must be writable, and `mbedtls_ecp_point_read_binary()` must support a group structure where only `P`, `pbits`, `A` and `B` are set.
+
 ## Function alternative implementations
 
 In some cases, it is possible to replace a single function or a small set of functions instead of [providing an alternative implementation of the whole module](#module-alternative-implementations).

--- a/docs/architecture/alternative-implementations.md
+++ b/docs/architecture/alternative-implementations.md
@@ -1,0 +1,66 @@
+Alternative implementations of Mbed TLS functionality
+=====================================================
+
+This document describes how parts of the Mbed TLS functionality can be replaced at compile time to integrate the library on a platform.
+
+This document is an overview. It is not exhaustive. Please consult the documentation of individual modules and read the library header files for more details.
+
+## Platform integration
+
+Mbed TLS works out of the box on Unix/Linux/POSIX-like systems and on Windows. On embedded platforms, you may need to customize some aspects of how Mbed TLS interacts with the underlying platform. This section discusses the main areas that can be configured.
+
+The platform module (`include/mbedtls/platform.h`) controls how Mbed TLS accesses standard library features such as memory management (`calloc`, `free`), `printf`, `exit`. You can define custom functions instead of the ones from the C standard library through `MBEDTLS_PLATFORM_XXX` options in the configuration file. Many options have two mechanisms: either define `MBEDTLS_PLATFORM_XXX_MACRO` to the name of a function to call instead of the standard function `xxx`, or define `MBEDTLS_PLATFORM_XXX_ALT` and [register an alternative implementation during the platform setup](#alternative-implementations-of-platform-functions).
+
+The storage of the non-volatile seed for random generation, enabled with `MBEDTLS_ENTROPY_NV_SEED`, is also controlled via the platform module.
+
+For timing functions, you can [declare an alternative implementation of the timing module](#module-alternative-implementations).
+
+On multithreaded platforms, [declare an alternative implementation of the threading module](#module-alternative-implementations).
+
+To configure entropy sources (hardware random generators), see the `MBEDTLS_ENTROPY_XXX` options in the configuration file.
+
+For networking, the `net_sockets` module does not currently support alternative implementations. If this module does not work on your platform, disable `MBEDTLS_NET_C` and use custom functions for TLS.
+
+If your platform has a cryptographic accelerator, you can use it via a [PSA driver](#psa-cryptography-drivers) or an [declare an alternative implementation of the corresponding module(s)](#module-alternative-implementations) or [specific functions](#function-alternative-implementations).
+
+## PSA cryptography drivers
+
+On platforms where a hardware cryptographic engine is present, you can implement a driver for this engine in the PSA interface. Drivers are supported for cryptographic operations with transparent keys (keys available in cleartext), for cryptographic operations with opaque keys (keys that are only available inside the cryptographic engine), and for random generation. Calls to `psa_xxx` functions that perform cryptographic operations are directed to drivers instead of the built-in code as applicable. See the [PSA cryptography driver interface specification](docs/proposed/psa-driver-interface.md), the [Mbed TLS PSA driver developer guide](docs/proposed/psa-driver-developer-guide.md) and the [Mbed TLS PSA driver integration guide](docs/proposed/psa-driver-integration-guide.md) for more information.
+
+As of Mbed TLS 3.0, this interface is still experimental and subject to change, and not all operations support drivers yet. The configuration option `MBEDTLS_USE_PSA_CRYPTO` causes parts of the `mbedtls_xxx` API to use PSA crypto and therefore to support drivers, however it is not yet compatible with all drivers.
+
+## Module alternative implementations
+
+You can replace the code of some modules of Mbed TLS at compile time by a custom implementation. This is possible for low-level cryptography modules (symmetric algorithms, DHM, RSA, ECP, ECJPAKE) and for some platform-related modules (threading, timing). Such custom implementations are called “alternative implementations”, or “ALT implementations” for short.
+
+The general principle of an alternative implementation is:
+* Enable `MBEDTLS_XXX_ALT` in the compile-time configuration where XXX is the module name. For example, `MBEDTLS_AES_ALT` for an implementation of the AES module. This is in addition to enabling `MBEDTLS_XXX_C`.
+* Create a header file `xxx_alt.h` that defines the context type(s) used by the module. For example, `mbedtls_aes_context` for AES.
+* Implement all the functions from the module, i.e. the functions declared in `include/mbedtls/xxx.h`.
+
+See https://tls.mbed.org/kb/development/hw_acc_guidelines for a more detailed guide.
+
+## Function alternative implementations
+
+In some cases, it is possible to replace a single function or a small set of functions instead of [providing an alternative implementation of the whole module](#module-alternative-implementations).
+
+### Alternative implementations of cryptographic functions
+
+Options to replace individual functions of cryptographic modules generally have a name obtained by upper-casing the function name and appending `_ALT`. If the function name contains `_internal`, `_ext` or `_ret`, this is removed in the `_ALT` symbol. When the corresponding option is enabled, the built-in implementation of the function will not be compiled, and you must provide an alternative implementation at link time.
+
+For example, enable `MBEDTLS_AES_ENCRYPT_ALT` at compile time and provide your own implementation of `mbedtls_aes_encrypt()` to provide an accelerated implementation of AES encryption that is compatible with the built-in key schedule. If you wish to implement key schedule differently, you can also enable `MBEDTLS_AES_SETKEY_ENC_ALT` and implement `mbedtls_aes_setkey_enc()`.
+
+Another example: enable `MBEDTLS_SHA256_PROCESS_ALT` and implement `mbedtls_internal_sha256_process()` to provide an accelerated implementation of SHA-256 and SHA-224.
+
+Note that since alternative implementations of individual functions cooperate with the built-in implementation of other functions, you must use the same layout for context objects as the built-in implementation. If you want to use different context types, you need to [provide an alternative implementation of the whole module](#module-alternative-implementations).
+
+### Alternative implementations of platform functions
+
+Several platform functions can be reconfigured dynamically by following the process described here. To reconfigure how Mbed TLS calls the standard library function `xxx()`:
+
+* Define the symbol `MBEDTLS_PLATFORM_XXX_ALT` at compile time.
+* During the initialization of your application, set the global variable `mbedtls_xxx` to an alternative implementation of `xxx()`.
+
+Merely enabling `MBEDTLS_PLATFORM_XXX_ALT` does not change the behavior: by default, `mbedtls_xxx` points to the standard function `xxx`.
+
+Note that there are variations on the naming pattern. Consult the documentation of individual configuration options and of the platform module for details.

--- a/docs/architecture/alternative-implementations.md
+++ b/docs/architecture/alternative-implementations.md
@@ -84,6 +84,8 @@ Several platform functions can be reconfigured dynamically by following the proc
 * Define the symbol `MBEDTLS_PLATFORM_XXX_ALT` at compile time.
 * During the initialization of your application, set the global variable `mbedtls_xxx` to an alternative implementation of `xxx()`.
 
+For example, to provide a custom `printf` function at run time, enable `MBEDTLS_PLATFORM_PRINTF_ALT` at compile time and assign to `mbedtls_printf` during the initialization of your application.
+
 Merely enabling `MBEDTLS_PLATFORM_XXX_ALT` does not change the behavior: by default, `mbedtls_xxx` points to the standard function `xxx`.
 
-Note that there are variations on the naming pattern. Consult the documentation of individual configuration options and of the platform module for details.
+Note that there are variations on the naming pattern. For example, some configurable functions are activated in pairs, such as `mbedtls_calloc` and `mbedtls_free` via `MBEDTLS_PLATFORM_MEMORY`. Consult the documentation of individual configuration options and of the platform module for details.

--- a/docs/architecture/alternative-implementations.md
+++ b/docs/architecture/alternative-implementations.md
@@ -21,7 +21,7 @@ To configure entropy sources (hardware random generators), see the `MBEDTLS_ENTR
 
 For networking, the `net_sockets` module does not currently support alternative implementations. If this module does not work on your platform, disable `MBEDTLS_NET_C` and use custom functions for TLS.
 
-If your platform has a cryptographic accelerator, you can use it via a [PSA driver](#psa-cryptography-drivers) or an [declare an alternative implementation of the corresponding module(s)](#module-alternative-implementations) or [specific functions](#function-alternative-implementations).
+If your platform has a cryptographic accelerator, you can use it via a [PSA driver](#psa-cryptography-drivers) or declare an [alternative implementation of the corresponding module(s)](#module-alternative-implementations) or [of specific functions](#function-alternative-implementations). PSA drivers will ultimately replace the alternative implementation mechanism, but alternative implementation will remain supported in at least all Mbed TLS versions of the form 3.x. The interface of PSA drivers is currently still experimental and subject to change.
 
 ## PSA cryptography drivers
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3155,7 +3155,6 @@
 //#define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT      384 /**< Maximum size of (re)seed buffer */
 
 /* ECP options */
-//#define MBEDTLS_ECP_MAX_BITS             521 /**< Maximum bit size of groups */
 //#define MBEDTLS_ECP_WINDOW_SIZE            6 /**< Maximum window size used */
 //#define MBEDTLS_ECP_FIXED_POINT_OPTIM      1 /**< Enable fixed-point speed-up */
 

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -85,6 +85,17 @@
 #define MBEDTLS_ERR_DHM_FILE_IO_ERROR                     -0x3480  /**< Read or write of file failed. */
 #define MBEDTLS_ERR_DHM_SET_GROUP_FAILED                  -0x3580  /**< Setting the modulus and generator failed. */
 
+/** Which parameter to access in mbedtls_dhm_get_value(). */
+typedef enum
+{
+    MBEDTLS_DHM_PARAM_P,  /*!<  The prime modulus. */
+    MBEDTLS_DHM_PARAM_G,  /*!<  The generator. */
+    MBEDTLS_DHM_PARAM_X,  /*!<  Our secret value. */
+    MBEDTLS_DHM_PARAM_GX, /*!<  Our public key = \c G^X mod \c P. */
+    MBEDTLS_DHM_PARAM_GY, /*!<  The public key of the peer = \c G^Y mod \c P. */
+    MBEDTLS_DHM_PARAM_K,  /*!<  The shared secret = \c G^(XY) mod \c P. */
+} mbedtls_dhm_parameter;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -300,6 +311,22 @@ size_t mbedtls_dhm_get_bitlen( const mbedtls_dhm_context *ctx );
  *                 i.e. the number n such that 2^(8*(n-1)) <= P < 2^(8*n).
  */
 size_t mbedtls_dhm_get_len( const mbedtls_dhm_context *ctx );
+
+/**
+ * \brief          This function copies a parameter of a DHM key.
+ *
+ * \param dest     The MPI object to copy the value into. It must be
+ *                 initialized.
+ * \param ctx      The DHM context to query.
+ * \param param    The parameter to copy.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_DHM_BAD_INPUT_DATA if \p field is invalid.
+ * \return         An \c MBEDTLS_ERR_MPI_XXX error code if the copy fails.
+ */
+int mbedtls_dhm_get_value( mbedtls_mpi *dest,
+                           const mbedtls_dhm_context *ctx,
+                           mbedtls_dhm_parameter param );
 
 /**
  * \brief          This function frees and clears the components

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -315,18 +315,18 @@ size_t mbedtls_dhm_get_len( const mbedtls_dhm_context *ctx );
 /**
  * \brief          This function copies a parameter of a DHM key.
  *
- * \param dest     The MPI object to copy the value into. It must be
- *                 initialized.
  * \param ctx      The DHM context to query.
  * \param param    The parameter to copy.
+ * \param dest     The MPI object to copy the value into. It must be
+ *                 initialized.
  *
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_DHM_BAD_INPUT_DATA if \p field is invalid.
  * \return         An \c MBEDTLS_ERR_MPI_XXX error code if the copy fails.
  */
-int mbedtls_dhm_get_value( mbedtls_mpi *dest,
-                           const mbedtls_dhm_context *ctx,
-                           mbedtls_dhm_parameter param );
+int mbedtls_dhm_get_value( const mbedtls_dhm_context *ctx,
+                           mbedtls_dhm_parameter param,
+                           mbedtls_mpi *dest );
 
 /**
  * \brief          This function frees and clears the components

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -96,7 +96,6 @@ extern "C" {
  */
 typedef struct mbedtls_dhm_context
 {
-    size_t MBEDTLS_PRIVATE(len);         /*!<  The size of \p P in Bytes. */
     mbedtls_mpi MBEDTLS_PRIVATE(P);      /*!<  The prime modulus. */
     mbedtls_mpi MBEDTLS_PRIVATE(G);      /*!<  The generator. */
     mbedtls_mpi MBEDTLS_PRIVATE(X);      /*!<  Our secret value. */
@@ -281,6 +280,26 @@ int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
                      unsigned char *output, size_t output_size, size_t *olen,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
+
+/**
+ * \brief          This function returns the size of the prime modulus in bits.
+ *
+ * \param ctx      The DHM context to query.
+ *
+ * \return         The size of the prime modulus in bits,
+ *                 i.e. the number n such that 2^(n-1) <= P < 2^n.
+ */
+size_t mbedtls_dhm_get_bitlen( const mbedtls_dhm_context *ctx );
+
+/**
+ * \brief          This function returns the size of the prime modulus in bytes.
+ *
+ * \param ctx      The DHM context to query.
+ *
+ * \return         The size of the prime modulus in bytes,
+ *                 i.e. the number n such that 2^(8*(n-1)) <= P < 2^(8*n).
+ */
+size_t mbedtls_dhm_get_len( const mbedtls_dhm_context *ctx );
 
 /**
  * \brief          This function frees and clears the components

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -132,6 +132,21 @@ int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
                            size_t len );
 
 /**
+ * \brief               Set the point format for future reads and writes.
+ *
+ * \param ctx           The ECJPAKE context to configure.
+ * \param point_format  The point format to use:
+ *                      #MBEDTLS_ECP_PF_UNCOMPRESSED (default)
+ *                      or #MBEDTLS_ECP_PF_COMPRESSED.
+ *
+ * \return              \c 0 if successful.
+ * \return              #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if \p point_format
+ *                      is invalid.
+ */
+int mbedtls_ecjpake_set_point_format( mbedtls_ecjpake_context *ctx,
+                                      int point_format );
+
+/**
  * \brief           Check if an ECJPAKE context is ready for use.
  *
  * \param ctx       The ECJPAKE context to check. This must be

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -206,25 +206,33 @@ mbedtls_ecp_point;
  * additions or subtractions. Therefore, it is only an approximative modular
  * reduction. It must return 0 on success and non-zero on failure.
  *
- * \note        Alternative implementations must keep the group IDs distinct. If
- *              two group structures have the same ID, then they must be
- *              identical.
- *
+ * \note        Alternative implementations of the ECP module must obey the
+ *              following constraints.
+ *              * Group IDs must be distinct: if two group structures have
+ *                the same ID, then they must be identical.
+ *              * The fields \c id, \c P, \c A, \c B, \c G, \c N,
+ *                \c pbits and \c nbits must have the same type and semantics
+ *                as in the built-in implementation.
+ *                They must be available for reading, but direct modification
+ *                of these fields does not need to be supported.
+ *                They do not need to be at the same offset in the structure.
  */
 typedef struct mbedtls_ecp_group
 {
-    mbedtls_ecp_group_id MBEDTLS_PRIVATE(id);    /*!< An internal group identifier. */
-    mbedtls_mpi MBEDTLS_PRIVATE(P);              /*!< The prime modulus of the base field. */
-    mbedtls_mpi MBEDTLS_PRIVATE(A);              /*!< For Short Weierstrass: \p A in the equation. For
+    mbedtls_ecp_group_id id;    /*!< An internal group identifier. */
+    mbedtls_mpi P;              /*!< The prime modulus of the base field. */
+    mbedtls_mpi A;              /*!< For Short Weierstrass: \p A in the equation. For
                                      Montgomery curves: <code>(A + 2) / 4</code>. */
-    mbedtls_mpi MBEDTLS_PRIVATE(B);              /*!< For Short Weierstrass: \p B in the equation.
+    mbedtls_mpi B;              /*!< For Short Weierstrass: \p B in the equation.
                                      For Montgomery curves: unused. */
-    mbedtls_ecp_point MBEDTLS_PRIVATE(G);        /*!< The generator of the subgroup used. */
-    mbedtls_mpi MBEDTLS_PRIVATE(N);              /*!< The order of \p G. */
-    size_t MBEDTLS_PRIVATE(pbits);               /*!< The number of bits in \p P.*/
-    size_t MBEDTLS_PRIVATE(nbits);               /*!< For Short Weierstrass: The number of bits in \p P.
+    mbedtls_ecp_point G;        /*!< The generator of the subgroup used. */
+    mbedtls_mpi N;              /*!< The order of \p G. */
+    size_t pbits;               /*!< The number of bits in \p P.*/
+    size_t nbits;               /*!< For Short Weierstrass: The number of bits in \p P.
                                      For Montgomery curves: the number of bits in the
                                      private keys. */
+    /* End of public fields */
+
     unsigned int MBEDTLS_PRIVATE(h);             /*!< \internal 1 if the constants are static. */
     int (*MBEDTLS_PRIVATE(modp))(mbedtls_mpi *); /*!< The function for fast pseudo-reduction
                                      mod \p P (see above).*/

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -102,7 +102,8 @@ extern "C" {
  *   MBEDTLS_ECP_yyy_ENABLED above.
  * - Add the necessary definitions to ecp_curves.c.
  * - Add the curve to the ecp_supported_curves array in ecp.c.
- * - Add the curve to applicable profiles in x509_crt.c if applicable.
+ * - Add the curve to applicable profiles in x509_crt.c.
+ * - Add the curve to applicable presets in ssl_tls.c.
  */
 typedef enum
 {

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -249,9 +249,6 @@ mbedtls_ecp_group;
 #define MBEDTLS_ECP_MAX_BITS     521   /**< The maximum size of groups, in bits. */
 #endif
 
-#define MBEDTLS_ECP_MAX_BYTES    ( ( MBEDTLS_ECP_MAX_BITS + 7 ) / 8 )
-#define MBEDTLS_ECP_MAX_PT_LEN   ( 2 * MBEDTLS_ECP_MAX_BYTES + 1 )
-
 #if !defined(MBEDTLS_ECP_WINDOW_SIZE)
 /*
  * Maximum "window" size used for point multiplication.
@@ -296,6 +293,9 @@ mbedtls_ecp_group;
 #else  /* MBEDTLS_ECP_ALT */
 #include "ecp_alt.h"
 #endif /* MBEDTLS_ECP_ALT */
+
+#define MBEDTLS_ECP_MAX_BYTES    ( ( MBEDTLS_ECP_MAX_BITS + 7 ) / 8 )
+#define MBEDTLS_ECP_MAX_PT_LEN   ( 2 * MBEDTLS_ECP_MAX_BYTES + 1 )
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -242,13 +242,6 @@ mbedtls_ecp_group;
  * \{
  */
 
-#if !defined(MBEDTLS_ECP_MAX_BITS)
-/**
- * The maximum size of the groups, that is, of \c N and \c P.
- */
-#define MBEDTLS_ECP_MAX_BITS     521   /**< The maximum size of groups, in bits. */
-#endif
-
 #if !defined(MBEDTLS_ECP_WINDOW_SIZE)
 /*
  * Maximum "window" size used for point multiplication.
@@ -293,6 +286,44 @@ mbedtls_ecp_group;
 #else  /* MBEDTLS_ECP_ALT */
 #include "ecp_alt.h"
 #endif /* MBEDTLS_ECP_ALT */
+
+/**
+ * The maximum size of the groups, that is, of \c N and \c P.
+ */
+#if !defined(MBEDTLS_ECP_C)
+/* Dummy definition to help code that has optional ECP support and
+ * defines an MBEDTLS_ECP_MAX_BYTES-sized array unconditionally. */
+#define MBEDTLS_ECP_MAX_BITS 1
+/* Note: the curves must be listed in DECREASING size! */
+#elif defined(MBEDTLS_ECP_DP_SECP521R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 521
+#elif defined(MBEDTLS_ECP_DP_BP512R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 512
+#elif defined(MBEDTLS_ECP_DP_CURVE448_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 448
+#elif defined(MBEDTLS_ECP_DP_BP384R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 384
+#elif defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 384
+#elif defined(MBEDTLS_ECP_DP_BP256R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 256
+#elif defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 256
+#elif defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 256
+#elif defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 255
+#elif defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 225 // n is slightly above 2^224
+#elif defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 224
+#elif defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 192
+#elif defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED)
+#define MBEDTLS_ECP_MAX_BITS 192
+#else
+#error "Missing definition of MBEDTLS_ECP_MAX_BITS"
+#endif
 
 #define MBEDTLS_ECP_MAX_BYTES    ( ( MBEDTLS_ECP_MAX_BITS + 7 ) / 8 )
 #define MBEDTLS_ECP_MAX_PT_LEN   ( 2 * MBEDTLS_ECP_MAX_BYTES + 1 )

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -93,6 +93,7 @@ extern "C" {
  * - Add it at the end of this enum, otherwise you'll break the ABI by
  *   changing the numerical value for existing curves.
  * - Increment MBEDTLS_ECP_DP_MAX below if needed.
+ * - Update the calculation of MBEDTLS_ECP_MAX_BITS below.
  * - Add the corresponding MBEDTLS_ECP_DP_xxx_ENABLED macro definition to
  *   config.h.
  * - List the curve as a dependency of MBEDTLS_ECP_C and

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -134,9 +134,9 @@ size_t mbedtls_dhm_get_len( const mbedtls_dhm_context *ctx )
     return( mbedtls_mpi_size( &ctx->P ) );
 }
 
-int mbedtls_dhm_get_value( mbedtls_mpi *dest,
-                           const mbedtls_dhm_context *ctx,
-                           mbedtls_dhm_parameter param )
+int mbedtls_dhm_get_value( const mbedtls_dhm_context *ctx,
+                           mbedtls_dhm_parameter param,
+                           mbedtls_mpi *dest )
 {
     const mbedtls_mpi *src = NULL;
     switch( param )

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -134,6 +134,37 @@ size_t mbedtls_dhm_get_len( const mbedtls_dhm_context *ctx )
     return( mbedtls_mpi_size( &ctx->P ) );
 }
 
+int mbedtls_dhm_get_value( mbedtls_mpi *dest,
+                           const mbedtls_dhm_context *ctx,
+                           mbedtls_dhm_parameter param )
+{
+    const mbedtls_mpi *src = NULL;
+    switch( param )
+    {
+        case MBEDTLS_DHM_PARAM_P:
+            src = &ctx->P;
+            break;
+        case MBEDTLS_DHM_PARAM_G:
+            src = &ctx->G;
+            break;
+        case MBEDTLS_DHM_PARAM_X:
+            src = &ctx->X;
+            break;
+        case MBEDTLS_DHM_PARAM_GX:
+            src = &ctx->GX;
+            break;
+        case MBEDTLS_DHM_PARAM_GY:
+            src = &ctx->GY;
+            break;
+        case MBEDTLS_DHM_PARAM_K:
+            src = &ctx->K;
+            break;
+        default:
+            return( MBEDTLS_ERR_DHM_BAD_INPUT_DATA );
+    }
+    return( mbedtls_mpi_copy( dest, src ) );
+}
+
 /*
  * Parse the ServerKeyExchange parameters
  */

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -128,6 +128,20 @@ cleanup:
     return( ret );
 }
 
+int mbedtls_ecjpake_set_point_format( mbedtls_ecjpake_context *ctx,
+                                      int point_format )
+{
+    switch( point_format )
+    {
+        case MBEDTLS_ECP_PF_UNCOMPRESSED:
+        case MBEDTLS_ECP_PF_COMPRESSED:
+            ctx->point_format = point_format;
+            return( 0 );
+        default:
+            return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
+    }
+}
+
 /*
  * Check if context is ready for use
  */

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -99,7 +99,7 @@
 #define mbedtls_free       free
 #endif
 
-#include "ecp_alt.h"
+#include "ecp_internal_alt.h"
 
 #if !defined(MBEDTLS_ECP_NO_INTERNAL_RNG)
 #if defined(MBEDTLS_HMAC_DRBG_C)

--- a/library/ecp_internal_alt.h
+++ b/library/ecp_internal_alt.h
@@ -1,5 +1,5 @@
 /**
- * \file ecp_alt.h
+ * \file ecp_internal_alt.h
  *
  * \brief Function declarations for alternative implementation of elliptic curve
  * point arithmetic.
@@ -293,5 +293,5 @@ int mbedtls_internal_ecp_normalize_mxz( const mbedtls_ecp_group *grp,
 
 #endif /* MBEDTLS_ECP_INTERNAL_ALT */
 
-#endif /* ecp_alt.h */
+#endif /* ecp_internal_alt.h */
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -178,6 +178,11 @@ static void rsa_free_wrap( void *ctx )
 
 static void rsa_debug( const void *ctx, mbedtls_pk_debug_item *items )
 {
+#if defined(MBEDTLS_RSA_ALT)
+    /* Not supported */
+    (void) ctx;
+    (void) items;
+#else
     items->type = MBEDTLS_PK_DEBUG_MPI;
     items->name = "rsa.N";
     items->value = &( ((mbedtls_rsa_context *) ctx)->N );
@@ -187,6 +192,7 @@ static void rsa_debug( const void *ctx, mbedtls_pk_debug_item *items )
     items->type = MBEDTLS_PK_DEBUG_MPI;
     items->name = "rsa.E";
     items->value = &( ((mbedtls_rsa_context *) ctx)->E );
+#endif
 }
 
 const mbedtls_pk_info_t mbedtls_rsa_info = {

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1663,7 +1663,8 @@ static int ssl_parse_supported_point_formats_ext( mbedtls_ssl_context *ssl,
             ssl->handshake->ecdh_ctx.point_format = p[0];
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
-            ssl->handshake->ecjpake_ctx.point_format = p[0];
+            mbedtls_ecjpake_set_point_format( &ssl->handshake->ecjpake_ctx,
+                                              p[0] );
 #endif
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "point format selected: %d", p[0] ) );
             return( 0 );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -2553,7 +2553,7 @@ static int ssl_parse_server_dh_params( mbedtls_ssl_context *ssl,
         return( ret );
     }
 
-    dhm_actual_bitlen = mbedtls_mpi_bitlen( &ssl->handshake->dhm_ctx.P );
+    dhm_actual_bitlen = mbedtls_dhm_get_bitlen( &ssl->handshake->dhm_ctx );
     if( dhm_actual_bitlen < ssl->conf->dhm_min_bitlen )
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "DHM prime too short: %" MBEDTLS_PRINTF_SIZET " < %u",
@@ -3588,14 +3588,14 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
         /*
          * DHM key exchange -- send G^X mod P
          */
-        content_len = ssl->handshake->dhm_ctx.len;
+        content_len = mbedtls_dhm_get_len( &ssl->handshake->dhm_ctx );
 
         ssl->out_msg[4] = (unsigned char)( content_len >> 8 );
         ssl->out_msg[5] = (unsigned char)( content_len      );
         header_len = 6;
 
         ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
-                          (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
+                          (int) mbedtls_dhm_get_len( &ssl->handshake->dhm_ctx ),
                           &ssl->out_msg[header_len], content_len,
                           ssl->conf->f_rng, ssl->conf->p_rng );
         if( ret != 0 )
@@ -3848,7 +3848,7 @@ ecdh_calc_secret:
             /*
              * ClientDiffieHellmanPublic public (DHM send G^X mod P)
              */
-            content_len = ssl->handshake->dhm_ctx.len;
+            content_len = mbedtls_dhm_get_len( &ssl->handshake->dhm_ctx );
 
             if( header_len + 2 + content_len >
                 MBEDTLS_SSL_OUT_CONTENT_LEN )
@@ -3862,7 +3862,7 @@ ecdh_calc_secret:
             ssl->out_msg[header_len++] = (unsigned char)( content_len      );
 
             ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
-                    (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
+                    (int) mbedtls_dhm_get_len( &ssl->handshake->dhm_ctx ),
                     &ssl->out_msg[header_len], content_len,
                     ssl->conf->f_rng, ssl->conf->p_rng );
             if( ret != 0 )

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -407,7 +407,8 @@ static int ssl_parse_supported_point_formats( mbedtls_ssl_context *ssl,
             ssl->handshake->ecdh_ctx.point_format = p[0];
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
-            ssl->handshake->ecjpake_ctx.point_format = p[0];
+            mbedtls_ecjpake_set_point_format( &ssl->handshake->ecjpake_ctx,
+                                              p[0] );
 #endif
             MBEDTLS_SSL_DEBUG_MSG( 4, ( "point format selected: %d", p[0] ) );
             return( 0 );

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -3049,7 +3049,7 @@ static int ssl_prepare_server_key_exchange( mbedtls_ssl_context *ssl,
 
         if( ( ret = mbedtls_dhm_make_params(
                   &ssl->handshake->dhm_ctx,
-                  (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
+                  (int) mbedtls_dhm_get_len( &ssl->handshake->dhm_ctx ),
                   ssl->out_msg + ssl->out_msglen, &len,
                   ssl->conf->f_rng, ssl->conf->p_rng ) ) != 0 )
         {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3871,8 +3871,10 @@ int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    if( ( ret = mbedtls_mpi_copy( &conf->dhm_P, &dhm_ctx->P ) ) != 0 ||
-        ( ret = mbedtls_mpi_copy( &conf->dhm_G, &dhm_ctx->G ) ) != 0 )
+    if( ( ret = mbedtls_dhm_get_value( &conf->dhm_P, dhm_ctx,
+                                       MBEDTLS_DHM_PARAM_P ) ) != 0 ||
+        ( ret = mbedtls_dhm_get_value( &conf->dhm_G, dhm_ctx,
+                                       MBEDTLS_DHM_PARAM_G ) ) != 0 )
     {
         mbedtls_mpi_free( &conf->dhm_P );
         mbedtls_mpi_free( &conf->dhm_G );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3871,10 +3871,10 @@ int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    if( ( ret = mbedtls_dhm_get_value( &conf->dhm_P, dhm_ctx,
-                                       MBEDTLS_DHM_PARAM_P ) ) != 0 ||
-        ( ret = mbedtls_dhm_get_value( &conf->dhm_G, dhm_ctx,
-                                       MBEDTLS_DHM_PARAM_G ) ) != 0 )
+    if( ( ret = mbedtls_dhm_get_value( dhm_ctx, MBEDTLS_DHM_PARAM_P,
+                                       &conf->dhm_P ) ) != 0 ||
+        ( ret = mbedtls_dhm_get_value( dhm_ctx, MBEDTLS_DHM_PARAM_G,
+                                       &conf->dhm_G ) ) != 0 )
     {
         mbedtls_mpi_free( &conf->dhm_P );
         mbedtls_mpi_free( &conf->dhm_G );

--- a/library/timing.c
+++ b/library/timing.c
@@ -387,6 +387,21 @@ static void busy_msleep( unsigned long msec )
     (void) j;
 }
 
+static void print_timers( struct mbedtls_timing_hr_time *hires,
+                          mbedtls_timing_delay_context *ctx )
+{
+#if defined(MBEDTLS_TIMING_ALT)
+    mbedtls_printf( " elapsed(hires)=%lu elapsed(ctx)=?? status(ctx)=%d\n",
+                    mbedtls_timing_get_timer( hires, 0 ),
+                    mbedtls_timing_get_delay( ctx ) );
+#else
+    mbedtls_printf( " elapsed(hires)=%lu elapsed(ctx)=%lu status(ctx)=%d\n",
+                    mbedtls_timing_get_timer( hires, 0 ),
+                    mbedtls_timing_get_timer( &ctx->timer, 0 ),
+                    mbedtls_timing_get_delay( ctx ) );
+#endif
+}
+
 #define FAIL    do                                                      \
     {                                                                   \
         if( verbose != 0 )                                              \
@@ -395,10 +410,7 @@ static void busy_msleep( unsigned long msec )
             mbedtls_printf( " cycles=%lu ratio=%lu millisecs=%lu secs=%lu hardfail=%d a=%lu b=%lu\n", \
                             cycles, ratio, millisecs, secs, hardfail,   \
                             (unsigned long) a, (unsigned long) b );     \
-            mbedtls_printf( " elapsed(hires)=%lu elapsed(ctx)=%lu status(ctx)=%d\n", \
-                            mbedtls_timing_get_timer( &hires, 0 ),      \
-                            mbedtls_timing_get_timer( &ctx.timer, 0 ),  \
-                            mbedtls_timing_get_delay( &ctx ) );         \
+            print_timers( &hires, &ctx );                               \
         }                                                               \
         return( 1 );                                                    \
     } while( 0 )

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -192,7 +192,8 @@ int main( void )
         goto exit;
     }
 
-    if( dhm.MBEDTLS_PRIVATE(len) < 64 || dhm.MBEDTLS_PRIVATE(len) > 512 )
+    n = mbedtls_dhm_get_len( &dhm );
+    if( n < 64 || n > 512 )
     {
         mbedtls_printf( " failed\n  ! Invalid DHM modulus size\n\n" );
         goto exit;
@@ -232,8 +233,8 @@ int main( void )
     mbedtls_printf( "\n  . Sending own public value to server" );
     fflush( stdout );
 
-    n = dhm.MBEDTLS_PRIVATE(len);
-    if( ( ret = mbedtls_dhm_make_public( &dhm, (int) dhm.MBEDTLS_PRIVATE(len), buf, n,
+    n = mbedtls_dhm_get_len( &dhm );
+    if( ( ret = mbedtls_dhm_make_public( &dhm, (int) n, buf, n,
                                  mbedtls_ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_dhm_make_public returned %d\n\n", ret );

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -254,14 +254,14 @@ int main( void )
 
     memset( buf, 0, sizeof( buf ) );
 
-    n = dhm.MBEDTLS_PRIVATE(len);
+    n = mbedtls_dhm_get_len( &dhm );
     if( ( ret = mbedtls_net_recv( &client_fd, buf, n ) ) != (int) n )
     {
         mbedtls_printf( " failed\n  ! mbedtls_net_recv returned %d\n\n", ret );
         goto exit;
     }
 
-    if( ( ret = mbedtls_dhm_read_public( &dhm, buf, dhm.MBEDTLS_PRIVATE(len) ) ) != 0 )
+    if( ( ret = mbedtls_dhm_read_public( &dhm, buf, n ) ) != 0 )
     {
         mbedtls_printf( " failed\n  ! mbedtls_dhm_read_public returned %d\n\n", ret );
         goto exit;

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -156,7 +156,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    mbedtls_printf( " ok (key size: %d bits)\n", (int) ctx_sign.MBEDTLS_PRIVATE(grp).MBEDTLS_PRIVATE(pbits) );
+    mbedtls_printf( " ok (key size: %d bits)\n", (int) ctx_sign.MBEDTLS_PRIVATE(grp).pbits );
 
     dump_pubkey( "  + Public key: ", &ctx_sign );
 

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -395,7 +395,7 @@ int main( int argc, char *argv[] )
     {
         mbedtls_ecp_keypair *ecp = mbedtls_pk_ec( key );
         mbedtls_printf( "curve: %s\n",
-                mbedtls_ecp_curve_info_from_grp_id( ecp->MBEDTLS_PRIVATE(grp).MBEDTLS_PRIVATE(id) )->MBEDTLS_PRIVATE(name) );
+                mbedtls_ecp_curve_info_from_grp_id( ecp->MBEDTLS_PRIVATE(grp).id )->MBEDTLS_PRIVATE(name) );
         mbedtls_mpi_write_file( "X_Q:   ", &ecp->MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(X), 16, NULL );
         mbedtls_mpi_write_file( "Y_Q:   ", &ecp->MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(Y), 16, NULL );
         mbedtls_mpi_write_file( "D:     ", &ecp->MBEDTLS_PRIVATE(d)  , 16, NULL );

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -827,6 +827,7 @@ int main( int argc, char *argv[] )
 
         mbedtls_dhm_context dhm;
         size_t olen;
+        size_t n;
         for( i = 0; (size_t) i < sizeof( dhm_sizes ) / sizeof( dhm_sizes[0] ); i++ )
         {
             mbedtls_dhm_init( &dhm );
@@ -839,14 +840,14 @@ int main( int argc, char *argv[] )
                 mbedtls_exit( 1 );
             }
 
-            dhm.len = mbedtls_mpi_size( &dhm.P );
-            mbedtls_dhm_make_public( &dhm, (int) dhm.len, buf, dhm.len, myrand, NULL );
+            n = mbedtls_mpi_size( &dhm.P );
+            mbedtls_dhm_make_public( &dhm, (int) n, buf, n, myrand, NULL );
             if( mbedtls_mpi_copy( &dhm.GY, &dhm.GX ) != 0 )
                 mbedtls_exit( 1 );
 
             mbedtls_snprintf( title, sizeof( title ), "DHE-%d", dhm_sizes[i] );
             TIME_PUBLIC( title, "handshake",
-                    ret |= mbedtls_dhm_make_public( &dhm, (int) dhm.len, buf, dhm.len,
+                    ret |= mbedtls_dhm_make_public( &dhm, (int) n, buf, n,
                                             myrand, NULL );
                     ret |= mbedtls_dhm_calc_secret( &dhm, buf, sizeof( buf ), &olen, myrand, NULL ) );
 

--- a/tests/include/alt-dummy/aes_alt.h
+++ b/tests/include/alt-dummy/aes_alt.h
@@ -1,0 +1,37 @@
+/* aes_alt.h with dummy types for MBEDTLS_AES_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef AES_ALT_H
+#define AES_ALT_H
+
+typedef struct mbedtls_aes_context
+{
+    int dummy;
+}
+mbedtls_aes_context;
+
+#if defined(MBEDTLS_CIPHER_MODE_XTS)
+
+typedef struct mbedtls_aes_xts_context
+{
+    int dummy;
+} mbedtls_aes_xts_context;
+#endif
+
+
+#endif /* aes_alt.h */

--- a/tests/include/alt-dummy/arc4_alt.h
+++ b/tests/include/alt-dummy/arc4_alt.h
@@ -1,0 +1,30 @@
+/* arc4_alt.h with dummy types for MBEDTLS_ARC4_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef ARC4_ALT_H
+#define ARC4_ALT_H
+
+typedef struct mbedtls_arc4_context
+{
+    int dummy;
+}
+mbedtls_arc4_context;
+
+
+#endif /* arc4_alt.h */

--- a/tests/include/alt-dummy/aria_alt.h
+++ b/tests/include/alt-dummy/aria_alt.h
@@ -1,0 +1,29 @@
+/* aria_alt.h with dummy types for MBEDTLS_ARIA_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ARIA_ALT_H
+#define ARIA_ALT_H
+
+typedef struct mbedtls_aria_context
+{
+    int dummy;
+}
+mbedtls_aria_context;
+
+
+#endif /* aria_alt.h */

--- a/tests/include/alt-dummy/blowfish_alt.h
+++ b/tests/include/alt-dummy/blowfish_alt.h
@@ -1,0 +1,29 @@
+/* blowfish_alt.h with dummy types for MBEDTLS_BLOWFISH_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BLOWFISH_ALT_H
+#define BLOWFISH_ALT_H
+
+typedef struct mbedtls_blowfish_context
+{
+    int dummy;
+}
+mbedtls_blowfish_context;
+
+
+#endif /* blowfish_alt.h */

--- a/tests/include/alt-dummy/camellia_alt.h
+++ b/tests/include/alt-dummy/camellia_alt.h
@@ -1,0 +1,29 @@
+/* camellia_alt.h with dummy types for MBEDTLS_CAMELLIA_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CAMELLIA_ALT_H
+#define CAMELLIA_ALT_H
+
+typedef struct mbedtls_camellia_context
+{
+    int dummy;
+}
+mbedtls_camellia_context;
+
+
+#endif /* camellia_alt.h */

--- a/tests/include/alt-dummy/ccm_alt.h
+++ b/tests/include/alt-dummy/ccm_alt.h
@@ -1,0 +1,29 @@
+/* ccm_alt.h with dummy types for MBEDTLS_CCM_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CCM_ALT_H
+#define CCM_ALT_H
+
+typedef struct mbedtls_ccm_context
+{
+    int dummy;
+}
+mbedtls_ccm_context;
+
+
+#endif /* ccm_alt.h */

--- a/tests/include/alt-dummy/chacha20_alt.h
+++ b/tests/include/alt-dummy/chacha20_alt.h
@@ -1,0 +1,29 @@
+/* chacha20_alt.h with dummy types for MBEDTLS_CHACHA20_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CHACHA20_ALT_H
+#define CHACHA20_ALT_H
+
+typedef struct mbedtls_chacha20_context
+{
+    int dummy;
+}
+mbedtls_chacha20_context;
+
+
+#endif /* chacha20_alt.h */

--- a/tests/include/alt-dummy/chachapoly_alt.h
+++ b/tests/include/alt-dummy/chachapoly_alt.h
@@ -1,0 +1,31 @@
+/* chachapoly_alt.h with dummy types for MBEDTLS_CHACHAPOLY_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CHACHAPOLY_ALT_H
+#define CHACHAPOLY_ALT_H
+
+#include "mbedtls/chacha20.h"
+
+typedef struct mbedtls_chachapoly_context
+{
+    int dummy;
+}
+mbedtls_chachapoly_context;
+
+
+#endif /* chachapoly_alt.h */

--- a/tests/include/alt-dummy/cmac_alt.h
+++ b/tests/include/alt-dummy/cmac_alt.h
@@ -1,0 +1,28 @@
+/* cmac_alt.h with dummy types for MBEDTLS_CMAC_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CMAC_ALT_H
+#define CMAC_ALT_H
+
+struct mbedtls_cmac_context_t
+{
+    int dummy;
+};
+
+
+#endif /* cmac_alt.h */

--- a/tests/include/alt-dummy/des_alt.h
+++ b/tests/include/alt-dummy/des_alt.h
@@ -1,0 +1,36 @@
+/* des_alt.h with dummy types for MBEDTLS_DES_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef DES_ALT_H
+#define DES_ALT_H
+
+typedef struct mbedtls_des_context
+{
+    int dummy;
+}
+mbedtls_des_context;
+
+typedef struct mbedtls_des3_context
+{
+    int dummy;
+}
+mbedtls_des3_context;
+
+
+#endif /* des_alt.h */

--- a/tests/include/alt-dummy/dhm_alt.h
+++ b/tests/include/alt-dummy/dhm_alt.h
@@ -1,0 +1,29 @@
+/* dhm_alt.h with dummy types for MBEDTLS_DHM_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef DHM_ALT_H
+#define DHM_ALT_H
+
+typedef struct mbedtls_dhm_context
+{
+    int dummy;
+}
+mbedtls_dhm_context;
+
+
+#endif /* dhm_alt.h */

--- a/tests/include/alt-dummy/ecjpake_alt.h
+++ b/tests/include/alt-dummy/ecjpake_alt.h
@@ -1,0 +1,28 @@
+/* ecjpake_alt.h with dummy types for MBEDTLS_ECJPAKE_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ECJPAKE_ALT_H
+#define ECJPAKE_ALT_H
+
+typedef struct mbedtls_ecjpake_context
+{
+    int dummy;
+} mbedtls_ecjpake_context;
+
+
+#endif /* ecjpake_alt.h */

--- a/tests/include/alt-dummy/ecp_alt.h
+++ b/tests/include/alt-dummy/ecp_alt.h
@@ -1,0 +1,39 @@
+/* ecp_alt.h with dummy types for MBEDTLS_ECP_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef ECP_ALT_H
+#define ECP_ALT_H
+
+typedef struct mbedtls_ecp_group
+{
+    int dummy;
+}
+mbedtls_ecp_group;
+
+#if !defined(MBEDTLS_ECP_WINDOW_SIZE)
+
+#define MBEDTLS_ECP_WINDOW_SIZE    6
+#endif
+
+#if !defined(MBEDTLS_ECP_FIXED_POINT_OPTIM)
+
+#define MBEDTLS_ECP_FIXED_POINT_OPTIM  1
+#endif
+
+
+#endif /* ecp_alt.h */

--- a/tests/include/alt-dummy/ecp_alt.h
+++ b/tests/include/alt-dummy/ecp_alt.h
@@ -21,19 +21,15 @@
 
 typedef struct mbedtls_ecp_group
 {
-    int dummy;
+    const mbedtls_ecp_group_id id;
+    const mbedtls_mpi P;
+    const mbedtls_mpi A;
+    const mbedtls_mpi B;
+    const mbedtls_ecp_point G;
+    const mbedtls_mpi N;
+    const size_t pbits;
+    const size_t nbits;
 }
 mbedtls_ecp_group;
-
-#if !defined(MBEDTLS_ECP_WINDOW_SIZE)
-
-#define MBEDTLS_ECP_WINDOW_SIZE    6
-#endif
-
-#if !defined(MBEDTLS_ECP_FIXED_POINT_OPTIM)
-
-#define MBEDTLS_ECP_FIXED_POINT_OPTIM  1
-#endif
-
 
 #endif /* ecp_alt.h */

--- a/tests/include/alt-dummy/gcm_alt.h
+++ b/tests/include/alt-dummy/gcm_alt.h
@@ -1,0 +1,29 @@
+/* gcm_alt.h with dummy types for MBEDTLS_GCM_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef GCM_ALT_H
+#define GCM_ALT_H
+
+typedef struct mbedtls_gcm_context
+{
+    int dummy;
+}
+mbedtls_gcm_context;
+
+
+#endif /* gcm_alt.h */

--- a/tests/include/alt-dummy/md2_alt.h
+++ b/tests/include/alt-dummy/md2_alt.h
@@ -1,0 +1,30 @@
+/* md2_alt.h with dummy types for MBEDTLS_MD2_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef MD2_ALT_H
+#define MD2_ALT_H
+
+typedef struct mbedtls_md2_context
+{
+    int dummy;
+}
+mbedtls_md2_context;
+
+
+#endif /* md2_alt.h */

--- a/tests/include/alt-dummy/md4_alt.h
+++ b/tests/include/alt-dummy/md4_alt.h
@@ -1,0 +1,30 @@
+/* md4_alt.h with dummy types for MBEDTLS_MD4_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef MD4_ALT_H
+#define MD4_ALT_H
+
+typedef struct mbedtls_md4_context
+{
+    int dummy;
+}
+mbedtls_md4_context;
+
+
+#endif /* md4_alt.h */

--- a/tests/include/alt-dummy/md5_alt.h
+++ b/tests/include/alt-dummy/md5_alt.h
@@ -1,0 +1,29 @@
+/* md5_alt.h with dummy types for MBEDTLS_MD5_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MD5_ALT_H
+#define MD5_ALT_H
+
+typedef struct mbedtls_md5_context
+{
+    int dummy;
+}
+mbedtls_md5_context;
+
+
+#endif /* md5_alt.h */

--- a/tests/include/alt-dummy/nist_kw_alt.h
+++ b/tests/include/alt-dummy/nist_kw_alt.h
@@ -1,0 +1,27 @@
+/* nist_kw_alt.h with dummy types for MBEDTLS_NIST_KW_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef NIST_KW_ALT_H
+#define NIST_KW_ALT_H
+
+typedef struct {
+    int dummy;
+} mbedtls_nist_kw_context;
+
+
+#endif /* nist_kw_alt.h */

--- a/tests/include/alt-dummy/platform_alt.h
+++ b/tests/include/alt-dummy/platform_alt.h
@@ -1,0 +1,29 @@
+/* platform_alt.h with dummy types for MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PLATFORM_ALT_H
+#define PLATFORM_ALT_H
+
+typedef struct mbedtls_platform_context
+{
+    int dummy;
+}
+mbedtls_platform_context;
+
+
+#endif /* platform_alt.h */

--- a/tests/include/alt-dummy/poly1305_alt.h
+++ b/tests/include/alt-dummy/poly1305_alt.h
@@ -1,0 +1,29 @@
+/* poly1305_alt.h with dummy types for MBEDTLS_POLY1305_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef POLY1305_ALT_H
+#define POLY1305_ALT_H
+
+typedef struct mbedtls_poly1305_context
+{
+    int dummy;
+}
+mbedtls_poly1305_context;
+
+
+#endif /* poly1305_alt.h */

--- a/tests/include/alt-dummy/ripemd160_alt.h
+++ b/tests/include/alt-dummy/ripemd160_alt.h
@@ -1,0 +1,29 @@
+/* ripemd160_alt.h with dummy types for MBEDTLS_RIPEMD160_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef RIPEMD160_ALT_H
+#define RIPEMD160_ALT_H
+
+typedef struct mbedtls_ripemd160_context
+{
+    int dummy;
+}
+mbedtls_ripemd160_context;
+
+
+#endif /* ripemd160_alt.h */

--- a/tests/include/alt-dummy/rsa_alt.h
+++ b/tests/include/alt-dummy/rsa_alt.h
@@ -1,0 +1,29 @@
+/* rsa_alt.h with dummy types for MBEDTLS_RSA_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef RSA_ALT_H
+#define RSA_ALT_H
+
+typedef struct mbedtls_rsa_context
+{
+    int dummy;
+}
+mbedtls_rsa_context;
+
+
+#endif /* rsa_alt.h */

--- a/tests/include/alt-dummy/sha1_alt.h
+++ b/tests/include/alt-dummy/sha1_alt.h
@@ -1,0 +1,29 @@
+/* sha1_alt.h with dummy types for MBEDTLS_SHA1_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SHA1_ALT_H
+#define SHA1_ALT_H
+
+typedef struct mbedtls_sha1_context
+{
+    int dummy;
+}
+mbedtls_sha1_context;
+
+
+#endif /* sha1_alt.h */

--- a/tests/include/alt-dummy/sha256_alt.h
+++ b/tests/include/alt-dummy/sha256_alt.h
@@ -1,0 +1,29 @@
+/* sha256_alt.h with dummy types for MBEDTLS_SHA256_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SHA256_ALT_H
+#define SHA256_ALT_H
+
+typedef struct mbedtls_sha256_context
+{
+    int dummy;
+}
+mbedtls_sha256_context;
+
+
+#endif /* sha256_alt.h */

--- a/tests/include/alt-dummy/sha512_alt.h
+++ b/tests/include/alt-dummy/sha512_alt.h
@@ -1,0 +1,29 @@
+/* sha512_alt.h with dummy types for MBEDTLS_SHA512_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SHA512_ALT_H
+#define SHA512_ALT_H
+
+typedef struct mbedtls_sha512_context
+{
+    int dummy;
+}
+mbedtls_sha512_context;
+
+
+#endif /* sha512_alt.h */

--- a/tests/include/alt-dummy/threading_alt.h
+++ b/tests/include/alt-dummy/threading_alt.h
@@ -1,0 +1,27 @@
+/* threading_alt.h with dummy types for MBEDTLS_THREADING_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef THREADING_ALT_H
+#define THREADING_ALT_H
+
+typedef struct mbedtls_threading_mutex_t
+{
+    int dummy;
+} mbedtls_threading_mutex_t;
+
+#endif /* threading_alt.h */

--- a/tests/include/alt-dummy/timing_alt.h
+++ b/tests/include/alt-dummy/timing_alt.h
@@ -1,0 +1,33 @@
+/* timing_alt.h with dummy types for MBEDTLS_TIMING_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef TIMING_ALT_H
+#define TIMING_ALT_H
+
+struct mbedtls_timing_hr_time
+{
+    int dummy;
+};
+
+typedef struct mbedtls_timing_delay_context
+{
+    int dummy;
+} mbedtls_timing_delay_context;
+
+
+#endif /* timing_alt.h */

--- a/tests/include/alt-dummy/xtea_alt.h
+++ b/tests/include/alt-dummy/xtea_alt.h
@@ -1,0 +1,29 @@
+/* xtea_alt.h with dummy types for MBEDTLS_XTEA_ALT */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef XTEA_ALT_H
+#define XTEA_ALT_H
+
+typedef struct mbedtls_xtea_context
+{
+    int dummy;
+}
+mbedtls_xtea_context;
+
+
+#endif /* xtea_alt.h */

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1371,9 +1371,6 @@ component_build_module_alt () {
     # aesni.c and padlock.c reference mbedtls_aes_context fields directly.
     scripts/config.py unset MBEDTLS_AESNI_C
     scripts/config.py unset MBEDTLS_PADLOCK_C
-    # The debug code accesses DHM context fields directly, so it is
-    # incompatible with MBEDTLS_DHM_ALT.
-    scripts/config.py unset MBEDTLS_DEBUG_C
     # You can only have one threading implementation: alt or pthread, not both.
     scripts/config.py unset MBEDTLS_THREADING_PTHREAD
     # The SpecifiedECDomain parsing code accesses mbedtls_ecp_group fields
@@ -1382,6 +1379,18 @@ component_build_module_alt () {
     # Enable all MBEDTLS_XXX_ALT for whole modules. Do not enable
     # MBEDTLS_XXX_YYY_ALT which are for single functions.
     scripts/config.py set-all 'MBEDTLS_([A-Z0-9]*|NIST_KW)_ALT'
+    scripts/config.py unset MBEDTLS_DHM_ALT #incompatible with MBEDTLS_DEBUG_C
+    # We can only compile, not link, since we don't have any implementations
+    # suitable for testing with the dummy alt headers.
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy' lib
+}
+
+component_build_dhm_alt () {
+    msg "build: MBEDTLS_DHM_ALT" # ~30s
+    scripts/config.py full
+    scripts/config.py set MBEDTLS_DHM_ALT
+    # debug.c currently references mbedtls_dhm_context fields directly.
+    scripts/config.py unset MBEDTLS_DEBUG_C
     # We can only compile, not link, since we don't have any implementations
     # suitable for testing with the dummy alt headers.
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy' lib

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1376,6 +1376,9 @@ component_build_module_alt () {
     scripts/config.py unset MBEDTLS_DEBUG_C
     # You can only have one threading implementation: alt or pthread, not both.
     scripts/config.py unset MBEDTLS_THREADING_PTHREAD
+    # The SpecifiedECDomain parsing code accesses mbedtls_ecp_group fields
+    # directly and assumes the implementation works with partial groups.
+    scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
     # Enable all MBEDTLS_XXX_ALT for whole modules. Do not enable
     # MBEDTLS_XXX_YYY_ALT which are for single functions.
     scripts/config.py set-all 'MBEDTLS_([A-Z0-9]*|NIST_KW)_ALT'

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1364,6 +1364,26 @@ component_build_default_make_gcc_and_cxx () {
     make TEST_CPP=1
 }
 
+component_build_module_alt () {
+    msg "build: MBEDTLS_XXX_ALT" # ~30s
+    scripts/config.py full
+    # Disable options that are incompatible with some ALT implementations.
+    # aesni.c and padlock.c reference mbedtls_aes_context fields directly.
+    scripts/config.py unset MBEDTLS_AESNI_C
+    scripts/config.py unset MBEDTLS_PADLOCK_C
+    # The debug code accesses DHM context fields directly, so it is
+    # incompatible with MBEDTLS_DHM_ALT.
+    scripts/config.py unset MBEDTLS_DEBUG_C
+    # You can only have one threading implementation: alt or pthread, not both.
+    scripts/config.py unset MBEDTLS_THREADING_PTHREAD
+    # Enable all MBEDTLS_XXX_ALT for whole modules. Do not enable
+    # MBEDTLS_XXX_YYY_ALT which are for single functions.
+    scripts/config.py set-all 'MBEDTLS_([A-Z0-9]*|NIST_KW)_ALT'
+    # We can only compile, not link, since we don't have any implementations
+    # suitable for testing with the dummy alt headers.
+    make CC=gcc CFLAGS='-Werror -Wall -Wextra -I../tests/include/alt-dummy' lib
+}
+
 component_test_no_use_psa_crypto_full_cmake_asan() {
     # full minus MBEDTLS_USE_PSA_CRYPTO: run the same set of tests as basic-build-test.sh
     msg "build: cmake, full config minus MBEDTLS_USE_PSA_CRYPTO, ASan"

--- a/tests/suites/test_suite_dhm.function
+++ b/tests/suites/test_suite_dhm.function
@@ -1,6 +1,23 @@
 /* BEGIN_HEADER */
 #include "mbedtls/dhm.h"
 
+int check_get_value( const mbedtls_dhm_context *ctx,
+                     mbedtls_dhm_parameter param,
+                     const mbedtls_mpi *expected )
+{
+    mbedtls_mpi actual;
+    int ok = 0;
+    mbedtls_mpi_init( &actual );
+
+    TEST_ASSERT( mbedtls_dhm_get_value( &actual, ctx, param ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &actual, expected ) == 0 );
+    ok = 1;
+
+exit:
+    mbedtls_mpi_free( &actual );
+    return( ok );
+}
+
 /* Sanity checks on a Diffie-Hellman parameter: check the length-value
  * syntax and check that the value is the expected one (taken from the
  * DHM context by the caller). */
@@ -102,6 +119,8 @@ void dhm_do_dhm( int radix_P, char *input_P, int x_size,
     TEST_ASSERT( mbedtls_mpi_read_string( &ctx_srv.P, radix_P, input_P ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &ctx_srv.G, radix_G, input_G ) == 0 );
     pub_cli_len = mbedtls_mpi_size( &ctx_srv.P );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_P, &ctx_srv.P ) );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_G, &ctx_srv.G ) );
 
     /*
      * First key exchange
@@ -118,6 +137,9 @@ void dhm_do_dhm( int radix_P, char *input_P, int x_size,
     ske[ske_len++] = 0;
     ske[ske_len++] = 0;
     TEST_ASSERT( mbedtls_dhm_read_params( &ctx_cli, &p, ske + ske_len ) == 0 );
+    /* The domain parameters must be the same on both side. */
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_P, &ctx_srv.P ) );
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_G, &ctx_srv.G ) );
 
     TEST_ASSERT( mbedtls_dhm_make_public( &ctx_cli, x_size, pub_cli, pub_cli_len,
                                           &mbedtls_test_rnd_pseudo_rand,
@@ -133,6 +155,17 @@ void dhm_do_dhm( int radix_P, char *input_P, int x_size,
     TEST_ASSERT( sec_srv_len == sec_cli_len );
     TEST_ASSERT( sec_srv_len != 0 );
     TEST_ASSERT( memcmp( sec_srv, sec_cli, sec_srv_len ) == 0 );
+
+    /* Internal value checks */
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_X, &ctx_cli.X ) );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_X, &ctx_srv.X ) );
+    /* Cross-checks */
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_GX, &ctx_srv.GY ) );
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_GY, &ctx_srv.GX ) );
+    TEST_ASSERT( check_get_value( &ctx_cli, MBEDTLS_DHM_PARAM_K, &ctx_srv.K ) );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_GX, &ctx_cli.GY ) );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_GY, &ctx_cli.GX ) );
+    TEST_ASSERT( check_get_value( &ctx_srv, MBEDTLS_DHM_PARAM_K, &ctx_cli.K ) );
 
     /* Re-do calc_secret on server a few times to test update of blinding values */
     for( i = 0; i < 3; i++ )
@@ -231,8 +264,8 @@ void dhm_file( char * filename, char * p, char * g, int len )
 
     TEST_EQUAL( mbedtls_dhm_get_len( &ctx ), (size_t) len );
     TEST_EQUAL( mbedtls_dhm_get_bitlen( &ctx ), mbedtls_mpi_bitlen( &P ) );
-    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &ctx.P, &P ) == 0 );
-    TEST_ASSERT( mbedtls_mpi_cmp_mpi( &ctx.G, &G ) == 0 );
+    TEST_ASSERT( check_get_value( &ctx, MBEDTLS_DHM_PARAM_P, &P ) );
+    TEST_ASSERT( check_get_value( &ctx, MBEDTLS_DHM_PARAM_G, &G ) );
 
 exit:
     mbedtls_mpi_free( &P ); mbedtls_mpi_free( &G );

--- a/tests/suites/test_suite_dhm.function
+++ b/tests/suites/test_suite_dhm.function
@@ -9,7 +9,7 @@ int check_get_value( const mbedtls_dhm_context *ctx,
     int ok = 0;
     mbedtls_mpi_init( &actual );
 
-    TEST_ASSERT( mbedtls_dhm_get_value( &actual, ctx, param ) == 0 );
+    TEST_ASSERT( mbedtls_dhm_get_value( ctx, param, &actual ) == 0 );
     TEST_ASSERT( mbedtls_mpi_cmp_mpi( &actual, expected ) == 0 );
     ok = 1;
 

--- a/tests/suites/test_suite_dhm.function
+++ b/tests/suites/test_suite_dhm.function
@@ -229,7 +229,8 @@ void dhm_file( char * filename, char * p, char * g, int len )
 
     TEST_ASSERT( mbedtls_dhm_parse_dhmfile( &ctx, filename ) == 0 );
 
-    TEST_ASSERT( ctx.len == (size_t) len );
+    TEST_EQUAL( mbedtls_dhm_get_len( &ctx ), (size_t) len );
+    TEST_EQUAL( mbedtls_dhm_get_bitlen( &ctx ), mbedtls_mpi_bitlen( &P ) );
     TEST_ASSERT( mbedtls_mpi_cmp_mpi( &ctx.P, &P ) == 0 );
     TEST_ASSERT( mbedtls_mpi_cmp_mpi( &ctx.G, &G ) == 0 );
 

--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -65,6 +65,8 @@ void mbedtls_ecp_curve_info( int id, int tls_id, int size, char * name )
     TEST_ASSERT( by_id == by_name );
 
     TEST_ASSERT( by_id->bit_size == size );
+    TEST_ASSERT( size <= MBEDTLS_ECP_MAX_BITS );
+    TEST_ASSERT( size <= MBEDTLS_ECP_MAX_BYTES * 8 );
 }
 /* END_CASE */
 
@@ -473,6 +475,7 @@ void ecp_muladd( int id,
     TEST_EQUAL( 0, mbedtls_ecp_point_write_binary(
                     &grp, &R, MBEDTLS_ECP_PF_UNCOMPRESSED,
                     &len, actual_result, sizeof( actual_result ) ) );
+    TEST_ASSERT( len <= MBEDTLS_ECP_MAX_PT_LEN );
 
     ASSERT_COMPARE( expected_result->x, expected_result->len,
                     actual_result, len );
@@ -544,6 +547,7 @@ void ecp_write_binary( int id, char * x, char * y, char * z, int format,
 
     if( ret == 0 )
     {
+        TEST_ASSERT( olen <= MBEDTLS_ECP_MAX_PT_LEN );
         TEST_ASSERT( mbedtls_test_hexcmp( buf, out->x, olen, out->len ) == 0 );
     }
 


### PR DESCRIPTION
* Write some basic documentation about alt implementation. This wasn't really in scope, but I needed some place to write the documentation for this task. Writing detailed, polished documentation is out of scope of this pull request.
* Fix some glitches of the ECP alt interface.
* Remove `MBEDTLS_ECP_MAX_BITS` as a configuration option.
* Add some accessor functions to the DHM and ECJPAKE modules to relax the constraints on context types from `MBEDTLS_DHM_ALT` and `MBEDTLS_ECJPAKE_ALT`.
* Tweak the code to relax constraints on the context types of several whole-module alternative implementations.
* Test the build with whole-module `MBEDTLS_XXX_ALT` defined. (Just building the library. Anything involving linking is out of scope.)
* Document the remaining constraints on context types.
* Add the constraint that context types must be movable. Fix #4451.

Fix https://github.com/ARMmbed/mbedtls/issues/4573.

Size note: it took me about a day to assemble this PR, so it fits in S. However, due to the diversity of the changes, this will be somewhat lengthy to review, hence estimating at M for review.
