### PR TITLE
psa_generate_test: tweak MSVC detection to work with non-English Visual Studio

### DIFF
--- a/scripts/mbedtls_dev/c_build_helper.py
+++ b/scripts/mbedtls_dev/c_build_helper.py
@@ -135,8 +135,7 @@ def get_c_expression_values(
                                 stdout=subprocess.DEVNULL,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True)
-        cc_is_msvc = 'Microsoft (R) C/C++ Optimizing Compiler' in \
-                      proc.communicate()[1]
+        cc_is_msvc = 'Microsoft (R) C/C++' in proc.communicate()[1]
 
         cmd += ['-I' + dir for dir in include_path]
         if cc_is_msvc:


### PR DESCRIPTION
Fix #4699

3.0 only: the corresponding script exists in 2.x, but there it's only a CI script and doesn't even work with MSVC.