### PR TITLE
Remove the duplicate code in mbedtls/include/mbedtls/check_config.h

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -469,10 +469,6 @@
 #error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PLATFORM_STD_CALLOC) && !defined(MBEDTLS_PLATFORM_MEMORY)
-#error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_PLATFORM_STD_FREE) && !defined(MBEDTLS_PLATFORM_MEMORY)
 #error "MBEDTLS_PLATFORM_STD_FREE defined, but not all prerequisites"
 #endif


### PR DESCRIPTION
Removing the extra preprocessor directives found within the specified
source file.

## Description
Removing the extra preprocessor directives found within the specified source file. Specifically, removing the duplicate code found within the source file mbedtls/include/mbedtls/check_config.h.
## Pull request type
[ ] Patch update
## Test results
[ ] No Tests required for this change





