### PR TITLE
Rename the _ret() functions

### DIFF
--- a/ChangeLog.d/issue4212.txt
+++ b/ChangeLog.d/issue4212.txt
@@ -1,0 +1,33 @@
+Changes
+   * Rename functions whose deprecated variants have been removed via #4029:
+     mbedtls_ctr_drbg_update_ret  -> mbedtls_ctr_drbg_update
+     mbedtls_hmac_drbg_update_ret -> mbedtls_hmac_drbg_update
+     mbedtls_md2_starts_ret       -> mbedtls_md2_starts
+     mbedtls_md2_update_ret       -> mbedtls_md2_update
+     mbedtls_md2_finish_ret       -> mbedtls_md2_finish
+     mbedtls_md2_ret              -> mbedtls_md2
+     mbedtls_md4_starts_ret       -> mbedtls_md4_starts
+     mbedtls_md4_update_ret       -> mbedtls_md4_update
+     mbedtls_md4_finish_ret       -> mbedtls_md4_finish
+     mbedtls_md4_ret              -> mbedtls_md4
+     mbedtls_md5_starts_ret       -> mbedtls_md5_starts
+     mbedtls_md5_update_ret       -> mbedtls_md5_update
+     mbedtls_md5_finish_ret       -> mbedtls_md5_finish
+     mbedtls_md5_ret              -> mbedtls_md5
+     mbedtls_ripemd160_starts_ret -> mbedtls_ripemd160_starts
+     mbedtls_ripemd160_update_ret -> mbedtls_ripemd160_update
+     mbedtls_ripemd160_finish_ret -> mbedtls_ripemd160_finish
+     mbedtls_ripemd160_ret        -> mbedtls_ripemd160
+     mbedtls_sha1_starts_ret      -> mbedtls_sha1_starts
+     mbedtls_sha1_update_ret      -> mbedtls_sha1_update
+     mbedtls_sha1_finish_ret      -> mbedtls_sha1_finish
+     mbedtls_sha1_ret             -> mbedtls_sha1
+     mbedtls_sha256_starts_ret    -> mbedtls_sha256_starts
+     mbedtls_sha256_update_ret    -> mbedtls_sha256_update
+     mbedtls_sha256_finish_ret    -> mbedtls_sha256_finish
+     mbedtls_sha256_ret           -> mbedtls_sha256
+     mbedtls_sha512_starts_ret    -> mbedtls_sha512_starts
+     mbedtls_sha512_update_ret    -> mbedtls_sha512_update
+     mbedtls_sha512_finish_ret    -> mbedtls_sha512_finish
+     mbedtls_sha512_ret           -> mbedtls_sha512.
+     Fixes #4212.

--- a/ChangeLog.d/issue4212.txt
+++ b/ChangeLog.d/issue4212.txt
@@ -1,33 +1,6 @@
 API changes
-   * Rename functions whose deprecated variants have been removed via #4029:
-     mbedtls_ctr_drbg_update_ret  -> mbedtls_ctr_drbg_update
-     mbedtls_hmac_drbg_update_ret -> mbedtls_hmac_drbg_update
-     mbedtls_md2_starts_ret       -> mbedtls_md2_starts
-     mbedtls_md2_update_ret       -> mbedtls_md2_update
-     mbedtls_md2_finish_ret       -> mbedtls_md2_finish
-     mbedtls_md2_ret              -> mbedtls_md2
-     mbedtls_md4_starts_ret       -> mbedtls_md4_starts
-     mbedtls_md4_update_ret       -> mbedtls_md4_update
-     mbedtls_md4_finish_ret       -> mbedtls_md4_finish
-     mbedtls_md4_ret              -> mbedtls_md4
-     mbedtls_md5_starts_ret       -> mbedtls_md5_starts
-     mbedtls_md5_update_ret       -> mbedtls_md5_update
-     mbedtls_md5_finish_ret       -> mbedtls_md5_finish
-     mbedtls_md5_ret              -> mbedtls_md5
-     mbedtls_ripemd160_starts_ret -> mbedtls_ripemd160_starts
-     mbedtls_ripemd160_update_ret -> mbedtls_ripemd160_update
-     mbedtls_ripemd160_finish_ret -> mbedtls_ripemd160_finish
-     mbedtls_ripemd160_ret        -> mbedtls_ripemd160
-     mbedtls_sha1_starts_ret      -> mbedtls_sha1_starts
-     mbedtls_sha1_update_ret      -> mbedtls_sha1_update
-     mbedtls_sha1_finish_ret      -> mbedtls_sha1_finish
-     mbedtls_sha1_ret             -> mbedtls_sha1
-     mbedtls_sha256_starts_ret    -> mbedtls_sha256_starts
-     mbedtls_sha256_update_ret    -> mbedtls_sha256_update
-     mbedtls_sha256_finish_ret    -> mbedtls_sha256_finish
-     mbedtls_sha256_ret           -> mbedtls_sha256
-     mbedtls_sha512_starts_ret    -> mbedtls_sha512_starts
-     mbedtls_sha512_update_ret    -> mbedtls_sha512_update
-     mbedtls_sha512_finish_ret    -> mbedtls_sha512_finish
-     mbedtls_sha512_ret           -> mbedtls_sha512.
-     Fixes #4212.
+   * In modules that implement cryptographic hash functions, many functions
+     mbedtls_xxx() now return int instead of void, and the corresponding
+     function mbedtls_xxx_ret() which was identical except for returning int
+     has been removed. This also concerns mbedtls_xxx_drbg_update(). See the
+     migration guide for more information. Fixes #4212.

--- a/ChangeLog.d/issue4212.txt
+++ b/ChangeLog.d/issue4212.txt
@@ -1,4 +1,4 @@
-Changes
+API changes
    * Rename functions whose deprecated variants have been removed via #4029:
      mbedtls_ctr_drbg_update_ret  -> mbedtls_ctr_drbg_update
      mbedtls_hmac_drbg_update_ret -> mbedtls_hmac_drbg_update

--- a/docs/3.0-migration-guide.d/rename_the__ret_functions.md
+++ b/docs/3.0-migration-guide.d/rename_the__ret_functions.md
@@ -1,0 +1,13 @@
+Rename mbedtls_*_ret() cryptography functions whose deprecated variants have been removed in #4029
+--
+
+This change affects users who were using the `mbedtls_*_ret()` criptography functions.
+
+Those functions were created based on now-deprecated functions according to a
+requirement that a function needs to return a value. This change brings back the
+original names of those functions.
+
+To migrate to the this change the user can keep the `*_ret` names in their code
+and include the `compat_2.x.h` header file which holds macros with proper
+renaming or to rename those function in their code according to the list from
+mentioned header file.

--- a/docs/3.0-migration-guide.d/rename_the__ret_functions.md
+++ b/docs/3.0-migration-guide.d/rename_the__ret_functions.md
@@ -1,7 +1,9 @@
-Rename mbedtls_*_ret() cryptography functions whose deprecated variants have been removed in #4029
---
+Rename mbedtls_*_ret() cryptography functions whose deprecated variants
+have been removed in #4029
+--------------------------
 
-This change affects users who were using the `mbedtls_*_ret()` criptography functions.
+This change affects users who were using the `mbedtls_*_ret()` cryptography
+functions.
 
 Those functions were created based on now-deprecated functions according to a
 requirement that a function needs to return a value. This change brings back the

--- a/docs/3.0-migration-guide.d/rename_the__ret_functions.md
+++ b/docs/3.0-migration-guide.d/rename_the__ret_functions.md
@@ -1,15 +1,51 @@
 Rename mbedtls_*_ret() cryptography functions whose deprecated variants
-have been removed in #4029
---------------------------
+have been removed
+-----------------
 
 This change affects users who were using the `mbedtls_*_ret()` cryptography
 functions.
 
 Those functions were created based on now-deprecated functions according to a
 requirement that a function needs to return a value. This change brings back the
-original names of those functions.
+original names of those functions. The renamed functions are:
+
+| name before this change      | after the change         |
+|------------------------------|--------------------------|
+| mbedtls_ctr_drbg_update_ret  | mbedtls_ctr_drbg_update  |
+| mbedtls_hmac_drbg_update_ret | mbedtls_hmac_drbg_update |
+| mbedtls_md2_starts_ret       | mbedtls_md2_starts       |
+| mbedtls_md2_update_ret       | mbedtls_md2_update       |
+| mbedtls_md2_finish_ret       | mbedtls_md2_finish       |
+| mbedtls_md2_ret              | mbedtls_md2              |
+| mbedtls_md4_starts_ret       | mbedtls_md4_starts       |
+| mbedtls_md4_update_ret       | mbedtls_md4_update       |
+| mbedtls_md4_finish_ret       | mbedtls_md4_finish       |
+| mbedtls_md4_ret              | mbedtls_md4              |
+| mbedtls_md5_starts_ret       | mbedtls_md5_starts       |
+| mbedtls_md5_update_ret       | mbedtls_md5_update       |
+| mbedtls_md5_finish_ret       | mbedtls_md5_finish       |
+| mbedtls_md5_ret              | mbedtls_md5              |
+| mbedtls_ripemd160_starts_ret | mbedtls_ripemd160_starts |
+| mbedtls_ripemd160_update_ret | mbedtls_ripemd160_update |
+| mbedtls_ripemd160_finish_ret | mbedtls_ripemd160_finish |
+| mbedtls_ripemd160_ret        | mbedtls_ripemd160        |
+| mbedtls_sha1_starts_ret      | mbedtls_sha1_starts      |
+| mbedtls_sha1_update_ret      | mbedtls_sha1_update      |
+| mbedtls_sha1_finish_ret      | mbedtls_sha1_finish      |
+| mbedtls_sha1_ret             | mbedtls_sha1             |
+| mbedtls_sha256_starts_ret    | mbedtls_sha256_starts    |
+| mbedtls_sha256_update_ret    | mbedtls_sha256_update    |
+| mbedtls_sha256_finish_ret    | mbedtls_sha256_finish    |
+| mbedtls_sha256_ret           | mbedtls_sha256           |
+| mbedtls_sha512_starts_ret    | mbedtls_sha512_starts    |
+| mbedtls_sha512_update_ret    | mbedtls_sha512_update    |
+| mbedtls_sha512_finish_ret    | mbedtls_sha512_finish    |
+| mbedtls_sha512_ret           | mbedtls_sha512           |
 
 To migrate to the this change the user can keep the `*_ret` names in their code
 and include the `compat_2.x.h` header file which holds macros with proper
 renaming or to rename those function in their code according to the list from
 mentioned header file.
+
+
+

--- a/include/mbedtls/compat-2.x.h
+++ b/include/mbedtls/compat-2.x.h
@@ -1,0 +1,69 @@
+/**
+ * \file compat-2.x.h
+ *
+ * \brief Compatibility definitions
+ *
+ * \deprecated Use the new names directly instead
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
+
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#warning "Including compat-2.x.h is deprecated"
+#endif
+
+#ifndef MBEDTLS_COMPAT2X_H
+#define MBEDTLS_COMPAT2X_H
+
+/*
+ * Macros for renamed functions
+ */
+#define mbedtls_ctr_drbg_update_ret   mbedtls_ctr_drbg_update
+#define mbedtls_hmac_drbg_update_ret  mbedtls_hmac_drbg_update
+#define mbedtls_md2_starts_ret        mbedtls_md2_starts
+#define mbedtls_md2_update_ret        mbedtls_md2_update
+#define mbedtls_md2_finish_ret        mbedtls_md2_finish
+#define mbedtls_md2_ret               mbedtls_md2
+#define mbedtls_md4_starts_ret        mbedtls_md4_starts
+#define mbedtls_md4_update_ret        mbedtls_md4_update
+#define mbedtls_md4_finish_ret        mbedtls_md4_finish
+#define mbedtls_md4_ret               mbedtls_md4
+#define mbedtls_md5_starts_ret        mbedtls_md5_starts
+#define mbedtls_md5_update_ret        mbedtls_md5_update
+#define mbedtls_md5_finish_ret        mbedtls_md5_finish
+#define mbedtls_md5_ret               mbedtls_md5
+#define mbedtls_ripemd160_starts_ret  mbedtls_ripemd160_starts
+#define mbedtls_ripemd160_update_ret  mbedtls_ripemd160_update
+#define mbedtls_ripemd160_finish_ret  mbedtls_ripemd160_finish
+#define mbedtls_ripemd160_ret         mbedtls_ripemd160
+#define mbedtls_sha1_starts_ret       mbedtls_sha1_starts
+#define mbedtls_sha1_update_ret       mbedtls_sha1_update
+#define mbedtls_sha1_finish_ret       mbedtls_sha1_finish
+#define mbedtls_sha1_ret              mbedtls_sha1
+#define mbedtls_sha256_starts_ret     mbedtls_sha256_starts
+#define mbedtls_sha256_update_ret     mbedtls_sha256_update
+#define mbedtls_sha256_finish_ret     mbedtls_sha256_finish
+#define mbedtls_sha256_ret            mbedtls_sha256
+#define mbedtls_sha512_starts_ret     mbedtls_sha512_starts
+#define mbedtls_sha512_update_ret     mbedtls_sha512_update
+#define mbedtls_sha512_finish_ret     mbedtls_sha512_finish
+#define mbedtls_sha512_ret            mbedtls_sha512
+
+#endif /* MBEDTLS_COMPAT2X_H */
+#endif /* MBEDTLS_DEPRECATED_REMOVED */

--- a/include/mbedtls/compat-2.x.h
+++ b/include/mbedtls/compat-2.x.h
@@ -22,8 +22,6 @@
  *  limitations under the License.
  */
 
-#if ! defined(MBEDTLS_DEPRECATED_REMOVED)
-
 #if defined(MBEDTLS_DEPRECATED_WARNING)
 #warning "Including compat-2.x.h is deprecated"
 #endif
@@ -66,4 +64,3 @@
 #define mbedtls_sha512_ret            mbedtls_sha512
 
 #endif /* MBEDTLS_COMPAT2X_H */
-#endif /* MBEDTLS_DEPRECATED_REMOVED */

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -462,9 +462,9 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
  *                     #MBEDTLS_CTR_DRBG_MAX_SEED_INPUT.
  * \return             An error from the underlying AES cipher on failure.
  */
-int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
-                                 const unsigned char *additional,
-                                 size_t add_len );
+int mbedtls_ctr_drbg_update( mbedtls_ctr_drbg_context *ctx,
+                             const unsigned char *additional,
+                             size_t add_len );
 
 /**
  * \brief   This function updates a CTR_DRBG instance with additional

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -294,8 +294,8 @@ void mbedtls_hmac_drbg_set_reseed_interval( mbedtls_hmac_drbg_context *ctx,
  * \return              \c 0 on success, or an error from the underlying
  *                      hash calculation.
  */
-int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
-                       const unsigned char *additional, size_t add_len );
+int mbedtls_hmac_drbg_update( mbedtls_hmac_drbg_context *ctx,
+                              const unsigned char *additional, size_t add_len );
 
 /**
  * \brief               This function reseeds the HMAC_DRBG context, that is

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -114,7 +114,7 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx );
+int mbedtls_md2_starts( mbedtls_md2_context *ctx );
 
 /**
  * \brief          MD2 process buffer
@@ -130,9 +130,9 @@ int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
-                            const unsigned char *input,
-                            size_t ilen );
+int mbedtls_md2_update( mbedtls_md2_context *ctx,
+                        const unsigned char *input,
+                        size_t ilen );
 
 /**
  * \brief          MD2 final digest
@@ -147,8 +147,8 @@ int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
-                            unsigned char output[16] );
+int mbedtls_md2_finish( mbedtls_md2_context *ctx,
+                        unsigned char output[16] );
 
 /**
  * \brief          MD2 process data block (internal use only)
@@ -176,9 +176,9 @@ int mbedtls_internal_md2_process( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_ret( const unsigned char *input,
-                     size_t ilen,
-                     unsigned char output[16] );
+int mbedtls_md2( const unsigned char *input,
+                 size_t ilen,
+                 unsigned char output[16] );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -113,7 +113,7 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  *                 constitutes a security risk. We recommend considering
  *                 stronger message digests instead.
  */
-int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx );
+int mbedtls_md4_starts( mbedtls_md4_context *ctx );
 
 /**
  * \brief          MD4 process buffer
@@ -129,9 +129,9 @@ int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
-                            const unsigned char *input,
-                            size_t ilen );
+int mbedtls_md4_update( mbedtls_md4_context *ctx,
+                        const unsigned char *input,
+                        size_t ilen );
 
 /**
  * \brief          MD4 final digest
@@ -146,8 +146,8 @@ int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
-                            unsigned char output[16] );
+int mbedtls_md4_finish( mbedtls_md4_context *ctx,
+                        unsigned char output[16] );
 
 /**
  * \brief          MD4 process data block (internal use only)
@@ -179,9 +179,9 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_ret( const unsigned char *input,
-                     size_t ilen,
-                     unsigned char output[16] );
+int mbedtls_md4( const unsigned char *input,
+                 size_t ilen,
+                 unsigned char output[16] );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -113,7 +113,7 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx );
+int mbedtls_md5_starts( mbedtls_md5_context *ctx );
 
 /**
  * \brief          MD5 process buffer
@@ -129,9 +129,9 @@ int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
-                            const unsigned char *input,
-                            size_t ilen );
+int mbedtls_md5_update( mbedtls_md5_context *ctx,
+                        const unsigned char *input,
+                        size_t ilen );
 
 /**
  * \brief          MD5 final digest
@@ -146,8 +146,8 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
-                            unsigned char output[16] );
+int mbedtls_md5_finish( mbedtls_md5_context *ctx,
+                        unsigned char output[16] );
 
 /**
  * \brief          MD5 process data block (internal use only)
@@ -179,9 +179,9 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_ret( const unsigned char *input,
-                     size_t ilen,
-                     unsigned char output[16] );
+int mbedtls_md5( const unsigned char *input,
+                 size_t ilen,
+                 unsigned char output[16] );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -84,7 +84,7 @@ void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx );
+int mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx );
 
 /**
  * \brief          RIPEMD-160 process buffer
@@ -95,9 +95,9 @@ int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx );
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
-                                  const unsigned char *input,
-                                  size_t ilen );
+int mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
+                              const unsigned char *input,
+                              size_t ilen );
 
 /**
  * \brief          RIPEMD-160 final digest
@@ -107,8 +107,8 @@ int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
-                                  unsigned char output[20] );
+int mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx,
+                              unsigned char output[20] );
 
 /**
  * \brief          RIPEMD-160 process data block (internal use only)
@@ -130,9 +130,9 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_ret( const unsigned char *input,
-                           size_t ilen,
-                           unsigned char output[20] );
+int mbedtls_ripemd160( const unsigned char *input,
+                       size_t ilen,
+                       unsigned char output[20] );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -123,7 +123,7 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \return         A negative error code on failure.
  *
  */
-int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
+int mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing SHA-1
@@ -142,9 +142,9 @@ int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
-                             const unsigned char *input,
-                             size_t ilen );
+int mbedtls_sha1_update( mbedtls_sha1_context *ctx,
+                         const unsigned char *input,
+                         size_t ilen );
 
 /**
  * \brief          This function finishes the SHA-1 operation, and writes
@@ -162,8 +162,8 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
-                             unsigned char output[20] );
+int mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
+                         unsigned char output[20] );
 
 /**
  * \brief          SHA-1 process data block (internal use only).
@@ -206,9 +206,9 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
  * \return         A negative error code on failure.
  *
  */
-int mbedtls_sha1_ret( const unsigned char *input,
-                      size_t ilen,
-                      unsigned char output[20] );
+int mbedtls_sha1( const unsigned char *input,
+                  size_t ilen,
+                  unsigned char output[20] );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -49,7 +49,7 @@ extern "C" {
  *
  *                 The structure is used both for SHA-256 and for SHA-224
  *                 checksum calculations. The choice between these two is
- *                 made in the call to mbedtls_sha256_starts_ret().
+ *                 made in the call to mbedtls_sha256_starts().
  */
 typedef struct mbedtls_sha256_context
 {
@@ -101,7 +101,7 @@ void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
+int mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing
@@ -116,9 +116,9 @@ int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
-                               const unsigned char *input,
-                               size_t ilen );
+int mbedtls_sha256_update( mbedtls_sha256_context *ctx,
+                           const unsigned char *input,
+                           size_t ilen );
 
 /**
  * \brief          This function finishes the SHA-256 operation, and writes
@@ -133,8 +133,8 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
-                               unsigned char *output );
+int mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
+                           unsigned char *output );
 
 /**
  * \brief          This function processes a single data block within
@@ -170,10 +170,10 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
  */
-int mbedtls_sha256_ret( const unsigned char *input,
-                        size_t ilen,
-                        unsigned char *output,
-                        int is224 );
+int mbedtls_sha256( const unsigned char *input,
+                    size_t ilen,
+                    unsigned char *output,
+                    int is224 );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -48,7 +48,7 @@ extern "C" {
  *
  *                 The structure is used both for SHA-384 and for SHA-512
  *                 checksum calculations. The choice between these two is
- *                 made in the call to mbedtls_sha512_starts_ret().
+ *                 made in the call to mbedtls_sha512_starts().
  */
 typedef struct mbedtls_sha512_context
 {
@@ -108,7 +108,7 @@ void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
+int mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing
@@ -123,9 +123,9 @@ int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
-                    const unsigned char *input,
-                    size_t ilen );
+int mbedtls_sha512_update( mbedtls_sha512_context *ctx,
+                           const unsigned char *input,
+                           size_t ilen );
 
 /**
  * \brief          This function finishes the SHA-512 operation, and writes
@@ -140,8 +140,8 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
-                               unsigned char *output );
+int mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
+                           unsigned char *output );
 
 /**
  * \brief          This function processes a single data block within
@@ -184,10 +184,10 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_ret( const unsigned char *input,
-                        size_t ilen,
-                        unsigned char *output,
-                        int is384 );
+int mbedtls_sha512( const unsigned char *input,
+                    size_t ilen,
+                    unsigned char *output,
+                    int is384 );
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -304,7 +304,7 @@ exit:
 }
 
 /* CTR_DRBG_Instantiate with derivation function (SP 800-90A &sect;10.2.1.3.2)
- * mbedtls_ctr_drbg_update_ret(ctx, additional, add_len)
+ * mbedtls_ctr_drbg_update(ctx, additional, add_len)
  * implements
  * CTR_DRBG_Instantiate(entropy_input, nonce, personalization_string,
  *                      security_strength) -> initial_working_state
@@ -315,7 +315,7 @@ exit:
  * and with outputs
  *   ctx = initial_working_state
  */
-int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
+int mbedtls_ctr_drbg_update( mbedtls_ctr_drbg_context *ctx,
                                  const unsigned char *additional,
                                  size_t add_len )
 {
@@ -657,7 +657,7 @@ int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx,
     fclose( f );
     f = NULL;
 
-    ret = mbedtls_ctr_drbg_update_ret( ctx, buf, n );
+    ret = mbedtls_ctr_drbg_update( ctx, buf, n );
 
 exit:
     mbedtls_platform_zeroize( buf, sizeof( buf ) );

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -164,10 +164,10 @@ static int entropy_update( mbedtls_entropy_context *ctx, unsigned char source_id
     if( use_len > MBEDTLS_ENTROPY_BLOCK_SIZE )
     {
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
-        if( ( ret = mbedtls_sha512_ret( data, len, tmp, 0 ) ) != 0 )
+        if( ( ret = mbedtls_sha512( data, len, tmp, 0 ) ) != 0 )
             goto cleanup;
 #else
-        if( ( ret = mbedtls_sha256_ret( data, len, tmp, 0 ) ) != 0 )
+        if( ( ret = mbedtls_sha256( data, len, tmp, 0 ) ) != 0 )
             goto cleanup;
 #endif
         p = tmp;
@@ -184,22 +184,22 @@ static int entropy_update( mbedtls_entropy_context *ctx, unsigned char source_id
      */
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     if( ctx->accumulator_started == 0 &&
-        ( ret = mbedtls_sha512_starts_ret( &ctx->accumulator, 0 ) ) != 0 )
+        ( ret = mbedtls_sha512_starts( &ctx->accumulator, 0 ) ) != 0 )
         goto cleanup;
     else
         ctx->accumulator_started = 1;
-    if( ( ret = mbedtls_sha512_update_ret( &ctx->accumulator, header, 2 ) ) != 0 )
+    if( ( ret = mbedtls_sha512_update( &ctx->accumulator, header, 2 ) ) != 0 )
         goto cleanup;
-    ret = mbedtls_sha512_update_ret( &ctx->accumulator, p, use_len );
+    ret = mbedtls_sha512_update( &ctx->accumulator, p, use_len );
 #else
     if( ctx->accumulator_started == 0 &&
-        ( ret = mbedtls_sha256_starts_ret( &ctx->accumulator, 0 ) ) != 0 )
+        ( ret = mbedtls_sha256_starts( &ctx->accumulator, 0 ) ) != 0 )
         goto cleanup;
     else
         ctx->accumulator_started = 1;
-    if( ( ret = mbedtls_sha256_update_ret( &ctx->accumulator, header, 2 ) ) != 0 )
+    if( ( ret = mbedtls_sha256_update( &ctx->accumulator, header, 2 ) ) != 0 )
         goto cleanup;
-    ret = mbedtls_sha256_update_ret( &ctx->accumulator, p, use_len );
+    ret = mbedtls_sha256_update( &ctx->accumulator, p, use_len );
 #endif
 
 cleanup:
@@ -361,7 +361,7 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
      * in a previous call to entropy_update(). If this is not guaranteed, the
      * code below will fail.
      */
-    if( ( ret = mbedtls_sha512_finish_ret( &ctx->accumulator, buf ) ) != 0 )
+    if( ( ret = mbedtls_sha512_finish( &ctx->accumulator, buf ) ) != 0 )
         goto exit;
 
     /*
@@ -369,20 +369,20 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
      */
     mbedtls_sha512_free( &ctx->accumulator );
     mbedtls_sha512_init( &ctx->accumulator );
-    if( ( ret = mbedtls_sha512_starts_ret( &ctx->accumulator, 0 ) ) != 0 )
+    if( ( ret = mbedtls_sha512_starts( &ctx->accumulator, 0 ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_sha512_update_ret( &ctx->accumulator, buf,
+    if( ( ret = mbedtls_sha512_update( &ctx->accumulator, buf,
                                            MBEDTLS_ENTROPY_BLOCK_SIZE ) ) != 0 )
         goto exit;
 
     /*
      * Perform second SHA-512 on entropy
      */
-    if( ( ret = mbedtls_sha512_ret( buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
+    if( ( ret = mbedtls_sha512( buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
                                     buf, 0 ) ) != 0 )
         goto exit;
 #else /* MBEDTLS_ENTROPY_SHA512_ACCUMULATOR */
-    if( ( ret = mbedtls_sha256_finish_ret( &ctx->accumulator, buf ) ) != 0 )
+    if( ( ret = mbedtls_sha256_finish( &ctx->accumulator, buf ) ) != 0 )
         goto exit;
 
     /*
@@ -390,16 +390,16 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len )
      */
     mbedtls_sha256_free( &ctx->accumulator );
     mbedtls_sha256_init( &ctx->accumulator );
-    if( ( ret = mbedtls_sha256_starts_ret( &ctx->accumulator, 0 ) ) != 0 )
+    if( ( ret = mbedtls_sha256_starts( &ctx->accumulator, 0 ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_sha256_update_ret( &ctx->accumulator, buf,
+    if( ( ret = mbedtls_sha256_update( &ctx->accumulator, buf,
                                            MBEDTLS_ENTROPY_BLOCK_SIZE ) ) != 0 )
         goto exit;
 
     /*
      * Perform second SHA-256 on entropy
      */
-    if( ( ret = mbedtls_sha256_ret( buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
+    if( ( ret = mbedtls_sha256( buf, MBEDTLS_ENTROPY_BLOCK_SIZE,
                                     buf, 0 ) ) != 0 )
         goto exit;
 #endif /* MBEDTLS_ENTROPY_SHA512_ACCUMULATOR */

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -59,7 +59,7 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx )
 /*
  * HMAC_DRBG update, using optional additional data (10.1.2.2)
  */
-int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
+int mbedtls_hmac_drbg_update( mbedtls_hmac_drbg_context *ctx,
                                   const unsigned char *additional,
                                   size_t add_len )
 {
@@ -130,7 +130,7 @@ int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
         return( ret );
     memset( ctx->V, 0x01, mbedtls_md_get_size( md_info ) );
 
-    if( ( ret = mbedtls_hmac_drbg_update_ret( ctx, data, data_len ) ) != 0 )
+    if( ( ret = mbedtls_hmac_drbg_update( ctx, data, data_len ) ) != 0 )
         return( ret );
 
     return( 0 );
@@ -205,7 +205,7 @@ static int hmac_drbg_reseed_core( mbedtls_hmac_drbg_context *ctx,
     }
 
     /* 2. Update state */
-    if( ( ret = mbedtls_hmac_drbg_update_ret( ctx, seed, seedlen ) ) != 0 )
+    if( ( ret = mbedtls_hmac_drbg_update( ctx, seed, seedlen ) ) != 0 )
         goto exit;
 
     /* 3. Reset reseed_counter */
@@ -348,7 +348,7 @@ int mbedtls_hmac_drbg_random_with_add( void *p_rng,
     /* 2. Use additional data if any */
     if( additional != NULL && add_len != 0 )
     {
-        if( ( ret = mbedtls_hmac_drbg_update_ret( ctx,
+        if( ( ret = mbedtls_hmac_drbg_update( ctx,
                                                   additional, add_len ) ) != 0 )
             goto exit;
     }
@@ -372,7 +372,7 @@ int mbedtls_hmac_drbg_random_with_add( void *p_rng,
     }
 
     /* 6. Update */
-    if( ( ret = mbedtls_hmac_drbg_update_ret( ctx,
+    if( ( ret = mbedtls_hmac_drbg_update( ctx,
                                               additional, add_len ) ) != 0 )
         goto exit;
 
@@ -479,7 +479,7 @@ int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const ch
     fclose( f );
     f = NULL;
 
-    ret = mbedtls_hmac_drbg_update_ret( ctx, buf, n );
+    ret = mbedtls_hmac_drbg_update( ctx, buf, n );
 
 exit:
     mbedtls_platform_zeroize( buf, sizeof( buf ) );

--- a/library/md.c
+++ b/library/md.c
@@ -503,39 +503,39 @@ int mbedtls_md_starts( mbedtls_md_context_t *ctx )
     {
 #if defined(MBEDTLS_MD2_C)
         case MBEDTLS_MD_MD2:
-            return( mbedtls_md2_starts_ret( ctx->md_ctx ) );
+            return( mbedtls_md2_starts( ctx->md_ctx ) );
 #endif
 #if defined(MBEDTLS_MD4_C)
         case MBEDTLS_MD_MD4:
-            return( mbedtls_md4_starts_ret( ctx->md_ctx ) );
+            return( mbedtls_md4_starts( ctx->md_ctx ) );
 #endif
 #if defined(MBEDTLS_MD5_C)
         case MBEDTLS_MD_MD5:
-            return( mbedtls_md5_starts_ret( ctx->md_ctx ) );
+            return( mbedtls_md5_starts( ctx->md_ctx ) );
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
         case MBEDTLS_MD_RIPEMD160:
-            return( mbedtls_ripemd160_starts_ret( ctx->md_ctx ) );
+            return( mbedtls_ripemd160_starts( ctx->md_ctx ) );
 #endif
 #if defined(MBEDTLS_SHA1_C)
         case MBEDTLS_MD_SHA1:
-            return( mbedtls_sha1_starts_ret( ctx->md_ctx ) );
+            return( mbedtls_sha1_starts( ctx->md_ctx ) );
 #endif
 #if defined(MBEDTLS_SHA224_C)
         case MBEDTLS_MD_SHA224:
-            return( mbedtls_sha256_starts_ret( ctx->md_ctx, 1 ) );
+            return( mbedtls_sha256_starts( ctx->md_ctx, 1 ) );
 #endif
 #if defined(MBEDTLS_SHA256_C)
         case MBEDTLS_MD_SHA256:
-            return( mbedtls_sha256_starts_ret( ctx->md_ctx, 0 ) );
+            return( mbedtls_sha256_starts( ctx->md_ctx, 0 ) );
 #endif
 #if defined(MBEDTLS_SHA384_C)
         case MBEDTLS_MD_SHA384:
-            return( mbedtls_sha512_starts_ret( ctx->md_ctx, 1 ) );
+            return( mbedtls_sha512_starts( ctx->md_ctx, 1 ) );
 #endif
 #if defined(MBEDTLS_SHA512_C)
         case MBEDTLS_MD_SHA512:
-            return( mbedtls_sha512_starts_ret( ctx->md_ctx, 0 ) );
+            return( mbedtls_sha512_starts( ctx->md_ctx, 0 ) );
 #endif
         default:
             return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
@@ -551,39 +551,39 @@ int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, si
     {
 #if defined(MBEDTLS_MD2_C)
         case MBEDTLS_MD_MD2:
-            return( mbedtls_md2_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_md2_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_MD4_C)
         case MBEDTLS_MD_MD4:
-            return( mbedtls_md4_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_md4_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_MD5_C)
         case MBEDTLS_MD_MD5:
-            return( mbedtls_md5_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_md5_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
         case MBEDTLS_MD_RIPEMD160:
-            return( mbedtls_ripemd160_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_ripemd160_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_SHA1_C)
         case MBEDTLS_MD_SHA1:
-            return( mbedtls_sha1_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_sha1_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_SHA224_C)
         case MBEDTLS_MD_SHA224:
-            return( mbedtls_sha256_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_sha256_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_SHA256_C)
         case MBEDTLS_MD_SHA256:
-            return( mbedtls_sha256_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_sha256_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_SHA384_C)
         case MBEDTLS_MD_SHA384:
-            return( mbedtls_sha512_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_sha512_update( ctx->md_ctx, input, ilen ) );
 #endif
 #if defined(MBEDTLS_SHA512_C)
         case MBEDTLS_MD_SHA512:
-            return( mbedtls_sha512_update_ret( ctx->md_ctx, input, ilen ) );
+            return( mbedtls_sha512_update( ctx->md_ctx, input, ilen ) );
 #endif
         default:
             return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
@@ -599,39 +599,39 @@ int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output )
     {
 #if defined(MBEDTLS_MD2_C)
         case MBEDTLS_MD_MD2:
-            return( mbedtls_md2_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_md2_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_MD4_C)
         case MBEDTLS_MD_MD4:
-            return( mbedtls_md4_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_md4_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_MD5_C)
         case MBEDTLS_MD_MD5:
-            return( mbedtls_md5_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_md5_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
         case MBEDTLS_MD_RIPEMD160:
-            return( mbedtls_ripemd160_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_ripemd160_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_SHA1_C)
         case MBEDTLS_MD_SHA1:
-            return( mbedtls_sha1_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_sha1_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_SHA224_C)
         case MBEDTLS_MD_SHA224:
-            return( mbedtls_sha256_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_sha256_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_SHA256_C)
         case MBEDTLS_MD_SHA256:
-            return( mbedtls_sha256_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_sha256_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_SHA384_C)
         case MBEDTLS_MD_SHA384:
-            return( mbedtls_sha512_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_sha512_finish( ctx->md_ctx, output ) );
 #endif
 #if defined(MBEDTLS_SHA512_C)
         case MBEDTLS_MD_SHA512:
-            return( mbedtls_sha512_finish_ret( ctx->md_ctx, output ) );
+            return( mbedtls_sha512_finish( ctx->md_ctx, output ) );
 #endif
         default:
             return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );
@@ -648,39 +648,39 @@ int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, si
     {
 #if defined(MBEDTLS_MD2_C)
         case MBEDTLS_MD_MD2:
-            return( mbedtls_md2_ret( input, ilen, output ) );
+            return( mbedtls_md2( input, ilen, output ) );
 #endif
 #if defined(MBEDTLS_MD4_C)
         case MBEDTLS_MD_MD4:
-            return( mbedtls_md4_ret( input, ilen, output ) );
+            return( mbedtls_md4( input, ilen, output ) );
 #endif
 #if defined(MBEDTLS_MD5_C)
         case MBEDTLS_MD_MD5:
-            return( mbedtls_md5_ret( input, ilen, output ) );
+            return( mbedtls_md5( input, ilen, output ) );
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
         case MBEDTLS_MD_RIPEMD160:
-            return( mbedtls_ripemd160_ret( input, ilen, output ) );
+            return( mbedtls_ripemd160( input, ilen, output ) );
 #endif
 #if defined(MBEDTLS_SHA1_C)
         case MBEDTLS_MD_SHA1:
-            return( mbedtls_sha1_ret( input, ilen, output ) );
+            return( mbedtls_sha1( input, ilen, output ) );
 #endif
 #if defined(MBEDTLS_SHA224_C)
         case MBEDTLS_MD_SHA224:
-            return( mbedtls_sha256_ret( input, ilen, output, 1 ) );
+            return( mbedtls_sha256( input, ilen, output, 1 ) );
 #endif
 #if defined(MBEDTLS_SHA256_C)
         case MBEDTLS_MD_SHA256:
-            return( mbedtls_sha256_ret( input, ilen, output, 0 ) );
+            return( mbedtls_sha256( input, ilen, output, 0 ) );
 #endif
 #if defined(MBEDTLS_SHA384_C)
         case MBEDTLS_MD_SHA384:
-            return( mbedtls_sha512_ret( input, ilen, output, 1 ) );
+            return( mbedtls_sha512( input, ilen, output, 1 ) );
 #endif
 #if defined(MBEDTLS_SHA512_C)
         case MBEDTLS_MD_SHA512:
-            return( mbedtls_sha512_ret( input, ilen, output, 0 ) );
+            return( mbedtls_sha512( input, ilen, output, 0 ) );
 #endif
         default:
             return( MBEDTLS_ERR_MD_BAD_INPUT_DATA );

--- a/library/md2.c
+++ b/library/md2.c
@@ -96,7 +96,7 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
 /*
  * MD2 context setup
  */
-int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx )
+int mbedtls_md2_starts( mbedtls_md2_context *ctx )
 {
     memset( ctx->cksum, 0, 16 );
     memset( ctx->state, 0, 46 );
@@ -151,7 +151,7 @@ int mbedtls_internal_md2_process( mbedtls_md2_context *ctx )
 /*
  * MD2 process buffer
  */
-int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
+int mbedtls_md2_update( mbedtls_md2_context *ctx,
                             const unsigned char *input,
                             size_t ilen )
 {
@@ -185,7 +185,7 @@ int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
 /*
  * MD2 final digest
  */
-int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
+int mbedtls_md2_finish( mbedtls_md2_context *ctx,
                             unsigned char output[16] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -214,7 +214,7 @@ int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
 /*
  * output = MD2( input buffer )
  */
-int mbedtls_md2_ret( const unsigned char *input,
+int mbedtls_md2( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] )
 {
@@ -223,13 +223,13 @@ int mbedtls_md2_ret( const unsigned char *input,
 
     mbedtls_md2_init( &ctx );
 
-    if( ( ret = mbedtls_md2_starts_ret( &ctx ) ) != 0 )
+    if( ( ret = mbedtls_md2_starts( &ctx ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md2_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_md2_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md2_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_md2_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -290,7 +290,7 @@ int mbedtls_md2_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD2 test #%d: ", i + 1 );
 
-        ret = mbedtls_md2_ret( md2_test_str[i], md2_test_strlen[i], md2sum );
+        ret = mbedtls_md2( md2_test_str[i], md2_test_strlen[i], md2sum );
         if( ret != 0 )
             goto fail;
 

--- a/library/md4.c
+++ b/library/md4.c
@@ -89,7 +89,7 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
 /*
  * MD4 context setup
  */
-int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx )
+int mbedtls_md4_starts( mbedtls_md4_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -236,7 +236,7 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
 /*
  * MD4 process buffer
  */
-int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
+int mbedtls_md4_update( mbedtls_md4_context *ctx,
                             const unsigned char *input,
                             size_t ilen )
 {
@@ -298,7 +298,7 @@ static const unsigned char md4_padding[64] =
 /*
  * MD4 final digest
  */
-int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
+int mbedtls_md4_finish( mbedtls_md4_context *ctx,
                             unsigned char output[16] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -316,11 +316,11 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    ret = mbedtls_md4_update_ret( ctx, (unsigned char *)md4_padding, padn );
+    ret = mbedtls_md4_update( ctx, (unsigned char *)md4_padding, padn );
     if( ret != 0 )
         return( ret );
 
-    if( ( ret = mbedtls_md4_update_ret( ctx, msglen, 8 ) ) != 0 )
+    if( ( ret = mbedtls_md4_update( ctx, msglen, 8 ) ) != 0 )
         return( ret );
 
 
@@ -337,7 +337,7 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
 /*
  * output = MD4( input buffer )
  */
-int mbedtls_md4_ret( const unsigned char *input,
+int mbedtls_md4( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] )
 {
@@ -346,13 +346,13 @@ int mbedtls_md4_ret( const unsigned char *input,
 
     mbedtls_md4_init( &ctx );
 
-    if( ( ret = mbedtls_md4_starts_ret( &ctx ) ) != 0 )
+    if( ( ret = mbedtls_md4_starts( &ctx ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md4_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_md4_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md4_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_md4_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -413,7 +413,7 @@ int mbedtls_md4_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD4 test #%d: ", i + 1 );
 
-        ret = mbedtls_md4_ret( md4_test_str[i], md4_test_strlen[i], md4sum );
+        ret = mbedtls_md4( md4_test_str[i], md4_test_strlen[i], md4sum );
         if( ret != 0 )
             goto fail;
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -88,7 +88,7 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
 /*
  * MD5 context setup
  */
-int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx )
+int mbedtls_md5_starts( mbedtls_md5_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -242,7 +242,7 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
 /*
  * MD5 process buffer
  */
-int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
+int mbedtls_md5_update( mbedtls_md5_context *ctx,
                             const unsigned char *input,
                             size_t ilen )
 {
@@ -293,7 +293,7 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
 /*
  * MD5 final digest
  */
-int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
+int mbedtls_md5_finish( mbedtls_md5_context *ctx,
                             unsigned char output[16] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -352,7 +352,7 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
 /*
  * output = MD5( input buffer )
  */
-int mbedtls_md5_ret( const unsigned char *input,
+int mbedtls_md5( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] )
 {
@@ -361,13 +361,13 @@ int mbedtls_md5_ret( const unsigned char *input,
 
     mbedtls_md5_init( &ctx );
 
-    if( ( ret = mbedtls_md5_starts_ret( &ctx ) ) != 0 )
+    if( ( ret = mbedtls_md5_starts( &ctx ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md5_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_md5_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_md5_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -427,7 +427,7 @@ int mbedtls_md5_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  MD5 test #%d: ", i + 1 );
 
-        ret = mbedtls_md5_ret( md5_test_buf[i], md5_test_buflen[i], md5sum );
+        ret = mbedtls_md5( md5_test_buf[i], md5_test_buflen[i], md5sum );
         if( ret != 0 )
             goto fail;
 

--- a/library/pem.c
+++ b/library/pem.c
@@ -87,13 +87,13 @@ static int pem_pbkdf1( unsigned char *key, size_t keylen,
     /*
      * key[ 0..15] = MD5(pwd || IV)
      */
-    if( ( ret = mbedtls_md5_starts_ret( &md5_ctx ) ) != 0 )
+    if( ( ret = mbedtls_md5_starts( &md5_ctx ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_update_ret( &md5_ctx, pwd, pwdlen ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &md5_ctx, pwd, pwdlen ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_update_ret( &md5_ctx, iv,  8 ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &md5_ctx, iv,  8 ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_finish_ret( &md5_ctx, md5sum ) ) != 0 )
+    if( ( ret = mbedtls_md5_finish( &md5_ctx, md5sum ) ) != 0 )
         goto exit;
 
     if( keylen <= 16 )
@@ -107,15 +107,15 @@ static int pem_pbkdf1( unsigned char *key, size_t keylen,
     /*
      * key[16..23] = MD5(key[ 0..15] || pwd || IV])
      */
-    if( ( ret = mbedtls_md5_starts_ret( &md5_ctx ) ) != 0 )
+    if( ( ret = mbedtls_md5_starts( &md5_ctx ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_update_ret( &md5_ctx, md5sum, 16 ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &md5_ctx, md5sum, 16 ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_update_ret( &md5_ctx, pwd, pwdlen ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &md5_ctx, pwd, pwdlen ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_update_ret( &md5_ctx, iv, 8 ) ) != 0 )
+    if( ( ret = mbedtls_md5_update( &md5_ctx, iv, 8 ) ) != 0 )
         goto exit;
-    if( ( ret = mbedtls_md5_finish_ret( &md5_ctx, md5sum ) ) != 0 )
+    if( ( ret = mbedtls_md5_finish( &md5_ctx, md5sum ) ) != 0 )
         goto exit;
 
     use_len = 16;

--- a/library/psa_crypto_hash.c
+++ b/library/psa_crypto_hash.c
@@ -203,55 +203,55 @@ static psa_status_t hash_setup(
 #if defined(BUILTIN_ALG_MD2)
         case PSA_ALG_MD2:
             mbedtls_md2_init( &operation->ctx.md2 );
-            ret = mbedtls_md2_starts_ret( &operation->ctx.md2 );
+            ret = mbedtls_md2_starts( &operation->ctx.md2 );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD4)
         case PSA_ALG_MD4:
             mbedtls_md4_init( &operation->ctx.md4 );
-            ret = mbedtls_md4_starts_ret( &operation->ctx.md4 );
+            ret = mbedtls_md4_starts( &operation->ctx.md4 );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD5)
         case PSA_ALG_MD5:
             mbedtls_md5_init( &operation->ctx.md5 );
-            ret = mbedtls_md5_starts_ret( &operation->ctx.md5 );
+            ret = mbedtls_md5_starts( &operation->ctx.md5 );
             break;
 #endif
 #if defined(BUILTIN_ALG_RIPEMD160)
         case PSA_ALG_RIPEMD160:
             mbedtls_ripemd160_init( &operation->ctx.ripemd160 );
-            ret = mbedtls_ripemd160_starts_ret( &operation->ctx.ripemd160 );
+            ret = mbedtls_ripemd160_starts( &operation->ctx.ripemd160 );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_1)
         case PSA_ALG_SHA_1:
             mbedtls_sha1_init( &operation->ctx.sha1 );
-            ret = mbedtls_sha1_starts_ret( &operation->ctx.sha1 );
+            ret = mbedtls_sha1_starts( &operation->ctx.sha1 );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_224)
         case PSA_ALG_SHA_224:
             mbedtls_sha256_init( &operation->ctx.sha256 );
-            ret = mbedtls_sha256_starts_ret( &operation->ctx.sha256, 1 );
+            ret = mbedtls_sha256_starts( &operation->ctx.sha256, 1 );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_256)
         case PSA_ALG_SHA_256:
             mbedtls_sha256_init( &operation->ctx.sha256 );
-            ret = mbedtls_sha256_starts_ret( &operation->ctx.sha256, 0 );
+            ret = mbedtls_sha256_starts( &operation->ctx.sha256, 0 );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_384)
         case PSA_ALG_SHA_384:
             mbedtls_sha512_init( &operation->ctx.sha512 );
-            ret = mbedtls_sha512_starts_ret( &operation->ctx.sha512, 1 );
+            ret = mbedtls_sha512_starts( &operation->ctx.sha512, 1 );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_512)
         case PSA_ALG_SHA_512:
             mbedtls_sha512_init( &operation->ctx.sha512 );
-            ret = mbedtls_sha512_starts_ret( &operation->ctx.sha512, 0 );
+            ret = mbedtls_sha512_starts( &operation->ctx.sha512, 0 );
             break;
 #endif
         default:
@@ -349,55 +349,55 @@ static psa_status_t hash_update(
     {
 #if defined(BUILTIN_ALG_MD2)
         case PSA_ALG_MD2:
-            ret = mbedtls_md2_update_ret( &operation->ctx.md2,
+            ret = mbedtls_md2_update( &operation->ctx.md2,
                                           input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD4)
         case PSA_ALG_MD4:
-            ret = mbedtls_md4_update_ret( &operation->ctx.md4,
+            ret = mbedtls_md4_update( &operation->ctx.md4,
                                           input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD5)
         case PSA_ALG_MD5:
-            ret = mbedtls_md5_update_ret( &operation->ctx.md5,
+            ret = mbedtls_md5_update( &operation->ctx.md5,
                                           input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_RIPEMD160)
         case PSA_ALG_RIPEMD160:
-            ret = mbedtls_ripemd160_update_ret( &operation->ctx.ripemd160,
+            ret = mbedtls_ripemd160_update( &operation->ctx.ripemd160,
                                                 input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_1)
         case PSA_ALG_SHA_1:
-            ret = mbedtls_sha1_update_ret( &operation->ctx.sha1,
+            ret = mbedtls_sha1_update( &operation->ctx.sha1,
                                            input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_224)
         case PSA_ALG_SHA_224:
-            ret = mbedtls_sha256_update_ret( &operation->ctx.sha256,
+            ret = mbedtls_sha256_update( &operation->ctx.sha256,
                                              input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_256)
         case PSA_ALG_SHA_256:
-            ret = mbedtls_sha256_update_ret( &operation->ctx.sha256,
+            ret = mbedtls_sha256_update( &operation->ctx.sha256,
                                              input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_384)
         case PSA_ALG_SHA_384:
-            ret = mbedtls_sha512_update_ret( &operation->ctx.sha512,
+            ret = mbedtls_sha512_update( &operation->ctx.sha512,
                                              input, input_length );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_512)
         case PSA_ALG_SHA_512:
-            ret = mbedtls_sha512_update_ret( &operation->ctx.sha512,
+            ret = mbedtls_sha512_update( &operation->ctx.sha512,
                                              input, input_length );
             break;
 #endif
@@ -439,47 +439,47 @@ static psa_status_t hash_finish(
     {
 #if defined(BUILTIN_ALG_MD2)
         case PSA_ALG_MD2:
-            ret = mbedtls_md2_finish_ret( &operation->ctx.md2, hash );
+            ret = mbedtls_md2_finish( &operation->ctx.md2, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD4)
         case PSA_ALG_MD4:
-            ret = mbedtls_md4_finish_ret( &operation->ctx.md4, hash );
+            ret = mbedtls_md4_finish( &operation->ctx.md4, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_MD5)
         case PSA_ALG_MD5:
-            ret = mbedtls_md5_finish_ret( &operation->ctx.md5, hash );
+            ret = mbedtls_md5_finish( &operation->ctx.md5, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_RIPEMD160)
         case PSA_ALG_RIPEMD160:
-            ret = mbedtls_ripemd160_finish_ret( &operation->ctx.ripemd160, hash );
+            ret = mbedtls_ripemd160_finish( &operation->ctx.ripemd160, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_1)
         case PSA_ALG_SHA_1:
-            ret = mbedtls_sha1_finish_ret( &operation->ctx.sha1, hash );
+            ret = mbedtls_sha1_finish( &operation->ctx.sha1, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_224)
         case PSA_ALG_SHA_224:
-            ret = mbedtls_sha256_finish_ret( &operation->ctx.sha256, hash );
+            ret = mbedtls_sha256_finish( &operation->ctx.sha256, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_256)
         case PSA_ALG_SHA_256:
-            ret = mbedtls_sha256_finish_ret( &operation->ctx.sha256, hash );
+            ret = mbedtls_sha256_finish( &operation->ctx.sha256, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_384)
         case PSA_ALG_SHA_384:
-            ret = mbedtls_sha512_finish_ret( &operation->ctx.sha512, hash );
+            ret = mbedtls_sha512_finish( &operation->ctx.sha512, hash );
             break;
 #endif
 #if defined(BUILTIN_ALG_SHA_512)
         case PSA_ALG_SHA_512:
-            ret = mbedtls_sha512_finish_ret( &operation->ctx.sha512, hash );
+            ret = mbedtls_sha512_finish( &operation->ctx.sha512, hash );
             break;
 #endif
         default:

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -89,7 +89,7 @@ void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
 /*
  * RIPEMD-160 context setup
  */
-int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx )
+int mbedtls_ripemd160_starts( mbedtls_ripemd160_context *ctx )
 {
     ctx->total[0] = 0;
     ctx->total[1] = 0;
@@ -305,7 +305,7 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
 /*
  * RIPEMD-160 process buffer
  */
-int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
+int mbedtls_ripemd160_update( mbedtls_ripemd160_context *ctx,
                                   const unsigned char *input,
                                   size_t ilen )
 {
@@ -365,7 +365,7 @@ static const unsigned char ripemd160_padding[64] =
 /*
  * RIPEMD-160 final digest
  */
-int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
+int mbedtls_ripemd160_finish( mbedtls_ripemd160_context *ctx,
                                   unsigned char output[20] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -383,11 +383,11 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
 
-    ret = mbedtls_ripemd160_update_ret( ctx, ripemd160_padding, padn );
+    ret = mbedtls_ripemd160_update( ctx, ripemd160_padding, padn );
     if( ret != 0 )
         return( ret );
 
-    ret = mbedtls_ripemd160_update_ret( ctx, msglen, 8 );
+    ret = mbedtls_ripemd160_update( ctx, msglen, 8 );
     if( ret != 0 )
         return( ret );
 
@@ -405,7 +405,7 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
 /*
  * output = RIPEMD-160( input buffer )
  */
-int mbedtls_ripemd160_ret( const unsigned char *input,
+int mbedtls_ripemd160( const unsigned char *input,
                            size_t ilen,
                            unsigned char output[20] )
 {
@@ -414,13 +414,13 @@ int mbedtls_ripemd160_ret( const unsigned char *input,
 
     mbedtls_ripemd160_init( &ctx );
 
-    if( ( ret = mbedtls_ripemd160_starts_ret( &ctx ) ) != 0 )
+    if( ( ret = mbedtls_ripemd160_starts( &ctx ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_ripemd160_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_ripemd160_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_ripemd160_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_ripemd160_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -487,7 +487,7 @@ int mbedtls_ripemd160_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  RIPEMD-160 test #%d: ", i + 1 );
 
-        ret = mbedtls_ripemd160_ret( ripemd160_test_str[i],
+        ret = mbedtls_ripemd160( ripemd160_test_str[i],
                                      ripemd160_test_strlen[i], output );
         if( ret != 0 )
             goto fail;

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2654,7 +2654,7 @@ int mbedtls_rsa_self_test( int verbose )
     if( verbose != 0 )
         mbedtls_printf( "  PKCS#1 data sign  : " );
 
-    if( mbedtls_sha1_ret( rsa_plaintext, PT_LEN, sha1sum ) != 0 )
+    if( mbedtls_sha1( rsa_plaintext, PT_LEN, sha1sum ) != 0 )
     {
         if( verbose != 0 )
             mbedtls_printf( "failed\n" );

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -98,7 +98,7 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
 /*
  * SHA-1 context setup
  */
-int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx )
+int mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
 {
     SHA1_VALIDATE_RET( ctx != NULL );
 
@@ -292,7 +292,7 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
 /*
  * SHA-1 process buffer
  */
-int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+int mbedtls_sha1_update( mbedtls_sha1_context *ctx,
                              const unsigned char *input,
                              size_t ilen )
 {
@@ -345,7 +345,7 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
 /*
  * SHA-1 final digest
  */
-int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+int mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
                              unsigned char output[20] )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -408,7 +408,7 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
 /*
  * output = SHA-1( input buffer )
  */
-int mbedtls_sha1_ret( const unsigned char *input,
+int mbedtls_sha1( const unsigned char *input,
                       size_t ilen,
                       unsigned char output[20] )
 {
@@ -420,13 +420,13 @@ int mbedtls_sha1_ret( const unsigned char *input,
 
     mbedtls_sha1_init( &ctx );
 
-    if( ( ret = mbedtls_sha1_starts_ret( &ctx ) ) != 0 )
+    if( ( ret = mbedtls_sha1_starts( &ctx ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha1_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_sha1_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha1_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_sha1_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -481,7 +481,7 @@ int mbedtls_sha1_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-1 test #%d: ", i + 1 );
 
-        if( ( ret = mbedtls_sha1_starts_ret( &ctx ) ) != 0 )
+        if( ( ret = mbedtls_sha1_starts( &ctx ) ) != 0 )
             goto fail;
 
         if( i == 2 )
@@ -490,20 +490,20 @@ int mbedtls_sha1_self_test( int verbose )
 
             for( j = 0; j < 1000; j++ )
             {
-                ret = mbedtls_sha1_update_ret( &ctx, buf, buflen );
+                ret = mbedtls_sha1_update( &ctx, buf, buflen );
                 if( ret != 0 )
                     goto fail;
             }
         }
         else
         {
-            ret = mbedtls_sha1_update_ret( &ctx, sha1_test_buf[i],
+            ret = mbedtls_sha1_update( &ctx, sha1_test_buf[i],
                                            sha1_test_buflen[i] );
             if( ret != 0 )
                 goto fail;
         }
 
-        if( ( ret = mbedtls_sha1_finish_ret( &ctx, sha1sum ) ) != 0 )
+        if( ( ret = mbedtls_sha1_finish( &ctx, sha1sum ) ) != 0 )
             goto fail;
 
         if( memcmp( sha1sum, sha1_test_sum[i], 20 ) != 0 )

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -100,7 +100,7 @@ void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
 /*
  * SHA-256 context setup
  */
-int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
+int mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 )
 {
     SHA256_VALIDATE_RET( ctx != NULL );
 
@@ -285,7 +285,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
 /*
  * SHA-256 process buffer
  */
-int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
+int mbedtls_sha256_update( mbedtls_sha256_context *ctx,
                                const unsigned char *input,
                                size_t ilen )
 {
@@ -338,7 +338,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
 /*
  * SHA-256 final digest
  */
-int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
+int mbedtls_sha256_finish( mbedtls_sha256_context *ctx,
                                unsigned char *output )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -408,7 +408,7 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
 /*
  * output = SHA-256( input buffer )
  */
-int mbedtls_sha256_ret( const unsigned char *input,
+int mbedtls_sha256( const unsigned char *input,
                         size_t ilen,
                         unsigned char *output,
                         int is224 )
@@ -427,13 +427,13 @@ int mbedtls_sha256_ret( const unsigned char *input,
 
     mbedtls_sha256_init( &ctx );
 
-    if( ( ret = mbedtls_sha256_starts_ret( &ctx, is224 ) ) != 0 )
+    if( ( ret = mbedtls_sha256_starts( &ctx, is224 ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha256_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_sha256_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha256_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_sha256_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -522,7 +522,7 @@ int mbedtls_sha256_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 256 - k * 32, j + 1 );
 
-        if( ( ret = mbedtls_sha256_starts_ret( &ctx, k ) ) != 0 )
+        if( ( ret = mbedtls_sha256_starts( &ctx, k ) ) != 0 )
             goto fail;
 
         if( j == 2 )
@@ -531,7 +531,7 @@ int mbedtls_sha256_self_test( int verbose )
 
             for( j = 0; j < 1000; j++ )
             {
-                ret = mbedtls_sha256_update_ret( &ctx, buf, buflen );
+                ret = mbedtls_sha256_update( &ctx, buf, buflen );
                 if( ret != 0 )
                     goto fail;
             }
@@ -539,13 +539,13 @@ int mbedtls_sha256_self_test( int verbose )
         }
         else
         {
-            ret = mbedtls_sha256_update_ret( &ctx, sha256_test_buf[j],
+            ret = mbedtls_sha256_update( &ctx, sha256_test_buf[j],
                                              sha256_test_buflen[j] );
             if( ret != 0 )
                  goto fail;
         }
 
-        if( ( ret = mbedtls_sha256_finish_ret( &ctx, sha256sum ) ) != 0 )
+        if( ( ret = mbedtls_sha256_finish( &ctx, sha256sum ) ) != 0 )
             goto fail;
 
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -123,7 +123,7 @@ void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
 /*
  * SHA-512 context setup
  */
-int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 )
+int mbedtls_sha512_starts( mbedtls_sha512_context *ctx, int is384 )
 {
     SHA512_VALIDATE_RET( ctx != NULL );
 #if defined(MBEDTLS_SHA384_C)
@@ -327,7 +327,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 /*
  * SHA-512 process buffer
  */
-int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
+int mbedtls_sha512_update( mbedtls_sha512_context *ctx,
                                const unsigned char *input,
                                size_t ilen )
 {
@@ -379,7 +379,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
 /*
  * SHA-512 final digest
  */
-int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
+int mbedtls_sha512_finish( mbedtls_sha512_context *ctx,
                                unsigned char *output )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -451,7 +451,7 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
 /*
  * output = SHA-512( input buffer )
  */
-int mbedtls_sha512_ret( const unsigned char *input,
+int mbedtls_sha512( const unsigned char *input,
                     size_t ilen,
                     unsigned char *output,
                     int is384 )
@@ -469,13 +469,13 @@ int mbedtls_sha512_ret( const unsigned char *input,
 
     mbedtls_sha512_init( &ctx );
 
-    if( ( ret = mbedtls_sha512_starts_ret( &ctx, is384 ) ) != 0 )
+    if( ( ret = mbedtls_sha512_starts( &ctx, is384 ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha512_update_ret( &ctx, input, ilen ) ) != 0 )
+    if( ( ret = mbedtls_sha512_update( &ctx, input, ilen ) ) != 0 )
         goto exit;
 
-    if( ( ret = mbedtls_sha512_finish_ret( &ctx, output ) ) != 0 )
+    if( ( ret = mbedtls_sha512_finish( &ctx, output ) ) != 0 )
         goto exit;
 
 exit:
@@ -591,7 +591,7 @@ int mbedtls_sha512_self_test( int verbose )
         if( verbose != 0 )
             mbedtls_printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
 
-        if( ( ret = mbedtls_sha512_starts_ret( &ctx, k ) ) != 0 )
+        if( ( ret = mbedtls_sha512_starts( &ctx, k ) ) != 0 )
             goto fail;
 
         if( j == 2 )
@@ -600,20 +600,20 @@ int mbedtls_sha512_self_test( int verbose )
 
             for( j = 0; j < 1000; j++ )
             {
-                ret = mbedtls_sha512_update_ret( &ctx, buf, buflen );
+                ret = mbedtls_sha512_update( &ctx, buf, buflen );
                 if( ret != 0 )
                     goto fail;
             }
         }
         else
         {
-            ret = mbedtls_sha512_update_ret( &ctx, sha512_test_buf[j],
+            ret = mbedtls_sha512_update( &ctx, sha512_test_buf[j],
                                              sha512_test_buflen[j] );
             if( ret != 0 )
                 goto fail;
         }
 
-        if( ( ret = mbedtls_sha512_finish_ret( &ctx, sha512sum ) ) != 0 )
+        if( ( ret = mbedtls_sha512_finish( &ctx, sha512sum ) ) != 0 )
             goto fail;
 
         if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1429,7 +1429,7 @@ void ssl_calc_verify_tls_sha256( const mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc verify sha256" ) );
 
     mbedtls_sha256_clone( &sha256, &ssl->handshake->fin_sha256 );
-    mbedtls_sha256_finish_ret( &sha256, hash );
+    mbedtls_sha256_finish( &sha256, hash );
 
     *hlen = 32;
 
@@ -1478,7 +1478,7 @@ void ssl_calc_verify_tls_sha384( const mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> calc verify sha384" ) );
 
     mbedtls_sha512_clone( &sha512, &ssl->handshake->fin_sha512 );
-    mbedtls_sha512_finish_ret( &sha512, hash );
+    mbedtls_sha512_finish( &sha512, hash );
 
     *hlen = 48;
 
@@ -2490,7 +2490,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
     psa_hash_abort( &ssl->handshake->fin_sha256_psa );
     psa_hash_setup( &ssl->handshake->fin_sha256_psa, PSA_ALG_SHA_256 );
 #else
-    mbedtls_sha256_starts_ret( &ssl->handshake->fin_sha256, 0 );
+    mbedtls_sha256_starts( &ssl->handshake->fin_sha256, 0 );
 #endif
 #endif
 #if defined(MBEDTLS_SHA384_C)
@@ -2498,7 +2498,7 @@ void mbedtls_ssl_reset_checksum( mbedtls_ssl_context *ssl )
     psa_hash_abort( &ssl->handshake->fin_sha384_psa );
     psa_hash_setup( &ssl->handshake->fin_sha384_psa, PSA_ALG_SHA_384 );
 #else
-    mbedtls_sha512_starts_ret( &ssl->handshake->fin_sha512, 1 );
+    mbedtls_sha512_starts( &ssl->handshake->fin_sha512, 1 );
 #endif
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
@@ -2512,14 +2512,14 @@ static void ssl_update_checksum_start( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_update( &ssl->handshake->fin_sha256_psa, buf, len );
 #else
-    mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256, buf, len );
+    mbedtls_sha256_update( &ssl->handshake->fin_sha256, buf, len );
 #endif
 #endif
 #if defined(MBEDTLS_SHA384_C)
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_update( &ssl->handshake->fin_sha384_psa, buf, len );
 #else
-    mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512, buf, len );
+    mbedtls_sha512_update( &ssl->handshake->fin_sha512, buf, len );
 #endif
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
@@ -2533,7 +2533,7 @@ static void ssl_update_checksum_sha256( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_update( &ssl->handshake->fin_sha256_psa, buf, len );
 #else
-    mbedtls_sha256_update_ret( &ssl->handshake->fin_sha256, buf, len );
+    mbedtls_sha256_update( &ssl->handshake->fin_sha256, buf, len );
 #endif
 }
 #endif
@@ -2545,7 +2545,7 @@ static void ssl_update_checksum_sha384( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_hash_update( &ssl->handshake->fin_sha384_psa, buf, len );
 #else
-    mbedtls_sha512_update_ret( &ssl->handshake->fin_sha512, buf, len );
+    mbedtls_sha512_update( &ssl->handshake->fin_sha512, buf, len );
 #endif
 }
 #endif
@@ -2613,7 +2613,7 @@ static void ssl_calc_finished_tls_sha256(
                    sha256.state, sizeof( sha256.state ) );
 #endif
 
-    mbedtls_sha256_finish_ret( &sha256, padbuf );
+    mbedtls_sha256_finish( &sha256, padbuf );
     mbedtls_sha256_free( &sha256 );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -2688,7 +2688,7 @@ static void ssl_calc_finished_tls_sha384(
     MBEDTLS_SSL_DEBUG_BUF( 4, "finished sha512 state", (unsigned char *)
                    sha512.state, sizeof( sha512.state ) );
 #endif
-    mbedtls_sha512_finish_ret( &sha512, padbuf );
+    mbedtls_sha512_finish( &sha512, padbuf );
 
     mbedtls_sha512_free( &sha512 );
 #endif
@@ -2988,7 +2988,7 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
     psa_hash_setup( &handshake->fin_sha256_psa, PSA_ALG_SHA_256 );
 #else
     mbedtls_sha256_init(   &handshake->fin_sha256    );
-    mbedtls_sha256_starts_ret( &handshake->fin_sha256, 0 );
+    mbedtls_sha256_starts( &handshake->fin_sha256, 0 );
 #endif
 #endif
 #if defined(MBEDTLS_SHA384_C)
@@ -2997,7 +2997,7 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
     psa_hash_setup( &handshake->fin_sha384_psa, PSA_ALG_SHA_384 );
 #else
     mbedtls_sha512_init(   &handshake->fin_sha512    );
-    mbedtls_sha512_starts_ret( &handshake->fin_sha512, 1 );
+    mbedtls_sha512_starts( &handshake->fin_sha512, 1 );
 #endif
 #endif
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -178,7 +178,7 @@ int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ct
     MBEDTLS_ASN1_CHK_ADD( len,
                 mbedtls_pk_write_pubkey( &c, buf, ctx->subject_key ) );
 
-    ret = mbedtls_sha1_ret( buf + sizeof( buf ) - len, len,
+    ret = mbedtls_sha1( buf + sizeof( buf ) - len, len,
                             buf + sizeof( buf ) - 20 );
     if( ret != 0 )
         return( ret );
@@ -206,7 +206,7 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
     MBEDTLS_ASN1_CHK_ADD( len,
                           mbedtls_pk_write_pubkey( &c, buf, ctx->issuer_key ) );
 
-    ret = mbedtls_sha1_ret( buf + sizeof( buf ) - len, len,
+    ret = mbedtls_sha1( buf + sizeof( buf ) - len, len,
                             buf + sizeof( buf ) - 20 );
     if( ret != 0 )
         return( ret );

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -55,7 +55,7 @@ int main( void )
 
     mbedtls_printf( "\n  MD5('%s') = ", str );
 
-    if( ( ret = mbedtls_md5_ret( (unsigned char *) str, 13, digest ) ) != 0 )
+    if( ( ret = mbedtls_md5( (unsigned char *) str, 13, digest ) ) != 0 )
         mbedtls_exit( MBEDTLS_EXIT_FAILURE );
 
     for( i = 0; i < 16; i++ )

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -214,9 +214,9 @@ int main( void )
         goto exit;
     }
 
-    if( ( ret = mbedtls_sha1_ret( buf, (int)( p - 2 - buf ), hash ) ) != 0 )
+    if( ( ret = mbedtls_sha1( buf, (int)( p - 2 - buf ), hash ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_sha1_ret returned %d\n\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_sha1 returned %d\n\n", ret );
         goto exit;
     }
 

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -220,9 +220,9 @@ int main( void )
     /*
      * 5. Sign the parameters and send them
      */
-    if( ( ret = mbedtls_sha1_ret( buf, n, hash ) ) != 0 )
+    if( ( ret = mbedtls_sha1( buf, n, hash ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_sha1_ret returned %d\n\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_sha1 returned %d\n\n", ret );
         goto exit;
     }
 

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -166,9 +166,9 @@ int main( int argc, char *argv[] )
     mbedtls_printf( "  . Computing message hash..." );
     fflush( stdout );
 
-    if( ( ret = mbedtls_sha256_ret( message, sizeof( message ), hash, 0 ) ) != 0 )
+    if( ( ret = mbedtls_sha256( message, sizeof( message ), hash, 0 ) ) != 0 )
     {
-        mbedtls_printf( " failed\n  ! mbedtls_sha256_ret returned %d\n", ret );
+        mbedtls_printf( " failed\n  ! mbedtls_sha256 returned %d\n", ret );
         goto exit;
     }
 

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -405,32 +405,32 @@ int main( int argc, char *argv[] )
 
 #if defined(MBEDTLS_MD4_C)
     if( todo.md4 )
-        TIME_AND_TSC( "MD4", mbedtls_md4_ret( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "MD4", mbedtls_md4( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_MD5_C)
     if( todo.md5 )
-        TIME_AND_TSC( "MD5", mbedtls_md5_ret( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "MD5", mbedtls_md5( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_RIPEMD160_C)
     if( todo.ripemd160 )
-        TIME_AND_TSC( "RIPEMD160", mbedtls_ripemd160_ret( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "RIPEMD160", mbedtls_ripemd160( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_SHA1_C)
     if( todo.sha1 )
-        TIME_AND_TSC( "SHA-1", mbedtls_sha1_ret( buf, BUFSIZE, tmp ) );
+        TIME_AND_TSC( "SHA-1", mbedtls_sha1( buf, BUFSIZE, tmp ) );
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
     if( todo.sha256 )
-        TIME_AND_TSC( "SHA-256", mbedtls_sha256_ret( buf, BUFSIZE, tmp, 0 ) );
+        TIME_AND_TSC( "SHA-256", mbedtls_sha256( buf, BUFSIZE, tmp, 0 ) );
 #endif
 
 #if defined(MBEDTLS_SHA512_C)
     if( todo.sha512 )
-        TIME_AND_TSC( "SHA-512", mbedtls_sha512_ret( buf, BUFSIZE, tmp, 0 ) );
+        TIME_AND_TSC( "SHA-512", mbedtls_sha512( buf, BUFSIZE, tmp, 0 ) );
 #endif
 
 #if defined(MBEDTLS_ARC4_C)

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -90,7 +90,7 @@ done
 
 printf "Likely typos: "
 sort -u actual-macros enum-consts > _caps
-HEADERS=$( ls include/mbedtls/*.h include/psa/*.h )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h | egrep -v 'compat-2\.x\.h' )
 HEADERS="$HEADERS library/*.h"
 HEADERS="$HEADERS 3rdparty/everest/include/everest/everest.h 3rdparty/everest/include/everest/x25519.h"
 LIBRARY="$( ls library/*.c )"

--- a/tests/scripts/list-enum-consts.pl
+++ b/tests/scripts/list-enum-consts.pl
@@ -23,8 +23,7 @@ use open qw(:std utf8);
 
 -d 'include/mbedtls' or die "$0: must be run from root\n";
 
-@ARGV = <include/mbedtls/*.h>;
-push @ARGV, <library/*.h>;
+@ARGV = grep { ! /compat-2\.x\.h/ } <include/mbedtls/*.h>;
 push @ARGV, "3rdparty/everest/include/everest/everest.h";
 push @ARGV, "3rdparty/everest/include/everest/x25519.h";
 push @ARGV, glob("library/*.h");

--- a/tests/scripts/list-identifiers.sh
+++ b/tests/scripts/list-identifiers.sh
@@ -47,9 +47,9 @@ done
 
 if [ $INTERNAL ]
 then
-    HEADERS=$( ls library/*.h )
+    HEADERS=$( ls include/mbedtls/*_internal.h library/*.h | egrep -v 'compat-2\.x\.h' )
 else
-    HEADERS=$( ls include/mbedtls/*.h include/psa/*.h library/*.h )
+    HEADERS=$( ls include/mbedtls/*.h include/psa/*.h library/*.h | egrep -v 'compat-2\.x\.h' )
     HEADERS="$HEADERS 3rdparty/everest/include/everest/everest.h 3rdparty/everest/include/everest/x25519.h"
 fi
 

--- a/tests/scripts/list-macros.sh
+++ b/tests/scripts/list-macros.sh
@@ -22,7 +22,7 @@ if [ -d include/mbedtls ]; then :; else
     exit 1
 fi
 
-HEADERS=$( ls include/mbedtls/*.h include/psa/*.h tests/include/test/drivers/*.h )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h tests/include/test/drivers/*.h | egrep -v 'compat-2\.x\.h' )
 HEADERS="$HEADERS library/*.h"
 HEADERS="$HEADERS 3rdparty/everest/include/everest/everest.h 3rdparty/everest/include/everest/x25519.h"
 

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -288,7 +288,7 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
     /* Call update with too much data (sizeof entropy > MAX(_SEED)_INPUT).
      * Make sure it's detected as an error and doesn't cause memory
      * corruption. */
-    TEST_ASSERT( mbedtls_ctr_drbg_update_ret(
+    TEST_ASSERT( mbedtls_ctr_drbg_update(
                      &ctx, entropy, sizeof( entropy ) ) != 0 );
 
     /* Now enable PR, so the next few calls should all reseed */

--- a/tests/suites/test_suite_mdx.function
+++ b/tests/suites/test_suite_mdx.function
@@ -17,7 +17,7 @@ void md2_text( char * text_src_string, data_t * hash )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    ret = mbedtls_md2_ret( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md2( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 ) ;
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
@@ -37,7 +37,7 @@ void md4_text( char * text_src_string, data_t * hash )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    ret = mbedtls_md4_ret( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md4( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
@@ -57,7 +57,7 @@ void md5_text( char * text_src_string, data_t * hash )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    ret = mbedtls_md5_ret( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_md5( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,
@@ -77,7 +77,7 @@ void ripemd160_text( char * text_src_string, data_t * hash )
 
     strncpy( (char *) src_str, text_src_string, sizeof(src_str) - 1 );
 
-    ret = mbedtls_ripemd160_ret( src_str, strlen( (char *) src_str ), output );
+    ret = mbedtls_ripemd160( src_str, strlen( (char *) src_str ), output );
     TEST_ASSERT( ret == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x,

--- a/tests/suites/test_suite_shax.function
+++ b/tests/suites/test_suite_shax.function
@@ -12,7 +12,7 @@ void mbedtls_sha1( data_t * src_str, data_t * hash )
     memset(output, 0x00, 41);
 
 
-    TEST_ASSERT( mbedtls_sha1_ret( src_str->x, src_str->len, output ) == 0 );
+    TEST_ASSERT( mbedtls_sha1( src_str->x, src_str->len, output ) == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 20, hash->len ) == 0 );
 }
@@ -28,10 +28,10 @@ void sha256_invalid_param( )
     int invalid_type = 42;
 
     TEST_EQUAL( MBEDTLS_ERR_SHA256_BAD_INPUT_DATA,
-                            mbedtls_sha256_starts_ret( &ctx, invalid_type ) );
+                            mbedtls_sha256_starts( &ctx, invalid_type ) );
 
     TEST_EQUAL( MBEDTLS_ERR_SHA256_BAD_INPUT_DATA,
-                            mbedtls_sha256_ret( buf, buflen,
+                            mbedtls_sha256( buf, buflen,
                                                 buf, invalid_type ) );
 
 exit:
@@ -47,7 +47,7 @@ void sha224( data_t * src_str, data_t * hash )
     memset(output, 0x00, 57);
 
 
-    TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_sha256( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 28, hash->len ) == 0 );
 }
@@ -61,7 +61,7 @@ void mbedtls_sha256( data_t * src_str, data_t * hash )
     memset(output, 0x00, 65);
 
 
-    TEST_ASSERT( mbedtls_sha256_ret( src_str->x, src_str->len, output, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_sha256( src_str->x, src_str->len, output, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 32, hash->len ) == 0 );
 }
@@ -77,10 +77,10 @@ void sha512_invalid_param( )
     int invalid_type = 42;
 
     TEST_EQUAL( MBEDTLS_ERR_SHA512_BAD_INPUT_DATA,
-                            mbedtls_sha512_starts_ret( &ctx, invalid_type ) );
+                            mbedtls_sha512_starts( &ctx, invalid_type ) );
 
     TEST_EQUAL( MBEDTLS_ERR_SHA512_BAD_INPUT_DATA,
-                            mbedtls_sha512_ret( buf, buflen,
+                            mbedtls_sha512( buf, buflen,
                                                 buf, invalid_type ) );
 
 exit:
@@ -96,7 +96,7 @@ void sha384( data_t * src_str, data_t * hash )
     memset(output, 0x00, 97);
 
 
-    TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 1 ) == 0 );
+    TEST_ASSERT( mbedtls_sha512( src_str->x, src_str->len, output, 1 ) == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 48, hash->len ) == 0 );
 }
@@ -110,7 +110,7 @@ void mbedtls_sha512( data_t * src_str, data_t * hash )
     memset(output, 0x00, 129);
 
 
-    TEST_ASSERT( mbedtls_sha512_ret( src_str->x, src_str->len, output, 0 ) == 0 );
+    TEST_ASSERT( mbedtls_sha512( src_str->x, src_str->len, output, 0 ) == 0 );
 
     TEST_ASSERT( mbedtls_test_hexcmp( output, hash->x, 64, hash->len ) == 0 );
 }


### PR DESCRIPTION
Signed-off-by: TRodziewicz <tomasz.rodziewicz@mobica.com>

## Description
Rename functions whose deprecated variant has been removed.

This is a follow-up to #4029 which is about removing deprecated things, in particular deprecated functions.

For _ret functions, where the only difference is returning void vs int, rename the function in 3.0 and define the old name as a #define alias.

Fixes #4212

## Status
IN DEVELOPMENT

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
