### PR TITLE
Backport 2.16: Disable OS X Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,6 @@ jobs:
       script:
         - tests/scripts/all.sh -k 'test_depends_*' 'build_key_exchanges'
 
-    - name: macOS
-      os: osx
-      compiler: clang
-      script:
-        - tests/scripts/all.sh -k test_default_out_of_box
-
     - name: Windows
       os: windows
       script:


### PR DESCRIPTION
Disable OS X builds on Travis due to changes in our plan & billing