### PR TITLE
Make the fields of mbedtls_x509_crt_profile public

### DIFF
--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -156,6 +156,10 @@ mbedtls_x509_subject_alternative_name;
  * Security profile for certificate verification.
  *
  * All lists are bitfields, built by ORing flags from MBEDTLS_X509_ID_FLAG().
+ *
+ * The fields of this structure are part of the public API and can be
+ * manipulated directly by applications. Future versions of the library may
+ * add extra fields or reorder existing fields.
  */
 typedef struct mbedtls_x509_crt_profile
 {

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -159,10 +159,10 @@ mbedtls_x509_subject_alternative_name;
  */
 typedef struct mbedtls_x509_crt_profile
 {
-    uint32_t MBEDTLS_PRIVATE(allowed_mds);       /**< MDs for signatures         */
-    uint32_t MBEDTLS_PRIVATE(allowed_pks);       /**< PK algs for signatures     */
-    uint32_t MBEDTLS_PRIVATE(allowed_curves);    /**< Elliptic curves for ECDSA  */
-    uint32_t MBEDTLS_PRIVATE(rsa_min_bitlen);    /**< Minimum size for RSA keys  */
+    uint32_t allowed_mds;       /**< MDs for signatures         */
+    uint32_t allowed_pks;       /**< PK algs for signatures     */
+    uint32_t allowed_curves;    /**< Elliptic curves for ECDSA  */
+    uint32_t rsa_min_bitlen;    /**< Minimum size for RSA keys  */
 }
 mbedtls_x509_crt_profile;
 

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -160,6 +160,22 @@ mbedtls_x509_subject_alternative_name;
  * The fields of this structure are part of the public API and can be
  * manipulated directly by applications. Future versions of the library may
  * add extra fields or reorder existing fields.
+ *
+ * You can create custom profiles by starting from a copy of
+ * an existing profile, such as mbedtls_x509_crt_profile_default or
+ * mbedtls_x509_ctr_profile_none and then tune it to your needs.
+ *
+ * For example to allow SHA-224 in addition to the default:
+ *
+ *  mbedtls_x509_crt_profile my_profile = mbedtls_x509_crt_profile_default;
+ *  my_profile.allowed_mds |= MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA224 );
+ *
+ * Or to allow only RSA-3072+ with SHA-256:
+ *
+ *  mbedtls_x509_crt_profile my_profile = mbedtls_x509_crt_profile_none;
+ *  my_profile.allowed_mds = MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA256 );
+ *  my_profile.allowed_pks = MBEDTLS_X509_ID_FLAG( MBEDTLS_PK_RSA );
+ *  my_profile.rsa_min_bitlen = 3072;
  */
 typedef struct mbedtls_x509_crt_profile
 {
@@ -349,6 +365,12 @@ extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_next;
  * NSA Suite B profile.
  */
 extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;
+
+/**
+ * Empty profile that allows nothing. Useful as a basis for constructing
+ * custom profiles.
+ */
+extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_none;
 
 /**
  * \brief          Parse a single DER formatted certificate and add it

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -157,6 +157,17 @@ const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb =
 };
 
 /*
+ * Empty / all-forbidden profile
+ */
+const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_none =
+{
+    0,
+    0,
+    0,
+    (uint32_t) -1,
+};
+
+/*
  * Check md_alg against profile
  * Return 0 if md_alg is acceptable for this profile, -1 otherwise
  */


### PR DESCRIPTION
These fields are supposed to be manipulated directly, that's how people
create custom profiles.

Evidence: we recommend direct manipulation of those fields [right in the migration guide](https://github.com/ARMmbed/mbedtls/pull/4604/files#diff-88d0e814bb6d367c041ee4e48cc7dc9480f0900060f2f73ccb254921995e2407R13)

Fixes #4603 
