### PR TITLE
Hide ssl deprecated constants

### DIFF
--- a/ChangeLog.d/issue4286.txt
+++ b/ChangeLog.d/issue4286.txt
@@ -2,13 +2,9 @@ Removals
    * Remove support for TLS 1.0, TLS 1.1 and DTLS 1.0, as well as support for
      CBC record splitting, fallback SCSV, and the ability to configure
      ciphersuites per version, which are no longer relevant. This removes the
-     following public constants: MBEDTLS_SSL_PROTO_TLS1,
-     MBEDTLS_SSL_PROTO_TLS1_1, MBEDTLS_SSL_MINOR_VERSION_1,
-     MBEDTLS_SSL_MINOR_VERSION_2, MBEDTLS_SSL_CBC_RECORD_SPLITTING,
-     MBEDTLS_SSL_CBC_RECORD_SPLITTING_ENABLED,
-     MBEDTLS_SSL_CBC_RECORD_SPLITTING_DISABLED,
-     MBEDTLS_SSL_FALLBACK_SCSV, MBEDTLS_SSL_FALLBACK_SCSV_VALUE,
-     MBEDTLS_SSL_IS_FALLBACK, MBEDTLS_SSL_IS_NOT_FALLBACK; and functions:
+     configuration options MBEDTLS_SSL_PROTO_TLS1,
+     MBEDTLS_SSL_PROTO_TLS1_1, MBEDTLS_SSL_CBC_RECORD_SPLITTING and
+     MBEDTLS_SSL_FALLBACK_SCSV as well as the functions
      mbedtls_ssl_conf_cbc_record_splitting(),
      mbedtls_ssl_get_key_exchange_md_ssl_tls(), mbedtls_ssl_conf_fallback(),
-     mbedtls_ssl_conf_ciphersuites_for_version(). Fixes #4286.
+     and mbedtls_ssl_conf_ciphersuites_for_version(). Fixes #4286.

--- a/ChangeLog.d/issue4286.txt
+++ b/ChangeLog.d/issue4286.txt
@@ -1,11 +1,14 @@
 Removals
-   * Remove the TLS 1.0, TLS 1.1 and DTLS 1.0 support by removing the following
-     library constants: MBEDTLS_SSL_PROTO_TLS1,
-     MBEDTLS_SSL_PROTO_TLS1_1, MBEDTLS_SSL_CBC_RECORD_SPLITTING,
+   * Remove support for TLS 1.0, TLS 1.1 and DTLS 1.0, as well as support for
+     CBC record splitting, fallback SCSV, and the ability to configure
+     ciphersuites per version, which are no longer relevant. This removes the
+     following public constants: MBEDTLS_SSL_PROTO_TLS1,
+     MBEDTLS_SSL_PROTO_TLS1_1, MBEDTLS_SSL_MINOR_VERSION_1,
+     MBEDTLS_SSL_MINOR_VERSION_2, MBEDTLS_SSL_CBC_RECORD_SPLITTING,
      MBEDTLS_SSL_CBC_RECORD_SPLITTING_ENABLED,
      MBEDTLS_SSL_CBC_RECORD_SPLITTING_DISABLED,
      MBEDTLS_SSL_FALLBACK_SCSV, MBEDTLS_SSL_FALLBACK_SCSV_VALUE,
-     MBEDTLS_SSL_IS_FALLBACK, MBEDTLS_SSL_IS_NOT_FALLBACK, and functions:
+     MBEDTLS_SSL_IS_FALLBACK, MBEDTLS_SSL_IS_NOT_FALLBACK; and functions:
      mbedtls_ssl_conf_cbc_record_splitting(),
-     mbedtls_ssl_get_key_exchange_md_ssl_tls(), mbedtls_ssl_conf_fallback().
-     Fixes #4286.
+     mbedtls_ssl_get_key_exchange_md_ssl_tls(), mbedtls_ssl_conf_fallback(),
+     mbedtls_ssl_conf_ciphersuites_for_version(). Fixes #4286.

--- a/docs/3.0-migration-guide.d/remove_support_for_tls_1.0_1.1_and_dtls_1.0.md
+++ b/docs/3.0-migration-guide.d/remove_support_for_tls_1.0_1.1_and_dtls_1.0.md
@@ -3,9 +3,25 @@ Remove suport for TLS 1.0, 1.1 and DTLS 1.0
 
 This change affects users of the TLS 1.0, 1.1 and DTLS 1.0 protocols.
 
-The versions of (D)TLS that are being removed are not as secure as the latest
-versions. Keeping them in the library creates opportunities for misconfiguration
+These versions have been deprecated by RFC 8996.
+Keeping them in the library creates opportunities for misconfiguration
 and possibly downgrade attacks. More generally, more code means a larger attack
 surface, even if the code is supposedly not used.
 
 The migration path is to adopt the latest versions of the protocol.
+
+As a consequence of removing 1.0, support for CBC record splitting was also
+removed, as it was a work-around for a weakness in this particular version.
+There is no migration path is no longer makes sense with newer versions.
+
+As a consequence of currently supporting only one version of (D)TLS (and in the
+future 1.3 which will have a different version negociation mechanism), support
+for fallback SCSV (RFC 7507) was also removed. There is no migration path as
+it's no longer useful with TLS 1.2 and later.
+
+As a consequence of currently supporting only one version of (D)TLS (and in the
+future 1.3 which will have a different concept of ciphersuites), support for
+configuring ciphersuites separately for each version via
+`mbedtls_ssl_conf_ciphersuites_for_version()` was removed. Use
+`mbedtls_ssl_conf_ciphersuites()` to configure ciphersuites to use with (D)TLS
+1.2; in the future a different API will be added for (D)TLS 1.3.

--- a/docs/3.0-migration-guide.d/remove_support_for_tls_1.0_1.1_and_dtls_1.0.md
+++ b/docs/3.0-migration-guide.d/remove_support_for_tls_1.0_1.1_and_dtls_1.0.md
@@ -10,9 +10,9 @@ surface, even if the code is supposedly not used.
 
 The migration path is to adopt the latest versions of the protocol.
 
-As a consequence of removing 1.0, support for CBC record splitting was also
-removed, as it was a work-around for a weakness in this particular version.
-There is no migration path is no longer makes sense with newer versions.
+As a consequence of removing TLS 1.0, support for CBC record splitting was
+also removed, as it was a work-around for a weakness in this particular
+version. There is no migration path since the feature is no longer relevant.
 
 As a consequence of currently supporting only one version of (D)TLS (and in the
 future 1.3 which will have a different version negociation mechanism), support

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3191,8 +3191,7 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result( const mbedtls_ssl_context *ss
  *
  * \param conf     SSL configuration
  * \param major    Major version number (only MBEDTLS_SSL_MAJOR_VERSION_3 supported)
- * \param minor    Minor version number (MBEDTLS_SSL_MINOR_VERSION_1 and MBEDTLS_SSL_MINOR_VERSION_2,
- *                 MBEDTLS_SSL_MINOR_VERSION_3 supported)
+ * \param minor    Minor version number (only MBEDTLS_SSL_MINOR_VERSION_3 supported)
  */
 void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int minor );
 
@@ -3207,9 +3206,7 @@ void mbedtls_ssl_conf_max_version( mbedtls_ssl_config *conf, int major, int mino
  *
  * \param conf     SSL configuration
  * \param major    Major version number (only MBEDTLS_SSL_MAJOR_VERSION_3 supported)
- * \param minor    Minor version number (MBEDTLS_SSL_MINOR_VERSION_1,
- *                 MBEDTLS_SSL_MINOR_VERSION_2,
- *                 MBEDTLS_SSL_MINOR_VERSION_3 supported)
+ * \param minor    Minor version number (only MBEDTLS_SSL_MINOR_VERSION_3 supported)
  */
 void mbedtls_ssl_conf_min_version( mbedtls_ssl_config *conf, int major, int minor );
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -976,10 +976,8 @@ struct mbedtls_ssl_config
      * Pointers
      */
 
-    /** Allowed ciphersuites per version. To access list's elements, please use
-     *  \c mbedtls_ssl_get_protocol_version_ciphersuites
-     */
-    const int *ciphersuite_list[3];
+    /** Allowed ciphersuites for (D)TLS 1.2 (0-terminated)                  */
+    const int *ciphersuite_list;
 
     /** Callback for printing debug output                                  */
     void (*f_dbg)(void *, int, const char *, int, const char *);
@@ -2508,17 +2506,6 @@ const mbedtls_ssl_session *mbedtls_ssl_get_session_pointer( const mbedtls_ssl_co
 void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
                                    const int *ciphersuites );
 
-/**
- * \brief               Get ciphersuite for given protocol's minor version.
- *
- * \param conf          The SSL configuration.
- * \param prot_version  Protocol version. One of MBEDTLS_SSL_MINOR_VERSION_x macros.
- * \return              Ciphersuites pointer if successful.
- * \return              \c NULL if no ciphersuites where found.
- */
-const int *mbedtls_ssl_get_protocol_version_ciphersuites(
-    const mbedtls_ssl_config *conf, int prot_version );
-
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 #define MBEDTLS_SSL_UNEXPECTED_CID_IGNORE 0
 #define MBEDTLS_SSL_UNEXPECTED_CID_FAIL   1
@@ -2557,27 +2544,6 @@ const int *mbedtls_ssl_get_protocol_version_ciphersuites(
 int mbedtls_ssl_conf_cid( mbedtls_ssl_config *conf, size_t len,
                           int ignore_other_cids );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-
-/**
- * \brief               Set the list of allowed ciphersuites and the
- *                      preference order for a specific version of the protocol.
- *                      (Only useful on the server side)
- *
- *                      The ciphersuites array is not copied, and must remain
- *                      valid for the lifetime of the ssl_config.
- *
- * \param conf          SSL configuration
- * \param ciphersuites  0-terminated list of allowed ciphersuites
- * \param major         Major version number (only MBEDTLS_SSL_MAJOR_VERSION_3
- *                      supported)
- * \param minor         Minor version number (only MBEDTLS_SSL_MINOR_VERSION_3
- *                      supported)
- *
- * \note                With DTLS, use MBEDTLS_SSL_MINOR_VERSION_3 for DTLS 1.2
- */
-void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
-                                       const int *ciphersuites,
-                                       int major, int minor );
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -125,14 +125,10 @@
  */
 
 /* These are the high an low bytes of ProtocolVersion as defined by:
- * - RFC 2246: ProtocolVersion version = { 3, 1 };     // TLS v1.0
- * - RFC 4346: ProtocolVersion version = { 3, 2 };     // TLS v1.1
  * - RFC 5246: ProtocolVersion version = { 3, 3 };     // TLS v1.2
  * - RFC 8446: see section 4.2.1
  */
 #define MBEDTLS_SSL_MAJOR_VERSION_3             3
-#define MBEDTLS_SSL_MINOR_VERSION_1             1   /*!< TLS v1.0 deprecated */
-#define MBEDTLS_SSL_MINOR_VERSION_2             2   /*!< TLS v1.1 deprecated */
 #define MBEDTLS_SSL_MINOR_VERSION_3             3   /*!< TLS v1.2 */
 #define MBEDTLS_SSL_MINOR_VERSION_4             4   /*!< TLS v1.3 (experimental) */
 

--- a/library/ssl_ciphersuites.c
+++ b/library/ssl_ciphersuites.c
@@ -31,6 +31,7 @@
 
 #include "mbedtls/ssl_ciphersuites.h"
 #include "mbedtls/ssl.h"
+#include "ssl_misc.h"
 
 #include <string.h>
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -1155,8 +1155,7 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     /*
      * Ciphersuite list
      */
-    ciphersuites = mbedtls_ssl_get_protocol_version_ciphersuites( ssl->conf,
-                                                                ssl->minor_ver );
+    ciphersuites = ssl->conf->ciphersuite_list;
 
     /* Skip writing ciphersuite length for now */
     n = 0;
@@ -2244,7 +2243,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
     i = 0;
     while( 1 )
     {
-        if( mbedtls_ssl_get_protocol_version_ciphersuites( ssl->conf, ssl->minor_ver )[i] == 0 )
+        if( ssl->conf->ciphersuite_list[i] == 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server hello message" ) );
             mbedtls_ssl_send_alert_message(
@@ -2254,7 +2253,7 @@ static int ssl_parse_server_hello( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO );
         }
 
-        if( mbedtls_ssl_get_protocol_version_ciphersuites( ssl->conf, ssl->minor_ver )[i++] ==
+        if( ssl->conf->ciphersuite_list[i++] ==
             ssl->session_negotiate->ciphersuite )
         {
             break;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -65,6 +65,16 @@
 #define inline __inline
 #endif
 
+/* Legacy minor version numbers as defined by:
+ * - RFC 2246: ProtocolVersion version = { 3, 1 };     // TLS v1.0
+ * - RFC 4346: ProtocolVersion version = { 3, 2 };     // TLS v1.1
+ *
+ * We no longer support these versions, but some code still references those
+ * constants, for keep them for now until we clean up that code.
+ */
+#define MBEDTLS_SSL_MINOR_VERSION_1             1
+#define MBEDTLS_SSL_MINOR_VERSION_2             2
+
 /* Determine minimum supported version */
 #define MBEDTLS_SSL_MIN_MAJOR_VERSION           MBEDTLS_SSL_MAJOR_VERSION_3
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1870,7 +1870,7 @@ read_record_header:
      * and certificate from the SNI callback triggered by the SNI extension.)
      */
     got_common_suite = 0;
-    ciphersuites = mbedtls_ssl_get_protocol_version_ciphersuites( ssl->conf, ssl->minor_ver );
+    ciphersuites = ssl->conf->ciphersuite_list;
     ciphersuite_info = NULL;
 #if defined(MBEDTLS_SSL_SRV_RESPECT_CLIENT_PREFERENCE)
     for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3514,73 +3514,10 @@ int mbedtls_ssl_set_session( mbedtls_ssl_context *ssl, const mbedtls_ssl_session
 }
 #endif /* MBEDTLS_SSL_CLI_C */
 
-static int protocol_version_to_ciphersuites_list_index(int prot_version)
-{
-    switch(prot_version) {
-        case MBEDTLS_SSL_MINOR_VERSION_1:
-            return 0;
-        case MBEDTLS_SSL_MINOR_VERSION_2:
-            return 1;
-        case MBEDTLS_SSL_MINOR_VERSION_3:
-            return 2;
-        default:
-            return -1;
-    };
-}
-
-static void set_protocol_version_ciphersuites( mbedtls_ssl_config *conf,
-                                               int prot_version,
-                                               const int* ciphersuites )
-{
-    int ciphersuite_list_index =
-        protocol_version_to_ciphersuites_list_index(prot_version);
-    if ( ciphersuite_list_index >= 0 &&
-         (unsigned int)ciphersuite_list_index <
-         sizeof(conf->ciphersuite_list)/sizeof(conf->ciphersuite_list[0]) )
-    {
-        conf->ciphersuite_list[ciphersuite_list_index] = ciphersuites;
-    }
-}
-
 void mbedtls_ssl_conf_ciphersuites( mbedtls_ssl_config *conf,
                                     const int *ciphersuites )
 {
-    set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_1,
-        ciphersuites);
-    set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_2,
-        ciphersuites);
-    set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_3,
-        ciphersuites);
-}
-
-const int *mbedtls_ssl_get_protocol_version_ciphersuites(
-    const mbedtls_ssl_config *conf, int prot_version )
-{
-    int ciphersuite_list_index =
-        protocol_version_to_ciphersuites_list_index(prot_version);
-    if ( ciphersuite_list_index >= 0 &&
-         (unsigned int)ciphersuite_list_index <
-         sizeof(conf->ciphersuite_list)/sizeof(conf->ciphersuite_list[0]) )
-    {
-        return conf->ciphersuite_list[ciphersuite_list_index];
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-void mbedtls_ssl_conf_ciphersuites_for_version( mbedtls_ssl_config *conf,
-                                       const int *ciphersuites,
-                                       int major, int minor )
-{
-    if( major != MBEDTLS_SSL_MAJOR_VERSION_3 )
-        return;
-
-    if( minor != MBEDTLS_SSL_MINOR_VERSION_3 )
-        return;
-
-    set_protocol_version_ciphersuites(conf, minor, ciphersuites);
+    conf->ciphersuite_list = ciphersuites;
 }
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -6278,12 +6215,7 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
             conf->max_major_ver = MBEDTLS_SSL_MAX_MAJOR_VERSION;
             conf->max_minor_ver = MBEDTLS_SSL_MAX_MINOR_VERSION;
 
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_1,
-                                              ssl_preset_suiteb_ciphersuites);
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_2,
-                                              ssl_preset_suiteb_ciphersuites);
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_3,
-                                              ssl_preset_suiteb_ciphersuites);
+            conf->ciphersuite_list = ssl_preset_suiteb_ciphersuites;
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
             conf->cert_profile = &mbedtls_x509_crt_profile_suiteb;
@@ -6317,13 +6249,7 @@ int mbedtls_ssl_config_defaults( mbedtls_ssl_config *conf,
             if( transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
                 conf->min_minor_ver = MBEDTLS_SSL_MINOR_VERSION_3;
 #endif
-            const int* default_ciphersuites = mbedtls_ssl_list_ciphersuites();
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_1,
-                                              default_ciphersuites);
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_2,
-                                              default_ciphersuites);
-            set_protocol_version_ciphersuites(conf, MBEDTLS_SSL_MINOR_VERSION_3,
-                                              default_ciphersuites);
+            conf->ciphersuite_list = mbedtls_ssl_list_ciphersuites();
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
             conf->cert_profile = &mbedtls_x509_crt_profile_default;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -93,7 +93,6 @@ int main( void )
 #define DFL_ECJPAKE_PW          NULL
 #define DFL_PSK_LIST            NULL
 #define DFL_FORCE_CIPHER        0
-#define DFL_VERSION_SUITES      NULL
 #define DFL_RENEGOTIATION       MBEDTLS_SSL_RENEGOTIATION_DISABLED
 #define DFL_ALLOW_LEGACY        -2
 #define DFL_RENEGOTIATE         0
@@ -501,9 +500,6 @@ int main( void )
     "    force_version=%%s    default: \"\" (none)\n"       \
     "                        options: tls1_2, dtls1_2\n" \
     "\n"                                                                \
-    "    version_suites=a,b,c        per-version ciphersuites\n"        \
-    "                                in order from tls1 to tls1_2\n"    \
-    "                                default: all enabled\n"            \
     "    force_ciphersuite=<name>    default: all enabled\n"            \
     "    query_config=<name>         return 0 if the specified\n"       \
     "                                configuration macro is defined and 1\n"  \
@@ -565,7 +561,6 @@ struct options
     char *psk_list;             /* list of PSK id/key pairs for callback    */
     const char *ecjpake_pw;     /* the EC J-PAKE password                   */
     int force_ciphersuite[2];   /* protocol/ciphersuite to use, or all      */
-    const char *version_suites; /* per-version ciphersuites                 */
     int renegotiation;          /* enable / disable renegotiation           */
     int allow_legacy;           /* allow legacy renegotiation               */
     int renegotiate;            /* attempt renegotiation?                   */
@@ -1253,7 +1248,6 @@ int main( int argc, char *argv[] )
 {
     int ret = 0, len, written, frags, exchanges_left;
     int query_config_ret = 0;
-    int version_suites[3][2];
     io_ctx_t io_ctx;
     unsigned char* buf = 0;
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
@@ -1481,7 +1475,6 @@ int main( int argc, char *argv[] )
     opt.psk_list            = DFL_PSK_LIST;
     opt.ecjpake_pw          = DFL_ECJPAKE_PW;
     opt.force_ciphersuite[0]= DFL_FORCE_CIPHER;
-    opt.version_suites      = DFL_VERSION_SUITES;
     opt.renegotiation       = DFL_RENEGOTIATION;
     opt.allow_legacy        = DFL_ALLOW_LEGACY;
     opt.renegotiate         = DFL_RENEGOTIATE;
@@ -1669,8 +1662,6 @@ int main( int argc, char *argv[] )
         }
         else if( strcmp( p, "curves" ) == 0 )
             opt.curves = q;
-        else if( strcmp( p, "version_suites" ) == 0 )
-            opt.version_suites = q;
         else if( strcmp( p, "renegotiation" ) == 0 )
         {
             opt.renegotiation = (atoi( q )) ?
@@ -2065,47 +2056,6 @@ int main( int argc, char *argv[] )
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
         }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-    }
-
-    if( opt.version_suites != NULL )
-    {
-        const char *name[3] = { 0 };
-
-        /* Parse 4-element coma-separated list */
-        for( i = 0, p = (char *) opt.version_suites;
-             i < 3 && *p != '\0';
-             i++ )
-        {
-            name[i] = p;
-
-            /* Terminate the current string and move on to next one */
-            while( *p != ',' && *p != '\0' )
-                p++;
-            if( *p == ',' )
-                *p++ = '\0';
-        }
-
-        if( i != 3 )
-        {
-            mbedtls_printf( "too few values for version_suites\n" );
-            ret = 1;
-            goto exit;
-        }
-
-        memset( version_suites, 0, sizeof( version_suites ) );
-
-        /* Get the suites identifiers from their name */
-        for( i = 0; i < 3; i++ )
-        {
-            version_suites[i][0] = mbedtls_ssl_get_ciphersuite_id( name[i] );
-
-            if( version_suites[i][0] == 0 )
-            {
-                mbedtls_printf( "unknown ciphersuite: '%s'\n", name[i] );
-                ret = 2;
-                goto usage;
-            }
-        }
     }
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -2688,19 +2638,6 @@ int main( int argc, char *argv[] )
 
     if( opt.force_ciphersuite[0] != DFL_FORCE_CIPHER )
         mbedtls_ssl_conf_ciphersuites( &conf, opt.force_ciphersuite );
-
-    if( opt.version_suites != NULL )
-    {
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[0],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_1 );
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[1],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_2 );
-        mbedtls_ssl_conf_ciphersuites_for_version( &conf, version_suites[2],
-                                          MBEDTLS_SSL_MAJOR_VERSION_3,
-                                          MBEDTLS_SSL_MINOR_VERSION_3 );
-    }
 
     if( opt.allow_legacy != DFL_ALLOW_LEGACY )
         mbedtls_ssl_conf_legacy_renegotiation( &conf, opt.allow_legacy );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2027,10 +2027,6 @@ int main( int argc, char *argv[] )
         if( opt.min_version < ciphersuite_info->min_minor_ver )
         {
             opt.min_version = ciphersuite_info->min_minor_ver;
-            /* DTLS starts with TLS 1.1 */
-            if( opt.transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM &&
-                opt.min_version < MBEDTLS_SSL_MINOR_VERSION_2 )
-                opt.min_version = MBEDTLS_SSL_MINOR_VERSION_2;
         }
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -5614,17 +5614,6 @@ run_test    "ECJPAKE: working, DTLS, nolog" \
              force_ciphersuite=TLS-ECJPAKE-WITH-AES-128-CCM-8" \
             0
 
-# Tests for ciphersuites per version
-
-requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_enabled MBEDTLS_CAMELLIA_C
-requires_config_enabled MBEDTLS_AES_C
-run_test    "Per-version suites: TLS 1.2" \
-            "$P_SRV version_suites=TLS-RSA-WITH-AES-256-CBC-SHA,TLS-RSA-WITH-AES-128-CBC-SHA,TLS-RSA-WITH-AES-128-GCM-SHA256" \
-            "$P_CLI force_version=tls1_2" \
-            0 \
-            -c "Ciphersuite is TLS-RSA-WITH-AES-128-GCM-SHA256"
-
 # Test for ClientHello without extensions
 
 requires_gnutls


### PR DESCRIPTION
This is a follow-up to #4495 and fixes #4285 (as the remaining parts are already tracked elsewhere). It removes the constants related to TLS 1.0 and TLS 1.1 from the public API and keeps them in a private header, as some code is still using them until we execute #4564.

Edit: turns out it was inconvenient to do that while `mbedtls_ssl_conf_ciphersuites_for_version()` was still part of the public API . It was already being removed in #4442, so I cherry-picked and completed #4442 (after discussing with Hanno) as that seem more convenient that having a dependency between two small PRs.
