### PR TITLE
Psa cipher and mac abort on error

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2394,12 +2394,8 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    /* Set the output length and content to a safe default, such that in
-     * case the caller misses an error check, the output would be an
-     * unachievable MAC. */
-    *mac_length = mac_size;
-
-    if( operation->id == 0 ) {
+    if( operation->id == 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto cleanup;
     }
@@ -2428,6 +2424,7 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
                                                  mac, operation->mac_size,
                                                  mac_length );
 
+cleanup:
     /* In case of success, set the potential excess room in the output buffer
      * to an invalid value, to avoid potentially leaking a longer MAC.
      * In case of error, set the output length and content to a safe default,
@@ -2444,7 +2441,6 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
         memset( &mac[operation->mac_size], '!',
                 mac_size - operation->mac_size );
 
-cleanup:
     abort_status = psa_mac_abort( operation );
 
     return( status == PSA_SUCCESS ? abort_status : status );

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2397,13 +2397,13 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
     if( operation->id == 0 )
     {
         status = PSA_ERROR_BAD_STATE;
-        goto cleanup;
+        goto exit;
     }
 
     if( ! operation->is_sign )
     {
         status = PSA_ERROR_BAD_STATE;
-        goto cleanup;
+        goto exit;
     }
 
     /* Sanity check. This will guarantee that mac_size != 0 (and so mac != NULL)
@@ -2411,20 +2411,20 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
     if( operation->mac_size == 0 )
     {
         status = PSA_ERROR_BAD_STATE;
-        goto cleanup;
+        goto exit;
     }
 
     if( mac_size < operation->mac_size )
     {
         status = PSA_ERROR_BUFFER_TOO_SMALL;
-        goto cleanup;
+        goto exit;
     }
 
     status = psa_driver_wrapper_mac_sign_finish( operation,
                                                  mac, operation->mac_size,
                                                  mac_length );
 
-cleanup:
+exit:
     /* In case of success, set the potential excess room in the output buffer
      * to an invalid value, to avoid potentially leaking a longer MAC.
      * In case of error, set the output length and content to a safe default,
@@ -2456,25 +2456,25 @@ psa_status_t psa_mac_verify_finish( psa_mac_operation_t *operation,
     if( operation->id == 0 )
     {
         status = PSA_ERROR_BAD_STATE;
-        goto cleanup;
+        goto exit;
     }
 
     if( operation->is_sign )
     {
         status = PSA_ERROR_BAD_STATE;
-        goto cleanup;
+        goto exit;
     }
 
     if( operation->mac_size != mac_length )
     {
         status = PSA_ERROR_INVALID_SIGNATURE;
-        goto cleanup;
+        goto exit;
     }
 
     status = psa_driver_wrapper_mac_verify_finish( operation,
                                                    mac, mac_length );
 
-cleanup:
+exit:
     abort_status = psa_mac_abort( operation );
 
     return( status == PSA_SUCCESS ? abort_status : status );

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2083,12 +2083,14 @@ psa_status_t psa_hash_setup( psa_hash_operation_t *operation,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* A context must be freshly initialized before it can be set up. */
-    if( operation->id != 0 ) {
+    if( operation->id != 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
 
-    if( !PSA_ALG_IS_HASH( alg ) ) {
+    if( !PSA_ALG_IS_HASH( alg ) )
+    {
         status = PSA_ERROR_INVALID_ARGUMENT;
         goto exit;
     }
@@ -2101,7 +2103,7 @@ psa_status_t psa_hash_setup( psa_hash_operation_t *operation,
 
 exit:
     if( status != PSA_SUCCESS )
-        psa_hash_abort(operation);
+        psa_hash_abort( operation );
 
     return status;
 }
@@ -2112,7 +2114,8 @@ psa_status_t psa_hash_update( psa_hash_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( operation->id == 0 ) {
+    if( operation->id == 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
@@ -2160,7 +2163,8 @@ psa_status_t psa_hash_verify( psa_hash_operation_t *operation,
     if( status != PSA_SUCCESS )
         goto exit;
 
-    if( actual_hash_length != hash_length ) {
+    if( actual_hash_length != hash_length )
+    {
         status = PSA_ERROR_INVALID_SIGNATURE;
         goto exit;
     }
@@ -2297,7 +2301,8 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
     psa_key_slot_t *slot = NULL;
 
     /* A context must be freshly initialized before it can be set up. */
-    if( operation->id != 0 ) {
+    if( operation->id != 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
@@ -2399,19 +2404,22 @@ psa_status_t psa_mac_sign_finish( psa_mac_operation_t *operation,
         goto cleanup;
     }
 
-    if( ! operation->is_sign ) {
+    if( ! operation->is_sign )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto cleanup;
     }
 
     /* Sanity check. This will guarantee that mac_size != 0 (and so mac != NULL)
      * once all the error checks are done. */
-    if( operation->mac_size == 0 ) {
+    if( operation->mac_size == 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto cleanup;
     }
 
-    if( mac_size < operation->mac_size ) {
+    if( mac_size < operation->mac_size )
+    {
         status = PSA_ERROR_BUFFER_TOO_SMALL;
         goto cleanup;
     }
@@ -2449,12 +2457,14 @@ psa_status_t psa_mac_verify_finish( psa_mac_operation_t *operation,
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t abort_status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( operation->id == 0 ) {
+    if( operation->id == 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto cleanup;
     }
 
-    if( operation->is_sign ) {
+    if( operation->is_sign )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto cleanup;
     }
@@ -3224,13 +3234,15 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
                               PSA_KEY_USAGE_DECRYPT );
 
     /* A context must be freshly initialized before it can be set up. */
-    if( operation->id != 0 ) {
+    if( operation->id != 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
 
     /* The requested algorithm must be one that can be processed by cipher. */
-    if( ! PSA_ALG_IS_CIPHER( alg ) ) {
+    if( ! PSA_ALG_IS_CIPHER( alg ) )
+    {
         status = PSA_ERROR_INVALID_ARGUMENT;
         goto exit;
     }
@@ -3345,17 +3357,20 @@ psa_status_t psa_cipher_set_iv( psa_cipher_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( operation->id == 0 ) {
+    if( operation->id == 0 )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
 
-    if( operation->iv_set || ! operation->iv_required ) {
+    if( operation->iv_set || ! operation->iv_required )
+    {
         status = PSA_ERROR_BAD_STATE;
         goto exit;
     }
 
-    if( iv_length > PSA_CIPHER_IV_MAX_SIZE ) {
+    if( iv_length > PSA_CIPHER_IV_MAX_SIZE )
+    {
         status = PSA_ERROR_INVALID_ARGUMENT;
         goto exit;
     }

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2294,11 +2294,13 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t unlock_status = PSA_ERROR_CORRUPTION_DETECTED;
-    psa_key_slot_t *slot;
+    psa_key_slot_t *slot = NULL;
 
     /* A context must be freshly initialized before it can be set up. */
-    if( operation->id != 0 )
-        return( PSA_ERROR_BAD_STATE );
+    if( operation->id != 0 ) {
+        status = PSA_ERROR_BAD_STATE;
+        goto exit;
+    }
 
     status = psa_get_and_lock_key_slot_with_policy(
                  key,
@@ -2306,7 +2308,7 @@ static psa_status_t psa_mac_setup( psa_mac_operation_t *operation,
                  is_sign ? PSA_KEY_USAGE_SIGN_HASH : PSA_KEY_USAGE_VERIFY_HASH,
                  alg );
     if( status != PSA_SUCCESS )
-        return( status );
+        goto exit;
 
     psa_key_attributes_t attributes = {
         .core = slot->attr
@@ -3216,18 +3218,22 @@ static psa_status_t psa_cipher_setup( psa_cipher_operation_t *operation,
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     psa_status_t unlock_status = PSA_ERROR_CORRUPTION_DETECTED;
-    psa_key_slot_t *slot;
+    psa_key_slot_t *slot = NULL;
     psa_key_usage_t usage = ( cipher_operation == MBEDTLS_ENCRYPT ?
                               PSA_KEY_USAGE_ENCRYPT :
                               PSA_KEY_USAGE_DECRYPT );
 
     /* A context must be freshly initialized before it can be set up. */
-    if( operation->id != 0 )
-        return( PSA_ERROR_BAD_STATE );
+    if( operation->id != 0 ) {
+        status = PSA_ERROR_BAD_STATE;
+        goto exit;
+    }
 
     /* The requested algorithm must be one that can be processed by cipher. */
-    if( ! PSA_ALG_IS_CIPHER( alg ) )
-        return( PSA_ERROR_INVALID_ARGUMENT );
+    if( ! PSA_ALG_IS_CIPHER( alg ) ) {
+        status = PSA_ERROR_INVALID_ARGUMENT;
+        goto exit;
+    }
 
     /* Fetch key material from key storage. */
     status = psa_get_and_lock_key_slot_with_policy( key, &slot, usage, alg );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1559,7 +1559,7 @@ void hash_bad_order( )
 
     /* Check that update calls abort on error. */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    operation.ctx.mbedtls_ctx.alg = PSA_ALG_XTS;
+    operation.id = UINT_MAX;
     ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_hash_update( &operation, input, sizeof( input ) ),
                 PSA_ERROR_BAD_STATE );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2305,6 +2305,7 @@ void cipher_bad_order( )
     PSA_ASSERT( psa_cipher_abort( &operation ) );
 
     /* Call update without an IV where an IV is required. */
+    PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
     TEST_EQUAL( psa_cipher_update( &operation,
                                    text, sizeof( text ),
                                    buffer, sizeof( buffer ),

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1545,14 +1545,27 @@ void hash_bad_order( )
 
     /* Call setup twice in a row. */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_hash_setup( &operation, alg ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_hash_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call update without calling setup beforehand. */
     TEST_EQUAL( psa_hash_update( &operation, input, sizeof( input ) ),
                 PSA_ERROR_BAD_STATE );
     PSA_ASSERT( psa_hash_abort( &operation ) );
+
+    /* Check that update calls abort on error. */
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    operation.ctx.mbedtls_ctx.alg = PSA_ALG_XTS;
+    ASSERT_OPERATION_IS_ACTIVE( operation );
+    TEST_EQUAL( psa_hash_update( &operation, input, sizeof( input ) ),
+                PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
+    PSA_ASSERT( psa_hash_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call update after finish. */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
@@ -1579,11 +1592,14 @@ void hash_bad_order( )
 
     /* Call verify twice in a row. */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     PSA_ASSERT( psa_hash_verify( &operation,
                                  valid_hash, sizeof( valid_hash ) ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     TEST_EQUAL( psa_hash_verify( &operation,
                                  valid_hash, sizeof( valid_hash ) ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_hash_abort( &operation ) );
 
     /* Call finish without calling setup beforehand. */
@@ -1632,8 +1648,12 @@ void hash_verify_bad_args( )
 
     /* psa_hash_verify with a smaller hash than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_hash_verify( &operation, hash, expected_size - 1 ),
                 PSA_ERROR_INVALID_SIGNATURE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
+    PSA_ASSERT( psa_hash_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* psa_hash_verify with a non-matching hash */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
@@ -1876,9 +1896,12 @@ void mac_bad_order( )
 
     /* Call setup twice in a row. */
     PSA_ASSERT( psa_mac_sign_setup( &operation, key, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_mac_sign_setup( &operation, key, alg ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_mac_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call update after sign finish. */
     PSA_ASSERT( psa_mac_sign_setup( &operation, key, alg ) );
@@ -2244,15 +2267,21 @@ void cipher_bad_order( )
 
     /* Call encrypt setup twice in a row. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_encrypt_setup( &operation, key, alg ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call decrypt setup twice in a row. */
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation, key, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_decrypt_setup( &operation, key, alg ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Generate an IV without calling setup beforehand. */
     TEST_EQUAL( psa_cipher_generate_iv( &operation,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -19,6 +19,11 @@
 /* If this comes up, it's a bug in the test code or in the test data. */
 #define UNUSED 0xdeadbeef
 
+/* Assert that an operation is (not) active.
+ * This serves as a proxy for checking if the operation is aborted. */
+#define ASSERT_OPERATION_IS_ACTIVE(   operation ) TEST_ASSERT( operation.id != 0 )
+#define ASSERT_OPERATION_IS_INACTIVE( operation ) TEST_ASSERT( operation.id == 0 )
+
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;
 
@@ -1919,19 +1924,25 @@ void mac_bad_order( )
     /* Setup sign but try verify. */
     PSA_ASSERT( psa_mac_sign_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_mac_update( &operation, input, sizeof( input ) ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_mac_verify_finish( &operation,
                                        verify_mac, sizeof( verify_mac ) ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_mac_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Setup verify but try sign. */
     PSA_ASSERT( psa_mac_verify_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_mac_update( &operation, input, sizeof( input ) ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_mac_sign_finish( &operation,
                                      sign_mac, sizeof( sign_mac ),
                                      &sign_mac_length ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_mac_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     PSA_ASSERT( psa_destroy_key( key ) );
 
@@ -2255,11 +2266,14 @@ void cipher_bad_order( )
     PSA_ASSERT( psa_cipher_generate_iv( &operation,
                                         buffer, sizeof( buffer ),
                                         &length ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_generate_iv( &operation,
                                         buffer, sizeof( buffer ),
                                         &length ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Generate an IV after it's already set. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
@@ -2281,10 +2295,13 @@ void cipher_bad_order( )
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
     PSA_ASSERT( psa_cipher_set_iv( &operation,
                                    iv, sizeof( iv ) ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_set_iv( &operation,
                                    iv, sizeof( iv ) ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Set an IV after it's already generated. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
@@ -2306,12 +2323,15 @@ void cipher_bad_order( )
 
     /* Call update without an IV where an IV is required. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_update( &operation,
                                    text, sizeof( text ),
                                    buffer, sizeof( buffer ),
                                    &length ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call update after finish. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
@@ -2336,10 +2356,13 @@ void cipher_bad_order( )
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );
     /* Not calling update means we are encrypting an empty buffer, which is OK
      * for cipher modes with padding. */
+    ASSERT_OPERATION_IS_ACTIVE( operation );
     TEST_EQUAL( psa_cipher_finish( &operation,
                                    buffer, sizeof( buffer ), &length ),
                 PSA_ERROR_BAD_STATE );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+    ASSERT_OPERATION_IS_INACTIVE( operation );
 
     /* Call finish twice in a row. */
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation, key, alg ) );


### PR DESCRIPTION
Addresses #4709 . Ensure that psa_cipher_abort and psa_mac_abort are called on error in some psa_cipher_xxx() and psa_mac_xxx() functions.

## Requires Backporting
Yes, for 2.x
