### PR TITLE
Turn _SSL_SRV_RESPECT_CLIENT_PREFERENCE config opt to a runtime opt

### DIFF
--- a/ChangeLog.d/issue4398.txt
+++ b/ChangeLog.d/issue4398.txt
@@ -1,9 +1,3 @@
 API changes
-    * Remove the MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE option from config.h.
-      Replace it with SSL runtime option which can be enabled or disabled using
-      new added API function mbedtls_ssl_conf_respect_client_preference(). Add
-      a new field respect_cli_pref in the mbedtls_ssl_config structure and two
-      defines used as a parameter: MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED
-      and MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED. Adapt the code used for
-      searching for a matching ciphersuite to use the new field instead of the
-      removed config.h option. Fixes #3498.
+    * Replace MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE by a runtime
+      configuration function mbedtls_ssl_conf_preference_order(). Fixes #4398.

--- a/ChangeLog.d/issue4398.txt
+++ b/ChangeLog.d/issue4398.txt
@@ -1,0 +1,9 @@
+API changes
+    * Remove the MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE option from config.h.
+      Replace it with SSL runtime option which can be enabled or disabled using
+      new added API function mbedtls_ssl_conf_respect_client_preference(). Add
+      a new field respect_cli_pref in the mbedtls_ssl_config structure and two
+      defines used as a parameter: MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED
+      and MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED. Adapt the code used for
+      searching for a matching ciphersuite to use the new field instead of the
+      removed config.h option. Fixes #3498.

--- a/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
+++ b/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
@@ -1,13 +1,14 @@
 Turn MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE configuration option into a runtime option
 --
 
-This change affects users who see the change of the SSL server vs. client
-preferred set of ciphersuites in runtime useful.
+This change affects users who were enabling MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
+option in the `config.h`
 
-The `MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE` `config.h` option has been
-removed and a new function with similar functionality has been introduced into the
-SSL API.
+This option has been removed and a new function with similar functionality has
+been introduced into the SSL API.
 
-This new function `mbedtls_ssl_conf_respect_client_preference()` can be used to
-change the preferred set of ciphersuites on the server to those used on the client.
-The default state is to use the server set of suites.
+This new function `mbedtls_ssl_conf_preference_order()` can be used to
+change the preferred order of ciphersuites on the server to those used on the client,
+e.g.: `mbedtls_ssl_conf_preference_order(ssl_config, MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_CLIENT)`
+has the same effect as enabling the removed option. The default state is to use
+the server order of suites.

--- a/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
+++ b/docs/3.0-migration-guide.d/turn_SSL_SRV_RESPECT_CLIENT_PREFERENCE_config_opt_to_runtime_opt.md
@@ -1,0 +1,13 @@
+Turn MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE configuration option into a runtime option
+--
+
+This change affects users who see the change of the SSL server vs. client
+preferred set of ciphersuites in runtime useful.
+
+The `MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE` `config.h` option has been
+removed and a new function with similar functionality has been introduced into the
+SSL API.
+
+This new function `mbedtls_ssl_conf_respect_client_preference()` can be used to
+change the preferred set of ciphersuites on the server to those used on the client.
+The default state is to use the server set of suites.

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1472,16 +1472,6 @@
 #define MBEDTLS_SSL_RENEGOTIATION
 
 /**
- * \def MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
- *
- * Pick the ciphersuite according to the client's preferences rather than ours
- * in the SSL Server module (MBEDTLS_SSL_SRV_C).
- *
- * Uncomment this macro to respect client's ciphersuite order
- */
-//#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE
-
-/**
  * \def MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
  *
  * Enable support for RFC 6066 max_fragment_length extension in SSL.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -200,8 +200,8 @@
 #define MBEDTLS_SSL_DTLS_SRTP_MKI_UNSUPPORTED    0
 #define MBEDTLS_SSL_DTLS_SRTP_MKI_SUPPORTED      1
 
-#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED    1
-#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED   0
+#define MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_CLIENT  1
+#define MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER  0
 
 /*
  * Default range for DTLS retransmission timer value, in milliseconds.
@@ -2498,9 +2498,12 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
  *                      The ciphersuites array is not copied, and must remain
  *                      valid for the lifetime of the ssl_config.
  *
- *                      Note: The server uses its own preferences
- *                      over the preference of the client unless
- *                      conf->respect_cli_pref is enabled!
+ *                      Note: By default, the server chooses its preferred
+ *                      ciphersuite among those that the client supports. If
+ *                      mbedtls_ssl_conf_preference_order() is called to prefer
+ *                      the client's preferences, the server instead chooses
+ *                      the client's preferred ciphersuite among those that
+ *                      the server supports.
  *
  * \param conf          SSL configuration
  * \param ciphersuites  0-terminated list of allowed ciphersuites
@@ -3300,15 +3303,15 @@ int mbedtls_ssl_conf_max_frag_len( mbedtls_ssl_config *conf, unsigned char mfl_c
 
 #if defined(MBEDTLS_SSL_SRV_C)
 /**
- * \brief          Pick the ciphersuite according to the client's preferences
- *                 rather than ours in the SSL Server module (MBEDTLS_SSL_SRV_C).
- *                 (Default: MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED)
+ * \brief          Pick the ciphersuites order according to the second parameter
+ *                 in the SSL Server module (MBEDTLS_SSL_SRV_C).
+ *                 (Default, if never called: MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER)
  *
  * \param conf     SSL configuration
- * \param enable   Enable or disable (MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED
- *                                 or MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED)
+ * \param order    Server or client (MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER
+ *                                or MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_CLIENT)
  */
-void mbedtls_ssl_conf_respect_client_preference( mbedtls_ssl_config *conf, int enable );
+void mbedtls_ssl_conf_preference_order( mbedtls_ssl_config *conf, int order );
 #endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -200,6 +200,9 @@
 #define MBEDTLS_SSL_DTLS_SRTP_MKI_UNSUPPORTED    0
 #define MBEDTLS_SSL_DTLS_SRTP_MKI_SUPPORTED      1
 
+#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED    1
+#define MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED   0
+
 /*
  * Default range for DTLS retransmission timer value, in milliseconds.
  * RFC 6347 4.2.4.1 says from 1 second to 60 seconds.
@@ -1185,6 +1188,9 @@ struct mbedtls_ssl_config
 #if defined(MBEDTLS_SSL_SRV_C)
     unsigned int cert_req_ca_list : 1;  /*!< enable sending CA list in
                                           Certificate Request messages?     */
+    unsigned int respect_cli_pref : 1;  /*!< pick the ciphersuite according to
+                                          the client's preferences rather
+                                          than ours                         */
 #endif
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     unsigned int ignore_unexpected_cid : 1; /*!< Determines whether DTLS
@@ -2494,7 +2500,7 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
  *
  *                      Note: The server uses its own preferences
  *                      over the preference of the client unless
- *                      MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE is defined!
+ *                      conf->respect_cli_pref is enabled!
  *
  * \param conf          SSL configuration
  * \param ciphersuites  0-terminated list of allowed ciphersuites
@@ -3291,6 +3297,19 @@ void mbedtls_ssl_conf_cert_req_ca_list( mbedtls_ssl_config *conf,
  */
 int mbedtls_ssl_conf_max_frag_len( mbedtls_ssl_config *conf, unsigned char mfl_code );
 #endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
+
+#if defined(MBEDTLS_SSL_SRV_C)
+/**
+ * \brief          Pick the ciphersuite according to the client's preferences
+ *                 rather than ours in the SSL Server module (MBEDTLS_SSL_SRV_C).
+ *                 (Default: MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED)
+ *
+ * \param conf     SSL configuration
+ * \param enable   Enable or disable (MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED
+ *                                 or MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED)
+ */
+void mbedtls_ssl_conf_respect_client_preference( mbedtls_ssl_config *conf, int enable );
+#endif /* MBEDTLS_SSL_SRV_C */
 
 #if defined(MBEDTLS_SSL_TRUNCATED_HMAC)
 /**

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1873,7 +1873,7 @@ read_record_header:
     ciphersuites = ssl->conf->ciphersuite_list;
     ciphersuite_info = NULL;
 
-    if (ssl->conf->respect_cli_pref == MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED)
+    if (ssl->conf->respect_cli_pref == MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_CLIENT)
     {
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
             for( i = 0; ciphersuites[i] != 0; i++ )
@@ -4433,9 +4433,9 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
     return( ret );
 }
 
-void mbedtls_ssl_conf_respect_client_preference( mbedtls_ssl_config *conf, int enable )
+void mbedtls_ssl_conf_preference_order( mbedtls_ssl_config *conf, int order )
 {
-    conf->respect_cli_pref = enable;
+    conf->respect_cli_pref = order;
 }
 
 #endif /* MBEDTLS_SSL_SRV_C */

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1872,27 +1872,43 @@ read_record_header:
     got_common_suite = 0;
     ciphersuites = ssl->conf->ciphersuite_list;
     ciphersuite_info = NULL;
-#if defined(MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE)
-    for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
-        for( i = 0; ciphersuites[i] != 0; i++ )
-#else
-    for( i = 0; ciphersuites[i] != 0; i++ )
+
+    if (ssl->conf->respect_cli_pref == MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_ENABLED)
+    {
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
-#endif
-        {
-            if( p[0] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
-                p[1] != ( ( ciphersuites[i]      ) & 0xFF ) )
-                continue;
+            for( i = 0; ciphersuites[i] != 0; i++ )
+            {
+                if( p[0] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
+                    p[1] != ( ( ciphersuites[i]      ) & 0xFF ) )
+                    continue;
 
-            got_common_suite = 1;
+                got_common_suite = 1;
 
-            if( ( ret = ssl_ciphersuite_match( ssl, ciphersuites[i],
-                                               &ciphersuite_info ) ) != 0 )
-                return( ret );
+                if( ( ret = ssl_ciphersuite_match( ssl, ciphersuites[i],
+                                                   &ciphersuite_info ) ) != 0 )
+                    return( ret );
 
-            if( ciphersuite_info != NULL )
-                goto have_ciphersuite;
-        }
+                if( ciphersuite_info != NULL )
+                    goto have_ciphersuite;
+            }
+    } else {
+        for( i = 0; ciphersuites[i] != 0; i++ )
+            for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
+            {
+                if( p[0] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
+                    p[1] != ( ( ciphersuites[i]      ) & 0xFF ) )
+                    continue;
+
+                got_common_suite = 1;
+
+                if( ( ret = ssl_ciphersuite_match( ssl, ciphersuites[i],
+                                                   &ciphersuite_info ) ) != 0 )
+                    return( ret );
+
+                if( ciphersuite_info != NULL )
+                    goto have_ciphersuite;
+            }
+    }
 
     if( got_common_suite )
     {
@@ -4416,4 +4432,10 @@ int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl )
 
     return( ret );
 }
+
+void mbedtls_ssl_conf_respect_client_preference( mbedtls_ssl_config *conf, int enable )
+{
+    conf->respect_cli_pref = enable;
+}
+
 #endif /* MBEDTLS_SSL_SRV_C */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6189,7 +6189,7 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_SRV_C)
     conf->cert_req_ca_list = MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED;
-    conf->respect_cli_pref = MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED;
+    conf->respect_cli_pref = MBEDTLS_SSL_SRV_CIPHERSUITE_ORDER_SERVER;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6189,6 +6189,7 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
 
 #if defined(MBEDTLS_SSL_SRV_C)
     conf->cert_req_ca_list = MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED;
+    conf->respect_cli_pref = MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREF_DISABLED;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)


### PR DESCRIPTION
Signed-off-by: TRodziewicz <tomasz.rodziewicz@mobica.com>

## Description
The configuration option MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE allows during TLS handshake to select the ciphersuite according to the client's preferences rather than the server's preferences. Change it into runtime option available as an API function.

Fixes #4398 

## Status
IN DEVELOPMENT

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
