### PR TITLE
Backport 2.16: Add Free context at the end of aes_crypt_xts_size()

### DIFF
--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
+Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
    * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176
+     test suite with an alternative AES implementation. Fixes #4176.

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular 
+   * Fix an issue where resource is never freed when running one particular
      test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular test suite with an alternative AES implementation
-Fixes #4176
+   * Fix an issue where resource is never freed when running one particular 
+     test suite with an alternative AES implementation. Fixes #4176

--- a/ChangeLog.d/issue4176.txt
+++ b/ChangeLog.d/issue4176.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an issue where resource is never freed when running one particular
-     test suite with an alternative AES implementation. Fixes #4176.
+   * Fix a resource leak in a test suite with an alternative AES
+     implementation. Fixes #4176.

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -208,6 +208,8 @@ void aes_crypt_xts_size( int size, int retval )
     /* Valid pointers are passed for builds with MBEDTLS_CHECK_PARAMS, as
      * otherwise we wouldn't get to the size check we're interested in. */
     TEST_ASSERT( mbedtls_aes_crypt_xts( &ctx, MBEDTLS_AES_ENCRYPT, length, data_unit, src, output ) == retval );
+exit:
+    mbedtls_aes_xts_free( &ctx );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
in file tests/suite/test_suite_aes.function, aes_crypt_xts_size()
did not free the context upon the function exit.
The function now frees the context on exit.

This modification has also taken place in:
 - [development](https://github.com/ARMmbed/mbedtls/pull/4676) 
 - [2.x](https://github.com/ARMmbed/mbedtls/pull/4678)

Closes #4176

## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO  
There is already a backport for 2.x, and the change has been made on 2.16 (here) and the development branch

## Migrations
NO

## Todos
- [x] Tests
- [x] Changelog updated


## Steps to test or reproduce
test_suite_aes
