### PR TITLE
Backport 2.16: pk.c: Ensure min hash_len in pk_hashlen_helper

### DIFF
--- a/ChangeLog.d/ensure_hash_len_is_valid.txt
+++ b/ChangeLog.d/ensure_hash_len_is_valid.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * mbedtls_pk_sign() and mbedtls_pk_verify() and their extended and
+     restartable variants now require at least the specified hash length if
+     nonzero. Before, for RSA, hash_len was ignored in favor of the length of
+     the specified hash algorithm.

--- a/library/pk.c
+++ b/library/pk.c
@@ -225,11 +225,14 @@ static inline int pk_hashlen_helper( mbedtls_md_type_t md_alg, size_t *hash_len 
 {
     const mbedtls_md_info_t *md_info;
 
-    if( *hash_len != 0 )
+    if( *hash_len != 0 && md_alg == MBEDTLS_MD_NONE )
         return( 0 );
 
     if( ( md_info = mbedtls_md_info_from_type( md_alg ) ) == NULL )
         return( -1 );
+
+    if ( *hash_len != 0 && *hash_len < mbedtls_md_get_size( md_info ) )
+        return ( -1 );
 
     *hash_len = mbedtls_md_get_size( md_info );
     return( 0 );


### PR DESCRIPTION
Backport of #4561 . Related to other backport for `development_2.x` #4718.

Very similar except rather than requiring the given `hashlen` to be equal to `mbedtls_md_get_size( md_info )`, it must be at least `mbedtls_md_get_size( md_info )`. This will not break the current `pk` tests so no commits were added like they were in #4561 and #4718 to address test failures. 