### PR TITLE
all.sh: Clean up old files before generating them

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -651,6 +651,9 @@ pre_check_tools () {
 }
 
 pre_generate_files() {
+    # since make doesn't have proper dependencies, remove any possibly outdate
+    # file that might be around before generating fresh ones
+    make neat
     make generated_files
 }
 


### PR DESCRIPTION
I was getting failures that went away when running `make neat` before invoking `all.sh`. 
