### PR TITLE
Remove duplicated check in `check_config.h`

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -461,10 +461,6 @@
 #error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_PLATFORM_STD_CALLOC) && !defined(MBEDTLS_PLATFORM_MEMORY)
-#error "MBEDTLS_PLATFORM_STD_CALLOC defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_PLATFORM_STD_FREE) && !defined(MBEDTLS_PLATFORM_MEMORY)
 #error "MBEDTLS_PLATFORM_STD_FREE defined, but not all prerequisites"
 #endif


### PR DESCRIPTION
## Description
Removing the extra preprocessor directives found within the specified source file. Specifically, removing the duplicate code found within the source file mbedtls/include/mbedtls/check_config.h. Fixes #4222 
## Pull request type
[ ] Patch update
## Test results
[ ] No Tests required for this change
