### PR TITLE
PSA driver wrapper C generation

### DIFF
--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -21,5 +21,112 @@ The features in this module are tailored towards generating glue code
 between Mbed TLS and PSA Crypto drivers. Suitability for any other purpose
 is coincidental.
 
-Unit tests are in ../tests/scripts/test_c_generator.py
+Construct C code snippets by building snippet objects and calling their
+``output`` method. The ``output`` method takes the following arguments:
+* ``stream``: an object with a ``write`` method that takes a string as
+  argument, for example a file or ``io.StringIO()``.
+* ``options`` (optional): an `Options` object to configure the presentation
+  of the code.
+* ``indent``: a string that is inserted at the beginning of each line.
+Calling ``output`` on a snippet object calls ``stream.write()`` one or
+more times to write the C code as a string.
+
+The following snippet classes are available:
+* `Simple`: a simple statement, or something like it such as a variable
+  declaration. This can be anything that C terminates with a semicolon.
+* `Block`: a block which is put between braces.
+
+Unit tests are in ``../tests/scripts/test_c_generator.py``.
 """
+
+from typing import List, Optional, Sequence, Tuple
+
+
+class Writable:
+    """Abstract class for typing hints."""
+    # pylint: disable=too-few-public-methods
+    def write(self, text: str) -> None:
+        raise NotImplementedError
+
+
+class Options:
+    """Options for code generation."""
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, indent: int = 4) -> None:
+        """Set options for code generation.
+
+        indent: the basic indent level.
+        """
+        self.indent = indent
+
+DEFAULT_OPTIONS = Options()
+
+
+class Snippet:
+    """Abstract base class for multi-line snippets of C code."""
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def output_line(stream: Writable, indent: str, *contents: str) -> None:
+        content = ''.join(contents).rstrip()
+        if content:
+            stream.write(indent + content + '\n')
+        else:
+            stream.write('\n')
+
+    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
+               indent: str = '') -> None:
+        raise NotImplementedError
+
+
+class Simple(Snippet):
+    """A simple statement or statement-like syntactic element.
+
+    This can be, for example, an expression statement, a jump statement,
+    or a declaration.
+    """
+
+    def __init__(self, content: str) -> None:
+        """A simple statement.
+
+        This can be anything that is normally written on a single line and
+        terminated by a semicolon, for example an expression statement,
+        a jump statement, or a declaration.
+
+        Pass the content without the terminating semicolon.
+        """
+        super().__init__()
+        self.set_content(content)
+
+    def get_content(self) -> str:
+        return self.content
+
+    def set_content(self, content: str) -> None:
+        self.content = content.strip()
+
+    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
+               indent: str = '') -> None:
+        self.output_line(stream, indent, self.content, ';')
+
+
+class Block(Snippet):
+    """A code block (statements between braces)."""
+
+    def __init__(self, *content) -> None:
+        """A block statement.
+
+        The arguments are the statements to put inside the block.
+        """
+        super().__init__()
+        self.content = list(content)
+
+    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
+               indent: str = '') -> None:
+        more_indent = indent + ' ' * options.indent
+        self.output_line(stream, indent, '{')
+        for item in self.content:
+            item.output(stream, options, more_indent)
+        self.output_line(stream, indent, '}')

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -39,7 +39,7 @@ The following snippet classes are available:
 Unit tests are in ``../tests/scripts/test_c_generator.py``.
 """
 
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple # pylint: disable=unused-import
 
 
 class Writable:
@@ -53,7 +53,7 @@ class Options:
     """Options for code generation."""
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, indent: int = 4) -> None:
+    def __init__(self, indent: int = 4) -> None: # pylint: disable=bad-whitespace
         """Set options for code generation.
 
         indent: the basic indent level.
@@ -77,8 +77,8 @@ class Snippet:
         else:
             stream.write('\n')
 
-    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
-               indent: str = '') -> None:
+    def output(self, stream: Writable,
+               options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
         raise NotImplementedError
 
 
@@ -107,8 +107,8 @@ class Simple(Snippet):
     def set_content(self, content: str) -> None:
         self.content = content.strip()
 
-    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
-               indent: str = '') -> None:
+    def output(self, stream: Writable,
+               options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
         self.output_line(stream, indent, self.content, ';')
 
 
@@ -123,8 +123,8 @@ class Block(Snippet):
         super().__init__()
         self.content = list(content)
 
-    def output(self, stream: Writable, options: Options = DEFAULT_OPTIONS,
-               indent: str = '') -> None:
+    def output(self, stream: Writable,
+               options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
         more_indent = indent + ' ' * options.indent
         self.output_line(stream, indent, '{')
         for item in self.content:

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -37,6 +37,7 @@ The following snippet classes are available:
 * `Return`: a ``return`` statement (with or without a value).
 * `Block`: a block which is put between braces.
 * `Comment`: a comment. It may contain multiple lines.
+* `Directive`: a preprocessor directive.
 
 Unit tests are in ``../tests/scripts/test_c_generator.py``.
 """
@@ -103,6 +104,26 @@ class Comment(Snippet):
             for line in self.lines[1:]:
                 self.output_line(stream, indent, ' * ', line)
             self.output_line(stream, indent, ' */')
+
+
+class Directive(Snippet):
+    """A preprocessor directive."""
+
+    def __init__(self, *parts: str) -> None:
+        """A preprocessor directive.
+
+        The arguments are joined with spaces. Typically the first argument is
+        the directive and subsequent arguments are its parameters.
+
+        Any newline character in an argument is replaced with backslash-newline.
+        """
+        super().__init__()
+        self.parts = parts
+
+    def output(self, stream: Writable,
+               options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
+        text = ' '.join(self.parts)
+        self.output_line(stream, '', '#' + text.replace('\n', '\\\n'))
 
 
 class Simple(Snippet):

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -36,6 +36,7 @@ The following snippet classes are available:
   declaration. This can be anything that C terminates with a semicolon.
 * `Return`: a ``return`` statement (with or without a value).
 * `Block`: a block which is put between braces.
+* `Comment`: a comment. It may contain multiple lines.
 
 Unit tests are in ``../tests/scripts/test_c_generator.py``.
 """
@@ -81,6 +82,27 @@ class Snippet:
     def output(self, stream: Writable,
                options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
         raise NotImplementedError
+
+
+class Comment(Snippet):
+    """A comment with its own line(s)."""
+
+    def __init__(self, *lines: str) -> None:
+        """A comment. Each argument is placed on its own line."""
+        super().__init__()
+        self.lines = [line.rstrip() for line in lines]
+
+    def output(self, stream: Writable,
+               options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
+        if len(self.lines) == 0:
+            return
+        elif len(self.lines) == 1:
+            self.output_line(stream, indent, '/* ', self.lines[0].lstrip(), ' */')
+        else:
+            self.output_line(stream, indent, '/* ', self.lines[0])
+            for line in self.lines[1:]:
+                self.output_line(stream, indent, ' * ', line)
+            self.output_line(stream, indent, ' */')
 
 
 class Simple(Snippet):
@@ -135,7 +157,8 @@ class Block(Snippet):
     def __init__(self, *content) -> None:
         """A block statement.
 
-        The arguments are the statements to put inside the block.
+        The arguments are the statements or pseudo-statements to put inside
+        the block.
         """
         super().__init__()
         self.content = list(content)

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -34,6 +34,7 @@ more times to write the C code as a string.
 The following snippet classes are available:
 * `Simple`: a simple statement, or something like it such as a variable
   declaration. This can be anything that C terminates with a semicolon.
+* `Return`: a ``return`` statement (with or without a value).
 * `Block`: a block which is put between braces.
 
 Unit tests are in ``../tests/scripts/test_c_generator.py``.
@@ -110,6 +111,22 @@ class Simple(Snippet):
     def output(self, stream: Writable,
                options: Options = DEFAULT_OPTIONS, indent: str = '') -> None: # pylint: disable=bad-whitespace
         self.output_line(stream, indent, self.content, ';')
+
+
+class Return(Simple):
+    """A return statement."""
+
+    def __init__(self, what: Optional[str]) -> None:
+        """A return statement.
+
+        Pass a string containing the expression to calculate the return value,
+        or `None` to return void.
+        """
+        if what is None:
+            content = 'return'
+        else:
+            content = 'return( ' + what.strip() + ' )'
+        super().__init__(content)
 
 
 class Block(Snippet):

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2020, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+"""This module provides a simple interface to generate C source code.
+
+The features in this module are tailored towards generating glue code
+between Mbed TLS and PSA Crypto drivers. Suitability for any other purpose
+is coincidental.
+"""

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -20,4 +20,6 @@
 The features in this module are tailored towards generating glue code
 between Mbed TLS and PSA Crypto drivers. Suitability for any other purpose
 is coincidental.
+
+Unit tests are in ../tests/scripts/test_c_generator.py
 """

--- a/scripts/c_generator.py
+++ b/scripts/c_generator.py
@@ -310,6 +310,22 @@ class Block(DecoratedBlock):
     def simple_block_items(self):
         return self.items
 
+class While(DecoratedBlock):
+    """A while loop."""
+
+    def __init__(self, condition: str, *instructions: Snippet) -> None:
+        super().__init__(*instructions)
+        self.set_condition(condition)
+
+    def get_condition(self) -> str:
+        return self.condition
+
+    def set_condition(self, condition: str):
+        self.condition = condition.strip()
+
+    def output_before(self, stream: Writable, options: Options, indent: str) -> None: # pylint: disable=bad-whitespace
+        self.output_line(stream, indent, 'while( ' + self.condition + ' )')
+
 
 class PreprocessorConditional(Snippet):
     """Code guarded by conditional compilation directives."""

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -2016,12 +2016,17 @@ component_check_python_files () {
     record_status tests/scripts/check-python-files.sh
 }
 
-component_check_generate_test_code () {
-    msg "uint test: generate_test_code.py"
+component_check_python_tests () {
     # unittest writes out mundane stuff like number or tests run on stderr.
     # Our convention is to reserve stderr for actual errors, and write
     # harmless info on stdout so it can be suppress with --quiet.
+    # Therefore we redirect unittest's stderr to stdout.
+
+    msg "unit test: generate_test_code.py"
     record_status ./tests/scripts/test_generate_test_code.py 2>&1
+
+    msg "unit test: test_c_generator.py"
+    record_status ./tests/scripts/test_c_generator.py 2>&1
 }
 
 ################################################################

--- a/tests/scripts/check-python-files.sh
+++ b/tests/scripts/check-python-files.sh
@@ -17,10 +17,12 @@
 #
 # This file is part of Mbed TLS (https://tls.mbed.org)
 #
-# Purpose:
-#
-# Run 'pylint' on Python files for programming errors and helps enforcing
-# PEP8 coding standards.
+# Purpose: check Python files for potential programming errors or maintenance
+# hurdles. Run pylint to detect some potential mistakes and enforce PEP8
+# coding standards. If available, run mypy to perform static type checking.
+
+# We'll keep going on errors and report the status at the end.
+ret=0
 
 if type python3 >/dev/null 2>/dev/null; then
     PYTHON=python3
@@ -28,4 +30,17 @@ else
     PYTHON=python
 fi
 
-$PYTHON -m pylint -j 2 scripts/*.py tests/scripts/*.py
+$PYTHON -m pylint -j 2 scripts/*.py tests/scripts/*.py || {
+    echo >&2 "pylint reported errors"
+    ret=1
+}
+
+# Check types if mypy is available
+if type mypy >/dev/null 2>/dev/null; then
+    echo
+    echo 'Running mypy ...'
+    mypy scripts/*.py tests/scripts/*.py ||
+      ret=1
+fi
+
+exit $ret

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -174,6 +174,53 @@ class PermissionIssueTracker(FileIssueTracker):
             self.files_with_issues[filepath] = None
 
 
+class ShebangIssueTracker(FileIssueTracker):
+    """Track files with a bad, missing or extraneous shebang line.
+
+    Executable scripts must start with a valid shebang (#!) line.
+    """
+
+    heading = "Invalid shebang line:"
+
+    # Allow either /bin/sh, /bin/bash, or /usr/bin/env.
+    # Allow at most one argument (this is a Linux limitation).
+    # For sh and bash, the argument if present must be options.
+    # For env, the argument must be the base name of the interpeter.
+    _shebang_re = re.compile(rb'^#! ?(?:/bin/(bash|sh)(?: -[^\n ]*)?'
+                             rb'|/usr/bin/env ([^\n /]+))$')
+    _extensions = {
+        b'bash': 'sh',
+        b'perl': 'pl',
+        b'python3': 'py',
+        b'sh': 'sh',
+    }
+
+    def is_valid_shebang(self, first_line, filepath):
+        m = re.match(self._shebang_re, first_line)
+        if not m:
+            return False
+        interpreter = m.group(1) or m.group(2)
+        if interpreter not in self._extensions:
+            return False
+        if not filepath.endswith('.' + self._extensions[interpreter]):
+            return False
+        return True
+
+    def check_file_for_issue(self, filepath):
+        is_executable = os.access(filepath, os.X_OK)
+        with open(filepath, "rb") as f:
+            first_line = f.readline()
+        if first_line.startswith(b'#!'):
+            if not is_executable:
+                # Shebang on a non-executable file
+                self.files_with_issues[filepath] = None
+            elif not self.is_valid_shebang(first_line, filepath):
+                self.files_with_issues[filepath] = [1]
+        elif is_executable:
+            # Executable without a shebang
+            self.files_with_issues[filepath] = None
+
+
 class EndOfFileNewlineIssueTracker(FileIssueTracker):
     """Track files that end with an incomplete line
     (no newline character at the end of the last line)."""
@@ -294,6 +341,7 @@ class IntegrityChecker:
         self.setup_logger(log_file)
         self.issues_to_check = [
             PermissionIssueTracker(),
+            ShebangIssueTracker(),
             EndOfFileNewlineIssueTracker(),
             Utf8BomIssueTracker(),
             UnixLineEndingIssueTracker(),

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -31,6 +31,10 @@ import codecs
 import re
 import subprocess
 import sys
+try:
+    from typing import FrozenSet, Optional, Pattern # pylint: disable=unused-import
+except ImportError:
+    pass
 
 
 class FileIssueTracker:
@@ -50,8 +54,8 @@ class FileIssueTracker:
     ``heading``: human-readable description of the issue
     """
 
-    suffix_exemptions = frozenset()
-    path_exemptions = None
+    suffix_exemptions = frozenset() #type: FrozenSet[str]
+    path_exemptions = None #type: Optional[Pattern[str]]
     # heading must be defined in derived classes.
     # pylint: disable=no-member
 

--- a/tests/scripts/check_files.py
+++ b/tests/scripts/check_files.py
@@ -163,9 +163,13 @@ class PermissionIssueTracker(FileIssueTracker):
 
     heading = "Incorrect permissions:"
 
+    # .py files can be either full scripts or modules, so they may or may
+    # not be executable.
+    suffix_exemptions = frozenset({".py"})
+
     def check_file_for_issue(self, filepath):
         is_executable = os.access(filepath, os.X_OK)
-        should_be_executable = filepath.endswith((".sh", ".pl", ".py"))
+        should_be_executable = filepath.endswith((".sh", ".pl"))
         if is_executable != should_be_executable:
             self.files_with_issues[filepath] = None
 

--- a/tests/scripts/mbedtls_test.py
+++ b/tests/scripts/mbedtls_test.py
@@ -40,7 +40,7 @@ import re
 import os
 import binascii
 
-from mbed_host_tests import BaseHostTest, event_callback # pylint: disable=import-error
+from mbed_host_tests import BaseHostTest, event_callback # type: ignore # pylint: disable=import-error
 
 
 class TestDataParserError(Exception):

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -104,6 +104,12 @@ class SnippetTest(unittest.TestCase):
     def test_simple_trailing_space(self):
         self.assertSnippet(C.Simple('hello '), 'hello;\n')
 
+    def test_return_none(self):
+        self.assertSnippet(C.Return(None), 'return;\n')
+
+    def test_return_value(self):
+        self.assertSnippet(C.Return('foo'), 'return( foo );\n')
+
     def test_block_empty(self):
         self.assertSnippet(C.Block(), """
 {

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -175,6 +175,45 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
+    def test_directive_foo(self):
+        self.assertSnippet(C.Directive('foo'),
+                           '#foo\n')
+
+    def test_directive_define(self):
+        self.assertSnippet(C.Directive('define', 'FOO', '42'),
+                           '#define FOO 42\n')
+
+    def test_directive_multiline(self):
+        self.assertSnippet(
+            C.Directive('define', 'FOO', 'one \ntwo\nthree'),
+            """
+#define FOO one \\
+two\\
+three
+            """)
+
+    def test_block_directive(self):
+        self.assertSnippet(C.Block(C.Directive('foo'), C.Simple('hello')), """
+{
+#foo
+    hello;
+}
+        """)
+
+    def test_block_directive_multiline(self):
+        self.assertSnippet(
+            C.Block(C.Directive('define', 'FOO', 'one \ntwo\nthree'),
+                    C.Simple('hello')),
+            """
+{
+#define FOO one \\
+two\\
+three
+    hello;
+}
+            """)
+
+
 
 def load_module():
     """Load the c_generator module.

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -507,6 +507,85 @@ three
 }
             """)
 
+    def test_pp_if(self):
+        ppc = C.PreprocessorConditional()
+        ppc.add_case('first', C.Simple('one'))
+        self.assertSnippet(ppc, """
+#if first
+one;
+#endif /* first */
+        """)
+
+    def test_pp_if_else(self):
+        ppc = C.PreprocessorConditional()
+        ppc.add_case('first', C.Simple('one'))
+        ppc.set_default(C.Simple('something'))
+        self.assertSnippet(ppc, """
+#if first
+one;
+#else /* !first */
+something;
+#endif /* !first */
+        """)
+
+    def test_pp_if_elif(self):
+        ppc = C.PreprocessorConditional()
+        ppc.add_case('first', C.Simple('one'))
+        ppc.add_case('second', C.Simple('two'))
+        ppc.add_case('third', C.Simple('three'))
+        self.assertSnippet(ppc, """
+#if first
+one;
+#elif second
+two;
+#elif third
+three;
+#endif /* third */
+        """)
+
+    def test_pp_if_elif_else(self):
+        ppc = C.PreprocessorConditional()
+        ppc.add_case('first', C.Simple('one'))
+        ppc.add_case('second', C.Simple('two'))
+        ppc.add_case('third', C.Simple('three'))
+        ppc.set_default(C.Simple('something'))
+        self.assertSnippet(ppc, """
+#if first
+one;
+#elif second
+two;
+#elif third
+three;
+#else /* !first && !second && !third */
+something;
+#endif /* !first && !second && !third */
+        """)
+
+    def test_pp_else_only(self):
+        ppc = C.PreprocessorConditional()
+        ppc.set_default(C.Simple('something'))
+        self.assertSnippet(ppc, """
+something;
+        """)
+
+    def test_pp_nothing(self):
+        ppc = C.PreprocessorConditional()
+        self.assertSnippet(ppc, '')
+
+    def test_pp_multiline(self):
+        ppc = C.PreprocessorConditional()
+        ppc.add_case('hello\nworld', C.Simple('one'))
+        ppc.add_case('foo\nbar\nqux', C.Simple('two'))
+        self.assertSnippet(ppc, """
+#if hello\\
+    world
+one;
+#elif foo\\
+      bar\\
+      qux
+two;
+#endif /* foo bar qux */
+        """)
 
 
 def load_module():

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -21,6 +21,7 @@
 
 import importlib
 import io
+import operator
 import os
 import sys
 import unittest
@@ -33,7 +34,7 @@ import unittest
 
 class OptionsTest(unittest.TestCase):
     """Test the exact rendering of a snippet under varying options."""
-    # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
 
     def assertSnippet(self, snippet, presented_output, **kwargs):
         stream = io.StringIO()
@@ -85,9 +86,302 @@ class OptionsTest(unittest.TestCase):
         """, options=C.Options(indent=3), indent='  ')
 
 
+class ConstructionTest(unittest.TestCase):
+    """Test get and set methods on snippets."""
+    # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
+
+    @classmethod
+    def get_block_structure(cls, snippet):
+        if isinstance(snippet, C.Block):
+            return [cls.get_block_structure(elt) for elt in snippet]
+        elif isinstance(snippet, C.Simple):
+            return snippet.get_content()
+        else:
+            return snippet
+
+    def assertBlock(self, block, expected):
+        """Check a nested structure of blocks and simple statements.
+
+        block must be a C.Snippet constructed from C.Block and C.Simple only.
+
+        expected describes the expected structure of the block, using lists
+        for blocks and strings for simple statements.
+
+        For example,
+            C.Block(C.Simple('foo'), C.Block(), C.Block('hello', 'world'))
+        corresponds to
+            ['foo', [], ['hello', 'world']
+        """
+        self.assertEqual(self.get_block_structure(block), expected)
+
+    def test_simple_get_initial(self):
+        c = C.Simple('initial')
+        self.assertEqual(c.get_content(), 'initial')
+
+    def test_simple_set_get(self):
+        c = C.Simple('initial')
+        c.set_content('updated')
+        self.assertEqual(c.get_content(), 'updated')
+        c.set_content('wibble')
+        self.assertEqual(c.get_content(), 'wibble')
+
+    def test_simple_get_initial_stripped(self):
+        c = C.Simple('  initial  ')
+        self.assertEqual(c.get_content(), 'initial')
+
+    def test_simple_set_get_stripped(self):
+        c = C.Simple('initial')
+        c.set_content('  updated  ')
+        self.assertEqual(c.get_content(), 'updated')
+        c.set_content('  wibble  ')
+        self.assertEqual(c.get_content(), 'wibble')
+
+    def test_block_len_0(self):
+        block = C.Block()
+        self.assertEqual(len(block), 0)
+
+    def test_block_len_1_simple(self):
+        block = C.Block(C.Simple('one'))
+        self.assertEqual(len(block), 1)
+
+    def test_block_len_1_nested(self):
+        block = C.Block(C.Block())
+        self.assertEqual(len(block), 1)
+
+    def test_block_len_2_simple(self):
+        block = C.Block(C.Simple('one'), C.Simple('two'))
+        self.assertEqual(len(block), 2)
+
+    def test_block_len_2_nested_0(self):
+        block = C.Block(C.Simple('one'),
+                        C.Block())
+        self.assertEqual(len(block), 2)
+
+    def test_block_len_2_nested_2(self):
+        block = C.Block(C.Simple('one'),
+                        C.Block(C.Simple('foo'), C.Simple('bar')))
+        self.assertEqual(len(block), 2)
+
+    def test_block_getitem_good(self):
+        block = C.Block(C.Simple('zero'),
+                        C.Simple('one'),
+                        C.Block(C.Simple('foo'), C.Simple('bar')),
+                        C.Simple('three'))
+        self.assertEqual(block[0].get_content(), 'zero')
+        self.assertEqual(block[1].get_content(), 'one')
+        self.assertEqual(block[2][0].get_content(), 'foo')
+        self.assertEqual(block[2][1].get_content(), 'bar')
+        self.assertEqual(block[3].get_content(), 'three')
+
+    def test_block_getitem_range(self):
+        self.assertRaises(IndexError, operator.getitem,
+                          C.Block(), 0)
+        self.assertRaises(IndexError, operator.getitem,
+                          C.Block(C.Simple('')), 1)
+        self.assertRaises(IndexError, operator.getitem,
+                          C.Block(C.Simple(''), C.Simple('')), 2)
+
+    def test_block_getitem_type(self):
+        self.assertRaises(TypeError, operator.getitem,
+                          C.Block(C.Simple('zero'), C.Simple('one')), 0.5)
+
+    def test_block_setitem_overwrite(self):
+        block = C.Block(C.Simple('foo 0'), C.Simple('foo 1'))
+        self.assertEqual(block[0].get_content(), 'foo 0')
+        self.assertEqual(block[1].get_content(), 'foo 1')
+        block[0] = C.Simple('bar 0')
+        self.assertEqual(block[0].get_content(), 'bar 0')
+        self.assertEqual(block[1].get_content(), 'foo 1')
+        block[1] = C.Simple('bar 1')
+        self.assertEqual(block[0].get_content(), 'bar 0')
+        self.assertEqual(block[1].get_content(), 'bar 1')
+
+    def test_block_setitem_range(self):
+        self.assertRaises(IndexError, operator.setitem,
+                          C.Block(), 0, C.Block())
+        self.assertRaises(IndexError, operator.setitem,
+                          C.Block(C.Simple('')), 1, C.Block())
+        self.assertRaises(IndexError, operator.setitem,
+                          C.Block(C.Simple(''), C.Simple('')), 2, C.Block())
+
+    def test_block_delitem_first(self):
+        block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
+        del block[0]
+        self.assertEqual(len(block), 2)
+        self.assertEqual(block[0].get_content(), 'one')
+        self.assertEqual(block[1].get_content(), 'two')
+
+    def test_block_delitem_middle(self):
+        block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
+        del block[1]
+        self.assertEqual(len(block), 2)
+        self.assertEqual(block[0].get_content(), 'zero')
+        self.assertEqual(block[1].get_content(), 'two')
+
+    def test_block_delitem_last(self):
+        block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
+        del block[2]
+        self.assertEqual(len(block), 2)
+        self.assertEqual(block[0].get_content(), 'zero')
+        self.assertEqual(block[1].get_content(), 'one')
+
+    def test_block_delitem_slice(self):
+        block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'),
+                        C.Simple('three'), C.Simple('four'))
+        del block[1:3]
+        self.assertEqual(len(block), 3)
+        self.assertEqual(block[0].get_content(), 'zero')
+        self.assertEqual(block[1].get_content(), 'three')
+        self.assertEqual(block[2].get_content(), 'four')
+
+    def test_block_delitem_range(self):
+        self.assertRaises(IndexError, operator.delitem,
+                          C.Block(), 0)
+        self.assertRaises(IndexError, operator.delitem,
+                          C.Block(C.Simple('')), 1)
+        self.assertRaises(IndexError, operator.delitem,
+                          C.Block(C.Simple(''), C.Simple('')), 2)
+
+    def test_block_iter_0(self):
+        self.assertRaises(StopIteration, next, iter(C.Block()))
+
+    def test_block_iter_2(self):
+        it = iter(C.Block(C.Simple('zero'), C.Simple('one')))
+        self.assertEqual(next(it).get_content(), 'zero')
+        self.assertEqual(next(it).get_content(), 'one')
+        self.assertRaises(StopIteration, next, it)
+
+    def test_block_empty_plus_simple(self):
+        block0 = C.Block()
+        block = block0 + C.Simple('wibble')
+        self.assertBlock(block0, [])
+        self.assertBlock(block, ['wibble'])
+
+    def test_block_1_plus_simple(self):
+        block0 = C.Block(C.Simple('foo'))
+        block = block0 + C.Simple('wibble')
+        self.assertBlock(block0, ['foo'])
+        self.assertBlock(block, ['foo', 'wibble'])
+
+    def test_block_2_plus_simple(self):
+        block0 = C.Block(C.Simple('foo'), C.Simple('bar'))
+        block = block0 + C.Simple('wibble')
+        self.assertBlock(block0, ['foo', 'bar'])
+        self.assertBlock(block, ['foo', 'bar', 'wibble'])
+
+    def test_block_empty_plus_block(self):
+        block0 = C.Block()
+        block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block0, [])
+        self.assertBlock(block, ['wibble', 'wobble'])
+
+    def test_block_1_plus_block(self):
+        block0 = C.Block(C.Simple('foo'))
+        block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block0, ['foo'])
+        self.assertBlock(block, ['foo', 'wibble', 'wobble'])
+
+    def test_block_2_plus_block(self):
+        block0 = C.Block(C.Simple('foo'), C.Simple('bar'))
+        block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block0, ['foo', 'bar'])
+        self.assertBlock(block, ['foo', 'bar', 'wibble', 'wobble'])
+
+    def test_block_1_plus_derived_block(self):
+        block0 = C.Block(C.Simple('foo'))
+        class MyBlock(C.Block):
+            # pylint: disable=too-few-public-methods
+            pass
+        block = block0 + MyBlock(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block0, ['foo'])
+        self.assertBlock(block, ['foo', 'wibble', 'wobble'])
+
+    def test_block_empty_plus_equal_simple(self):
+        block = C.Block()
+        block += C.Simple('wibble')
+        self.assertBlock(block, ['wibble'])
+
+    def test_block_1_plus_equal_simple(self):
+        block = C.Block(C.Simple('foo'))
+        block += C.Simple('wibble')
+        self.assertBlock(block, ['foo', 'wibble'])
+
+    def test_block_2_plus_equal_simple(self):
+        block = C.Block(C.Simple('foo'), C.Simple('bar'))
+        block += C.Simple('wibble')
+        self.assertBlock(block, ['foo', 'bar', 'wibble'])
+
+    def test_block_empty_plus_equal_block(self):
+        block = C.Block()
+        block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block, ['wibble', 'wobble'])
+
+    def test_block_1_plus_equal_block(self):
+        block = C.Block(C.Simple('foo'))
+        block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block, ['foo', 'wibble', 'wobble'])
+
+    def test_block_2_plus_equal_block(self):
+        block = C.Block(C.Simple('foo'), C.Simple('bar'))
+        block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block, ['foo', 'bar', 'wibble', 'wobble'])
+
+    def test_block_1_plus_equal_derived_block(self):
+        block = C.Block(C.Simple('foo'))
+        class MyBlock(C.Block):
+            # pylint: disable=too-few-public-methods
+            pass
+        block += MyBlock(C.Simple('wibble'), C.Simple('wobble'))
+        self.assertBlock(block, ['foo', 'wibble', 'wobble'])
+
+    def test_block_append_simple(self):
+        block = C.Block()
+        block.append(C.Simple('one'))
+        self.assertBlock(block, ['one'])
+        block.append(C.Simple('two'))
+        self.assertBlock(block, ['one', 'two'])
+
+    def test_block_append_block_0(self):
+        block = C.Block()
+        block.append(C.Block())
+        self.assertBlock(block, [[]])
+        block.append(C.Block(C.Simple('foo')))
+        self.assertBlock(block, [[], ['foo']])
+
+    def test_block_copy_0_append_original(self):
+        block0 = C.Block()
+        block1 = block0.copy()
+        block0.append('foo')
+        self.assertBlock(block0, ['foo'])
+        self.assertBlock(block1, [])
+
+    def test_block_copy_0_append_copy(self):
+        block0 = C.Block()
+        block1 = block0.copy()
+        block1.append('bar')
+        self.assertBlock(block0, [])
+        self.assertBlock(block1, ['bar'])
+
+    def test_block_copy_0_append_both(self):
+        block0 = C.Block()
+        block1 = block0.copy()
+        block0.append('foo')
+        block1.append('bar')
+        self.assertBlock(block0, ['foo'])
+        self.assertBlock(block1, ['bar'])
+
+    def test_block_copy_is_shallow(self):
+        block0 = C.Block(C.Block(C.Simple('foo')), C.Simple('wibble'))
+        block1 = block0.copy()
+        block1[0][0] = C.Simple('bar')
+        block1[1] = C.Simple('wobble')
+        self.assertBlock(block0, [['bar'], 'wibble'])
+        self.assertBlock(block1, [['bar'], 'wobble'])
+
+
 class SnippetTest(unittest.TestCase):
     """Test the exact rendering of a snippet under default options."""
-    # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
 
     def assertSnippet(self, snippet, presented_output):
         stream = io.StringIO()

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -153,6 +153,27 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
+    def test_comment_empty(self):
+        self.assertSnippet(C.Comment(), '')
+
+    def test_comment_1(self):
+        self.assertSnippet(C.Comment('hello'), '/* hello */\n')
+
+    def test_comment_2(self):
+        self.assertSnippet(C.Comment('hello', 'world'), """
+/* hello
+ * world
+ */
+        """)
+
+    def test_block_comment(self):
+        self.assertSnippet(C.Block(C.Comment('hello', 'world')), """
+{
+    /* hello
+     * world
+     */
+}
+        """)
 
 
 def load_module():

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+"""Unit tests for ../scripts/test_c_generator.py"""
+
+import importlib
+import os
+import sys
+import unittest
+
+
+class SmokeTest(unittest.TestCase):
+    """Test that we seem to have loaded the right module."""
+    # pylint: disable=missing-docstring
+
+    def test_docstring(self):
+        self.assertTrue(len(c_generator.__doc__) > 0)
+
+
+def load_module():
+    """Load the c_generator module.
+
+    The module is located in a different directory from the test script,
+    hence all the complication.
+    """
+    # Part of the reason to do this in a function is to keep Pylint
+    # warnings local to this function at most.
+    scripts_dir = os.path.join(os.path.dirname(__file__),
+                               os.pardir, os.pardir, 'scripts')
+    save_sys_path = sys.path
+    try:
+        # pylint: disable=invalid-name,global-variable-undefined
+        sys.path = [scripts_dir] + sys.path
+        global c_generator
+        c_generator = importlib.import_module('c_generator')
+    finally:
+        sys.path = save_sys_path
+
+if __name__ == '__main__':
+    load_module()
+    unittest.main()

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -47,22 +47,24 @@ class OptionsTest(unittest.TestCase):
     """Test the exact rendering of a snippet under varying options."""
     # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
 
-    def assertSnippet(self, snippet, presented_output, **kwargs):
+    def assertSnippet(self, snippet: C.Snippet,
+                      presented_output: str, **kwargs) -> None:
+        self.assertIsInstance(snippet, C.Snippet)
         stream = io.StringIO()
         snippet.output(stream, **kwargs)
         expected_output = presented_output.lstrip('\n').rstrip(' ')
         self.assertEqual(stream.getvalue(), expected_output)
 
-    def test_default_line(self):
+    def test_default_line(self) -> None:
         self.assertSnippet(C.Simple('hello'), 'hello;\n')
 
-    def test_indent_spaces(self):
+    def test_indent_spaces(self) -> None:
         self.assertSnippet(C.Simple('hello'), '    hello;\n', indent='    ')
 
-    def test_indent_tab(self):
+    def test_indent_tab(self) -> None:
         self.assertSnippet(C.Simple('hello'), '\thello;\n', indent='\t')
 
-    def test_default_block(self):
+    def test_default_block(self) -> None:
         self.assertSnippet(C.Block(C.Simple('hello'), C.Simple('world')), """
 {
     hello;
@@ -70,7 +72,7 @@ class OptionsTest(unittest.TestCase):
 }
         """)
 
-    def test_option_indent(self):
+    def test_option_indent(self) -> None:
         self.assertSnippet(C.Block(C.Simple('hello'), C.Simple('world')), """
 {
    hello;
@@ -78,7 +80,7 @@ class OptionsTest(unittest.TestCase):
 }
         """, options=C.Options(indent=3))
 
-    def test_option_indent_nested(self):
+    def test_option_indent_nested(self) -> None:
         self.assertSnippet(C.Block(C.Block(C.Simple('hello'))), """
 {
    {
@@ -87,7 +89,7 @@ class OptionsTest(unittest.TestCase):
 }
         """, options=C.Options(indent=3))
 
-    def test_indent_and_option_indent(self):
+    def test_indent_and_option_indent(self) -> None:
         self.assertSnippet(C.Block(C.Block(C.Simple('hello'))), """
   {
      {
@@ -101,16 +103,22 @@ class ConstructionTest(unittest.TestCase):
     """Test get and set methods on snippets."""
     # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
 
-    @classmethod
-    def get_block_structure(cls, snippet):
-        if isinstance(snippet, C.Block):
-            return [cls.get_block_structure(elt) for elt in snippet]
-        elif isinstance(snippet, C.Simple):
-            return snippet.get_content()
-        else:
-            return snippet
+    def assertSimple(self, snippet: C.Snippet, expected) -> None:
+        self.assertIsInstance(snippet, C.Simple)
+        assert isinstance(snippet, C.Simple) # redundant at runtime but needed for mypy
+        self.assertEqual(snippet.get_content(), expected)
 
-    def assertBlock(self, block, expected):
+    def get_block_structure(self, snippet):
+        if isinstance(snippet, C.Block):
+            return [self.get_block_structure(elt) for elt in snippet]
+        else:
+            self.assertIsInstance(snippet, C.Simple)
+            return snippet.get_content()
+
+    # No type annotation for `expected` because mypy currently doesn't
+    # support recursive types.
+    # https://github.com/python/mypy/issues/731
+    def assertBlock(self, block: C.Snippet, expected) -> None:
         """Check a nested structure of blocks and simple statements.
 
         block must be a C.Snippet constructed from C.Block and C.Simple only.
@@ -125,66 +133,65 @@ class ConstructionTest(unittest.TestCase):
         """
         self.assertEqual(self.get_block_structure(block), expected)
 
-    def test_simple_get_initial(self):
+    def test_simple_get_initial(self) -> None:
         c = C.Simple('initial')
-        self.assertEqual(c.get_content(), 'initial')
+        self.assertSimple(c, 'initial')
 
-    def test_simple_set_get(self):
+    def test_simple_set_get(self) -> None:
         c = C.Simple('initial')
         c.set_content('updated')
-        self.assertEqual(c.get_content(), 'updated')
+        self.assertSimple(c, 'updated')
         c.set_content('wibble')
-        self.assertEqual(c.get_content(), 'wibble')
+        self.assertSimple(c, 'wibble')
 
-    def test_simple_get_initial_stripped(self):
+    def test_simple_get_initial_stripped(self) -> None:
         c = C.Simple('  initial  ')
-        self.assertEqual(c.get_content(), 'initial')
+        self.assertSimple(c, 'initial')
 
-    def test_simple_set_get_stripped(self):
+    def test_simple_set_get_stripped(self) -> None:
         c = C.Simple('initial')
         c.set_content('  updated  ')
-        self.assertEqual(c.get_content(), 'updated')
+        self.assertSimple(c, 'updated')
         c.set_content('  wibble  ')
-        self.assertEqual(c.get_content(), 'wibble')
+        self.assertSimple(c, 'wibble')
 
-    def test_block_len_0(self):
+    def test_block_len_0(self) -> None:
         block = C.Block()
         self.assertEqual(len(block), 0)
 
-    def test_block_len_1_simple(self):
+    def test_block_len_1_simple(self) -> None:
         block = C.Block(C.Simple('one'))
         self.assertEqual(len(block), 1)
 
-    def test_block_len_1_nested(self):
+    def test_block_len_1_nested(self) -> None:
         block = C.Block(C.Block())
         self.assertEqual(len(block), 1)
 
-    def test_block_len_2_simple(self):
+    def test_block_len_2_simple(self) -> None:
         block = C.Block(C.Simple('one'), C.Simple('two'))
         self.assertEqual(len(block), 2)
 
-    def test_block_len_2_nested_0(self):
+    def test_block_len_2_nested_0(self) -> None:
         block = C.Block(C.Simple('one'),
                         C.Block())
         self.assertEqual(len(block), 2)
 
-    def test_block_len_2_nested_2(self):
+    def test_block_len_2_nested_2(self) -> None:
         block = C.Block(C.Simple('one'),
                         C.Block(C.Simple('foo'), C.Simple('bar')))
         self.assertEqual(len(block), 2)
 
-    def test_block_getitem_good(self):
+    def test_block_getitem_good(self) -> None:
         block = C.Block(C.Simple('zero'),
                         C.Simple('one'),
                         C.Block(C.Simple('foo'), C.Simple('bar')),
                         C.Simple('three'))
-        self.assertEqual(block[0].get_content(), 'zero')
-        self.assertEqual(block[1].get_content(), 'one')
-        self.assertEqual(block[2][0].get_content(), 'foo')
-        self.assertEqual(block[2][1].get_content(), 'bar')
-        self.assertEqual(block[3].get_content(), 'three')
+        self.assertSimple(block[0], 'zero')
+        self.assertSimple(block[1], 'one')
+        self.assertBlock(block[2], ['foo', 'bar'])
+        self.assertSimple(block[3], 'three')
 
-    def test_block_getitem_range(self):
+    def test_block_getitem_range(self) -> None:
         self.assertRaises(IndexError, operator.getitem,
                           C.Block(), 0)
         self.assertRaises(IndexError, operator.getitem,
@@ -192,22 +199,22 @@ class ConstructionTest(unittest.TestCase):
         self.assertRaises(IndexError, operator.getitem,
                           C.Block(C.Simple(''), C.Simple('')), 2)
 
-    def test_block_getitem_type(self):
+    def test_block_getitem_type(self) -> None:
         self.assertRaises(TypeError, operator.getitem,
                           C.Block(C.Simple('zero'), C.Simple('one')), 0.5)
 
-    def test_block_setitem_overwrite(self):
+    def test_block_setitem_overwrite(self) -> None:
         block = C.Block(C.Simple('foo 0'), C.Simple('foo 1'))
-        self.assertEqual(block[0].get_content(), 'foo 0')
-        self.assertEqual(block[1].get_content(), 'foo 1')
+        self.assertSimple(block[0], 'foo 0')
+        self.assertSimple(block[1], 'foo 1')
         block[0] = C.Simple('bar 0')
-        self.assertEqual(block[0].get_content(), 'bar 0')
-        self.assertEqual(block[1].get_content(), 'foo 1')
+        self.assertSimple(block[0], 'bar 0')
+        self.assertSimple(block[1], 'foo 1')
         block[1] = C.Simple('bar 1')
-        self.assertEqual(block[0].get_content(), 'bar 0')
-        self.assertEqual(block[1].get_content(), 'bar 1')
+        self.assertSimple(block[0], 'bar 0')
+        self.assertSimple(block[1], 'bar 1')
 
-    def test_block_setitem_range(self):
+    def test_block_setitem_range(self) -> None:
         self.assertRaises(IndexError, operator.setitem,
                           C.Block(), 0, C.Block())
         self.assertRaises(IndexError, operator.setitem,
@@ -215,37 +222,37 @@ class ConstructionTest(unittest.TestCase):
         self.assertRaises(IndexError, operator.setitem,
                           C.Block(C.Simple(''), C.Simple('')), 2, C.Block())
 
-    def test_block_delitem_first(self):
+    def test_block_delitem_first(self) -> None:
         block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
         del block[0]
         self.assertEqual(len(block), 2)
-        self.assertEqual(block[0].get_content(), 'one')
-        self.assertEqual(block[1].get_content(), 'two')
+        self.assertSimple(block[0], 'one')
+        self.assertSimple(block[1], 'two')
 
-    def test_block_delitem_middle(self):
+    def test_block_delitem_middle(self) -> None:
         block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
         del block[1]
         self.assertEqual(len(block), 2)
-        self.assertEqual(block[0].get_content(), 'zero')
-        self.assertEqual(block[1].get_content(), 'two')
+        self.assertSimple(block[0], 'zero')
+        self.assertSimple(block[1], 'two')
 
-    def test_block_delitem_last(self):
+    def test_block_delitem_last(self) -> None:
         block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'))
         del block[2]
         self.assertEqual(len(block), 2)
-        self.assertEqual(block[0].get_content(), 'zero')
-        self.assertEqual(block[1].get_content(), 'one')
+        self.assertSimple(block[0], 'zero')
+        self.assertSimple(block[1], 'one')
 
-    def test_block_delitem_slice(self):
+    def test_block_delitem_slice(self) -> None:
         block = C.Block(C.Simple('zero'), C.Simple('one'), C.Simple('two'),
                         C.Simple('three'), C.Simple('four'))
         del block[1:3]
         self.assertEqual(len(block), 3)
-        self.assertEqual(block[0].get_content(), 'zero')
-        self.assertEqual(block[1].get_content(), 'three')
-        self.assertEqual(block[2].get_content(), 'four')
+        self.assertSimple(block[0], 'zero')
+        self.assertSimple(block[1], 'three')
+        self.assertSimple(block[2], 'four')
 
-    def test_block_delitem_range(self):
+    def test_block_delitem_range(self) -> None:
         self.assertRaises(IndexError, operator.delitem,
                           C.Block(), 0)
         self.assertRaises(IndexError, operator.delitem,
@@ -253,52 +260,52 @@ class ConstructionTest(unittest.TestCase):
         self.assertRaises(IndexError, operator.delitem,
                           C.Block(C.Simple(''), C.Simple('')), 2)
 
-    def test_block_iter_0(self):
+    def test_block_iter_0(self) -> None:
         self.assertRaises(StopIteration, next, iter(C.Block()))
 
-    def test_block_iter_2(self):
+    def test_block_iter_2(self) -> None:
         it = iter(C.Block(C.Simple('zero'), C.Simple('one')))
-        self.assertEqual(next(it).get_content(), 'zero')
-        self.assertEqual(next(it).get_content(), 'one')
+        self.assertSimple(next(it), 'zero')
+        self.assertSimple(next(it), 'one')
         self.assertRaises(StopIteration, next, it)
 
-    def test_block_empty_plus_simple(self):
+    def test_block_empty_plus_simple(self) -> None:
         block0 = C.Block()
         block = block0 + C.Simple('wibble')
         self.assertBlock(block0, [])
         self.assertBlock(block, ['wibble'])
 
-    def test_block_1_plus_simple(self):
+    def test_block_1_plus_simple(self) -> None:
         block0 = C.Block(C.Simple('foo'))
         block = block0 + C.Simple('wibble')
         self.assertBlock(block0, ['foo'])
         self.assertBlock(block, ['foo', 'wibble'])
 
-    def test_block_2_plus_simple(self):
+    def test_block_2_plus_simple(self) -> None:
         block0 = C.Block(C.Simple('foo'), C.Simple('bar'))
         block = block0 + C.Simple('wibble')
         self.assertBlock(block0, ['foo', 'bar'])
         self.assertBlock(block, ['foo', 'bar', 'wibble'])
 
-    def test_block_empty_plus_block(self):
+    def test_block_empty_plus_block(self) -> None:
         block0 = C.Block()
         block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block0, [])
         self.assertBlock(block, ['wibble', 'wobble'])
 
-    def test_block_1_plus_block(self):
+    def test_block_1_plus_block(self) -> None:
         block0 = C.Block(C.Simple('foo'))
         block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block0, ['foo'])
         self.assertBlock(block, ['foo', 'wibble', 'wobble'])
 
-    def test_block_2_plus_block(self):
+    def test_block_2_plus_block(self) -> None:
         block0 = C.Block(C.Simple('foo'), C.Simple('bar'))
         block = block0 + C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block0, ['foo', 'bar'])
         self.assertBlock(block, ['foo', 'bar', 'wibble', 'wobble'])
 
-    def test_block_1_plus_derived_block(self):
+    def test_block_1_plus_derived_block(self) -> None:
         block0 = C.Block(C.Simple('foo'))
         class MyBlock(C.Block):
             # pylint: disable=too-few-public-methods
@@ -307,37 +314,37 @@ class ConstructionTest(unittest.TestCase):
         self.assertBlock(block0, ['foo'])
         self.assertBlock(block, ['foo', 'wibble', 'wobble'])
 
-    def test_block_empty_plus_equal_simple(self):
+    def test_block_empty_plus_equal_simple(self) -> None:
         block = C.Block()
         block += C.Simple('wibble')
         self.assertBlock(block, ['wibble'])
 
-    def test_block_1_plus_equal_simple(self):
+    def test_block_1_plus_equal_simple(self) -> None:
         block = C.Block(C.Simple('foo'))
         block += C.Simple('wibble')
         self.assertBlock(block, ['foo', 'wibble'])
 
-    def test_block_2_plus_equal_simple(self):
+    def test_block_2_plus_equal_simple(self) -> None:
         block = C.Block(C.Simple('foo'), C.Simple('bar'))
         block += C.Simple('wibble')
         self.assertBlock(block, ['foo', 'bar', 'wibble'])
 
-    def test_block_empty_plus_equal_block(self):
+    def test_block_empty_plus_equal_block(self) -> None:
         block = C.Block()
         block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block, ['wibble', 'wobble'])
 
-    def test_block_1_plus_equal_block(self):
+    def test_block_1_plus_equal_block(self) -> None:
         block = C.Block(C.Simple('foo'))
         block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block, ['foo', 'wibble', 'wobble'])
 
-    def test_block_2_plus_equal_block(self):
+    def test_block_2_plus_equal_block(self) -> None:
         block = C.Block(C.Simple('foo'), C.Simple('bar'))
         block += C.Block(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block, ['foo', 'bar', 'wibble', 'wobble'])
 
-    def test_block_1_plus_equal_derived_block(self):
+    def test_block_1_plus_equal_derived_block(self) -> None:
         block = C.Block(C.Simple('foo'))
         class MyBlock(C.Block):
             # pylint: disable=too-few-public-methods
@@ -345,45 +352,46 @@ class ConstructionTest(unittest.TestCase):
         block += MyBlock(C.Simple('wibble'), C.Simple('wobble'))
         self.assertBlock(block, ['foo', 'wibble', 'wobble'])
 
-    def test_block_append_simple(self):
+    def test_block_append_simple(self) -> None:
         block = C.Block()
         block.append(C.Simple('one'))
         self.assertBlock(block, ['one'])
         block.append(C.Simple('two'))
         self.assertBlock(block, ['one', 'two'])
 
-    def test_block_append_block_0(self):
+    def test_block_append_block_0(self) -> None:
         block = C.Block()
         block.append(C.Block())
         self.assertBlock(block, [[]])
         block.append(C.Block(C.Simple('foo')))
         self.assertBlock(block, [[], ['foo']])
 
-    def test_block_copy_0_append_original(self):
+    def test_block_copy_0_append_original(self) -> None:
         block0 = C.Block()
         block1 = block0.copy()
-        block0.append('foo')
+        block0.append(C.Simple('foo'))
         self.assertBlock(block0, ['foo'])
         self.assertBlock(block1, [])
 
-    def test_block_copy_0_append_copy(self):
+    def test_block_copy_0_append_copy(self) -> None:
         block0 = C.Block()
         block1 = block0.copy()
-        block1.append('bar')
+        block1.append(C.Simple('bar'))
         self.assertBlock(block0, [])
         self.assertBlock(block1, ['bar'])
 
-    def test_block_copy_0_append_both(self):
+    def test_block_copy_0_append_both(self) -> None:
         block0 = C.Block()
         block1 = block0.copy()
-        block0.append('foo')
-        block1.append('bar')
+        block0.append(C.Simple('foo'))
+        block1.append(C.Simple('bar'))
         self.assertBlock(block0, ['foo'])
         self.assertBlock(block1, ['bar'])
 
-    def test_block_copy_is_shallow(self):
+    def test_block_copy_is_shallow(self) -> None:
         block0 = C.Block(C.Block(C.Simple('foo')), C.Simple('wibble'))
         block1 = block0.copy()
+        assert isinstance(block1[0], C.Block)
         block1[0][0] = C.Simple('bar')
         block1[1] = C.Simple('wobble')
         self.assertBlock(block0, [['bar'], 'wibble'])
@@ -394,34 +402,35 @@ class SnippetTest(unittest.TestCase):
     """Test the exact rendering of a snippet under default options."""
     # pylint: disable=invalid-name,missing-docstring,too-many-public-methods
 
-    def assertSnippet(self, snippet, presented_output):
+    def assertSnippet(self, snippet: C.Snippet, presented_output: str) -> None:
+        self.assertIsInstance(snippet, C.Snippet)
         stream = io.StringIO()
         snippet.output(stream)
         expected_output = presented_output.lstrip('\n').rstrip(' ')
         self.assertEqual(stream.getvalue(), expected_output)
 
-    def test_simple(self):
+    def test_simple(self) -> None:
         self.assertSnippet(C.Simple('hello'), 'hello;\n')
 
-    def test_simple_leading_space(self):
+    def test_simple_leading_space(self) -> None:
         self.assertSnippet(C.Simple(' hello'), 'hello;\n')
 
-    def test_simple_trailing_space(self):
+    def test_simple_trailing_space(self) -> None:
         self.assertSnippet(C.Simple('hello '), 'hello;\n')
 
-    def test_return_none(self):
+    def test_return_none(self) -> None:
         self.assertSnippet(C.Return(None), 'return;\n')
 
-    def test_return_value(self):
+    def test_return_value(self) -> None:
         self.assertSnippet(C.Return('foo'), 'return( foo );\n')
 
-    def test_block_empty(self):
+    def test_block_empty(self) -> None:
         self.assertSnippet(C.Block(), """
 {
 }
         """)
 
-    def test_block_simple(self):
+    def test_block_simple(self) -> None:
         self.assertSnippet(C.Block(C.Simple('hello'), C.Simple('world')), """
 {
     hello;
@@ -429,7 +438,7 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
-    def test_block_nested(self):
+    def test_block_nested(self) -> None:
         self.assertSnippet(C.Block(C.Simple('hello'),
                                    C.Block(C.Simple('nested')),
                                    C.Simple('world')), """
@@ -442,7 +451,7 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
-    def test_block_multiple(self):
+    def test_block_multiple(self) -> None:
         self.assertSnippet(C.Block(C.Block(C.Simple('nested')),
                                    C.Block(C.Simple('again')),
                                    C.Block()), """
@@ -458,20 +467,20 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
-    def test_comment_empty(self):
+    def test_comment_empty(self) -> None:
         self.assertSnippet(C.Comment(), '')
 
-    def test_comment_1(self):
+    def test_comment_1(self) -> None:
         self.assertSnippet(C.Comment('hello'), '/* hello */\n')
 
-    def test_comment_2(self):
+    def test_comment_2(self) -> None:
         self.assertSnippet(C.Comment('hello', 'world'), """
 /* hello
  * world
  */
         """)
 
-    def test_block_comment(self):
+    def test_block_comment(self) -> None:
         self.assertSnippet(C.Block(C.Comment('hello', 'world')), """
 {
     /* hello
@@ -480,15 +489,15 @@ class SnippetTest(unittest.TestCase):
 }
         """)
 
-    def test_directive_foo(self):
+    def test_directive_foo(self) -> None:
         self.assertSnippet(C.Directive('foo'),
                            '#foo\n')
 
-    def test_directive_define(self):
+    def test_directive_define(self) -> None:
         self.assertSnippet(C.Directive('define', 'FOO', '42'),
                            '#define FOO 42\n')
 
-    def test_directive_multiline(self):
+    def test_directive_multiline(self) -> None:
         self.assertSnippet(
             C.Directive('define', 'FOO', 'one \ntwo\nthree'),
             """
@@ -497,7 +506,7 @@ two\\
 three
             """)
 
-    def test_block_directive(self):
+    def test_block_directive(self) -> None:
         self.assertSnippet(C.Block(C.Directive('foo'), C.Simple('hello')), """
 {
 #foo
@@ -505,7 +514,7 @@ three
 }
         """)
 
-    def test_block_directive_multiline(self):
+    def test_block_directive_multiline(self) -> None:
         self.assertSnippet(
             C.Block(C.Directive('define', 'FOO', 'one \ntwo\nthree'),
                     C.Simple('hello')),
@@ -518,7 +527,7 @@ three
 }
             """)
 
-    def test_pp_if(self):
+    def test_pp_if(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.add_case('first', C.Simple('one'))
         self.assertSnippet(ppc, """
@@ -527,7 +536,7 @@ one;
 #endif /* first */
         """)
 
-    def test_pp_if_else(self):
+    def test_pp_if_else(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.add_case('first', C.Simple('one'))
         ppc.set_default(C.Simple('something'))
@@ -539,7 +548,7 @@ something;
 #endif /* !first */
         """)
 
-    def test_pp_if_elif(self):
+    def test_pp_if_elif(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.add_case('first', C.Simple('one'))
         ppc.add_case('second', C.Simple('two'))
@@ -554,7 +563,7 @@ three;
 #endif /* third */
         """)
 
-    def test_pp_if_elif_else(self):
+    def test_pp_if_elif_else(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.add_case('first', C.Simple('one'))
         ppc.add_case('second', C.Simple('two'))
@@ -572,18 +581,18 @@ something;
 #endif /* !first && !second && !third */
         """)
 
-    def test_pp_else_only(self):
+    def test_pp_else_only(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.set_default(C.Simple('something'))
         self.assertSnippet(ppc, """
 something;
         """)
 
-    def test_pp_nothing(self):
+    def test_pp_nothing(self) -> None:
         ppc = C.PreprocessorConditional()
         self.assertSnippet(ppc, '')
 
-    def test_pp_multiline(self):
+    def test_pp_multiline(self) -> None:
         ppc = C.PreprocessorConditional()
         ppc.add_case('hello\nworld', C.Simple('one'))
         ppc.add_case('foo\nbar\nqux', C.Simple('two'))

--- a/tests/scripts/test_c_generator.py
+++ b/tests/scripts/test_c_generator.py
@@ -19,17 +19,28 @@
 
 """Unit tests for ../scripts/test_c_generator.py"""
 
-import importlib
+import contextlib
 import io
 import operator
 import os
 import sys
 import unittest
 
+
 # The file c_generator.py is not in the same directory. To make this testing
-# program self-contained, go and look for it in ../../scripts. This is done
-# below with C = load_module().
-# # import c_generator as C
+# program self-contained, go and look for it in ../../scripts.
+@contextlib.contextmanager
+def saved_sys_path(*directories):
+    saved = sys.path
+    sys.path = list(directories) + sys.path
+    try:
+        yield
+    finally:
+        sys.path = saved
+
+with saved_sys_path(os.path.join(os.path.dirname(__file__),
+                                 os.pardir, os.pardir, 'scripts')):
+    import c_generator as C
 
 
 class OptionsTest(unittest.TestCase):
@@ -588,24 +599,5 @@ two;
         """)
 
 
-def load_module():
-    """Load the c_generator module.
-
-    The module is located in a different directory from the test script,
-    hence all the complication.
-    """
-    # Part of the reason to do this in a function is to keep Pylint
-    # warnings local to this function at most.
-    scripts_dir = os.path.join(os.path.dirname(__file__),
-                               os.pardir, os.pardir, 'scripts')
-    save_sys_path = sys.path
-    try:
-        # pylint: disable=invalid-name,global-variable-undefined
-        sys.path = [scripts_dir] + sys.path
-        return importlib.import_module('c_generator')
-    finally:
-        sys.path = save_sys_path
-
 if __name__ == '__main__':
-    C = load_module()
     unittest.main()

--- a/tests/scripts/test_generate_test_code.py
+++ b/tests/scripts/test_generate_test_code.py
@@ -22,21 +22,10 @@
 Unit tests for generate_test_code.py
 """
 
-# pylint: disable=wrong-import-order
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import StringIO
 from unittest import TestCase, main as unittest_main
-try:
-    # Python 2
-    from mock import patch
-except ImportError:
-    # Python 3
-    from unittest.mock import patch
-# pylint: enable=wrong-import-order
+from unittest.mock import patch
+
 from generate_test_code import gen_dependencies, gen_dependencies_one_line
 from generate_test_code import gen_function_wrapper, gen_dispatch
 from generate_test_code import parse_until_pattern, GeneratorInputError
@@ -319,25 +308,16 @@ class StringIOWrapper(StringIO):
         :return: Line read from file.
         """
         parent = super(StringIOWrapper, self)
-        if getattr(parent, 'next', None):
-            # Python 2
-            line = parent.next()
-        else:
-            # Python 3
-            line = parent.__next__()
+        line = parent.__next__()
         return line
 
-    # Python 3
-    __next__ = next
-
-    def readline(self, length=0):
+    def readline(self, _length=0):
         """
         Wrap the base class readline.
 
         :param length:
         :return:
         """
-        # pylint: disable=unused-argument
         line = super(StringIOWrapper, self).readline()
         if line is not None:
             self.line_no += 1
@@ -551,38 +531,6 @@ class ParseFunctionCode(TestCase):
     Test suite for testing parse_function_code()
     """
 
-    def assert_raises_regex(self, exp, regex, func, *args):
-        """
-        Python 2 & 3 portable wrapper of assertRaisesRegex(p)? function.
-
-        :param exp: Exception type expected to be raised by cb.
-        :param regex: Expected exception message
-        :param func: callable object under test
-        :param args: variable positional arguments
-        """
-        parent = super(ParseFunctionCode, self)
-
-        # Pylint does not appreciate that the super method called
-        # conditionally can be available in other Python version
-        # then that of Pylint.
-        # Workaround is to call the method via getattr.
-        # Pylint ignores that the method got via getattr is
-        # conditionally executed. Method has to be a callable.
-        # Hence, using a dummy callable for getattr default.
-        dummy = lambda *x: None
-        # First Python 3 assertRaisesRegex is checked, since Python 2
-        # assertRaisesRegexp is also available in Python 3 but is
-        # marked deprecated.
-        for name in ('assertRaisesRegex', 'assertRaisesRegexp'):
-            method = getattr(parent, name, dummy)
-            if method is not dummy:
-                method(exp, regex, func, *args)
-                break
-        else:
-            raise AttributeError(" 'ParseFunctionCode' object has no attribute"
-                                 " 'assertRaisesRegex' or 'assertRaisesRegexp'"
-                                )
-
     def test_no_function(self):
         """
         Test no test function found.
@@ -595,8 +543,8 @@ function
 '''
         stream = StringIOWrapper('test_suite_ut.function', data)
         err_msg = 'file: test_suite_ut.function - Test functions not found!'
-        self.assert_raises_regex(GeneratorInputError, err_msg,
-                                 parse_function_code, stream, [], [])
+        self.assertRaisesRegex(GeneratorInputError, err_msg,
+                               parse_function_code, stream, [], [])
 
     def test_no_end_case_comment(self):
         """
@@ -611,8 +559,8 @@ void test_func()
         stream = StringIOWrapper('test_suite_ut.function', data)
         err_msg = r'file: test_suite_ut.function - '\
                   'end case pattern .*? not found!'
-        self.assert_raises_regex(GeneratorInputError, err_msg,
-                                 parse_function_code, stream, [], [])
+        self.assertRaisesRegex(GeneratorInputError, err_msg,
+                               parse_function_code, stream, [], [])
 
     @patch("generate_test_code.parse_function_arguments")
     def test_function_called(self,
@@ -729,8 +677,8 @@ exit:
         data = 'int entropy_threshold( char * a, data_t * h, int result )'
         err_msg = 'file: test_suite_ut.function - Test functions not found!'
         stream = StringIOWrapper('test_suite_ut.function', data)
-        self.assert_raises_regex(GeneratorInputError, err_msg,
-                                 parse_function_code, stream, [], [])
+        self.assertRaisesRegex(GeneratorInputError, err_msg,
+                               parse_function_code, stream, [], [])
 
     @patch("generate_test_code.gen_dispatch")
     @patch("generate_test_code.gen_dependencies")


### PR DESCRIPTION
This is work in progress on C generation for PSA driver wrapper code generation. I'm putting this out as a pull request so that it's easy to find. The work was done for an earlier version of Mbed TLS. It contains some work on mypy integration and Python library structure (so that `tests/scripts/*.py` can use Python modules outside of `tests/scripts`) that has since then been merged into Mbed TLS in a different form.

This is the second prototype branch after https://github.com/ARMmbed/mbedtls/pull/3313.
