### PR TITLE
Remove mbedtls_rsa_init() padding parameters

### DIFF
--- a/ChangeLog.d/rsa-padding.txt
+++ b/ChangeLog.d/rsa-padding.txt
@@ -1,0 +1,5 @@
+API changes
+   * mbedtls_rsa_init() now always selects the PKCS#1v1.5 encoding for an RSA
+     key. To use an RSA key with PSS or OAEP, call mbedtls_rsa_set_padding()
+     after initializing the context. mbedtls_rsa_set_padding() now returns an
+     error if its parameters are invalid.

--- a/docs/3.0-migration-guide.d/rsa-padding.md
+++ b/docs/3.0-migration-guide.d/rsa-padding.md
@@ -1,0 +1,29 @@
+Remove the padding parameters from mbedtls_rsa_init()
+-----------------------------------------------------
+
+This affects all users who use the RSA encryption, decryption, sign and
+verify APIs.
+
+The function mbedtls_rsa_init() no longer supports selecting the PKCS#1 v2.1
+encoding and its hash. It just selects the PKCS#1 v1.5 encoding by default. If
+you were using the PKCS#1 v2.1 encoding you now need, subsequently to the call
+to mbedtls_rsa_init(), to call mbedtls_rsa_set_padding() to set it.
+
+Code migration examples:
+```C
+    mbedtls_rsa_init(ctx, padding, hash_id);
+```
+to
+```C
+    mbedtls_rsa_init(ctx);
+    mbedtls_rsa_set_padding(ctx, padding, hash_id);
+```
+or
+```C
+    mbedtls_rsa_init(ctx, MBEDTLS_RSA_PKCS_V15, <ignored>);
+```
+to
+```C
+    mbedtls_rsa_init(ctx);
+```
+

--- a/docs/3.0-migration-guide.d/rsa-padding.md
+++ b/docs/3.0-migration-guide.d/rsa-padding.md
@@ -9,21 +9,21 @@ encoding and its hash. It just selects the PKCS#1 v1.5 encoding by default. If
 you were using the PKCS#1 v2.1 encoding you now need, subsequently to the call
 to mbedtls_rsa_init(), to call mbedtls_rsa_set_padding() to set it.
 
-Code migration examples:
+To choose the padding type when initializing a context, instead of
 ```C
     mbedtls_rsa_init(ctx, padding, hash_id);
 ```
-to
+, use
 ```C
     mbedtls_rsa_init(ctx);
     mbedtls_rsa_set_padding(ctx, padding, hash_id);
 ```
-or
+
+To use PKCS#1 v1.5 padding, instead of
 ```C
     mbedtls_rsa_init(ctx, MBEDTLS_RSA_PKCS_V15, <ignored>);
 ```
-to
+, just use
 ```C
     mbedtls_rsa_init(ctx);
 ```
-

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -135,10 +135,9 @@ mbedtls_rsa_context;
  * \brief          This function initializes an RSA context.
  *
  * \note           This function initializes the padding and the hash
- *                 identifier for #MBEDTLS_RSA_PKCS_V21 to respectively
- *                 #MBEDTLS_RSA_PKCS_V15 and #MBEDTLS_MD_NONE. See
- *                 mbedtls_rsa_set_padding() for more information about
- *                 those parameters.
+ *                 identifier to respectively #MBEDTLS_RSA_PKCS_V15 and
+ *                 #MBEDTLS_MD_NONE. See mbedtls_rsa_set_padding() for more
+ *                 information about those parameters.
  *
  * \param ctx      The RSA context to initialize. This must not be \c NULL.
  */
@@ -169,9 +168,10 @@ void mbedtls_rsa_init( mbedtls_rsa_context *ctx );
  * \param ctx      The initialized RSA context to be configured.
  * \param padding  The padding mode to use. This must be either
  *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
- * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
- *                 #MBEDTLS_MD_NONE is accepted by this function but may be
- *                 not suitable for some operations.
+ * \param hash_id  The hash identifier for PSS or OAEP, if \p padding is
+ *                 #MBEDTLS_RSA_PKCS_V21. #MBEDTLS_MD_NONE is accepted by this
+ *                 function but may be not suitable for some operations.
+ *                 Ignored if \p padding is #MBEDTLS_RSA_PKCS_V15.
  *
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_RSA_INVALID_PADDING failure:

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -134,33 +134,51 @@ mbedtls_rsa_context;
 /**
  * \brief          This function initializes an RSA context.
  *
+ * \note           This function initializes the padding and the hash
+ *                 identifier for #MBEDTLS_RSA_PKCS_V21 to respectively
+ *                 #MBEDTLS_RSA_PKCS_V15 and #MBEDTLS_MD_NONE. See
+ *                 mbedtls_rsa_set_padding() for more information about
+ *                 those parameters.
+ *
+ * \param ctx      The RSA context to initialize. This must not be \c NULL.
+ */
+void mbedtls_rsa_init( mbedtls_rsa_context *ctx );
+
+/**
+ * \brief          This function sets padding for an already initialized RSA
+ *                 context.
+ *
  * \note           Set padding to #MBEDTLS_RSA_PKCS_V21 for the RSAES-OAEP
  *                 encryption scheme and the RSASSA-PSS signature scheme.
  *
  * \note           The \p hash_id parameter is ignored when using
  *                 #MBEDTLS_RSA_PKCS_V15 padding.
  *
- * \note           The choice of padding mode is strictly enforced for private key
- *                 operations, since there might be security concerns in
+ * \note           The choice of padding mode is strictly enforced for private
+ *                 key operations, since there might be security concerns in
  *                 mixing padding modes. For public key operations it is
  *                 a default value, which can be overridden by calling specific
- *                 \c rsa_rsaes_xxx or \c rsa_rsassa_xxx functions.
+ *                 \c mbedtls_rsa_rsaes_xxx or \c mbedtls_rsa_rsassa_xxx
+ *                 functions.
  *
  * \note           The hash selected in \p hash_id is always used for OEAP
  *                 encryption. For PSS signatures, it is always used for
  *                 making signatures, but can be overridden for verifying them.
  *                 If set to #MBEDTLS_MD_NONE, it is always overridden.
  *
- * \param ctx      The RSA context to initialize. This must not be \c NULL.
+ * \param ctx      The initialized RSA context to be configured.
  * \param padding  The padding mode to use. This must be either
  *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
- * \param hash_id  The hash identifier of ::mbedtls_md_type_t type, if
- *                 \p padding is #MBEDTLS_RSA_PKCS_V21. It is unused
- *                 otherwise.
+ * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
+ *                 #MBEDTLS_MD_NONE is accepted by this function but may be
+ *                 not suitable for some operations.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_RSA_INVALID_PADDING failure:
+ *                 \p padding or \p hash_id is invalid.
  */
-void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
-                       int padding,
-                       int hash_id );
+int mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+                             mbedtls_md_type_t hash_id );
 
 /**
  * \brief          This function imports a set of core parameters into an
@@ -390,24 +408,6 @@ int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
  */
 int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
                             mbedtls_mpi *DP, mbedtls_mpi *DQ, mbedtls_mpi *QP );
-
-/**
- * \brief          This function sets padding for an already initialized RSA
- *                 context. See mbedtls_rsa_init() for details.
- *
- * \param ctx      The initialized RSA context to be configured.
- * \param padding  The padding mode to use. This must be either
- *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
- * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
- *                 #MBEDTLS_MD_NONE is accepted by this function but may be
- *                 not suitable for some operations.
- *
- * \return         \c 0 on success.
- * \return         #MBEDTLS_ERR_RSA_INVALID_PADDING failure:
- *                 \p padding or \p hash_id is invalid.
- */
-int mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
-                             mbedtls_md_type_t hash_id );
 
 /**
  * \brief          This function retrieves the length of RSA modulus in Bytes.

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -399,9 +399,15 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
  * \param padding  The padding mode to use. This must be either
  *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
  * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
+ *                 #MBEDTLS_MD_NONE is accepted by this function but may be
+ *                 not suitable for some operations.
+ *
+ * \return         \c 0 on success.
+ * \return         #MBEDTLS_ERR_RSA_INVALID_PADDING failure:
+ *                 \p padding or \p hash_id is invalid.
  */
-void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
-                              int hash_id );
+int mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+                             mbedtls_md_type_t hash_id );
 
 /**
  * \brief          This function retrieves the length of RSA modulus in Bytes.

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -165,7 +165,7 @@ static void *rsa_alloc_wrap( void )
     void *ctx = mbedtls_calloc( 1, sizeof( mbedtls_rsa_context ) );
 
     if( ctx != NULL )
-        mbedtls_rsa_init( (mbedtls_rsa_context *) ctx, 0, 0 );
+        mbedtls_rsa_init( (mbedtls_rsa_context *) ctx );
 
     return( ctx );
 }

--- a/library/psa_crypto_rsa.c
+++ b/library/psa_crypto_rsa.c
@@ -416,29 +416,36 @@ static psa_status_t rsa_sign_hash(
 #if defined(BUILTIN_ALG_RSA_PKCS1V15_SIGN)
     if( PSA_ALG_IS_RSA_PKCS1V15_SIGN( alg ) )
     {
-        mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V15,
-                                 MBEDTLS_MD_NONE );
-        ret = mbedtls_rsa_pkcs1_sign( rsa,
-                                      mbedtls_psa_get_random,
-                                      MBEDTLS_PSA_RANDOM_STATE,
-                                      md_alg,
-                                      (unsigned int) hash_length,
-                                      hash,
-                                      signature );
+        ret = mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V15,
+                                       MBEDTLS_MD_NONE );
+        if( ret == 0 )
+        {
+            ret = mbedtls_rsa_pkcs1_sign( rsa,
+                                          mbedtls_psa_get_random,
+                                          MBEDTLS_PSA_RANDOM_STATE,
+                                          md_alg,
+                                          (unsigned int) hash_length,
+                                          hash,
+                                          signature );
+        }
     }
     else
 #endif /* BUILTIN_ALG_RSA_PKCS1V15_SIGN */
 #if defined(BUILTIN_ALG_RSA_PSS)
     if( PSA_ALG_IS_RSA_PSS( alg ) )
     {
-        mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V21, md_alg );
-        ret = mbedtls_rsa_rsassa_pss_sign( rsa,
-                                           mbedtls_psa_get_random,
-                                           MBEDTLS_PSA_RANDOM_STATE,
-                                           MBEDTLS_MD_NONE,
-                                           (unsigned int) hash_length,
-                                           hash,
-                                           signature );
+        ret = mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V21, md_alg );
+
+        if( ret == 0 )
+        {
+            ret = mbedtls_rsa_rsassa_pss_sign( rsa,
+                                               mbedtls_psa_get_random,
+                                               MBEDTLS_PSA_RANDOM_STATE,
+                                               MBEDTLS_MD_NONE,
+                                               (unsigned int) hash_length,
+                                               hash,
+                                               signature );
+        }
     }
     else
 #endif /* BUILTIN_ALG_RSA_PSS */
@@ -489,25 +496,31 @@ static psa_status_t rsa_verify_hash(
 #if defined(BUILTIN_ALG_RSA_PKCS1V15_SIGN)
     if( PSA_ALG_IS_RSA_PKCS1V15_SIGN( alg ) )
     {
-        mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V15,
-                                 MBEDTLS_MD_NONE );
-        ret = mbedtls_rsa_pkcs1_verify( rsa,
-                                        md_alg,
-                                        (unsigned int) hash_length,
-                                        hash,
-                                        signature );
+        ret = mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V15,
+                                       MBEDTLS_MD_NONE );
+        if( ret == 0 )
+        {
+            ret = mbedtls_rsa_pkcs1_verify( rsa,
+                                            md_alg,
+                                            (unsigned int) hash_length,
+                                            hash,
+                                            signature );
+        }
     }
     else
 #endif /* BUILTIN_ALG_RSA_PKCS1V15_SIGN */
 #if defined(BUILTIN_ALG_RSA_PSS)
     if( PSA_ALG_IS_RSA_PSS( alg ) )
     {
-        mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V21, md_alg );
-        ret = mbedtls_rsa_rsassa_pss_verify( rsa,
-                                             MBEDTLS_MD_NONE,
-                                             (unsigned int) hash_length,
-                                             hash,
-                                             signature );
+        ret = mbedtls_rsa_set_padding( rsa, MBEDTLS_RSA_PKCS_V21, md_alg );
+        if( ret == 0 )
+        {
+            ret = mbedtls_rsa_rsassa_pss_verify( rsa,
+                                                 MBEDTLS_MD_NONE,
+                                                 (unsigned int) hash_length,
+                                                 hash,
+                                                 signature );
+        }
     }
     else
 #endif /* BUILTIN_ALG_RSA_PSS */

--- a/library/psa_crypto_rsa.c
+++ b/library/psa_crypto_rsa.c
@@ -317,7 +317,7 @@ static psa_status_t rsa_generate_key(
     if( status != PSA_SUCCESS )
         return( status );
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE );
+    mbedtls_rsa_init( &rsa );
     ret = mbedtls_rsa_gen_key( &rsa,
                                mbedtls_psa_get_random,
                                MBEDTLS_PSA_RANDOM_STATE,

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -500,9 +500,20 @@ void mbedtls_rsa_init( mbedtls_rsa_context *ctx )
 int mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
                              mbedtls_md_type_t hash_id )
 {
-    if( ( padding != MBEDTLS_RSA_PKCS_V15 ) &&
-        ( padding != MBEDTLS_RSA_PKCS_V21 ) )
-        return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    switch( padding )
+    {
+#if defined(MBEDTLS_PKCS1_V15)
+        case MBEDTLS_RSA_PKCS_V15:
+            break;
+#endif
+
+#if defined(MBEDTLS_PKCS1_V21)
+        case MBEDTLS_RSA_PKCS_V21:
+            break;
+#endif
+        default:
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
 
     if( ( padding == MBEDTLS_RSA_PKCS_V21 ) &&
         ( hash_id != MBEDTLS_MD_NONE ) )

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -477,17 +477,14 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
 /*
  * Initialize an RSA context
  */
-void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
-               int padding,
-               int hash_id )
+void mbedtls_rsa_init( mbedtls_rsa_context *ctx )
 {
     RSA_VALIDATE( ctx != NULL );
-    RSA_VALIDATE( padding == MBEDTLS_RSA_PKCS_V15 ||
-                  padding == MBEDTLS_RSA_PKCS_V21 );
 
     memset( ctx, 0, sizeof( mbedtls_rsa_context ) );
 
-    mbedtls_rsa_set_padding( ctx, padding, hash_id );
+    ctx->padding = MBEDTLS_RSA_PKCS_V15;
+    ctx->hash_id = MBEDTLS_MD_NONE;
 
 #if defined(MBEDTLS_THREADING_C)
     /* Set ctx->ver to nonzero to indicate that the mutex has been
@@ -2592,7 +2589,7 @@ int mbedtls_rsa_self_test( int verbose )
     mbedtls_mpi K;
 
     mbedtls_mpi_init( &K );
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_read_string( &K, 16, RSA_N  ) );
     MBEDTLS_MPI_CHK( mbedtls_rsa_import( &rsa, &K, NULL, NULL, NULL, NULL ) );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -500,15 +500,27 @@ void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
 /*
  * Set padding for an existing RSA context
  */
-void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
-                              int hash_id )
+int mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+                             mbedtls_md_type_t hash_id )
 {
-    RSA_VALIDATE( ctx != NULL );
-    RSA_VALIDATE( padding == MBEDTLS_RSA_PKCS_V15 ||
-                  padding == MBEDTLS_RSA_PKCS_V21 );
+    if( ( padding != MBEDTLS_RSA_PKCS_V15 ) &&
+        ( padding != MBEDTLS_RSA_PKCS_V21 ) )
+        return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+
+    if( ( padding == MBEDTLS_RSA_PKCS_V21 ) &&
+        ( hash_id != MBEDTLS_MD_NONE ) )
+    {
+        const mbedtls_md_info_t *md_info;
+
+        md_info = mbedtls_md_info_from_type( hash_id );
+        if( md_info == NULL )
+            return( MBEDTLS_ERR_RSA_INVALID_PADDING );
+    }
 
     ctx->padding = padding;
     ctx->hash_id = hash_id;
+
+    return( 0 );
 }
 
 /*

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -92,7 +92,6 @@ int main( void )
     mbedtls_aes_context aes;
 
     mbedtls_net_init( &server_fd );
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256 );
     mbedtls_dhm_init( &dhm );
     mbedtls_aes_init( &aes );
     mbedtls_ctr_drbg_init( &ctr_drbg );
@@ -125,7 +124,7 @@ int main( void )
         goto exit;
     }
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
 
     if( ( ret = mbedtls_mpi_read_file( &rsa.N, 16, f ) ) != 0 ||
         ( ret = mbedtls_mpi_read_file( &rsa.E, 16, f ) ) != 0 )

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -95,7 +95,6 @@ int main( void )
 
     mbedtls_net_init( &listen_fd );
     mbedtls_net_init( &client_fd );
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256 );
     mbedtls_dhm_init( &dhm );
     mbedtls_aes_init( &aes );
     mbedtls_ctr_drbg_init( &ctr_drbg );
@@ -131,7 +130,7 @@ int main( void )
         goto exit;
     }
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
 
     if( ( ret = mbedtls_mpi_read_file( &N , 16, f ) ) != 0 ||
         ( ret = mbedtls_mpi_read_file( &E , 16, f ) ) != 0 ||

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -90,7 +90,7 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
     mbedtls_ctr_drbg_init( &ctr_drbg );
     mbedtls_entropy_init( &entropy );
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P ); mbedtls_mpi_init( &Q );

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -87,7 +87,7 @@ int main( int argc, char *argv[] )
     fflush( stdout );
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
     mbedtls_ctr_drbg_init( &ctr_drbg );
     mbedtls_entropy_init( &entropy );
 

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -75,7 +75,7 @@ int main( void )
     const char *pers = "rsa_genkey";
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P ); mbedtls_mpi_init( &Q );
     mbedtls_mpi_init( &D ); mbedtls_mpi_init( &E ); mbedtls_mpi_init( &DP );
     mbedtls_mpi_init( &DQ ); mbedtls_mpi_init( &QP );

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -67,7 +67,7 @@ int main( int argc, char *argv[] )
     char filename[512];
     mbedtls_mpi N, P, Q, D, E, DP, DQ, QP;
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P ); mbedtls_mpi_init( &Q );
     mbedtls_mpi_init( &D ); mbedtls_mpi_init( &E ); mbedtls_mpi_init( &DP );

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -115,7 +115,13 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
+    if( ( ret = mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ),
+                                         MBEDTLS_RSA_PKCS_V21,
+                                         MBEDTLS_MD_SHA256 ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! Invalid padding\n" );
+        goto exit;
+    }
 
     /*
      * Compute the SHA-256 hash of the input file,

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -119,7 +119,7 @@ int main( int argc, char *argv[] )
                                          MBEDTLS_RSA_PKCS_V21,
                                          MBEDTLS_MD_SHA256 ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! Invalid padding\n" );
+        mbedtls_printf( " failed\n  ! Padding not supported\n" );
         goto exit;
     }
 

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -66,7 +66,7 @@ int main( int argc, char *argv[] )
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
     char filename[512];
 
-    mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &rsa );
 
     if( argc != 2 )
     {

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -98,7 +98,13 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-    mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ), MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256 );
+    if( ( ret = mbedtls_rsa_set_padding( mbedtls_pk_rsa( pk ),
+                                         MBEDTLS_RSA_PKCS_V21,
+                                         MBEDTLS_MD_SHA256 ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! Invalid padding\n" );
+        goto exit;
+    }
 
     /*
      * Extract the RSA signature from the file

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -786,7 +786,7 @@ int main( int argc, char *argv[] )
         {
             mbedtls_snprintf( title, sizeof( title ), "RSA-%d", keysize );
 
-            mbedtls_rsa_init( &rsa, MBEDTLS_RSA_PKCS_V15, 0 );
+            mbedtls_rsa_init( &rsa );
             mbedtls_rsa_gen_key( &rsa, myrand, NULL, keysize, 65537 );
 
             TIME_PUBLIC( title, " public",

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -863,7 +863,7 @@ void pk_rsa_alt(  )
     size_t sig_len, ciph_len, test_len;
     int ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
-    mbedtls_rsa_init( &raw, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE );
+    mbedtls_rsa_init( &raw );
     mbedtls_pk_init( &rsa ); mbedtls_pk_init( &alt );
 
     memset( hash, 0x2a, sizeof hash );

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -26,7 +26,8 @@ void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V15, hash ) == 0 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -73,7 +74,8 @@ void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V15, hash ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
@@ -280,7 +282,8 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V15, hash ) == 0 );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -329,7 +332,8 @@ void pkcs1_rsassa_v15_verify( int mod, int radix_N, char * input_N,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V15, hash ) == 0 );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );

--- a/tests/suites/test_suite_pkcs1_v15.function
+++ b/tests/suites/test_suite_pkcs1_v15.function
@@ -25,7 +25,8 @@ void pkcs1_rsaes_v15_encrypt( int mod, int radix_N, char * input_N,
     info.length = rnd_buf->len;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -71,7 +72,8 @@ void pkcs1_rsaes_v15_decrypt( int mod, int radix_P, char * input_P,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
@@ -193,7 +195,7 @@ void pkcs1_v15_decode( data_t *input,
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
     mbedtls_mpi_init( &Nmpi ); mbedtls_mpi_init( &Empi );
     mbedtls_mpi_init( &Pmpi ); mbedtls_mpi_init( &Qmpi );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &ctx );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &Nmpi, N, sizeof( N ) ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_binary( &Empi, E, sizeof( E ) ) == 0 );
@@ -277,7 +279,8 @@ void pkcs1_rsassa_v15_sign( int mod, int radix_P, char * input_P, int radix_Q,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -325,7 +328,8 @@ void pkcs1_rsassa_v15_verify( int mod, int radix_N, char * input_N,
     ((void) salt);
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V15, hash );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -24,7 +24,8 @@ void pkcs1_rsaes_oaep_encrypt( int mod, data_t * input_N, data_t * input_E,
     info.length = rnd_buf->len;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );
@@ -67,7 +68,8 @@ void pkcs1_rsaes_oaep_decrypt( int mod, data_t * input_P, data_t * input_Q,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
@@ -131,7 +133,8 @@ void pkcs1_rsassa_pss_sign( int mod, data_t * input_P, data_t * input_Q,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -189,7 +192,8 @@ void pkcs1_rsassa_pss_verify( int mod, data_t * input_N, data_t * input_E,
     ((void) salt);
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );
@@ -225,7 +229,8 @@ void pkcs1_rsassa_pss_verify_ext( int mod, data_t * input_N, data_t * input_E,
     mbedtls_mpi N, E;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V21, ctx_hash );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, ctx_hash );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );

--- a/tests/suites/test_suite_pkcs1_v21.function
+++ b/tests/suites/test_suite_pkcs1_v21.function
@@ -25,7 +25,8 @@ void pkcs1_rsaes_oaep_encrypt( int mod, data_t * input_N, data_t * input_E,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V21, hash ) == 0 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );
@@ -69,7 +70,8 @@ void pkcs1_rsaes_oaep_decrypt( int mod, data_t * input_P, data_t * input_Q,
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V21, hash ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
@@ -134,7 +136,8 @@ void pkcs1_rsassa_pss_sign( int mod, data_t * input_P, data_t * input_Q,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V21, hash ) == 0 );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -193,7 +196,8 @@ void pkcs1_rsassa_pss_verify( int mod, data_t * input_N, data_t * input_E,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V21, hash ) == 0 );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );
@@ -230,7 +234,8 @@ void pkcs1_rsassa_pss_verify_ext( int mod, data_t * input_N, data_t * input_E,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, MBEDTLS_RSA_PKCS_V21, ctx_hash );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,
+                                          MBEDTLS_RSA_PKCS_V21, ctx_hash ) == 0 );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_binary( &N, input_N->x, input_N->len ) == 0 );

--- a/tests/suites/test_suite_rsa.data
+++ b/tests/suites/test_suite_rsa.data
@@ -1,3 +1,6 @@
+RSA parameter validation
+rsa_invalid_param:
+
 RSA init-free-free
 rsa_init_free:0
 

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -18,6 +18,30 @@
  */
 
 /* BEGIN_CASE */
+void rsa_invalid_param( )
+{
+    mbedtls_rsa_context ctx;
+    const int invalid_padding = 42;
+    const int invalid_hash_id = 0xff;
+
+    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE );
+
+    TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
+                                         invalid_padding,
+                                         MBEDTLS_MD_NONE ),
+                MBEDTLS_ERR_RSA_INVALID_PADDING );
+
+    TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
+                                         MBEDTLS_RSA_PKCS_V21,
+                                         invalid_hash_id ),
+                MBEDTLS_ERR_RSA_INVALID_PADDING );
+
+exit:
+    mbedtls_rsa_free( &ctx );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void rsa_init_free( int reinit )
 {
     mbedtls_rsa_context ctx;

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -36,6 +36,20 @@ void rsa_invalid_param( )
                                          invalid_hash_id ),
                 MBEDTLS_ERR_RSA_INVALID_PADDING );
 
+#if !defined(MBEDTLS_PKCS1_V15)
+    TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
+                                         MBEDTLS_RSA_PKCS_V15,
+                                         MBEDTLS_MD_NONE ),
+                MBEDTLS_ERR_RSA_INVALID_PADDING );
+#endif
+
+#if !defined(MBEDTLS_PKCS1_V21)
+    TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
+                                         MBEDTLS_RSA_PKCS_V21,
+                                         MBEDTLS_MD_NONE ),
+                MBEDTLS_ERR_RSA_INVALID_PADDING );
+#endif
+
 exit:
     mbedtls_rsa_free( &ctx );
 }

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -80,7 +80,8 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx,padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -130,7 +131,8 @@ void mbedtls_rsa_pkcs1_verify( data_t * message_str, int padding_mode,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -165,7 +167,8 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
     mbedtls_test_rnd_pseudo_info rnd_info;
 
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
@@ -213,7 +216,8 @@ void rsa_pkcs1_verify_raw( data_t * hash_result,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
 
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -248,7 +252,8 @@ void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -290,7 +295,8 @@ void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -336,7 +342,8 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
     mbedtls_rsa_init( &ctx );
-    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
+    TEST_ASSERT( mbedtls_rsa_set_padding( &ctx, padding_mode,
+                                          MBEDTLS_MD_NONE ) == 0 );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );

--- a/tests/suites/test_suite_rsa.function
+++ b/tests/suites/test_suite_rsa.function
@@ -24,7 +24,7 @@ void rsa_invalid_param( )
     const int invalid_padding = 42;
     const int invalid_hash_id = 0xff;
 
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE );
+    mbedtls_rsa_init( &ctx );
 
     TEST_EQUAL( mbedtls_rsa_set_padding( &ctx,
                                          invalid_padding,
@@ -51,11 +51,11 @@ void rsa_init_free( int reinit )
      * unconditionally on an error path without checking whether it has
      * already been called in the success path. */
 
-    mbedtls_rsa_init( &ctx, 0, 0 );
+    mbedtls_rsa_init( &ctx );
     mbedtls_rsa_free( &ctx );
 
     if( reinit )
-        mbedtls_rsa_init( &ctx, 0, 0 );
+        mbedtls_rsa_init( &ctx );
     mbedtls_rsa_free( &ctx );
 
     /* This test case always succeeds, functionally speaking. A plausible
@@ -79,7 +79,8 @@ void mbedtls_rsa_pkcs1_sign( data_t * message_str, int padding_mode,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
 
     memset( hash_result, 0x00, sizeof( hash_result ) );
     memset( output, 0x00, sizeof( output ) );
@@ -128,7 +129,8 @@ void mbedtls_rsa_pkcs1_verify( data_t * message_str, int padding_mode,
     mbedtls_mpi N, E;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
     memset( hash_result, 0x00, sizeof( hash_result ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -162,7 +164,8 @@ void rsa_pkcs1_sign_raw( data_t * hash_result,
     mbedtls_mpi N, P, Q, E;
     mbedtls_test_rnd_pseudo_info rnd_info;
 
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
@@ -209,7 +212,8 @@ void rsa_pkcs1_verify_raw( data_t * hash_result,
     mbedtls_mpi N, E;
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
 
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -243,7 +247,8 @@ void mbedtls_rsa_pkcs1_encrypt( data_t * message_str, int padding_mode,
 
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -284,7 +289,8 @@ void rsa_pkcs1_encrypt_bad_rng( data_t * message_str, int padding_mode,
     mbedtls_mpi N, E;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -329,7 +335,8 @@ void mbedtls_rsa_pkcs1_decrypt( data_t * message_str, int padding_mode,
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
 
-    mbedtls_rsa_init( &ctx, padding_mode, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_set_padding( &ctx, padding_mode, MBEDTLS_MD_NONE );
 
     memset( output, 0x00, sizeof( output ) );
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
@@ -377,8 +384,8 @@ void mbedtls_rsa_public( data_t * message_str, int mod, int radix_N,
     mbedtls_mpi N, E;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, 0 );
-    mbedtls_rsa_init( &ctx2, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_init( &ctx2 );
     memset( output, 0x00, sizeof( output ) );
 
     TEST_ASSERT( mbedtls_mpi_read_string( &N, radix_N, input_N ) == 0 );
@@ -435,8 +442,8 @@ void mbedtls_rsa_private( data_t * message_str, int mod, int radix_P,
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, 0 );
-    mbedtls_rsa_init( &ctx2, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &ctx );
+    mbedtls_rsa_init( &ctx2 );
 
     memset( &rnd_info, 0, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
@@ -512,7 +519,7 @@ void mbedtls_rsa_check_pubkey( int radix_N, char * input_N, int radix_E,
     mbedtls_mpi N, E;
 
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &E );
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &ctx );
 
     if( strlen( input_N ) )
     {
@@ -543,7 +550,7 @@ void mbedtls_rsa_check_privkey( int mod, int radix_P, char * input_P,
 {
     mbedtls_rsa_context ctx;
 
-    mbedtls_rsa_init( &ctx, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &ctx );
 
     ctx.len = mod / 8;
     if( strlen( input_P ) )
@@ -604,8 +611,8 @@ void rsa_check_pubpriv( int mod, int radix_Npub, char * input_Npub,
 {
     mbedtls_rsa_context pub, prv;
 
-    mbedtls_rsa_init( &pub, MBEDTLS_RSA_PKCS_V15, 0 );
-    mbedtls_rsa_init( &prv, MBEDTLS_RSA_PKCS_V15, 0 );
+    mbedtls_rsa_init( &pub );
+    mbedtls_rsa_init( &prv );
 
     pub.len = mod / 8;
     prv.len = mod / 8;
@@ -676,7 +683,7 @@ void mbedtls_rsa_gen_key( int nrbits, int exponent, int result)
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
     mbedtls_entropy_init( &entropy );
-    mbedtls_rsa_init ( &ctx, 0, 0 );
+    mbedtls_rsa_init ( &ctx );
 
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
                                         &entropy, (const unsigned char *) pers,
@@ -828,7 +835,7 @@ void mbedtls_rsa_import( int radix_N, char *input_N,
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
     mbedtls_entropy_init( &entropy );
-    mbedtls_rsa_init( &ctx, 0, 0 );
+    mbedtls_rsa_init( &ctx );
 
     mbedtls_mpi_init( &N );
     mbedtls_mpi_init( &P ); mbedtls_mpi_init( &Q );
@@ -969,7 +976,7 @@ void mbedtls_rsa_export( int radix_N, char *input_N,
 
     mbedtls_rsa_context ctx;
 
-    mbedtls_rsa_init( &ctx, 0, 0 );
+    mbedtls_rsa_init( &ctx );
 
     mbedtls_mpi_init( &N );
     mbedtls_mpi_init( &P ); mbedtls_mpi_init( &Q );
@@ -1149,7 +1156,7 @@ void mbedtls_rsa_export_raw( data_t *input_N, data_t *input_P,
 
     mbedtls_rsa_context ctx;
 
-    mbedtls_rsa_init( &ctx, 0, 0 );
+    mbedtls_rsa_init( &ctx );
 
     /* Setup RSA context */
     TEST_ASSERT( mbedtls_rsa_import_raw( &ctx,
@@ -1251,7 +1258,7 @@ void mbedtls_rsa_import_raw( data_t *input_N,
 
     mbedtls_ctr_drbg_init( &ctr_drbg );
     mbedtls_entropy_init( &entropy );
-    mbedtls_rsa_init( &ctx, 0, 0 );
+    mbedtls_rsa_init( &ctx );
 
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func,
                                         &entropy, (const unsigned char *) pers,


### PR DESCRIPTION
## Description
Fix #4523

## Status
Ready

## Requires Backporting
NO, 3.0 only.  

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Migration guide