### PR TITLE
Backport 2.x: config: Allow Mbed to implement TIMING_C

### DIFF
--- a/ChangeLog.d/mbed-can-do-timing.txt
+++ b/ChangeLog.d/mbed-can-do-timing.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Remove outdated check-config.h check that prevented implementing the
+     timing module on Mbed OS. Fixes #4633.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -55,9 +55,8 @@
 #endif
 #endif /* _WIN32 */
 
-#if defined(TARGET_LIKE_MBED) && \
-    ( defined(MBEDTLS_NET_C) || defined(MBEDTLS_TIMING_C) )
-#error "The NET and TIMING modules are not available for mbed OS - please use the network and timing functions provided by mbed OS"
+#if defined(TARGET_LIKE_MBED) && defined(MBEDTLS_NET_C)
+#error "The NET module is not available for mbed OS - please use the network functions provided by Mbed OS"
 #endif
 
 #if defined(MBEDTLS_DEPRECATED_WARNING) && \


### PR DESCRIPTION
Direct backport of https://github.com/ARMmbed/mbedtls/pull/4634 for fixing #4633

## Status
**READY**

## Migrations
NO

## Todos
- ~[ ] Tests~
- ~[ ] Documentation~
- [X] Changelog updated
- ~[ ] Backported~
