### PR TITLE
Add missing free context in at the end of aes_crypt_xts_size()

### DIFF
--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
+Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
    * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176
+     test suite with an alternative AES implementation. Fixes #4176.

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular 
+   * Fix an issue where resource is never freed when running one particular
      test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
-Fixes #4176
+   * Fix an issue where resource is never freed when running one particular 
+     test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176.
+   * Fix a resource leak in a test suite with an alternative AES
+     implementation. Fixes #4176.

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -207,6 +207,8 @@ void aes_crypt_xts_size( int size, int retval )
     memset( data_unit, 0x00, sizeof( data_unit ) );
 
     TEST_ASSERT( mbedtls_aes_crypt_xts( &ctx, MBEDTLS_AES_ENCRYPT, length, data_unit, src, output ) == retval );
+exit:
+    mbedtls_aes_xts_free(&ctx);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -208,7 +208,7 @@ void aes_crypt_xts_size( int size, int retval )
 
     TEST_ASSERT( mbedtls_aes_crypt_xts( &ctx, MBEDTLS_AES_ENCRYPT, length, data_unit, src, output ) == retval );
 exit:
-    mbedtls_aes_xts_free(&ctx);
+    mbedtls_aes_xts_free( &ctx );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
in file tests/suite/test_suite_aes.function, aes_crypt_xts_size()
did not free the context upon the function exit.
The function now frees the context on exit.

This Closes #4176

## Status
**READY**

## Requires Backporting
Yes 
[development_2.x](https://github.com/ARMmbed/mbedtls/pull/4678)
[mbedtls-2.16](https://github.com/ARMmbed/mbedtls/pull/4684)

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Todos
- [x] Changelog
- [x] Backported: [2.x](https://github.com/ARMmbed/mbedtls/pull/4678), [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/pull/4684)


## Steps to test or reproduce
test_suite_aes