### PR TITLE
Fix PSA_CRYPTO_SPM builds of some source files

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -26,7 +26,6 @@
 #include "check_crypto_config.h"
 #endif
 
-#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 
 #include "psa_crypto_cipher.h"

--- a/library/psa_crypto_client.c
+++ b/library/psa_crypto_client.c
@@ -19,7 +19,6 @@
  */
 
 #include "common.h"
-#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)

--- a/library/psa_crypto_client.c
+++ b/library/psa_crypto_client.c
@@ -19,6 +19,7 @@
  */
 
 #include "common.h"
+#include "psa_crypto_core.h"
 #include "psa/crypto.h"
 
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT)

--- a/library/psa_crypto_core.h
+++ b/library/psa_crypto_core.h
@@ -27,6 +27,7 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"
 

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -22,7 +22,6 @@
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 
-#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 
 #include "psa_crypto_core.h"


### PR DESCRIPTION
Fix https://github.com/ARMmbed/mbedtls/issues/4649

No testing, that's [a separate topic](https://github.com/ARMmbed/mbedtls/issues/4651).

Needs backport: 2.x
