### PR TITLE
Fix net_sockets regression on Windows

### DIFF
--- a/ChangeLog.d/winsock.txt
+++ b/ChangeLog.d/winsock.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix mbedtls_net_poll() and mbedtls_net_recv_timeout() often failing with
+     MBEDTLS_ERR_NET_POLL_FAILED on Windows. Fixes #4465.
+

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -145,12 +145,17 @@ static int check_fd( int fd, int for_select )
     if( fd < 0 )
         return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
 
+#if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
+    !defined(EFI32)
+    (void) for_select;
+#else
     /* A limitation of select() is that it only works with file descriptors
      * that are strictly less than FD_SETSIZE. This is a limitation of the
      * fd_set type. Error out early, because attempting to call FD_SET on a
      * large file descriptor is a buffer overflow on typical platforms. */
     if( for_select && fd >= FD_SETSIZE )
         return( MBEDTLS_ERR_NET_POLL_FAILED );
+#endif
 
     return( 0 );
 }


### PR DESCRIPTION
Fix https://github.com/ARMmbed/mbedtls/issues/4465: `mbedtls_net_poll()` and `mbedtls_net_recv_timeout()` became unusable on Windows in Mbed TLS 2.26 and 2.16.10. No intended behavior change on other platforms.

Backports:

* 2.x: https://github.com/ARMmbed/mbedtls/pull/4688
* 2.16: https://github.com/ARMmbed/mbedtls/pull/4689
