### PR TITLE
Backport 2.16: Byte Reading Macros

### DIFF
--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -1,4 +1,0 @@
-Changes
-   * Create 4 byte reading macros in relevant files in library/:
-     MBEDTLS_BYTE_0... MBEDTLS_BYTE_3. Fixes #4274.
-

--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -1,0 +1,3 @@
+Changes
+   * Create 4 byte reading macros in relevant files in library/:
+     MBEDTLS_BYTE_0... MBEDTLS_BYTE_3. Fixes #4274.

--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -1,3 +1,4 @@
 Changes
    * Create 4 byte reading macros in relevant files in library/:
      MBEDTLS_BYTE_0... MBEDTLS_BYTE_3. Fixes #4274.
+

--- a/library/aes.c
+++ b/library/aes.c
@@ -81,11 +81,18 @@
 
 #if !defined(MBEDTLS_AES_ALT)
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 /* Parameter validation macros based on platform_util.h */
 #define AES_VALIDATE_RET( cond )    \
     MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_AES_BAD_INPUT_DATA )
 #define AES_VALIDATE( cond )        \
     MBEDTLS_INTERNAL_VALIDATE( cond )
+
 
 /*
  * 32-bit integer manipulation macros (little endian)
@@ -439,7 +446,7 @@ static void aes_gen_tables( void )
     {
         pow[i] = x;
         log[x] = i;
-        x = ( x ^ XTIME( x ) ) & 0xFF;
+        x = BYTE_0( x ^ XTIME( x ) );
     }
 
     /*
@@ -448,7 +455,7 @@ static void aes_gen_tables( void )
     for( i = 0, x = 1; i < 10; i++ )
     {
         RCON[i] = (uint32_t) x;
-        x = XTIME( x ) & 0xFF;
+        x = BYTE_0( XTIME( x ) );
     }
 
     /*
@@ -461,10 +468,10 @@ static void aes_gen_tables( void )
     {
         x = pow[255 - log[i]];
 
-        y  = x; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        y  = x; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
         x ^= y ^ 0x63;
 
         FSb[i] = (unsigned char) x;
@@ -477,8 +484,8 @@ static void aes_gen_tables( void )
     for( i = 0; i < 256; i++ )
     {
         x = FSb[i];
-        y = XTIME( x ) & 0xFF;
-        z =  ( y ^ x ) & 0xFF;
+        y = BYTE_0( XTIME( x ) );
+        z = BYTE_0( y ^ x );
 
         FT0[i] = ( (uint32_t) y       ) ^
                  ( (uint32_t) x <<  8 ) ^
@@ -630,10 +637,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 10; i++, RK += 4 )
             {
                 RK[4]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[3] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[3] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[3] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[3]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ BYTE_1( RK[3] ) ]       ) ^
+                ( (uint32_t) FSb[ BYTE_2( RK[3] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ BYTE_3( RK[3] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ BYTE_0( RK[3] ) ] << 24 );
 
                 RK[5]  = RK[1] ^ RK[4];
                 RK[6]  = RK[2] ^ RK[5];
@@ -646,10 +653,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 8; i++, RK += 6 )
             {
                 RK[6]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[5] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[5] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[5] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[5]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ BYTE_1( RK[5] ) ]       ) ^
+                ( (uint32_t) FSb[ BYTE_2( RK[5] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ BYTE_3( RK[5] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ BYTE_0( RK[5] ) ] << 24 );
 
                 RK[7]  = RK[1] ^ RK[6];
                 RK[8]  = RK[2] ^ RK[7];
@@ -664,20 +671,20 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 7; i++, RK += 8 )
             {
                 RK[8]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[7] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[7] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[7] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[7]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ BYTE_1( RK[7] ) ]       ) ^
+                ( (uint32_t) FSb[ BYTE_2( RK[7] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ BYTE_3( RK[7] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ BYTE_0( RK[7] ) ] << 24 );
 
                 RK[9]  = RK[1] ^ RK[8];
                 RK[10] = RK[2] ^ RK[9];
                 RK[11] = RK[3] ^ RK[10];
 
                 RK[12] = RK[4] ^
-                ( (uint32_t) FSb[ ( RK[11]       ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[11] >>  8 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[11] >> 16 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[11] >> 24 ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ BYTE_0( RK[11] ) ]       ) ^
+                ( (uint32_t) FSb[ BYTE_1( RK[11] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ BYTE_2( RK[11] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ BYTE_3( RK[11] ) ] << 24 );
 
                 RK[13] = RK[5] ^ RK[12];
                 RK[14] = RK[6] ^ RK[13];
@@ -743,10 +750,10 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
     {
         for( j = 0; j < 4; j++, SK++ )
         {
-            *RK++ = AES_RT0( FSb[ ( *SK       ) & 0xFF ] ) ^
-                    AES_RT1( FSb[ ( *SK >>  8 ) & 0xFF ] ) ^
-                    AES_RT2( FSb[ ( *SK >> 16 ) & 0xFF ] ) ^
-                    AES_RT3( FSb[ ( *SK >> 24 ) & 0xFF ] );
+            *RK++ = AES_RT0( FSb[ BYTE_0( *SK ) ] ) ^
+                    AES_RT1( FSb[ BYTE_1( *SK ) ] ) ^
+                    AES_RT2( FSb[ BYTE_2( *SK ) ] ) ^
+                    AES_RT3( FSb[ BYTE_3( *SK ) ] );
         }
     }
 
@@ -842,49 +849,49 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
 #define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                     \
     do                                                          \
     {                                                           \
-        (X0) = *RK++ ^ AES_FT0( ( (Y0)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y1) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y2) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y3) >> 24 ) & 0xFF );        \
-                                                                \
-        (X1) = *RK++ ^ AES_FT0( ( (Y1)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y2) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y3) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y0) >> 24 ) & 0xFF );        \
-                                                                \
-        (X2) = *RK++ ^ AES_FT0( ( (Y2)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y3) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y0) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y1) >> 24 ) & 0xFF );        \
-                                                                \
-        (X3) = *RK++ ^ AES_FT0( ( (Y3)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y0) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y1) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y2) >> 24 ) & 0xFF );        \
+        (X0) = *RK++ ^ AES_FT0( BYTE_0( Y0 ) ) ^    \
+                       AES_FT1( BYTE_1( Y1 ) ) ^    \
+                       AES_FT2( BYTE_2( Y2 ) ) ^    \
+                       AES_FT3( BYTE_3( Y3 ) );     \
+                                                    \
+        (X1) = *RK++ ^ AES_FT0( BYTE_0( Y1 ) ) ^    \
+                       AES_FT1( BYTE_1( Y2 ) ) ^    \
+                       AES_FT2( BYTE_2( Y3 ) ) ^    \
+                       AES_FT3( BYTE_3( Y0 ) );     \
+                                                    \
+        (X2) = *RK++ ^ AES_FT0( BYTE_0( Y2 ) ) ^    \
+                       AES_FT1( BYTE_1( Y3 ) ) ^    \
+                       AES_FT2( BYTE_2( Y0 ) ) ^    \
+                       AES_FT3( BYTE_3( Y1 ) );     \
+                                                    \
+        (X3) = *RK++ ^ AES_FT0( BYTE_0( Y3 ) ) ^    \
+                       AES_FT1( BYTE_1( Y0 ) ) ^    \
+                       AES_FT2( BYTE_2( Y1 ) ) ^    \
+                       AES_FT3( BYTE_3( Y2 ) );     \
     } while( 0 )
 
 #define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                 \
     do                                                      \
     {                                                       \
-        (X0) = *RK++ ^ AES_RT0( ( (Y0)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y3) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y2) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y1) >> 24 ) & 0xFF );    \
-                                                            \
-        (X1) = *RK++ ^ AES_RT0( ( (Y1)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y0) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y3) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y2) >> 24 ) & 0xFF );    \
-                                                            \
-        (X2) = *RK++ ^ AES_RT0( ( (Y2)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y1) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y0) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y3) >> 24 ) & 0xFF );    \
-                                                            \
-        (X3) = *RK++ ^ AES_RT0( ( (Y3)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y2) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y1) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y0) >> 24 ) & 0xFF );    \
+        (X0) = *RK++ ^ AES_RT0( BYTE_0( Y0 ) ) ^    \
+                       AES_RT1( BYTE_1( Y3 ) ) ^    \
+                       AES_RT2( BYTE_2( Y2 ) ) ^    \
+                       AES_RT3( BYTE_3( Y1 ) );     \
+                                                    \
+        (X1) = *RK++ ^ AES_RT0( BYTE_0( Y1 ) ) ^    \
+                       AES_RT1( BYTE_1( Y0 ) ) ^    \
+                       AES_RT2( BYTE_2( Y3 ) ) ^    \
+                       AES_RT3( BYTE_3( Y2 ) );     \
+                                                    \
+        (X2) = *RK++ ^ AES_RT0( BYTE_0( Y2 ) ) ^    \
+                       AES_RT1( BYTE_1( Y1 ) ) ^    \
+                       AES_RT2( BYTE_2( Y0 ) ) ^    \
+                       AES_RT3( BYTE_3( Y3 ) );     \
+                                                    \
+        (X3) = *RK++ ^ AES_RT0( BYTE_0( Y3 ) ) ^    \
+                       AES_RT1( BYTE_1( Y2 ) ) ^    \
+                       AES_RT2( BYTE_2( Y1 ) ) ^    \
+                       AES_RT3( BYTE_3( Y0 ) );     \
     } while( 0 )
 
 /*
@@ -917,28 +924,28 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     AES_FROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[0]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) FSb[ BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[1]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) FSb[ BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ BYTE_3( t.Y[0] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[2]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) FSb[ BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[3]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) FSb[ BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ BYTE_3( t.Y[2] ) ] << 24 );
 
     PUT_UINT32_LE( t.X[0], output,  0 );
     PUT_UINT32_LE( t.X[1], output,  4 );
@@ -990,28 +997,28 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
     AES_RROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[0]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) RSb[ BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[1]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) RSb[ BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ BYTE_3( t.Y[2] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[2]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) RSb[ BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[3]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) RSb[ BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ BYTE_3( t.Y[0] ) ] << 24 );
 
     PUT_UINT32_LE( t.X[0], output,  0 );
     PUT_UINT32_LE( t.X[1], output,  4 );

--- a/library/aes.c
+++ b/library/aes.c
@@ -93,7 +93,6 @@
 #define AES_VALIDATE( cond )        \
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
-
 /*
  * 32-bit integer manipulation macros (little endian)
  */

--- a/library/aes.c
+++ b/library/aes.c
@@ -82,10 +82,10 @@
 #if !defined(MBEDTLS_AES_ALT)
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 /* Parameter validation macros based on platform_util.h */
 #define AES_VALIDATE_RET( cond )    \
@@ -445,7 +445,7 @@ static void aes_gen_tables( void )
     {
         pow[i] = x;
         log[x] = i;
-        x = BYTE_0( x ^ XTIME( x ) );
+        x = MBEDTLS_BYTE_0( x ^ XTIME( x ) );
     }
 
     /*
@@ -454,7 +454,7 @@ static void aes_gen_tables( void )
     for( i = 0, x = 1; i < 10; i++ )
     {
         RCON[i] = (uint32_t) x;
-        x = BYTE_0( XTIME( x ) );
+        x = MBEDTLS_BYTE_0( XTIME( x ) );
     }
 
     /*
@@ -467,10 +467,10 @@ static void aes_gen_tables( void )
     {
         x = pow[255 - log[i]];
 
-        y  = x; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
-        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
-        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
-        x ^= y; y = BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        y  = x; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
         x ^= y ^ 0x63;
 
         FSb[i] = (unsigned char) x;
@@ -483,8 +483,8 @@ static void aes_gen_tables( void )
     for( i = 0; i < 256; i++ )
     {
         x = FSb[i];
-        y = BYTE_0( XTIME( x ) );
-        z = BYTE_0( y ^ x );
+        y = MBEDTLS_BYTE_0( XTIME( x ) );
+        z = MBEDTLS_BYTE_0( y ^ x );
 
         FT0[i] = ( (uint32_t) y       ) ^
                  ( (uint32_t) x <<  8 ) ^
@@ -636,10 +636,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 10; i++, RK += 4 )
             {
                 RK[4]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ BYTE_1( RK[3] ) ]       ) ^
-                ( (uint32_t) FSb[ BYTE_2( RK[3] ) ] <<  8 ) ^
-                ( (uint32_t) FSb[ BYTE_3( RK[3] ) ] << 16 ) ^
-                ( (uint32_t) FSb[ BYTE_0( RK[3] ) ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[3] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[3] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[3] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[3] ) ] << 24 );
 
                 RK[5]  = RK[1] ^ RK[4];
                 RK[6]  = RK[2] ^ RK[5];
@@ -652,10 +652,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 8; i++, RK += 6 )
             {
                 RK[6]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ BYTE_1( RK[5] ) ]       ) ^
-                ( (uint32_t) FSb[ BYTE_2( RK[5] ) ] <<  8 ) ^
-                ( (uint32_t) FSb[ BYTE_3( RK[5] ) ] << 16 ) ^
-                ( (uint32_t) FSb[ BYTE_0( RK[5] ) ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[5] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[5] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[5] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[5] ) ] << 24 );
 
                 RK[7]  = RK[1] ^ RK[6];
                 RK[8]  = RK[2] ^ RK[7];
@@ -670,20 +670,20 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 7; i++, RK += 8 )
             {
                 RK[8]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ BYTE_1( RK[7] ) ]       ) ^
-                ( (uint32_t) FSb[ BYTE_2( RK[7] ) ] <<  8 ) ^
-                ( (uint32_t) FSb[ BYTE_3( RK[7] ) ] << 16 ) ^
-                ( (uint32_t) FSb[ BYTE_0( RK[7] ) ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[7] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[7] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[7] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[7] ) ] << 24 );
 
                 RK[9]  = RK[1] ^ RK[8];
                 RK[10] = RK[2] ^ RK[9];
                 RK[11] = RK[3] ^ RK[10];
 
                 RK[12] = RK[4] ^
-                ( (uint32_t) FSb[ BYTE_0( RK[11] ) ]       ) ^
-                ( (uint32_t) FSb[ BYTE_1( RK[11] ) ] <<  8 ) ^
-                ( (uint32_t) FSb[ BYTE_2( RK[11] ) ] << 16 ) ^
-                ( (uint32_t) FSb[ BYTE_3( RK[11] ) ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[11] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[11] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[11] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[11] ) ] << 24 );
 
                 RK[13] = RK[5] ^ RK[12];
                 RK[14] = RK[6] ^ RK[13];
@@ -749,10 +749,10 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
     {
         for( j = 0; j < 4; j++, SK++ )
         {
-            *RK++ = AES_RT0( FSb[ BYTE_0( *SK ) ] ) ^
-                    AES_RT1( FSb[ BYTE_1( *SK ) ] ) ^
-                    AES_RT2( FSb[ BYTE_2( *SK ) ] ) ^
-                    AES_RT3( FSb[ BYTE_3( *SK ) ] );
+            *RK++ = AES_RT0( FSb[ MBEDTLS_BYTE_0( *SK ) ] ) ^
+                    AES_RT1( FSb[ MBEDTLS_BYTE_1( *SK ) ] ) ^
+                    AES_RT2( FSb[ MBEDTLS_BYTE_2( *SK ) ] ) ^
+                    AES_RT3( FSb[ MBEDTLS_BYTE_3( *SK ) ] );
         }
     }
 
@@ -848,49 +848,49 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
 #define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                     \
     do                                                          \
     {                                                           \
-        (X0) = *RK++ ^ AES_FT0( BYTE_0( Y0 ) ) ^    \
-                       AES_FT1( BYTE_1( Y1 ) ) ^    \
-                       AES_FT2( BYTE_2( Y2 ) ) ^    \
-                       AES_FT3( BYTE_3( Y3 ) );     \
+        (X0) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y0 ) ) ^    \
+                       AES_FT1( MBEDTLS_BYTE_1( Y1 ) ) ^    \
+                       AES_FT2( MBEDTLS_BYTE_2( Y2 ) ) ^    \
+                       AES_FT3( MBEDTLS_BYTE_3( Y3 ) );     \
                                                     \
-        (X1) = *RK++ ^ AES_FT0( BYTE_0( Y1 ) ) ^    \
-                       AES_FT1( BYTE_1( Y2 ) ) ^    \
-                       AES_FT2( BYTE_2( Y3 ) ) ^    \
-                       AES_FT3( BYTE_3( Y0 ) );     \
+        (X1) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y1 ) ) ^    \
+                       AES_FT1( MBEDTLS_BYTE_1( Y2 ) ) ^    \
+                       AES_FT2( MBEDTLS_BYTE_2( Y3 ) ) ^    \
+                       AES_FT3( MBEDTLS_BYTE_3( Y0 ) );     \
                                                     \
-        (X2) = *RK++ ^ AES_FT0( BYTE_0( Y2 ) ) ^    \
-                       AES_FT1( BYTE_1( Y3 ) ) ^    \
-                       AES_FT2( BYTE_2( Y0 ) ) ^    \
-                       AES_FT3( BYTE_3( Y1 ) );     \
+        (X2) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y2 ) ) ^    \
+                       AES_FT1( MBEDTLS_BYTE_1( Y3 ) ) ^    \
+                       AES_FT2( MBEDTLS_BYTE_2( Y0 ) ) ^    \
+                       AES_FT3( MBEDTLS_BYTE_3( Y1 ) );     \
                                                     \
-        (X3) = *RK++ ^ AES_FT0( BYTE_0( Y3 ) ) ^    \
-                       AES_FT1( BYTE_1( Y0 ) ) ^    \
-                       AES_FT2( BYTE_2( Y1 ) ) ^    \
-                       AES_FT3( BYTE_3( Y2 ) );     \
+        (X3) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y3 ) ) ^    \
+                       AES_FT1( MBEDTLS_BYTE_1( Y0 ) ) ^    \
+                       AES_FT2( MBEDTLS_BYTE_2( Y1 ) ) ^    \
+                       AES_FT3( MBEDTLS_BYTE_3( Y2 ) );     \
     } while( 0 )
 
 #define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                 \
     do                                                      \
     {                                                       \
-        (X0) = *RK++ ^ AES_RT0( BYTE_0( Y0 ) ) ^    \
-                       AES_RT1( BYTE_1( Y3 ) ) ^    \
-                       AES_RT2( BYTE_2( Y2 ) ) ^    \
-                       AES_RT3( BYTE_3( Y1 ) );     \
+        (X0) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y0 ) ) ^    \
+                       AES_RT1( MBEDTLS_BYTE_1( Y3 ) ) ^    \
+                       AES_RT2( MBEDTLS_BYTE_2( Y2 ) ) ^    \
+                       AES_RT3( MBEDTLS_BYTE_3( Y1 ) );     \
                                                     \
-        (X1) = *RK++ ^ AES_RT0( BYTE_0( Y1 ) ) ^    \
-                       AES_RT1( BYTE_1( Y0 ) ) ^    \
-                       AES_RT2( BYTE_2( Y3 ) ) ^    \
-                       AES_RT3( BYTE_3( Y2 ) );     \
+        (X1) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y1 ) ) ^    \
+                       AES_RT1( MBEDTLS_BYTE_1( Y0 ) ) ^    \
+                       AES_RT2( MBEDTLS_BYTE_2( Y3 ) ) ^    \
+                       AES_RT3( MBEDTLS_BYTE_3( Y2 ) );     \
                                                     \
-        (X2) = *RK++ ^ AES_RT0( BYTE_0( Y2 ) ) ^    \
-                       AES_RT1( BYTE_1( Y1 ) ) ^    \
-                       AES_RT2( BYTE_2( Y0 ) ) ^    \
-                       AES_RT3( BYTE_3( Y3 ) );     \
+        (X2) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y2 ) ) ^    \
+                       AES_RT1( MBEDTLS_BYTE_1( Y1 ) ) ^    \
+                       AES_RT2( MBEDTLS_BYTE_2( Y0 ) ) ^    \
+                       AES_RT3( MBEDTLS_BYTE_3( Y3 ) );     \
                                                     \
-        (X3) = *RK++ ^ AES_RT0( BYTE_0( Y3 ) ) ^    \
-                       AES_RT1( BYTE_1( Y2 ) ) ^    \
-                       AES_RT2( BYTE_2( Y1 ) ) ^    \
-                       AES_RT3( BYTE_3( Y0 ) );     \
+        (X3) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y3 ) ) ^    \
+                       AES_RT1( MBEDTLS_BYTE_1( Y2 ) ) ^    \
+                       AES_RT2( MBEDTLS_BYTE_2( Y1 ) ) ^    \
+                       AES_RT3( MBEDTLS_BYTE_3( Y0 ) );     \
     } while( 0 )
 
 /*
@@ -923,28 +923,28 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     AES_FROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) FSb[ BYTE_0( t.Y[0] ) ]       ) ^
-            ( (uint32_t) FSb[ BYTE_1( t.Y[1] ) ] <<  8 ) ^
-            ( (uint32_t) FSb[ BYTE_2( t.Y[2] ) ] << 16 ) ^
-            ( (uint32_t) FSb[ BYTE_3( t.Y[3] ) ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) FSb[ BYTE_0( t.Y[1] ) ]       ) ^
-            ( (uint32_t) FSb[ BYTE_1( t.Y[2] ) ] <<  8 ) ^
-            ( (uint32_t) FSb[ BYTE_2( t.Y[3] ) ] << 16 ) ^
-            ( (uint32_t) FSb[ BYTE_3( t.Y[0] ) ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[0] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) FSb[ BYTE_0( t.Y[2] ) ]       ) ^
-            ( (uint32_t) FSb[ BYTE_1( t.Y[3] ) ] <<  8 ) ^
-            ( (uint32_t) FSb[ BYTE_2( t.Y[0] ) ] << 16 ) ^
-            ( (uint32_t) FSb[ BYTE_3( t.Y[1] ) ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) FSb[ BYTE_0( t.Y[3] ) ]       ) ^
-            ( (uint32_t) FSb[ BYTE_1( t.Y[0] ) ] <<  8 ) ^
-            ( (uint32_t) FSb[ BYTE_2( t.Y[1] ) ] << 16 ) ^
-            ( (uint32_t) FSb[ BYTE_3( t.Y[2] ) ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[2] ) ] << 24 );
 
     PUT_UINT32_LE( t.X[0], output,  0 );
     PUT_UINT32_LE( t.X[1], output,  4 );
@@ -996,28 +996,28 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
     AES_RROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) RSb[ BYTE_0( t.Y[0] ) ]       ) ^
-            ( (uint32_t) RSb[ BYTE_1( t.Y[3] ) ] <<  8 ) ^
-            ( (uint32_t) RSb[ BYTE_2( t.Y[2] ) ] << 16 ) ^
-            ( (uint32_t) RSb[ BYTE_3( t.Y[1] ) ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) RSb[ BYTE_0( t.Y[1] ) ]       ) ^
-            ( (uint32_t) RSb[ BYTE_1( t.Y[0] ) ] <<  8 ) ^
-            ( (uint32_t) RSb[ BYTE_2( t.Y[3] ) ] << 16 ) ^
-            ( (uint32_t) RSb[ BYTE_3( t.Y[2] ) ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[2] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) RSb[ BYTE_0( t.Y[2] ) ]       ) ^
-            ( (uint32_t) RSb[ BYTE_1( t.Y[1] ) ] <<  8 ) ^
-            ( (uint32_t) RSb[ BYTE_2( t.Y[0] ) ] << 16 ) ^
-            ( (uint32_t) RSb[ BYTE_3( t.Y[3] ) ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) RSb[ BYTE_0( t.Y[3] ) ]       ) ^
-            ( (uint32_t) RSb[ BYTE_1( t.Y[2] ) ] <<  8 ) ^
-            ( (uint32_t) RSb[ BYTE_2( t.Y[1] ) ] << 16 ) ^
-            ( (uint32_t) RSb[ BYTE_3( t.Y[0] ) ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[0] ) ] << 24 );
 
     PUT_UINT32_LE( t.X[0], output,  0 );
     PUT_UINT32_LE( t.X[1], output,  4 );

--- a/library/aes.c
+++ b/library/aes.c
@@ -96,8 +96,8 @@
 /*
  * 32-bit integer manipulation macros (little endian)
  */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ]       )             \
         | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
@@ -106,8 +106,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                    \
 {                                                               \
     (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
     (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -626,7 +626,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 
     for( i = 0; i < ( keybits >> 5 ); i++ )
     {
-        GET_UINT32_LE( RK[i], key, i << 2 );
+        MBEDTLS_GET_UINT32_LE( RK[i], key, i << 2 );
     }
 
     switch( ctx->nr )
@@ -909,10 +909,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {
@@ -946,10 +946,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
             ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
             ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[2] ) ] << 24 );
 
-    PUT_UINT32_LE( t.X[0], output,  0 );
-    PUT_UINT32_LE( t.X[1], output,  4 );
-    PUT_UINT32_LE( t.X[2], output,  8 );
-    PUT_UINT32_LE( t.X[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( t.X[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( t.X[3], output, 12 );
 
     mbedtls_platform_zeroize( &t, sizeof( t ) );
 
@@ -982,10 +982,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {
@@ -1019,10 +1019,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
             ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
             ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[0] ) ] << 24 );
 
-    PUT_UINT32_LE( t.X[0], output,  0 );
-    PUT_UINT32_LE( t.X[1], output,  4 );
-    PUT_UINT32_LE( t.X[2], output,  8 );
-    PUT_UINT32_LE( t.X[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( t.X[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( t.X[3], output, 12 );
 
     mbedtls_platform_zeroize( &t, sizeof( t ) );
 
@@ -1152,8 +1152,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 
 /* Endianess with 64 bits values */
-#ifndef GET_UINT64_LE
-#define GET_UINT64_LE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT64_LE
+#define MBEDTLS_GET_UINT64_LE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint64_t) (b)[(i) + 7] << 56 )             \
         | ( (uint64_t) (b)[(i) + 6] << 48 )             \
@@ -1166,8 +1166,8 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 }
 #endif
 
-#ifndef PUT_UINT64_LE
-#define PUT_UINT64_LE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT64_LE
+#define MBEDTLS_PUT_UINT64_LE(n,b,i)                            \
 {                                                       \
     (b)[(i) + 7] = (unsigned char) ( (n) >> 56 );       \
     (b)[(i) + 6] = (unsigned char) ( (n) >> 48 );       \
@@ -1195,14 +1195,14 @@ static void mbedtls_gf128mul_x_ble( unsigned char r[16],
 {
     uint64_t a, b, ra, rb;
 
-    GET_UINT64_LE( a, x, 0 );
-    GET_UINT64_LE( b, x, 8 );
+    MBEDTLS_GET_UINT64_LE( a, x, 0 );
+    MBEDTLS_GET_UINT64_LE( b, x, 8 );
 
     ra = ( a << 1 )  ^ 0x0087 >> ( 8 - ( ( b >> 63 ) << 3 ) );
     rb = ( a >> 63 ) | ( b << 1 );
 
-    PUT_UINT64_LE( ra, r, 0 );
-    PUT_UINT64_LE( rb, r, 8 );
+    MBEDTLS_PUT_UINT64_LE( ra, r, 0 );
+    MBEDTLS_PUT_UINT64_LE( rb, r, 8 );
 }
 
 /*

--- a/library/aria.c
+++ b/library/aria.c
@@ -109,6 +109,12 @@
 }
 #endif
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 /*
  * modify byte order: ( A B C D ) -> ( B A D C ), i.e. swap pairs of bytes
  *
@@ -266,22 +272,22 @@ static inline void aria_sl( uint32_t *a, uint32_t *b,
                             const uint8_t sa[256], const uint8_t sb[256],
                             const uint8_t sc[256], const uint8_t sd[256] )
 {
-    *a = ( (uint32_t) sa[ *a        & 0xFF]       ) ^
-         (((uint32_t) sb[(*a >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*a >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *a >> 24        ]) << 24);
-    *b = ( (uint32_t) sa[ *b        & 0xFF]       ) ^
-         (((uint32_t) sb[(*b >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*b >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *b >> 24        ]) << 24);
-    *c = ( (uint32_t) sa[ *c        & 0xFF]       ) ^
-         (((uint32_t) sb[(*c >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*c >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *c >> 24        ]) << 24);
-    *d = ( (uint32_t) sa[ *d        & 0xFF]       ) ^
-         (((uint32_t) sb[(*d >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*d >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *d >> 24        ]) << 24);
+    *a = ( (uint32_t) sa[ BYTE_0( *a ) ]       ) ^
+         (((uint32_t) sb[ BYTE_1( *a ) ]) <<  8) ^
+         (((uint32_t) sc[ BYTE_2( *a ) ]) << 16) ^
+         (((uint32_t) sd[ *a >> 24     ]) << 24);
+    *b = ( (uint32_t) sa[ BYTE_0( *b ) ]       ) ^
+         (((uint32_t) sb[ BYTE_1( *b ) ]) <<  8) ^
+         (((uint32_t) sc[ BYTE_2( *b ) ]) << 16) ^
+         (((uint32_t) sd[ *b >> 24     ]) << 24);
+    *c = ( (uint32_t) sa[ BYTE_0( *c ) ]       ) ^
+         (((uint32_t) sb[ BYTE_1( *c ) ]) <<  8) ^
+         (((uint32_t) sc[ BYTE_2( *c ) ]) << 16) ^
+         (((uint32_t) sd[ *c >> 24     ]) << 24);
+    *d = ( (uint32_t) sa[ BYTE_0( *d ) ]       ) ^
+         (((uint32_t) sb[ BYTE_1( *d ) ]) <<  8) ^
+         (((uint32_t) sc[ BYTE_2( *d ) ]) << 16) ^
+         (((uint32_t) sd[ *d >> 24     ]) << 24);
 }
 
 /*

--- a/library/aria.c
+++ b/library/aria.c
@@ -89,8 +89,8 @@
 /*
  * 32-bit integer manipulation macros (little endian)
  */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE( n, b, i )                \
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE( n, b, i )                \
 {                                               \
     (n) = ( (uint32_t) (b)[(i)    ]       )     \
         | ( (uint32_t) (b)[(i) + 1] <<  8 )     \
@@ -99,8 +99,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE( n, b, i )                                \
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE( n, b, i )                                \
 {                                                               \
     (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
     (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -445,7 +445,7 @@ static void aria_fe_xor( uint32_t r[4], const uint32_t p[4],
  * Big endian 128-bit rotation: r = a ^ (b <<< n), used only in key setup.
  *
  * We chose to store bytes into 32-bit words in little-endian format (see
- * GET/PUT_UINT32_LE) so we need to reverse bytes here.
+ * GET/MBEDTLS_PUT_UINT32_LE) so we need to reverse bytes here.
  */
 static void aria_rot128( uint32_t r[4], const uint32_t a[4],
                          const uint32_t b[4], uint8_t n )
@@ -493,21 +493,21 @@ int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
         return( MBEDTLS_ERR_ARIA_BAD_INPUT_DATA );
 
     /* Copy key to W0 (and potential remainder to W1) */
-    GET_UINT32_LE( w[0][0], key,  0 );
-    GET_UINT32_LE( w[0][1], key,  4 );
-    GET_UINT32_LE( w[0][2], key,  8 );
-    GET_UINT32_LE( w[0][3], key, 12 );
+    MBEDTLS_GET_UINT32_LE( w[0][0], key,  0 );
+    MBEDTLS_GET_UINT32_LE( w[0][1], key,  4 );
+    MBEDTLS_GET_UINT32_LE( w[0][2], key,  8 );
+    MBEDTLS_GET_UINT32_LE( w[0][3], key, 12 );
 
     memset( w[1], 0, 16 );
     if( keybits >= 192 )
     {
-        GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
-        GET_UINT32_LE( w[1][1], key, 20 );
+        MBEDTLS_GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
+        MBEDTLS_GET_UINT32_LE( w[1][1], key, 20 );
     }
     if( keybits == 256 )
     {
-        GET_UINT32_LE( w[1][2], key, 24 );  // 256 bit key
-        GET_UINT32_LE( w[1][3], key, 28 );
+        MBEDTLS_GET_UINT32_LE( w[1][2], key, 24 );  // 256 bit key
+        MBEDTLS_GET_UINT32_LE( w[1][3], key, 28 );
     }
 
     i = ( keybits - 128 ) >> 6;             // index: 0, 1, 2
@@ -584,10 +584,10 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
     ARIA_VALIDATE_RET( input != NULL );
     ARIA_VALIDATE_RET( output != NULL );
 
-    GET_UINT32_LE( a, input,  0 );
-    GET_UINT32_LE( b, input,  4 );
-    GET_UINT32_LE( c, input,  8 );
-    GET_UINT32_LE( d, input, 12 );
+    MBEDTLS_GET_UINT32_LE( a, input,  0 );
+    MBEDTLS_GET_UINT32_LE( b, input,  4 );
+    MBEDTLS_GET_UINT32_LE( c, input,  8 );
+    MBEDTLS_GET_UINT32_LE( d, input, 12 );
 
     i = 0;
     while( 1 )
@@ -619,10 +619,10 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
     c ^= ctx->rk[i][2];
     d ^= ctx->rk[i][3];
 
-    PUT_UINT32_LE( a, output,  0 );
-    PUT_UINT32_LE( b, output,  4 );
-    PUT_UINT32_LE( c, output,  8 );
-    PUT_UINT32_LE( d, output, 12 );
+    MBEDTLS_PUT_UINT32_LE( a, output,  0 );
+    MBEDTLS_PUT_UINT32_LE( b, output,  4 );
+    MBEDTLS_PUT_UINT32_LE( c, output,  8 );
+    MBEDTLS_PUT_UINT32_LE( d, output, 12 );
 
     return( 0 );
 }

--- a/library/aria.c
+++ b/library/aria.c
@@ -110,10 +110,10 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 /*
  * modify byte order: ( A B C D ) -> ( B A D C ), i.e. swap pairs of bytes
@@ -272,21 +272,21 @@ static inline void aria_sl( uint32_t *a, uint32_t *b,
                             const uint8_t sa[256], const uint8_t sb[256],
                             const uint8_t sc[256], const uint8_t sd[256] )
 {
-    *a = ( (uint32_t) sa[ BYTE_0( *a ) ]       ) ^
-         (((uint32_t) sb[ BYTE_1( *a ) ]) <<  8) ^
-         (((uint32_t) sc[ BYTE_2( *a ) ]) << 16) ^
+    *a = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *a ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *a ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *a ) ]) << 16) ^
          (((uint32_t) sd[ *a >> 24     ]) << 24);
-    *b = ( (uint32_t) sa[ BYTE_0( *b ) ]       ) ^
-         (((uint32_t) sb[ BYTE_1( *b ) ]) <<  8) ^
-         (((uint32_t) sc[ BYTE_2( *b ) ]) << 16) ^
+    *b = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *b ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *b ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *b ) ]) << 16) ^
          (((uint32_t) sd[ *b >> 24     ]) << 24);
-    *c = ( (uint32_t) sa[ BYTE_0( *c ) ]       ) ^
-         (((uint32_t) sb[ BYTE_1( *c ) ]) <<  8) ^
-         (((uint32_t) sc[ BYTE_2( *c ) ]) << 16) ^
+    *c = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *c ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *c ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *c ) ]) << 16) ^
          (((uint32_t) sd[ *c >> 24     ]) << 24);
-    *d = ( (uint32_t) sa[ BYTE_0( *d ) ]       ) ^
-         (((uint32_t) sb[ BYTE_1( *d ) ]) <<  8) ^
-         (((uint32_t) sc[ BYTE_2( *d ) ]) << 16) ^
+    *d = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *d ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *d ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *d ) ]) << 16) ^
          (((uint32_t) sd[ *d >> 24     ]) << 24);
 }
 

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -57,10 +57,10 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
-#define BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
-#define BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+#define MBEDTLS_BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define MBEDTLS_BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define MBEDTLS_BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define MBEDTLS_BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -96,8 +96,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 3 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = BYTE_0( len );
-        *--(*p) = BYTE_1( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
         *--(*p) = 0x82;
         return( 3 );
     }
@@ -107,9 +107,9 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 4 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = BYTE_0( len );
-        *--(*p) = BYTE_1( len );
-        *--(*p) = BYTE_2( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
+        *--(*p) = MBEDTLS_BYTE_2( len );
         *--(*p) = 0x83;
         return( 4 );
     }
@@ -121,10 +121,10 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = BYTE_0( len );
-        *--(*p) = BYTE_1( len );
-        *--(*p) = BYTE_2( len );
-        *--(*p) = BYTE_3( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
+        *--(*p) = MBEDTLS_BYTE_2( len );
+        *--(*p) = MBEDTLS_BYTE_3( len );
         *--(*p) = 0x84;
         return( 5 );
     }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -56,6 +56,12 @@
 
 #include <string.h>
 
+/* Byte reading macros */
+#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
@@ -90,8 +96,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 3 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
+        *--(*p) = CHAR_0( len );
+        *--(*p) = CHAR_1( len );
         *--(*p) = 0x82;
         return( 3 );
     }
@@ -101,9 +107,9 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 4 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
-        *--(*p) = ( len >> 16 ) & 0xFF;
+        *--(*p) = CHAR_0( len );
+        *--(*p) = CHAR_1( len );
+        *--(*p) = CHAR_2( len );
         *--(*p) = 0x83;
         return( 4 );
     }
@@ -115,10 +121,10 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
-        *--(*p) = ( len >> 16 ) & 0xFF;
-        *--(*p) = ( len >> 24 ) & 0xFF;
+        *--(*p) = CHAR_0( len );
+        *--(*p) = CHAR_1( len );
+        *--(*p) = CHAR_2( len );
+        *--(*p) = CHAR_3( len );
         *--(*p) = 0x84;
         return( 5 );
     }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -57,10 +57,10 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
-#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
-#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -96,8 +96,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 3 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = CHAR_0( len );
-        *--(*p) = CHAR_1( len );
+        *--(*p) = BYTE_0( len );
+        *--(*p) = BYTE_1( len );
         *--(*p) = 0x82;
         return( 3 );
     }
@@ -107,9 +107,9 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 4 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = CHAR_0( len );
-        *--(*p) = CHAR_1( len );
-        *--(*p) = CHAR_2( len );
+        *--(*p) = BYTE_0( len );
+        *--(*p) = BYTE_1( len );
+        *--(*p) = BYTE_2( len );
         *--(*p) = 0x83;
         return( 4 );
     }
@@ -121,10 +121,10 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = CHAR_0( len );
-        *--(*p) = CHAR_1( len );
-        *--(*p) = CHAR_2( len );
-        *--(*p) = CHAR_3( len );
+        *--(*p) = BYTE_0( len );
+        *--(*p) = BYTE_1( len );
+        *--(*p) = BYTE_2( len );
+        *--(*p) = BYTE_3( len );
         *--(*p) = 0x84;
         return( 5 );
     }

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -74,8 +74,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -84,8 +84,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -273,8 +273,8 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
     BLOWFISH_VALIDATE_RET( input  != NULL );
     BLOWFISH_VALIDATE_RET( output != NULL );
 
-    GET_UINT32_BE( X0, input,  0 );
-    GET_UINT32_BE( X1, input,  4 );
+    MBEDTLS_GET_UINT32_BE( X0, input,  0 );
+    MBEDTLS_GET_UINT32_BE( X1, input,  4 );
 
     if( mode == MBEDTLS_BLOWFISH_DECRYPT )
     {
@@ -285,8 +285,8 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
         blowfish_enc( ctx, &X0, &X1 );
     }
 
-    PUT_UINT32_BE( X0, output,  0 );
-    PUT_UINT32_BE( X1, output,  4 );
+    MBEDTLS_PUT_UINT32_BE( X0, output,  0 );
+    MBEDTLS_PUT_UINT32_BE( X1, output,  4 );
 
     return( 0 );
 }

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -63,6 +63,12 @@
 
 #include <string.h>
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -332,14 +338,14 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
     I0 = x[0] ^ k[0];
     I1 = x[1] ^ k[1];
 
-    I0 = ((uint32_t) SBOX1((I0 >> 24) & 0xFF) << 24) |
-         ((uint32_t) SBOX2((I0 >> 16) & 0xFF) << 16) |
-         ((uint32_t) SBOX3((I0 >>  8) & 0xFF) <<  8) |
-         ((uint32_t) SBOX4((I0      ) & 0xFF)      );
-    I1 = ((uint32_t) SBOX2((I1 >> 24) & 0xFF) << 24) |
-         ((uint32_t) SBOX3((I1 >> 16) & 0xFF) << 16) |
-         ((uint32_t) SBOX4((I1 >>  8) & 0xFF) <<  8) |
-         ((uint32_t) SBOX1((I1      ) & 0xFF)      );
+    I0 = ((uint32_t) SBOX1( BYTE_3( I0 ) ) << 24 ) |
+         ((uint32_t) SBOX2( BYTE_2( I0 ) ) << 16 ) |
+         ((uint32_t) SBOX3( BYTE_1( I0 ) ) <<  8 ) |
+         ((uint32_t) SBOX4( BYTE_0( I0 ) )       );
+    I1 = ((uint32_t) SBOX2( BYTE_3( I1 ) ) << 24 ) |
+         ((uint32_t) SBOX3( BYTE_2( I1 ) ) << 16 ) |
+         ((uint32_t) SBOX4( BYTE_1( I1 ) ) <<  8 ) |
+         ((uint32_t) SBOX1( BYTE_0( I1 ) )       );
 
     I0 ^= (I1 << 8) | (I1 >> 24);
     I1 ^= (I0 << 16) | (I0 >> 16);

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -89,8 +89,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -99,8 +99,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -413,8 +413,8 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
      * Prepare SIGMA values
      */
     for( i = 0; i < 6; i++ ) {
-        GET_UINT32_BE( SIGMA[i][0], SIGMA_CHARS[i], 0 );
-        GET_UINT32_BE( SIGMA[i][1], SIGMA_CHARS[i], 4 );
+        MBEDTLS_GET_UINT32_BE( SIGMA[i][0], SIGMA_CHARS[i], 0 );
+        MBEDTLS_GET_UINT32_BE( SIGMA[i][1], SIGMA_CHARS[i], 4 );
     }
 
     /*
@@ -425,7 +425,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
 
     /* Store KL, KR */
     for( i = 0; i < 8; i++ )
-        GET_UINT32_BE( KC[i], t, i * 4 );
+        MBEDTLS_GET_UINT32_BE( KC[i], t, i * 4 );
 
     /* Generate KA */
     for( i = 0; i < 4; ++i )
@@ -551,10 +551,10 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
     NR = ctx->nr;
     RK = ctx->rk;
 
-    GET_UINT32_BE( X[0], input,  0 );
-    GET_UINT32_BE( X[1], input,  4 );
-    GET_UINT32_BE( X[2], input,  8 );
-    GET_UINT32_BE( X[3], input, 12 );
+    MBEDTLS_GET_UINT32_BE( X[0], input,  0 );
+    MBEDTLS_GET_UINT32_BE( X[1], input,  4 );
+    MBEDTLS_GET_UINT32_BE( X[2], input,  8 );
+    MBEDTLS_GET_UINT32_BE( X[3], input, 12 );
 
     X[0] ^= *RK++;
     X[1] ^= *RK++;
@@ -589,10 +589,10 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
     X[0] ^= *RK++;
     X[1] ^= *RK++;
 
-    PUT_UINT32_BE( X[2], output,  0 );
-    PUT_UINT32_BE( X[3], output,  4 );
-    PUT_UINT32_BE( X[0], output,  8 );
-    PUT_UINT32_BE( X[1], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( X[2], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( X[3], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( X[0], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( X[1], output, 12 );
 
     return( 0 );
 }

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -64,10 +64,10 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 #if defined(MBEDTLS_SELF_TEST)
 #if defined(MBEDTLS_PLATFORM_C)
@@ -338,14 +338,14 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
     I0 = x[0] ^ k[0];
     I1 = x[1] ^ k[1];
 
-    I0 = ((uint32_t) SBOX1( BYTE_3( I0 ) ) << 24 ) |
-         ((uint32_t) SBOX2( BYTE_2( I0 ) ) << 16 ) |
-         ((uint32_t) SBOX3( BYTE_1( I0 ) ) <<  8 ) |
-         ((uint32_t) SBOX4( BYTE_0( I0 ) )       );
-    I1 = ((uint32_t) SBOX2( BYTE_3( I1 ) ) << 24 ) |
-         ((uint32_t) SBOX3( BYTE_2( I1 ) ) << 16 ) |
-         ((uint32_t) SBOX4( BYTE_1( I1 ) ) <<  8 ) |
-         ((uint32_t) SBOX1( BYTE_0( I1 ) )       );
+    I0 = ((uint32_t) SBOX1( MBEDTLS_BYTE_3( I0 ) ) << 24 ) |
+         ((uint32_t) SBOX2( MBEDTLS_BYTE_2( I0 ) ) << 16 ) |
+         ((uint32_t) SBOX3( MBEDTLS_BYTE_1( I0 ) ) <<  8 ) |
+         ((uint32_t) SBOX4( MBEDTLS_BYTE_0( I0 ) )       );
+    I1 = ((uint32_t) SBOX2( MBEDTLS_BYTE_3( I1 ) ) << 24 ) |
+         ((uint32_t) SBOX3( MBEDTLS_BYTE_2( I1 ) ) << 16 ) |
+         ((uint32_t) SBOX4( MBEDTLS_BYTE_1( I1 ) ) <<  8 ) |
+         ((uint32_t) SBOX1( MBEDTLS_BYTE_0( I1 ) )       );
 
     I0 ^= (I1 << 8) | (I1 >> 24);
     I1 ^= (I0 << 16) | (I0 >> 16);

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -66,6 +66,11 @@
 
 #include <string.h>
 
+
+/* Byte reading macros */
+#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -229,7 +234,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = (unsigned char)( len_left & 0xFF );
+        b[15-i] = CHAR_0( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
@@ -250,8 +255,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
-        b[1] = (unsigned char)( ( add_len      ) & 0xFF );
+        b[0] = CHAR_1( add_len );
+        b[1] = CHAR_0( add_len );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -68,8 +68,8 @@
 
 
 /* Byte reading macros */
-#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 #if defined(MBEDTLS_PLATFORM_C)
@@ -234,7 +234,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = CHAR_0( len_left );
+        b[15-i] = BYTE_0( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
@@ -255,8 +255,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = CHAR_1( add_len );
-        b[1] = CHAR_0( add_len );
+        b[0] = BYTE_1( add_len );
+        b[1] = BYTE_0( add_len );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -68,8 +68,8 @@
 
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define MBEDTLS_BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define MBEDTLS_BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 #if defined(MBEDTLS_PLATFORM_C)
@@ -234,7 +234,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = BYTE_0( len_left );
+        b[15-i] = MBEDTLS_BYTE_0( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
@@ -255,8 +255,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = BYTE_1( add_len );
-        b[1] = BYTE_0( add_len );
+        b[0] = MBEDTLS_BYTE_1( add_len );
+        b[1] = MBEDTLS_BYTE_0( add_len );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -75,6 +75,12 @@
 #endif /* MBEDTLS_PLATFORM_C */
 #endif /* MBEDTLS_SELF_TEST */
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 /*
  * CTR_DRBG context initialization
  */
@@ -147,10 +153,10 @@ static int block_cipher_df( unsigned char *output,
      *     (Total is padded to a multiple of 16-bytes with zeroes)
      */
     p = buf + MBEDTLS_CTR_DRBG_BLOCKSIZE;
-    *p++ = ( data_len >> 24 ) & 0xff;
-    *p++ = ( data_len >> 16 ) & 0xff;
-    *p++ = ( data_len >> 8  ) & 0xff;
-    *p++ = ( data_len       ) & 0xff;
+    *p++ = BYTE_3( data_len );
+    *p++ = BYTE_2( data_len );
+    *p++ = BYTE_1( data_len );
+    *p++ = BYTE_0( data_len );
     p += 3;
     *p++ = MBEDTLS_CTR_DRBG_SEEDLEN;
     memcpy( p, data, data_len );

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -76,10 +76,10 @@
 #endif /* MBEDTLS_SELF_TEST */
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 /*
  * CTR_DRBG context initialization
@@ -153,10 +153,10 @@ static int block_cipher_df( unsigned char *output,
      *     (Total is padded to a multiple of 16-bytes with zeroes)
      */
     p = buf + MBEDTLS_CTR_DRBG_BLOCKSIZE;
-    *p++ = BYTE_3( data_len );
-    *p++ = BYTE_2( data_len );
-    *p++ = BYTE_1( data_len );
-    *p++ = BYTE_0( data_len );
+    *p++ = MBEDTLS_BYTE_3( data_len );
+    *p++ = MBEDTLS_BYTE_2( data_len );
+    *p++ = MBEDTLS_BYTE_1( data_len );
+    *p++ = MBEDTLS_BYTE_0( data_len );
     p += 3;
     *p++ = MBEDTLS_CTR_DRBG_SEEDLEN;
     memcpy( p, data, data_len );

--- a/library/debug.c
+++ b/library/debug.c
@@ -73,6 +73,12 @@
 #define inline __inline
 #endif
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 #define DEBUG_BUF_SIZE      512
 
 static int debug_threshold = 0;
@@ -292,7 +298,7 @@ void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
             size_t limb_offset = n / sizeof( mbedtls_mpi_uint );
             size_t offset_in_limb = n % sizeof( mbedtls_mpi_uint );
             unsigned char octet =
-                ( X->p[limb_offset] >> ( offset_in_limb * 8 ) ) & 0xff;
+                BYTE_0( X->p[limb_offset] >> ( offset_in_limb * 8 ) );
             mbedtls_snprintf( str + idx, sizeof( str ) - idx, " %02x", octet );
             idx += 3;
             /* Wrap lines after 16 octets that each take 3 columns */

--- a/library/debug.c
+++ b/library/debug.c
@@ -74,10 +74,10 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 #define DEBUG_BUF_SIZE      512
 
@@ -298,7 +298,7 @@ void mbedtls_debug_print_mpi( const mbedtls_ssl_context *ssl, int level,
             size_t limb_offset = n / sizeof( mbedtls_mpi_uint );
             size_t offset_in_limb = n % sizeof( mbedtls_mpi_uint );
             unsigned char octet =
-                BYTE_0( X->p[limb_offset] >> ( offset_in_limb * 8 ) );
+                MBEDTLS_BYTE_0( X->p[limb_offset] >> ( offset_in_limb * 8 ) );
             mbedtls_snprintf( str + idx, sizeof( str ) - idx, " %02x", octet );
             idx += 3;
             /* Wrap lines after 16 octets that each take 3 columns */

--- a/library/des.c
+++ b/library/des.c
@@ -77,8 +77,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -87,8 +87,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -454,8 +454,8 @@ void mbedtls_des_setkey( uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KE
     int i;
     uint32_t X, Y, T;
 
-    GET_UINT32_BE( X, key, 0 );
-    GET_UINT32_BE( Y, key, 4 );
+    MBEDTLS_GET_UINT32_BE( X, key, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, key, 4 );
 
     /*
      * Permuted Choice 1
@@ -664,8 +664,8 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
 
     SK = ctx->sk;
 
-    GET_UINT32_BE( X, input, 0 );
-    GET_UINT32_BE( Y, input, 4 );
+    MBEDTLS_GET_UINT32_BE( X, input, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
 
     DES_IP( X, Y );
 
@@ -677,8 +677,8 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
 
     DES_FP( Y, X );
 
-    PUT_UINT32_BE( Y, output, 0 );
-    PUT_UINT32_BE( X, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( Y, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( X, output, 4 );
 
     return( 0 );
 }
@@ -751,8 +751,8 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
 
     SK = ctx->sk;
 
-    GET_UINT32_BE( X, input, 0 );
-    GET_UINT32_BE( Y, input, 4 );
+    MBEDTLS_GET_UINT32_BE( X, input, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
 
     DES_IP( X, Y );
 
@@ -776,8 +776,8 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
 
     DES_FP( Y, X );
 
-    PUT_UINT32_BE( Y, output, 0 );
-    PUT_UINT32_BE( X, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( Y, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( X, output, 4 );
 
     return( 0 );
 }

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -63,10 +63,10 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
-#define BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
-#define BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+#define MBEDTLS_BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define MBEDTLS_BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define MBEDTLS_BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define MBEDTLS_BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
 
 #if !defined(MBEDTLS_ECJPAKE_ALT)
 
@@ -202,10 +202,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = BYTE_3( len );
-    (*p)[1] = BYTE_2( len );
-    (*p)[2] = BYTE_1( len );
-    (*p)[3] = BYTE_0( len );
+    (*p)[0] = MBEDTLS_BYTE_3( len );
+    (*p)[1] = MBEDTLS_BYTE_2( len );
+    (*p)[2] = MBEDTLS_BYTE_1( len );
+    (*p)[3] = MBEDTLS_BYTE_0( len );
 
     *p += 4 + len;
 
@@ -245,10 +245,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = BYTE_3( id_len );
-    *p++ = BYTE_2( id_len );
-    *p++ = BYTE_1( id_len );
-    *p++ = BYTE_0( id_len );
+    *p++ = MBEDTLS_BYTE_3( id_len );
+    *p++ = MBEDTLS_BYTE_2( id_len );
+    *p++ = MBEDTLS_BYTE_1( id_len );
+    *p++ = MBEDTLS_BYTE_0( id_len );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
@@ -388,7 +388,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = BYTE_0( len );
+    *(*p)++ = MBEDTLS_BYTE_0( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -63,10 +63,10 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
-#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
-#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define BYTE_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define BYTE_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
 
 #if !defined(MBEDTLS_ECJPAKE_ALT)
 
@@ -202,10 +202,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = CHAR_3( len );
-    (*p)[1] = CHAR_2( len );
-    (*p)[2] = CHAR_1( len );
-    (*p)[3] = CHAR_0( len );
+    (*p)[0] = BYTE_3( len );
+    (*p)[1] = BYTE_2( len );
+    (*p)[2] = BYTE_1( len );
+    (*p)[3] = BYTE_0( len );
 
     *p += 4 + len;
 
@@ -245,10 +245,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = CHAR_3( id_len );
-    *p++ = CHAR_2( id_len );
-    *p++ = CHAR_1( id_len );
-    *p++ = CHAR_0( id_len );
+    *p++ = BYTE_3( id_len );
+    *p++ = BYTE_2( id_len );
+    *p++ = BYTE_1( id_len );
+    *p++ = BYTE_0( id_len );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
@@ -388,7 +388,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = CHAR_0( len );
+    *(*p)++ = BYTE_0( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -62,6 +62,12 @@
 
 #include <string.h>
 
+/* Byte reading macros */
+#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
+
 #if !defined(MBEDTLS_ECJPAKE_ALT)
 
 /* Parameter validation macros based on platform_util.h */
@@ -196,10 +202,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = (unsigned char)( ( len >> 24 ) & 0xFF );
-    (*p)[1] = (unsigned char)( ( len >> 16 ) & 0xFF );
-    (*p)[2] = (unsigned char)( ( len >>  8 ) & 0xFF );
-    (*p)[3] = (unsigned char)( ( len       ) & 0xFF );
+    (*p)[0] = CHAR_3( len );
+    (*p)[1] = CHAR_2( len );
+    (*p)[2] = CHAR_1( len );
+    (*p)[3] = CHAR_0( len );
 
     *p += 4 + len;
 
@@ -239,10 +245,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = (unsigned char)( ( id_len >> 24 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >> 16 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >>  8 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len       ) & 0xFF );
+    *p++ = CHAR_3( id_len );
+    *p++ = CHAR_2( id_len );
+    *p++ = CHAR_1( id_len );
+    *p++ = CHAR_0( id_len );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
@@ -382,7 +388,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = (unsigned char)( len & 0xFF );
+    *(*p)++ = CHAR_0( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -91,8 +91,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -101,8 +101,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -141,12 +141,12 @@ static int gcm_gen_table( mbedtls_gcm_context *ctx )
         return( ret );
 
     /* pack h as two 64-bits ints, big-endian */
-    GET_UINT32_BE( hi, h,  0  );
-    GET_UINT32_BE( lo, h,  4  );
+    MBEDTLS_GET_UINT32_BE( hi, h,  0  );
+    MBEDTLS_GET_UINT32_BE( lo, h,  4  );
     vh = (uint64_t) hi << 32 | lo;
 
-    GET_UINT32_BE( hi, h,  8  );
-    GET_UINT32_BE( lo, h,  12 );
+    MBEDTLS_GET_UINT32_BE( hi, h,  8  );
+    MBEDTLS_GET_UINT32_BE( lo, h,  12 );
     vl = (uint64_t) hi << 32 | lo;
 
     /* 8 = 1000 corresponds to 1 in GF(2^128) */
@@ -252,10 +252,10 @@ static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_CLMUL ) ) {
         unsigned char h[16];
 
-        PUT_UINT32_BE( ctx->HH[8] >> 32, h,  0 );
-        PUT_UINT32_BE( ctx->HH[8],       h,  4 );
-        PUT_UINT32_BE( ctx->HL[8] >> 32, h,  8 );
-        PUT_UINT32_BE( ctx->HL[8],       h, 12 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HH[8] >> 32, h,  0 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HH[8],       h,  4 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HL[8] >> 32, h,  8 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HL[8],       h, 12 );
 
         mbedtls_aesni_gcm_mult( output, x, h );
         return;
@@ -291,10 +291,10 @@ static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
         zl ^= ctx->HL[hi];
     }
 
-    PUT_UINT32_BE( zh >> 32, output, 0 );
-    PUT_UINT32_BE( zh, output, 4 );
-    PUT_UINT32_BE( zl >> 32, output, 8 );
-    PUT_UINT32_BE( zl, output, 12 );
+    MBEDTLS_PUT_UINT32_BE( zh >> 32, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( zh, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( zl >> 32, output, 8 );
+    MBEDTLS_PUT_UINT32_BE( zl, output, 12 );
 }
 
 int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
@@ -338,7 +338,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     else
     {
         memset( work_buf, 0x00, 16 );
-        PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
+        MBEDTLS_PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
 
         p = iv;
         while( iv_len > 0 )
@@ -471,10 +471,10 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     {
         memset( work_buf, 0x00, 16 );
 
-        PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
-        PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );
-        PUT_UINT32_BE( ( orig_len     >> 32 ), work_buf, 8  );
-        PUT_UINT32_BE( ( orig_len           ), work_buf, 12 );
+        MBEDTLS_PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_len     >> 32 ), work_buf, 8  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_len           ), work_buf, 12 );
 
         for( i = 0; i < 16; i++ )
             ctx->buf[i] ^= work_buf[i];

--- a/library/md4.c
+++ b/library/md4.c
@@ -77,8 +77,8 @@
 /*
  * 32-bit integer manipulation macros (little endian)
  */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ]       )             \
         | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
@@ -87,8 +87,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                    \
 {                                                               \
     (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
     (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -148,22 +148,22 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
@@ -363,8 +363,8 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  msglen, 0 );
-    PUT_UINT32_LE( high, msglen, 4 );
+    MBEDTLS_PUT_UINT32_LE( low,  msglen, 0 );
+    MBEDTLS_PUT_UINT32_LE( high, msglen, 4 );
 
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
@@ -377,10 +377,10 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
         return( ret );
 
 
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
 
     return( 0 );
 }

--- a/library/md5.c
+++ b/library/md5.c
@@ -76,8 +76,8 @@
 /*
  * 32-bit integer manipulation macros (little endian)
  */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ]       )             \
         | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
@@ -86,8 +86,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                    \
 {                                                               \
     (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
     (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -147,22 +147,22 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
 #define S(x,n)                                                          \
     ( ( (x) << (n) ) | ( ( (x) & 0xFFFFFFFF) >> ( 32 - (n) ) ) )
@@ -383,8 +383,8 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  ctx->buffer, 56 );
-    PUT_UINT32_LE( high, ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_LE( low,  ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_LE( high, ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_md5_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -392,10 +392,10 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
 
     return( 0 );
 }

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -205,7 +205,7 @@ static void calc_a_xor_t( unsigned char A[KW_SEMIBLOCK_LENGTH], uint64_t t )
     size_t i = 0;
     for( i = 0; i < sizeof( t ); i++ )
     {
-        A[i] ^= BYTE_0( t >> ( ( sizeof( t ) - 1 - i ) * 8 ) );
+        A[i] ^= ( t >> ( ( sizeof( t ) - 1 - i ) * 8 ) ) & 0xff;
     }
 }
 

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -113,8 +113,8 @@ static const unsigned char NIST_KW_ICV1[] = {0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
 /*! The 32-bit default integrity check value (ICV) for KWP mode. */
 static const  unsigned char NIST_KW_ICV2[] = {0xA6, 0x59, 0x59, 0xA6};
 
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 do {                                                    \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -123,8 +123,8 @@ do {                                                    \
 } while( 0 )
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 do {                                                    \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -279,7 +279,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
         }
 
         memcpy( output, NIST_KW_ICV2, KW_SEMIBLOCK_LENGTH / 2 );
-        PUT_UINT32_BE( ( in_len & 0xffffffff ), output,
+        MBEDTLS_PUT_UINT32_BE( ( in_len & 0xffffffff ), output,
                        KW_SEMIBLOCK_LENGTH / 2 );
 
         memcpy( output + KW_SEMIBLOCK_LENGTH, input, in_len );
@@ -510,7 +510,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
         }
 
-        GET_UINT32_BE( Plen, A, KW_SEMIBLOCK_LENGTH / 2 );
+        MBEDTLS_GET_UINT32_BE( Plen, A, KW_SEMIBLOCK_LENGTH / 2 );
 
         /*
          * Plen is the length of the plaintext, when the input is valid.

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -83,10 +83,10 @@
 #define MIN_SEMIBLOCKS_COUNT   3
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 /* constant-time buffer comparison */
 static inline unsigned char mbedtls_nist_kw_safer_memcmp( const void *a, const void *b, size_t n )

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -82,6 +82,12 @@
 #define KW_SEMIBLOCK_LENGTH    8
 #define MIN_SEMIBLOCKS_COUNT   3
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 /* constant-time buffer comparison */
 static inline unsigned char mbedtls_nist_kw_safer_memcmp( const void *a, const void *b, size_t n )
 {
@@ -199,7 +205,7 @@ static void calc_a_xor_t( unsigned char A[KW_SEMIBLOCK_LENGTH], uint64_t t )
     size_t i = 0;
     for( i = 0; i < sizeof( t ); i++ )
     {
-        A[i] ^= ( t >> ( ( sizeof( t ) - 1 - i ) * 8 ) ) & 0xff;
+        A[i] ^= BYTE_0( t >> ( ( sizeof( t ) - 1 - i ) * 8 ) );
     }
 }
 

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -77,8 +77,8 @@
 /*
  * 32-bit integer manipulation macros (little endian)
  */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ]       )             \
         | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
@@ -87,8 +87,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                    \
 {                                                               \
     (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
     (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -152,22 +152,22 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
         uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
     local.A = local.Ap = ctx->state[0];
     local.B = local.Bp = ctx->state[1];
@@ -430,8 +430,8 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  msglen, 0 );
-    PUT_UINT32_LE( high, msglen, 4 );
+    MBEDTLS_PUT_UINT32_LE( low,  msglen, 0 );
+    MBEDTLS_PUT_UINT32_LE( high, msglen, 4 );
 
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
@@ -444,11 +444,11 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
     if( ret != 0 )
         return( ret );
 
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
-    PUT_UINT32_LE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[4], output, 16 );
 
     return( 0 );
 }

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -81,8 +81,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -91,8 +91,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -163,22 +163,22 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     SHA1_VALIDATE_RET( ctx != NULL );
     SHA1_VALIDATE_RET( (const unsigned char *)data != NULL );
 
-    GET_UINT32_BE( local.W[ 0], data,  0 );
-    GET_UINT32_BE( local.W[ 1], data,  4 );
-    GET_UINT32_BE( local.W[ 2], data,  8 );
-    GET_UINT32_BE( local.W[ 3], data, 12 );
-    GET_UINT32_BE( local.W[ 4], data, 16 );
-    GET_UINT32_BE( local.W[ 5], data, 20 );
-    GET_UINT32_BE( local.W[ 6], data, 24 );
-    GET_UINT32_BE( local.W[ 7], data, 28 );
-    GET_UINT32_BE( local.W[ 8], data, 32 );
-    GET_UINT32_BE( local.W[ 9], data, 36 );
-    GET_UINT32_BE( local.W[10], data, 40 );
-    GET_UINT32_BE( local.W[11], data, 44 );
-    GET_UINT32_BE( local.W[12], data, 48 );
-    GET_UINT32_BE( local.W[13], data, 52 );
-    GET_UINT32_BE( local.W[14], data, 56 );
-    GET_UINT32_BE( local.W[15], data, 60 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_BE( local.W[10], data, 40 );
+    MBEDTLS_GET_UINT32_BE( local.W[11], data, 44 );
+    MBEDTLS_GET_UINT32_BE( local.W[12], data, 48 );
+    MBEDTLS_GET_UINT32_BE( local.W[13], data, 52 );
+    MBEDTLS_GET_UINT32_BE( local.W[14], data, 56 );
+    MBEDTLS_GET_UINT32_BE( local.W[15], data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
@@ -438,8 +438,8 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_BE( high, ctx->buffer, 56 );
-    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_BE( high, ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_BE( low,  ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -447,11 +447,11 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_BE( ctx->state[0], output,  0 );
-    PUT_UINT32_BE( ctx->state[1], output,  4 );
-    PUT_UINT32_BE( ctx->state[2], output,  8 );
-    PUT_UINT32_BE( ctx->state[3], output, 12 );
-    PUT_UINT32_BE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[4], output, 16 );
 
     return( 0 );
 }

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -83,8 +83,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 do {                                                    \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -93,8 +93,8 @@ do {                                                    \
 } while( 0 )
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 do {                                                    \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -244,7 +244,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     for( i = 0; i < 64; i++ )
     {
         if( i < 16 )
-            GET_UINT32_BE( local.W[i], data, 4 * i );
+            MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
         else
             R( i );
 
@@ -259,7 +259,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     }
 #else /* MBEDTLS_SHA256_SMALLER */
     for( i = 0; i < 16; i++ )
-        GET_UINT32_BE( local.W[i], data, 4 * i );
+        MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
 
     for( i = 0; i < 16; i += 8 )
     {
@@ -425,8 +425,8 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_BE( high, ctx->buffer, 56 );
-    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_BE( high, ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_BE( low,  ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -434,16 +434,16 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_BE( ctx->state[0], output,  0 );
-    PUT_UINT32_BE( ctx->state[1], output,  4 );
-    PUT_UINT32_BE( ctx->state[2], output,  8 );
-    PUT_UINT32_BE( ctx->state[3], output, 12 );
-    PUT_UINT32_BE( ctx->state[4], output, 16 );
-    PUT_UINT32_BE( ctx->state[5], output, 20 );
-    PUT_UINT32_BE( ctx->state[6], output, 24 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[5], output, 20 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[6], output, 24 );
 
     if( ctx->is224 == 0 )
-        PUT_UINT32_BE( ctx->state[7], output, 28 );
+        MBEDTLS_PUT_UINT32_BE( ctx->state[7], output, 28 );
 
     return( 0 );
 }

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -89,8 +89,8 @@
 /*
  * 64-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT64_BE
-#define GET_UINT64_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT64_BE
+#define MBEDTLS_GET_UINT64_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
         | ( (uint64_t) (b)[(i) + 1] << 48 )       \
@@ -101,10 +101,10 @@
         | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
         | ( (uint64_t) (b)[(i) + 7]       );      \
 }
-#endif /* GET_UINT64_BE */
+#endif /* MBEDTLS_GET_UINT64_BE */
 
-#ifndef PUT_UINT64_BE
-#define PUT_UINT64_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT64_BE
+#define MBEDTLS_PUT_UINT64_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
@@ -115,7 +115,7 @@
     (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
     (b)[(i) + 7] = (unsigned char) ( (n)       );       \
 }
-#endif /* PUT_UINT64_BE */
+#endif /* MBEDTLS_PUT_UINT64_BE */
 
 void mbedtls_sha512_init( mbedtls_sha512_context *ctx )
 {
@@ -274,7 +274,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 
     for( i = 0; i < 16; i++ )
     {
-        GET_UINT64_BE( local.W[i], data, i << 3 );
+        MBEDTLS_GET_UINT64_BE( local.W[i], data, i << 3 );
     }
 
     for( ; i < 80; i++ )
@@ -442,8 +442,8 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT64_BE( high, ctx->buffer, 112 );
-    PUT_UINT64_BE( low,  ctx->buffer, 120 );
+    MBEDTLS_PUT_UINT64_BE( high, ctx->buffer, 112 );
+    MBEDTLS_PUT_UINT64_BE( low,  ctx->buffer, 120 );
 
     if( ( ret = mbedtls_internal_sha512_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -451,17 +451,17 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT64_BE( ctx->state[0], output,  0 );
-    PUT_UINT64_BE( ctx->state[1], output,  8 );
-    PUT_UINT64_BE( ctx->state[2], output, 16 );
-    PUT_UINT64_BE( ctx->state[3], output, 24 );
-    PUT_UINT64_BE( ctx->state[4], output, 32 );
-    PUT_UINT64_BE( ctx->state[5], output, 40 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[1], output,  8 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[2], output, 16 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[3], output, 24 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[4], output, 32 );
+    MBEDTLS_PUT_UINT64_BE( ctx->state[5], output, 40 );
 
     if( ctx->is384 == 0 )
     {
-        PUT_UINT64_BE( ctx->state[6], output, 48 );
-        PUT_UINT64_BE( ctx->state[7], output, 56 );
+        MBEDTLS_PUT_UINT64_BE( ctx->state[6], output, 48 );
+        MBEDTLS_PUT_UINT64_BE( ctx->state[7], output, 56 );
     }
 
     return( 0 );

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -77,8 +77,8 @@
 #endif
 
 /* Byte reading macros */
-#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
@@ -128,18 +128,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SERVERNAME );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME );
 
-    *p++ = CHAR_1( hostname_len + 5 );
-    *p++ = CHAR_0( hostname_len + 5 );
+    *p++ = BYTE_1( hostname_len + 5 );
+    *p++ = BYTE_0( hostname_len + 5 );
 
-    *p++ = CHAR_1( hostname_len + 3 );
-    *p++ = CHAR_0( hostname_len + 3 );
+    *p++ = BYTE_1( hostname_len + 3 );
+    *p++ = BYTE_0( hostname_len + 3 );
 
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
-    *p++ = CHAR_1( hostname_len );
-    *p++ = CHAR_0( hostname_len );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = BYTE_1( hostname_len );
+    *p++ = BYTE_0( hostname_len );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -173,8 +173,8 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
     *p++ = 0x00;
     *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
@@ -273,14 +273,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SIG_ALG );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SIG_ALG );
 
-    *p++ = CHAR_1( sig_alg_len + 2 );
-    *p++ = CHAR_0( sig_alg_len + 2 );
+    *p++ = BYTE_1( sig_alg_len + 2 );
+    *p++ = BYTE_0( sig_alg_len + 2 );
 
-    *p++ = CHAR_1( sig_alg_len );
-    *p++ = CHAR_0( sig_alg_len );
+    *p++ = BYTE_1( sig_alg_len );
+    *p++ = BYTE_0( sig_alg_len );
 
     *olen = 6 + sig_alg_len;
 
@@ -348,14 +348,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
 
-    *p++ = CHAR_1( elliptic_curve_len + 2 );
-    *p++ = CHAR_0( elliptic_curve_len + 2 );
+    *p++ = BYTE_1( elliptic_curve_len + 2 );
+    *p++ = BYTE_0( elliptic_curve_len + 2 );
 
-    *p++ = CHAR_1( elliptic_curve_len     );
-    *p++ = CHAR_0( elliptic_curve_len     );
+    *p++ = BYTE_1( elliptic_curve_len     );
+    *p++ = BYTE_0( elliptic_curve_len     );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -376,8 +376,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -413,8 +413,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -456,8 +456,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = CHAR_1( kkpp_len );
-    *p++ = CHAR_0( kkpp_len );
+    *p++ = BYTE_1( kkpp_len );
+    *p++ = BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 
@@ -483,8 +483,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -515,8 +515,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -546,8 +546,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -577,8 +577,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -609,11 +609,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
-    *p++ = CHAR_1( tlen );
-    *p++ = CHAR_0( tlen );
+    *p++ = BYTE_1( tlen );
+    *p++ = BYTE_0( tlen );
 
     *olen = 4;
 
@@ -653,8 +653,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ALPN );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -681,12 +681,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = CHAR_1( *olen - 6 );
-    buf[5] = CHAR_0( *olen - 6 );
+    buf[4] = BYTE_1( *olen - 6 );
+    buf[5] = BYTE_0( *olen - 6 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = CHAR_1( *olen - 4 );
-    buf[3] = CHAR_0( *olen - 4 );
+    buf[2] = BYTE_1( *olen - 4 );
+    buf[3] = BYTE_0( *olen - 4 );
 
     return( 0 );
 }
@@ -1215,8 +1215,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = CHAR_1( ext_len );
-        *p++ = CHAR_0( ext_len );
+        *p++ = BYTE_1( ext_len );
+        *p++ = BYTE_0( ext_len );
         p += ext_len;
     }
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -76,6 +76,10 @@
 #include "mbedtls/platform_util.h"
 #endif
 
+/* Byte reading macros */
+#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
                                    unsigned char *buf,
@@ -124,18 +128,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME );
 
-    *p++ = (unsigned char)( ( (hostname_len + 5) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 5)      ) & 0xFF );
+    *p++ = CHAR_1( hostname_len + 5 );
+    *p++ = CHAR_0( hostname_len + 5 );
 
-    *p++ = (unsigned char)( ( (hostname_len + 3) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 3)      ) & 0xFF );
+    *p++ = CHAR_1( hostname_len + 3 );
+    *p++ = CHAR_0( hostname_len + 3 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len      ) & 0xFF );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = CHAR_1( hostname_len );
+    *p++ = CHAR_0( hostname_len );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -169,10 +173,8 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      )
-                            & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
     *p++ = 0x00;
     *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
@@ -271,14 +273,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SIG_ALG );
 
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 )      ) & 0xFF );
+    *p++ = CHAR_1( sig_alg_len + 2 );
+    *p++ = CHAR_0( sig_alg_len + 2 );
 
-    *p++ = (unsigned char)( ( sig_alg_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( sig_alg_len      ) & 0xFF );
+    *p++ = CHAR_1( sig_alg_len );
+    *p++ = CHAR_0( sig_alg_len );
 
     *olen = 6 + sig_alg_len;
 
@@ -346,16 +348,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES      )
-                            & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 )      ) & 0xFF );
+    *p++ = CHAR_1( elliptic_curve_len + 2 );
+    *p++ = CHAR_0( elliptic_curve_len + 2 );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     )      ) & 0xFF );
+    *p++ = CHAR_1( elliptic_curve_len     );
+    *p++ = CHAR_0( elliptic_curve_len     );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -376,10 +376,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      )
-                            & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -415,8 +413,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -458,8 +456,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = CHAR_1( kkpp_len );
+    *p++ = CHAR_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 
@@ -485,10 +483,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      )
-                            & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -519,8 +515,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -550,8 +546,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -581,10 +577,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      )
-                            & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -615,11 +609,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
-    *p++ = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( tlen      ) & 0xFF );
+    *p++ = CHAR_1( tlen );
+    *p++ = CHAR_0( tlen );
 
     *olen = 4;
 
@@ -659,8 +653,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ALPN );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -687,12 +681,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = CHAR_1( *olen - 6 );
+    buf[5] = CHAR_0( *olen - 6 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = CHAR_1( *olen - 4 );
+    buf[3] = CHAR_0( *olen - 4 );
 
     return( 0 );
 }
@@ -1221,8 +1215,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = CHAR_1( ext_len );
+        *p++ = CHAR_0( ext_len );
         p += ext_len;
     }
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -77,8 +77,8 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define MBEDTLS_BYTE_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define MBEDTLS_BYTE_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
@@ -128,18 +128,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SERVERNAME );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME );
 
-    *p++ = BYTE_1( hostname_len + 5 );
-    *p++ = BYTE_0( hostname_len + 5 );
+    *p++ = MBEDTLS_BYTE_1( hostname_len + 5 );
+    *p++ = MBEDTLS_BYTE_0( hostname_len + 5 );
 
-    *p++ = BYTE_1( hostname_len + 3 );
-    *p++ = BYTE_0( hostname_len + 3 );
+    *p++ = MBEDTLS_BYTE_1( hostname_len + 3 );
+    *p++ = MBEDTLS_BYTE_0( hostname_len + 3 );
 
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
-    *p++ = BYTE_1( hostname_len );
-    *p++ = BYTE_0( hostname_len );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = MBEDTLS_BYTE_1( hostname_len );
+    *p++ = MBEDTLS_BYTE_0( hostname_len );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -173,8 +173,8 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
     *p++ = 0x00;
     *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
@@ -273,14 +273,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SIG_ALG );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SIG_ALG );
 
-    *p++ = BYTE_1( sig_alg_len + 2 );
-    *p++ = BYTE_0( sig_alg_len + 2 );
+    *p++ = MBEDTLS_BYTE_1( sig_alg_len + 2 );
+    *p++ = MBEDTLS_BYTE_0( sig_alg_len + 2 );
 
-    *p++ = BYTE_1( sig_alg_len );
-    *p++ = BYTE_0( sig_alg_len );
+    *p++ = MBEDTLS_BYTE_1( sig_alg_len );
+    *p++ = MBEDTLS_BYTE_0( sig_alg_len );
 
     *olen = 6 + sig_alg_len;
 
@@ -348,14 +348,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
 
-    *p++ = BYTE_1( elliptic_curve_len + 2 );
-    *p++ = BYTE_0( elliptic_curve_len + 2 );
+    *p++ = MBEDTLS_BYTE_1( elliptic_curve_len + 2 );
+    *p++ = MBEDTLS_BYTE_0( elliptic_curve_len + 2 );
 
-    *p++ = BYTE_1( elliptic_curve_len     );
-    *p++ = BYTE_0( elliptic_curve_len     );
+    *p++ = MBEDTLS_BYTE_1( elliptic_curve_len     );
+    *p++ = MBEDTLS_BYTE_0( elliptic_curve_len     );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -376,8 +376,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -413,8 +413,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -456,8 +456,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = BYTE_1( kkpp_len );
-    *p++ = BYTE_0( kkpp_len );
+    *p++ = MBEDTLS_BYTE_1( kkpp_len );
+    *p++ = MBEDTLS_BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 
@@ -483,8 +483,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -515,8 +515,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -546,8 +546,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -577,8 +577,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -609,11 +609,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
-    *p++ = BYTE_1( tlen );
-    *p++ = BYTE_0( tlen );
+    *p++ = MBEDTLS_BYTE_1( tlen );
+    *p++ = MBEDTLS_BYTE_0( tlen );
 
     *olen = 4;
 
@@ -653,8 +653,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ALPN );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -681,12 +681,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = BYTE_1( *olen - 6 );
-    buf[5] = BYTE_0( *olen - 6 );
+    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
+    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = BYTE_1( *olen - 4 );
-    buf[3] = BYTE_0( *olen - 4 );
+    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
+    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
 
     return( 0 );
 }
@@ -1215,8 +1215,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = BYTE_1( ext_len );
-        *p++ = BYTE_0( ext_len );
+        *p++ = MBEDTLS_BYTE_1( ext_len );
+        *p++ = MBEDTLS_BYTE_0( ext_len );
         p += ext_len;
     }
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -75,6 +75,12 @@
 #include "mbedtls/platform_time.h"
 #endif
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
                                  const unsigned char *info,
@@ -1118,8 +1124,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     for( i = 0, p = buf + 6; i < ciph_len; i += 3, p += 3 )
     {
         if( p[0] == 0 &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[2] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+            p[1] == (unsigned char)( BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
+            p[2] == (unsigned char)( BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
@@ -1871,8 +1877,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
     for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
-        if( p[0] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+        if( p[0] == (unsigned char)( BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
+            p[1] == (unsigned char)( BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -81,11 +81,6 @@
 #define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 #define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
-#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
-#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
-#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
-
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
                                  const unsigned char *info,
@@ -1161,8 +1156,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 #endif
         {
             if( p[0] != 0 ||
-                p[1] != CHAR_1(ciphersuites[i]) ||
-                p[2] != CHAR_0(ciphersuites[i]) )
+                p[1] != BYTE_1(ciphersuites[i]) ||
+                p[2] != BYTE_0(ciphersuites[i]) )
                 continue;
 
             got_common_suite = 1;
@@ -2001,8 +1996,8 @@ read_record_header:
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
 #endif
         {
-            if( p[0] != CHAR_1( ciphersuites[i] ) ||
-                p[1] != CHAR_0( ciphersuites[i] ) )
+            if( p[0] != BYTE_1( ciphersuites[i] ) ||
+                p[1] != BYTE_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2086,8 +2081,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2129,8 +2124,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2156,8 +2151,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2181,8 +2176,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2205,8 +2200,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2246,8 +2241,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2276,8 +2271,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2314,8 +2309,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2326,8 +2321,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = CHAR_1( kkpp_len );
-    *p++ = CHAR_0( kkpp_len );
+    *p++ = BYTE_1( kkpp_len );
+    *p++ = BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 }
@@ -2352,18 +2347,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = CHAR_1( MBEDTLS_TLS_EXT_ALPN );
-    buf[1] = CHAR_0( MBEDTLS_TLS_EXT_ALPN );
+    buf[0] = BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    buf[1] = BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = CHAR_1( *olen - 4 );
-    buf[3] = CHAR_0( *olen - 4 );
+    buf[2] = BYTE_1( *olen - 4 );
+    buf[3] = BYTE_0( *olen - 4 );
 
-    buf[4] = CHAR_1( *olen - 6 );
-    buf[5] = CHAR_0( *olen - 6 );
+    buf[4] = BYTE_1( *olen - 6 );
+    buf[5] = BYTE_0( *olen - 6 );
 
-    buf[6] = CHAR_0( *olen - 7 );
+    buf[6] = BYTE_0( *olen - 7 );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2656,8 +2651,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = CHAR_1( ext_len );
-        *p++ = CHAR_0( ext_len );
+        *p++ = BYTE_1( ext_len );
+        *p++ = BYTE_0( ext_len );
         p += ext_len;
     }
 
@@ -3525,8 +3520,8 @@ static int ssl_decrypt_encrypted_pms( mbedtls_ssl_context *ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
         }
-        if( *p++ != CHAR_1( len ) ||
-            *p++ != CHAR_0( len ) )
+        if( *p++ != BYTE_1( len ) ||
+            *p++ != BYTE_0( len ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
@@ -4255,13 +4250,13 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = CHAR_3( lifetime );
-    ssl->out_msg[5] = CHAR_2( lifetime );
-    ssl->out_msg[6] = CHAR_1( lifetime );
-    ssl->out_msg[7] = CHAR_0( lifetime );
+    ssl->out_msg[4] = BYTE_3( lifetime );
+    ssl->out_msg[5] = BYTE_2( lifetime );
+    ssl->out_msg[6] = BYTE_1( lifetime );
+    ssl->out_msg[7] = BYTE_0( lifetime );
 
-    ssl->out_msg[8] = CHAR_1( tlen );
-    ssl->out_msg[9] = CHAR_0( tlen );
+    ssl->out_msg[8] = BYTE_1( tlen );
+    ssl->out_msg[9] = BYTE_0( tlen );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -76,10 +76,10 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
@@ -1124,8 +1124,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     for( i = 0, p = buf + 6; i < ciph_len; i += 3, p += 3 )
     {
         if( p[0] == 0 &&
-            p[1] == (unsigned char)( BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
-            p[2] == (unsigned char)( BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
+            p[1] == (unsigned char)( MBEDTLS_BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
+            p[2] == (unsigned char)( MBEDTLS_BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
@@ -1156,8 +1156,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 #endif
         {
             if( p[0] != 0 ||
-                p[1] != BYTE_1(ciphersuites[i]) ||
-                p[2] != BYTE_0(ciphersuites[i]) )
+                p[1] != MBEDTLS_BYTE_1(ciphersuites[i]) ||
+                p[2] != MBEDTLS_BYTE_0(ciphersuites[i]) )
                 continue;
 
             got_common_suite = 1;
@@ -1877,8 +1877,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
     for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
-        if( p[0] == (unsigned char)( BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
-            p[1] == (unsigned char)( BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
+        if( p[0] == (unsigned char)( MBEDTLS_BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) &&
+            p[1] == (unsigned char)( MBEDTLS_BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 
@@ -1996,8 +1996,8 @@ read_record_header:
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
 #endif
         {
-            if( p[0] != BYTE_1( ciphersuites[i] ) ||
-                p[1] != BYTE_0( ciphersuites[i] ) )
+            if( p[0] != MBEDTLS_BYTE_1( ciphersuites[i] ) ||
+                p[1] != MBEDTLS_BYTE_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2081,8 +2081,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2124,8 +2124,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2151,8 +2151,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2176,8 +2176,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2200,8 +2200,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2241,8 +2241,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2271,8 +2271,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2309,8 +2309,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2321,8 +2321,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = BYTE_1( kkpp_len );
-    *p++ = BYTE_0( kkpp_len );
+    *p++ = MBEDTLS_BYTE_1( kkpp_len );
+    *p++ = MBEDTLS_BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 }
@@ -2347,18 +2347,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = BYTE_1( MBEDTLS_TLS_EXT_ALPN );
-    buf[1] = BYTE_0( MBEDTLS_TLS_EXT_ALPN );
+    buf[0] = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    buf[1] = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = BYTE_1( *olen - 4 );
-    buf[3] = BYTE_0( *olen - 4 );
+    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
+    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
 
-    buf[4] = BYTE_1( *olen - 6 );
-    buf[5] = BYTE_0( *olen - 6 );
+    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
+    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
 
-    buf[6] = BYTE_0( *olen - 7 );
+    buf[6] = MBEDTLS_BYTE_0( *olen - 7 );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2651,8 +2651,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = BYTE_1( ext_len );
-        *p++ = BYTE_0( ext_len );
+        *p++ = MBEDTLS_BYTE_1( ext_len );
+        *p++ = MBEDTLS_BYTE_0( ext_len );
         p += ext_len;
     }
 
@@ -3520,8 +3520,8 @@ static int ssl_decrypt_encrypted_pms( mbedtls_ssl_context *ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
         }
-        if( *p++ != BYTE_1( len ) ||
-            *p++ != BYTE_0( len ) )
+        if( *p++ != MBEDTLS_BYTE_1( len ) ||
+            *p++ != MBEDTLS_BYTE_0( len ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
@@ -4250,13 +4250,13 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = BYTE_3( lifetime );
-    ssl->out_msg[5] = BYTE_2( lifetime );
-    ssl->out_msg[6] = BYTE_1( lifetime );
-    ssl->out_msg[7] = BYTE_0( lifetime );
+    ssl->out_msg[4] = MBEDTLS_BYTE_3( lifetime );
+    ssl->out_msg[5] = MBEDTLS_BYTE_2( lifetime );
+    ssl->out_msg[6] = MBEDTLS_BYTE_1( lifetime );
+    ssl->out_msg[7] = MBEDTLS_BYTE_0( lifetime );
 
-    ssl->out_msg[8] = BYTE_1( tlen );
-    ssl->out_msg[9] = BYTE_0( tlen );
+    ssl->out_msg[8] = MBEDTLS_BYTE_1( tlen );
+    ssl->out_msg[9] = MBEDTLS_BYTE_0( tlen );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -76,10 +76,15 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >>  8 ) & 0xff ) )
 #define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 #define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
+#define CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xFF))
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF))
+#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF))
+#define CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xFF))
 
 #if defined(MBEDTLS_SSL_DTLS_HELLO_VERIFY)
 int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
@@ -1156,8 +1161,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 #endif
         {
             if( p[0] != 0 ||
-                p[1] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
-                p[2] != ( ( ciphersuites[i]      ) & 0xFF ) )
+                p[1] != CHAR_1(ciphersuites[i]) ||
+                p[2] != CHAR_0(ciphersuites[i]) )
                 continue;
 
             got_common_suite = 1;
@@ -1996,8 +2001,8 @@ read_record_header:
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
 #endif
         {
-            if( p[0] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
-                p[1] != ( ( ciphersuites[i]      ) & 0xFF ) )
+            if( p[0] != CHAR_1( ciphersuites[i] ) ||
+                p[1] != CHAR_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2081,8 +2086,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2124,8 +2129,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2151,8 +2156,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2176,8 +2181,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2200,8 +2205,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2241,8 +2246,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2271,8 +2276,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2309,8 +2314,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2321,8 +2326,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = CHAR_1( kkpp_len );
+    *p++ = CHAR_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 }
@@ -2347,18 +2352,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    buf[1] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    buf[0] = CHAR_1( MBEDTLS_TLS_EXT_ALPN );
+    buf[1] = CHAR_0( MBEDTLS_TLS_EXT_ALPN );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = CHAR_1( *olen - 4 );
+    buf[3] = CHAR_0( *olen - 4 );
 
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = CHAR_1( *olen - 6 );
+    buf[5] = CHAR_0( *olen - 6 );
 
-    buf[6] = (unsigned char)( ( ( *olen - 7 )      ) & 0xFF );
+    buf[6] = CHAR_0( *olen - 7 );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2651,8 +2656,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = CHAR_1( ext_len );
+        *p++ = CHAR_0( ext_len );
         p += ext_len;
     }
 
@@ -3520,8 +3525,8 @@ static int ssl_decrypt_encrypted_pms( mbedtls_ssl_context *ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
         }
-        if( *p++ != ( ( len >> 8 ) & 0xFF ) ||
-            *p++ != ( ( len      ) & 0xFF ) )
+        if( *p++ != CHAR_1( len ) ||
+            *p++ != CHAR_0( len ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
@@ -4250,13 +4255,13 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = ( lifetime >> 24 ) & 0xFF;
-    ssl->out_msg[5] = ( lifetime >> 16 ) & 0xFF;
-    ssl->out_msg[6] = ( lifetime >>  8 ) & 0xFF;
-    ssl->out_msg[7] = ( lifetime       ) & 0xFF;
+    ssl->out_msg[4] = CHAR_3( lifetime );
+    ssl->out_msg[5] = CHAR_2( lifetime );
+    ssl->out_msg[6] = CHAR_1( lifetime );
+    ssl->out_msg[7] = CHAR_0( lifetime );
 
-    ssl->out_msg[8] = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    ssl->out_msg[9] = (unsigned char)( ( tlen      ) & 0xFF );
+    ssl->out_msg[8] = CHAR_1( tlen );
+    ssl->out_msg[9] = CHAR_0( tlen );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -66,6 +66,12 @@
 
 #include <string.h>
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 /*
  * Initialze context
  */
@@ -368,8 +374,8 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-    state_len_bytes[0] = ( clear_len >> 8 ) & 0xff;
-    state_len_bytes[1] = ( clear_len      ) & 0xff;
+    state_len_bytes[0] = BYTE_1( clear_len );
+    state_len_bytes[1] = BYTE_0( clear_len );
 
     /* Encrypt and authenticate */
     tag = state + clear_len;

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -67,10 +67,12 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
+
+#define CHAR_0( x ) ( (unsigned char) ( ( ( x )       ) & 0xFF ) )
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF ) )
+#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF ) )
 
 /*
  * Initialze context
@@ -233,9 +235,9 @@ static int ssl_save_session( const mbedtls_ssl_session *session,
     if( left < 3 + cert_len )
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
-    *p++ = (unsigned char)( ( cert_len >> 16 ) & 0xFF );
-    *p++ = (unsigned char)( ( cert_len >>  8 ) & 0xFF );
-    *p++ = (unsigned char)( ( cert_len       ) & 0xFF );
+    *p++ = CHAR_2( cert_len );
+    *p++ = CHAR_1( cert_len );
+    *p++ = CHAR_0( cert_len );
 
     if( session->peer_cert != NULL )
         memcpy( p, session->peer_cert->raw.p, cert_len );

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -67,9 +67,9 @@
 #include <string.h>
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 
 /*
  * Initialze context
@@ -232,9 +232,9 @@ static int ssl_save_session( const mbedtls_ssl_session *session,
     if( left < 3 + cert_len )
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
-    *p++ = BYTE_2( cert_len );
-    *p++ = BYTE_1( cert_len );
-    *p++ = BYTE_0( cert_len );
+    *p++ = MBEDTLS_BYTE_2( cert_len );
+    *p++ = MBEDTLS_BYTE_1( cert_len );
+    *p++ = MBEDTLS_BYTE_0( cert_len );
 
     if( session->peer_cert != NULL )
         memcpy( p, session->peer_cert->raw.p, cert_len );
@@ -373,8 +373,8 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-    state_len_bytes[0] = BYTE_1( clear_len );
-    state_len_bytes[1] = BYTE_0( clear_len );
+    state_len_bytes[0] = MBEDTLS_BYTE_1( clear_len );
+    state_len_bytes[1] = MBEDTLS_BYTE_0( clear_len );
 
     /* Encrypt and authenticate */
     tag = state + clear_len;

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -69,7 +69,7 @@
 /* Byte reading macros */
 #define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
 #define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xFF ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 
 /*
  * Initialze context

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -69,10 +69,7 @@
 /* Byte reading macros */
 #define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
 #define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
-
-#define CHAR_0( x ) ( (unsigned char) ( ( ( x )       ) & 0xFF ) )
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF ) )
-#define CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xFF ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xFF ) )
 
 /*
  * Initialze context
@@ -235,9 +232,9 @@ static int ssl_save_session( const mbedtls_ssl_session *session,
     if( left < 3 + cert_len )
         return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
 
-    *p++ = CHAR_2( cert_len );
-    *p++ = CHAR_1( cert_len );
-    *p++ = CHAR_0( cert_len );
+    *p++ = BYTE_2( cert_len );
+    *p++ = BYTE_1( cert_len );
+    *p++ = BYTE_0( cert_len );
 
     if( session->peer_cert != NULL )
         memcpy( p, session->peer_cert->raw.p, cert_len );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -80,9 +80,9 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 
 static void ssl_reset_in_out_pointers( mbedtls_ssl_context *ssl );
 static uint32_t ssl_get_hs_total_len( mbedtls_ssl_context const *ssl );
@@ -1574,8 +1574,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->out_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = BYTE_1( ssl->out_msglen );
-        add_data[12] = BYTE_0( ssl->out_msglen );
+        add_data[11] = MBEDTLS_BYTE_1( ssl->out_msglen );
+        add_data[12] = MBEDTLS_BYTE_0( ssl->out_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -1749,8 +1749,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->out_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->out_hdr, 3 );
-            pseudo_hdr[11] = BYTE_1( ssl->out_msglen );
-            pseudo_hdr[12] = BYTE_0( ssl->out_msglen );
+            pseudo_hdr[11] = MBEDTLS_BYTE_1( ssl->out_msglen );
+            pseudo_hdr[12] = MBEDTLS_BYTE_0( ssl->out_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -2032,8 +2032,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->in_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = BYTE_1( ssl->in_msglen );
-        add_data[12] = BYTE_0( ssl->in_msglen );
+        add_data[11] = MBEDTLS_BYTE_1( ssl->in_msglen );
+        add_data[12] = MBEDTLS_BYTE_0( ssl->in_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -2145,8 +2145,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->in_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->in_hdr, 3 );
-            pseudo_hdr[11] = BYTE_1( ssl->in_msglen );
-            pseudo_hdr[12] = BYTE_0( ssl->in_msglen );
+            pseudo_hdr[11] = MBEDTLS_BYTE_1( ssl->in_msglen );
+            pseudo_hdr[12] = MBEDTLS_BYTE_0( ssl->in_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -3151,13 +3151,13 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
              * Handshake headers: type(1) len(3) seq(2) f_off(3) f_len(3) */
             memcpy( ssl->out_msg, cur->p, 6 );
 
-            ssl->out_msg[6] = BYTE_2( frag_off );
-            ssl->out_msg[7] = BYTE_1( frag_off );
-            ssl->out_msg[8] = BYTE_0( frag_off );
+            ssl->out_msg[6] = MBEDTLS_BYTE_2( frag_off );
+            ssl->out_msg[7] = MBEDTLS_BYTE_1( frag_off );
+            ssl->out_msg[8] = MBEDTLS_BYTE_0( frag_off );
 
-            ssl->out_msg[ 9] = BYTE_2( cur_hs_frag_len );
-            ssl->out_msg[10] = BYTE_1( cur_hs_frag_len );
-            ssl->out_msg[11] = BYTE_0( cur_hs_frag_len );
+            ssl->out_msg[ 9] = MBEDTLS_BYTE_2( cur_hs_frag_len );
+            ssl->out_msg[10] = MBEDTLS_BYTE_1( cur_hs_frag_len );
+            ssl->out_msg[11] = MBEDTLS_BYTE_0( cur_hs_frag_len );
 
             MBEDTLS_SSL_DEBUG_BUF( 3, "handshake header", ssl->out_msg, 12 );
 
@@ -3383,8 +3383,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = BYTE_1( ssl->handshake->out_msg_seq );
-                ssl->out_msg[5] = BYTE_0( ssl->handshake->out_msg_seq );
+                ssl->out_msg[4] = MBEDTLS_BYTE_1( ssl->handshake->out_msg_seq );
+                ssl->out_msg[5] = MBEDTLS_BYTE_0( ssl->handshake->out_msg_seq );
                 ++( ssl->handshake->out_msg_seq );
             }
             else

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -84,9 +84,6 @@
 #define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
 #define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 
-#define CHAR_0( x ) ( (unsigned char) ( ( ( x )       ) & 0xFF ) )
-#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF ) )
-
 static void ssl_reset_in_out_pointers( mbedtls_ssl_context *ssl );
 static uint32_t ssl_get_hs_total_len( mbedtls_ssl_context const *ssl );
 
@@ -1577,8 +1574,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->out_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = CHAR_1( ssl->out_msglen );
-        add_data[12] = CHAR_0( ssl->out_msglen );
+        add_data[11] = BYTE_1( ssl->out_msglen );
+        add_data[12] = BYTE_0( ssl->out_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -1752,8 +1749,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->out_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->out_hdr, 3 );
-            pseudo_hdr[11] = CHAR_1( ssl->out_msglen );
-            pseudo_hdr[12] = CHAR_0( ssl->out_msglen );
+            pseudo_hdr[11] = BYTE_1( ssl->out_msglen );
+            pseudo_hdr[12] = BYTE_0( ssl->out_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -2035,8 +2032,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->in_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = CHAR_1( ssl->in_msglen );
-        add_data[12] = CHAR_0( ssl->in_msglen );
+        add_data[11] = BYTE_1( ssl->in_msglen );
+        add_data[12] = BYTE_0( ssl->in_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -2148,8 +2145,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->in_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->in_hdr, 3 );
-            pseudo_hdr[11] = CHAR_1( ssl->in_msglen );
-            pseudo_hdr[12] = CHAR_0( ssl->in_msglen );
+            pseudo_hdr[11] = BYTE_1( ssl->in_msglen );
+            pseudo_hdr[12] = BYTE_0( ssl->in_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -3386,8 +3383,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = CHAR_1( ssl->handshake->out_msg_seq );
-                ssl->out_msg[5] = CHAR_0( ssl->handshake->out_msg_seq );
+                ssl->out_msg[4] = BYTE_1( ssl->handshake->out_msg_seq );
+                ssl->out_msg[5] = BYTE_0( ssl->handshake->out_msg_seq );
                 ++( ssl->handshake->out_msg_seq );
             }
             else

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -80,10 +80,12 @@
 #endif
 
 /* Byte reading macros */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
 #define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
+#define CHAR_0( x ) ( (unsigned char) ( ( ( x )       ) & 0xFF ) )
+#define CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xFF ) )
 
 static void ssl_reset_in_out_pointers( mbedtls_ssl_context *ssl );
 static uint32_t ssl_get_hs_total_len( mbedtls_ssl_context const *ssl );
@@ -1575,8 +1577,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->out_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = ( ssl->out_msglen >> 8 ) & 0xFF;
-        add_data[12] = ssl->out_msglen & 0xFF;
+        add_data[11] = CHAR_1( ssl->out_msglen );
+        add_data[12] = CHAR_0( ssl->out_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -1750,8 +1752,8 @@ static int ssl_encrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->out_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->out_hdr, 3 );
-            pseudo_hdr[11] = (unsigned char)( ( ssl->out_msglen >> 8 ) & 0xFF );
-            pseudo_hdr[12] = (unsigned char)( ( ssl->out_msglen      ) & 0xFF );
+            pseudo_hdr[11] = CHAR_1( ssl->out_msglen );
+            pseudo_hdr[12] = CHAR_0( ssl->out_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -2033,8 +2035,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
         add_data[8]  = ssl->in_msgtype;
         mbedtls_ssl_write_version( ssl->major_ver, ssl->minor_ver,
                            ssl->conf->transport, add_data + 9 );
-        add_data[11] = ( ssl->in_msglen >> 8 ) & 0xFF;
-        add_data[12] = ssl->in_msglen & 0xFF;
+        add_data[11] = CHAR_1( ssl->in_msglen );
+        add_data[12] = CHAR_0( ssl->in_msglen );
 
         MBEDTLS_SSL_DEBUG_BUF( 4, "additional data for AEAD", add_data, 13 );
 
@@ -2146,8 +2148,8 @@ static int ssl_decrypt_buf( mbedtls_ssl_context *ssl )
 
             memcpy( pseudo_hdr +  0, ssl->in_ctr, 8 );
             memcpy( pseudo_hdr +  8, ssl->in_hdr, 3 );
-            pseudo_hdr[11] = (unsigned char)( ( ssl->in_msglen >> 8 ) & 0xFF );
-            pseudo_hdr[12] = (unsigned char)( ( ssl->in_msglen      ) & 0xFF );
+            pseudo_hdr[11] = CHAR_1( ssl->in_msglen );
+            pseudo_hdr[12] = CHAR_0( ssl->in_msglen );
 
             MBEDTLS_SSL_DEBUG_BUF( 4, "MAC'd meta-data", pseudo_hdr, 13 );
 
@@ -3384,8 +3386,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = ( ssl->handshake->out_msg_seq >> 8 ) & 0xFF;
-                ssl->out_msg[5] = ( ssl->handshake->out_msg_seq      ) & 0xFF;
+                ssl->out_msg[4] = CHAR_1( ssl->handshake->out_msg_seq );
+                ssl->out_msg[5] = CHAR_0( ssl->handshake->out_msg_seq );
                 ++( ssl->handshake->out_msg_seq );
             }
             else

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -79,6 +79,12 @@
 #include "mbedtls/oid.h"
 #endif
 
+/* Byte reading macros */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff )  )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8 ) & 0xff )  )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 static void ssl_reset_in_out_pointers( mbedtls_ssl_context *ssl );
 static uint32_t ssl_get_hs_total_len( mbedtls_ssl_context const *ssl );
 
@@ -3146,13 +3152,13 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
              * Handshake headers: type(1) len(3) seq(2) f_off(3) f_len(3) */
             memcpy( ssl->out_msg, cur->p, 6 );
 
-            ssl->out_msg[6] = ( ( frag_off >> 16 ) & 0xff );
-            ssl->out_msg[7] = ( ( frag_off >>  8 ) & 0xff );
-            ssl->out_msg[8] = ( ( frag_off       ) & 0xff );
+            ssl->out_msg[6] = BYTE_2( frag_off );
+            ssl->out_msg[7] = BYTE_1( frag_off );
+            ssl->out_msg[8] = BYTE_0( frag_off );
 
-            ssl->out_msg[ 9] = ( ( cur_hs_frag_len >> 16 ) & 0xff );
-            ssl->out_msg[10] = ( ( cur_hs_frag_len >>  8 ) & 0xff );
-            ssl->out_msg[11] = ( ( cur_hs_frag_len       ) & 0xff );
+            ssl->out_msg[ 9] = BYTE_2( cur_hs_frag_len );
+            ssl->out_msg[10] = BYTE_1( cur_hs_frag_len );
+            ssl->out_msg[11] = BYTE_0( cur_hs_frag_len );
 
             MBEDTLS_SSL_DEBUG_BUF( 3, "handshake header", ssl->out_msg, 12 );
 

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -71,8 +71,8 @@
 /*
  * 32-bit integer manipulation macros (big endian)
  */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
 {                                                       \
     (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
         | ( (uint32_t) (b)[(i) + 1] << 16 )             \
@@ -81,8 +81,8 @@
 }
 #endif
 
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
 {                                                       \
     (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
     (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
@@ -115,7 +115,7 @@ void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] 
 
     for( i = 0; i < 4; i++ )
     {
-        GET_UINT32_BE( ctx->k[i], key, i << 2 );
+        MBEDTLS_GET_UINT32_BE( ctx->k[i], key, i << 2 );
     }
 }
 
@@ -129,8 +129,8 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx, int mode,
 
     k = ctx->k;
 
-    GET_UINT32_BE( v0, input, 0 );
-    GET_UINT32_BE( v1, input, 4 );
+    MBEDTLS_GET_UINT32_BE( v0, input, 0 );
+    MBEDTLS_GET_UINT32_BE( v1, input, 4 );
 
     if( mode == MBEDTLS_XTEA_ENCRYPT )
     {
@@ -155,8 +155,8 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx, int mode,
         }
     }
 
-    PUT_UINT32_BE( v0, output, 0 );
-    PUT_UINT32_BE( v1, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( v0, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( v1, output, 4 );
 
     return( 0 );
 }


### PR DESCRIPTION
## Description

Defined `BYTE_x` macros and replaced lines using `& 0xff )` with the macro function call.
To improve readability by saving horizontal and vertical space.
Unlike the development branch, this backport doesn't utilise a common header file, so the macros are defined per file.

`MBEDTLS_BYTE_x` and `MBEDTLS_GET/PUT_UINT32/64_LE/BE` macros are defined in `development` and `2.x`. For consistency we decided to also prefix the macros with `MBEDTLS_` in this backport, however, `check-names.sh` does not allow for this unless the macros exist in a common header file. Rather than trick `check-names.sh` by moving the definitions into a file such as `ssl_interal.h` and copy its definition to files that do not already use it, or define a new common header file, we have elected to close this backport as it would be making too many changes to the code for an LTS version. Furthermore, 2.16 is expected to only continue support until 2021, and therefore making any drastic changes seems unnecessary.

Closes #4274

## Status
**CLOSED**

## Requires Backporting
NO  
This is a backport from [development](https://github.com/ARMmbed/mbedtls/pull/4716)

## Migrations
NO

## Additional comments
Instances of UINT32 and & 0xff ) etc. were located using a simple bash script which just takes a given parameter and uses it to locate for all instances of a string all .c files. I can therefore say that I believe all instances of the code that could be replaced by the macros, has been.

## Todos
- [x] Tests
- No Changelog needed

## Steps to test or reproduce
As multiple files are modified in library/, running all tests with make test seems most appropriate.