### PR TITLE
config: Allow Mbed to implement TIMING_C

### DIFF
--- a/ChangeLog.d/mbed-can-do-timing.txt
+++ b/ChangeLog.d/mbed-can-do-timing.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Remove outdated check-config.h check that prevented implementing the
+     timing module on Mbed OS. Fixes #4633.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -55,9 +55,8 @@
 #endif
 #endif /* _WIN32 */
 
-#if defined(TARGET_LIKE_MBED) && \
-    ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
-#error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"
+#if defined(TARGET_LIKE_MBED) && defined(MBEDTLS_NET_C)
+#error "The NET module is not available for mbed OS - please use the network functions provided by Mbed OS"
 #endif
 
 #if defined(MBEDTLS_DEPRECATED_WARNING) && \


### PR DESCRIPTION
## Description

Mbed OS now provides POSIX-like time functions, although not alarm() nor
signal(). It is possible to implement MBEDTLS_TIMING_ALT on Mbed OS, so
we should not artificially prevent this in check-config. Remove the the
check that prevents implementing MBEDTLS_TIMING_ALT on Mbed OS.

Note that this limitation originally was added in the following commit,
although there isn't much context around why the restriction was
imposed: 63e7ebaaa184 ("Add material for generating yotta module"). In
2015, Mbed OS was quite a different thing: no RTOS, no threads, just an
asynchronous event loop model. I'd suppose the asynchronous event loop
model made it difficult before to implement MBEDTLS_TIMING_C on Mbed OS,
but that is no longer the case.

Fixes #4633

Signed-off-by: Jaeden Amero <jaeden.amero@arm.com>

## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes
- [ ] development_2.x

Others branches if desired, although likely not useful because Mbed OS doesn't integrate versions other than the latest 2.x at the moment and this bug fix is only relevant for Mbed OS.

## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- ~[ ] Tests~ Removing unnecessary check-config check
- ~[ ] Documentation~
- [X] Changelog updated
- [x] Backported


## Steps to test or reproduce

Implement `MBEDTLS_TIMING_ALT` for Mbed OS, and get blocked by this legacy check which doesn't make sense anymore.