### PR TITLE
Backport 2.x: Add missing free context at the end of aes_crypt_xts_size()

### DIFF
--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
+Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
    * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176
+     test suite with an alternative AES implementation. Fixes #4176.

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular 
+   * Fix an issue where resource is never freed when running one particular
      test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
-Fixes #4176
+   * Fix an issue where resource is never freed when running one particular 
+     test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176.
+   * Fix a resource leak in a test suite with an alternative AES
+     implementation. Fixes #4176.

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -210,6 +210,8 @@ void aes_crypt_xts_size( int size, int retval )
     /* Valid pointers are passed for builds with MBEDTLS_CHECK_PARAMS, as
      * otherwise we wouldn't get to the size check we're interested in. */
     TEST_ASSERT( mbedtls_aes_crypt_xts( &ctx, MBEDTLS_AES_ENCRYPT, length, data_unit, src, output ) == retval );
+exit:
+    mbedtls_aes_xts_free( &ctx );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
in file tests/suite/test_suite_aes.function, aes_crypt_xts_size()
did not free the context upon the function exit.
The function now frees the context on exit.

Issue also resolved in [development](https://github.com/ARMmbed/mbedtls/pull/4676)
and [mbedtls-2.16](https://github.com/ARMmbed/mbedtls/pull/4684)

Closes #4176

## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Todos
- [x] Changelog
- [x] Tests

## Steps to test or reproduce
test_suite_aes