### PR TITLE
Backport 2.x: Byte Reading Macros

### DIFF
--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -1,0 +1,6 @@
+Changes
+   * Create 4 byte reading macros in library/common.h, used in files
+     within the same directory: MBEDTLS_BYTE_0... MBEDTLS_BYTE_3.
+   * Move the (PUT and GET) UINT32_ (BE and LE) macro functions into
+     library/common.h. Rename with the prefix MBEDTLS_ to satisfy
+     test/scripts/check-names.sh (e.g MBEDTLS_PUT_UINT32_LE). Fixes #4274.

--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -4,3 +4,4 @@ Changes
    * Move the (PUT and GET) UINT32_ (BE and LE) macro functions into
      library/common.h. Rename with the prefix MBEDTLS_ to satisfy
      test/scripts/check-names.sh (e.g MBEDTLS_PUT_UINT32_LE). Fixes #4274.
+

--- a/ChangeLog.d/issue4274.txt
+++ b/ChangeLog.d/issue4274.txt
@@ -1,7 +1,0 @@
-Changes
-   * Create 4 byte reading macros in library/common.h, used in files
-     within the same directory: MBEDTLS_BYTE_0... MBEDTLS_BYTE_3.
-   * Move the (PUT and GET) UINT32_ (BE and LE) macro functions into
-     library/common.h. Rename with the prefix MBEDTLS_ to satisfy
-     test/scripts/check-names.sh (e.g MBEDTLS_PUT_UINT32_LE). Fixes #4274.
-

--- a/library/aes.c
+++ b/library/aes.c
@@ -386,7 +386,7 @@ static void aes_gen_tables( void )
     {
         pow[i] = x;
         log[x] = i;
-        x = ( x ^ XTIME( x ) ) & 0xFF;
+        x = MBEDTLS_BYTE_0( x ^ XTIME( x ) );
     }
 
     /*
@@ -395,7 +395,7 @@ static void aes_gen_tables( void )
     for( i = 0, x = 1; i < 10; i++ )
     {
         RCON[i] = (uint32_t) x;
-        x = XTIME( x ) & 0xFF;
+        x = MBEDTLS_BYTE_0( XTIME( x ) );
     }
 
     /*
@@ -408,10 +408,10 @@ static void aes_gen_tables( void )
     {
         x = pow[255 - log[i]];
 
-        y  = x; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
-        x ^= y; y = ( ( y << 1 ) | ( y >> 7 ) ) & 0xFF;
+        y  = x; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
+        x ^= y; y = MBEDTLS_BYTE_0( ( y << 1 ) | ( y >> 7 ) );
         x ^= y ^ 0x63;
 
         FSb[i] = (unsigned char) x;
@@ -424,8 +424,8 @@ static void aes_gen_tables( void )
     for( i = 0; i < 256; i++ )
     {
         x = FSb[i];
-        y = XTIME( x ) & 0xFF;
-        z =  ( y ^ x ) & 0xFF;
+        y = MBEDTLS_BYTE_0( XTIME( x ) );
+        z = MBEDTLS_BYTE_0( y ^ x );
 
         FT0[i] = ( (uint32_t) y       ) ^
                  ( (uint32_t) x <<  8 ) ^
@@ -577,10 +577,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 10; i++, RK += 4 )
             {
                 RK[4]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[3] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[3] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[3] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[3]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[3] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[3] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[3] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[3] ) ] << 24 );
 
                 RK[5]  = RK[1] ^ RK[4];
                 RK[6]  = RK[2] ^ RK[5];
@@ -593,10 +593,10 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 8; i++, RK += 6 )
             {
                 RK[6]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[5] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[5] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[5] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[5]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[5] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[5] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[5] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[5] ) ] << 24 );
 
                 RK[7]  = RK[1] ^ RK[6];
                 RK[8]  = RK[2] ^ RK[7];
@@ -611,20 +611,20 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
             for( i = 0; i < 7; i++, RK += 8 )
             {
                 RK[8]  = RK[0] ^ RCON[i] ^
-                ( (uint32_t) FSb[ ( RK[7] >>  8 ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[7] >> 16 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[7] >> 24 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[7]       ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[7] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[7] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[7] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[7] ) ] << 24 );
 
                 RK[9]  = RK[1] ^ RK[8];
                 RK[10] = RK[2] ^ RK[9];
                 RK[11] = RK[3] ^ RK[10];
 
                 RK[12] = RK[4] ^
-                ( (uint32_t) FSb[ ( RK[11]       ) & 0xFF ]       ) ^
-                ( (uint32_t) FSb[ ( RK[11] >>  8 ) & 0xFF ] <<  8 ) ^
-                ( (uint32_t) FSb[ ( RK[11] >> 16 ) & 0xFF ] << 16 ) ^
-                ( (uint32_t) FSb[ ( RK[11] >> 24 ) & 0xFF ] << 24 );
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_0( RK[11] ) ]       ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_1( RK[11] ) ] <<  8 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_2( RK[11] ) ] << 16 ) ^
+                ( (uint32_t) FSb[ MBEDTLS_BYTE_3( RK[11] ) ] << 24 );
 
                 RK[13] = RK[5] ^ RK[12];
                 RK[14] = RK[6] ^ RK[13];
@@ -690,10 +690,10 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
     {
         for( j = 0; j < 4; j++, SK++ )
         {
-            *RK++ = AES_RT0( FSb[ ( *SK       ) & 0xFF ] ) ^
-                    AES_RT1( FSb[ ( *SK >>  8 ) & 0xFF ] ) ^
-                    AES_RT2( FSb[ ( *SK >> 16 ) & 0xFF ] ) ^
-                    AES_RT3( FSb[ ( *SK >> 24 ) & 0xFF ] );
+            *RK++ = AES_RT0( FSb[ MBEDTLS_BYTE_0( *SK ) ] ) ^
+                    AES_RT1( FSb[ MBEDTLS_BYTE_1( *SK ) ] ) ^
+                    AES_RT2( FSb[ MBEDTLS_BYTE_2( *SK ) ] ) ^
+                    AES_RT3( FSb[ MBEDTLS_BYTE_3( *SK ) ] );
         }
     }
 
@@ -786,52 +786,52 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
 }
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
-#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                     \
-    do                                                          \
-    {                                                           \
-        (X0) = *RK++ ^ AES_FT0( ( (Y0)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y1) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y2) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y3) >> 24 ) & 0xFF );        \
-                                                                \
-        (X1) = *RK++ ^ AES_FT0( ( (Y1)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y2) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y3) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y0) >> 24 ) & 0xFF );        \
-                                                                \
-        (X2) = *RK++ ^ AES_FT0( ( (Y2)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y3) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y0) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y1) >> 24 ) & 0xFF );        \
-                                                                \
-        (X3) = *RK++ ^ AES_FT0( ( (Y3)       ) & 0xFF ) ^       \
-                       AES_FT1( ( (Y0) >>  8 ) & 0xFF ) ^       \
-                       AES_FT2( ( (Y1) >> 16 ) & 0xFF ) ^       \
-                       AES_FT3( ( (Y2) >> 24 ) & 0xFF );        \
+#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                    \
+    do                                                         \
+    {                                                          \
+        (X0) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y0 ) ) ^       \
+                       AES_FT1( MBEDTLS_BYTE_1( Y1 ) ) ^       \
+                       AES_FT2( MBEDTLS_BYTE_2( Y2 ) ) ^       \
+                       AES_FT3( MBEDTLS_BYTE_3( Y3 ) );        \
+                                                               \
+        (X1) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y1 ) ) ^       \
+                       AES_FT1( MBEDTLS_BYTE_1( Y2 ) ) ^       \
+                       AES_FT2( MBEDTLS_BYTE_2( Y3 ) ) ^       \
+                       AES_FT3( MBEDTLS_BYTE_3( Y0 ) );        \
+                                                               \
+        (X2) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y2 ) ) ^       \
+                       AES_FT1( MBEDTLS_BYTE_1( Y3 ) ) ^       \
+                       AES_FT2( MBEDTLS_BYTE_2( Y0 ) ) ^       \
+                       AES_FT3( MBEDTLS_BYTE_3( Y1 ) );        \
+                                                               \
+        (X3) = *RK++ ^ AES_FT0( MBEDTLS_BYTE_0( Y3 ) ) ^       \
+                       AES_FT1( MBEDTLS_BYTE_1( Y0 ) ) ^       \
+                       AES_FT2( MBEDTLS_BYTE_2( Y1 ) ) ^       \
+                       AES_FT3( MBEDTLS_BYTE_3( Y2 ) );        \
     } while( 0 )
 
-#define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                 \
-    do                                                      \
-    {                                                       \
-        (X0) = *RK++ ^ AES_RT0( ( (Y0)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y3) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y2) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y1) >> 24 ) & 0xFF );    \
-                                                            \
-        (X1) = *RK++ ^ AES_RT0( ( (Y1)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y0) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y3) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y2) >> 24 ) & 0xFF );    \
-                                                            \
-        (X2) = *RK++ ^ AES_RT0( ( (Y2)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y1) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y0) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y3) >> 24 ) & 0xFF );    \
-                                                            \
-        (X3) = *RK++ ^ AES_RT0( ( (Y3)       ) & 0xFF ) ^   \
-                       AES_RT1( ( (Y2) >>  8 ) & 0xFF ) ^   \
-                       AES_RT2( ( (Y1) >> 16 ) & 0xFF ) ^   \
-                       AES_RT3( ( (Y0) >> 24 ) & 0xFF );    \
+#define AES_RROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)                    \
+    do                                                         \
+    {                                                          \
+        (X0) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y0 ) ) ^       \
+                       AES_RT1( MBEDTLS_BYTE_1( Y3 ) ) ^       \
+                       AES_RT2( MBEDTLS_BYTE_2( Y2 ) ) ^       \
+                       AES_RT3( MBEDTLS_BYTE_3( Y1 ) );        \
+                                                               \
+        (X1) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y1 ) ) ^       \
+                       AES_RT1( MBEDTLS_BYTE_1( Y0 ) ) ^       \
+                       AES_RT2( MBEDTLS_BYTE_2( Y3 ) ) ^       \
+                       AES_RT3( MBEDTLS_BYTE_3( Y2 ) );        \
+                                                               \
+        (X2) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y2 ) ) ^       \
+                       AES_RT1( MBEDTLS_BYTE_1( Y1 ) ) ^       \
+                       AES_RT2( MBEDTLS_BYTE_2( Y0 ) ) ^       \
+                       AES_RT3( MBEDTLS_BYTE_3( Y3 ) );        \
+                                                               \
+        (X3) = *RK++ ^ AES_RT0( MBEDTLS_BYTE_0( Y3 ) ) ^       \
+                       AES_RT1( MBEDTLS_BYTE_1( Y2 ) ) ^       \
+                       AES_RT2( MBEDTLS_BYTE_2( Y1 ) ) ^       \
+                       AES_RT3( MBEDTLS_BYTE_3( Y0 ) );        \
     } while( 0 )
 
 /*
@@ -864,28 +864,28 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
     AES_FROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[0]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[1]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[0] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[2]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[3] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) FSb[ ( t.Y[3]       ) & 0xFF ]       ) ^
-            ( (uint32_t) FSb[ ( t.Y[0] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) FSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) FSb[ ( t.Y[2] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) FSb[ MBEDTLS_BYTE_3( t.Y[2] ) ] << 24 );
 
     MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
     MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );
@@ -937,28 +937,28 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
     AES_RROUND( t.Y[0], t.Y[1], t.Y[2], t.Y[3], t.X[0], t.X[1], t.X[2], t.X[3] );
 
     t.X[0] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[0]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[0] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[3] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[2] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[1] ) ] << 24 );
 
     t.X[1] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[1]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[1] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[0] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[3] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[2] ) ] << 24 );
 
     t.X[2] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[2]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[3] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[2] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[1] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[0] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[3] ) ] << 24 );
 
     t.X[3] = *RK++ ^ \
-            ( (uint32_t) RSb[ ( t.Y[3]       ) & 0xFF ]       ) ^
-            ( (uint32_t) RSb[ ( t.Y[2] >>  8 ) & 0xFF ] <<  8 ) ^
-            ( (uint32_t) RSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
-            ( (uint32_t) RSb[ ( t.Y[0] >> 24 ) & 0xFF ] << 24 );
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_0( t.Y[3] ) ]       ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_1( t.Y[2] ) ] <<  8 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_2( t.Y[1] ) ] << 16 ) ^
+            ( (uint32_t) RSb[ MBEDTLS_BYTE_3( t.Y[0] ) ] << 24 );
 
     MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
     MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );

--- a/library/aes.c
+++ b/library/aes.c
@@ -567,7 +567,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 
     for( i = 0; i < ( keybits >> 5 ); i++ )
     {
-        MBEDTLS_GET_UINT32_LE( RK[i], key, i << 2 );
+        RK[i] = MBEDTLS_GET_UINT32_LE( key, i << 2 );
     }
 
     switch( ctx->nr )
@@ -850,10 +850,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    t.X[0] = MBEDTLS_GET_UINT32_LE( input,  0 ); t.X[0] ^= *RK++;
+    t.X[1] = MBEDTLS_GET_UINT32_LE( input,  4 ); t.X[1] ^= *RK++;
+    t.X[2] = MBEDTLS_GET_UINT32_LE( input,  8 ); t.X[2] ^= *RK++;
+    t.X[3] = MBEDTLS_GET_UINT32_LE( input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {
@@ -923,10 +923,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    t.X[0] = MBEDTLS_GET_UINT32_LE( input,  0 ); t.X[0] ^= *RK++;
+    t.X[1] = MBEDTLS_GET_UINT32_LE( input,  4 ); t.X[1] ^= *RK++;
+    t.X[2] = MBEDTLS_GET_UINT32_LE( input,  8 ); t.X[2] ^= *RK++;
+    t.X[3] = MBEDTLS_GET_UINT32_LE( input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {

--- a/library/aes.c
+++ b/library/aes.c
@@ -57,29 +57,6 @@
 #define AES_VALIDATE( cond )        \
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
-/*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
 #if defined(MBEDTLS_PADLOCK_C) &&                      \
     ( defined(MBEDTLS_HAVE_X86) || defined(MBEDTLS_PADLOCK_ALIGN16) )
 static int aes_padlock_ace = -1;
@@ -590,7 +567,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
 
     for( i = 0; i < ( keybits >> 5 ); i++ )
     {
-        GET_UINT32_LE( RK[i], key, i << 2 );
+        MBEDTLS_GET_UINT32_LE( RK[i], key, i << 2 );
     }
 
     switch( ctx->nr )
@@ -873,10 +850,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {
@@ -910,10 +887,10 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
             ( (uint32_t) FSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
             ( (uint32_t) FSb[ ( t.Y[2] >> 24 ) & 0xFF ] << 24 );
 
-    PUT_UINT32_LE( t.X[0], output,  0 );
-    PUT_UINT32_LE( t.X[1], output,  4 );
-    PUT_UINT32_LE( t.X[2], output,  8 );
-    PUT_UINT32_LE( t.X[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( t.X[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( t.X[3], output, 12 );
 
     mbedtls_platform_zeroize( &t, sizeof( t ) );
 
@@ -946,10 +923,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
         uint32_t Y[4];
     } t;
 
-    GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
-    GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
-    GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
-    GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[0], input,  0 ); t.X[0] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[1], input,  4 ); t.X[1] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[2], input,  8 ); t.X[2] ^= *RK++;
+    MBEDTLS_GET_UINT32_LE( t.X[3], input, 12 ); t.X[3] ^= *RK++;
 
     for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
     {
@@ -983,10 +960,10 @@ int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
             ( (uint32_t) RSb[ ( t.Y[1] >> 16 ) & 0xFF ] << 16 ) ^
             ( (uint32_t) RSb[ ( t.Y[0] >> 24 ) & 0xFF ] << 24 );
 
-    PUT_UINT32_LE( t.X[0], output,  0 );
-    PUT_UINT32_LE( t.X[1], output,  4 );
-    PUT_UINT32_LE( t.X[2], output,  8 );
-    PUT_UINT32_LE( t.X[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( t.X[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( t.X[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( t.X[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( t.X[3], output, 12 );
 
     mbedtls_platform_zeroize( &t, sizeof( t ) );
 

--- a/library/aes.c
+++ b/library/aes.c
@@ -1092,35 +1092,6 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 
-/* Endianess with 64 bits values */
-#ifndef GET_UINT64_LE
-#define GET_UINT64_LE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint64_t) (b)[(i) + 7] << 56 )             \
-        | ( (uint64_t) (b)[(i) + 6] << 48 )             \
-        | ( (uint64_t) (b)[(i) + 5] << 40 )             \
-        | ( (uint64_t) (b)[(i) + 4] << 32 )             \
-        | ( (uint64_t) (b)[(i) + 3] << 24 )             \
-        | ( (uint64_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint64_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint64_t) (b)[(i)    ]       );            \
-}
-#endif
-
-#ifndef PUT_UINT64_LE
-#define PUT_UINT64_LE(n,b,i)                            \
-{                                                       \
-    (b)[(i) + 7] = (unsigned char) ( (n) >> 56 );       \
-    (b)[(i) + 6] = (unsigned char) ( (n) >> 48 );       \
-    (b)[(i) + 5] = (unsigned char) ( (n) >> 40 );       \
-    (b)[(i) + 4] = (unsigned char) ( (n) >> 32 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i)    ] = (unsigned char) ( (n)       );       \
-}
-#endif
-
 typedef unsigned char mbedtls_be128[16];
 
 /*
@@ -1136,14 +1107,14 @@ static void mbedtls_gf128mul_x_ble( unsigned char r[16],
 {
     uint64_t a, b, ra, rb;
 
-    GET_UINT64_LE( a, x, 0 );
-    GET_UINT64_LE( b, x, 8 );
+    a = MBEDTLS_GET_UINT64_LE( x, 0 );
+    b = MBEDTLS_GET_UINT64_LE( x, 8 );
 
     ra = ( a << 1 )  ^ 0x0087 >> ( 8 - ( ( b >> 63 ) << 3 ) );
     rb = ( a >> 63 ) | ( b << 1 );
 
-    PUT_UINT64_LE( ra, r, 0 );
-    PUT_UINT64_LE( rb, r, 8 );
+    MBEDTLS_PUT_UINT64_LE( ra, r, 0 );
+    MBEDTLS_PUT_UINT64_LE( rb, r, 8 );
 }
 
 /*

--- a/library/aria.c
+++ b/library/aria.c
@@ -433,21 +433,21 @@ int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
         return( MBEDTLS_ERR_ARIA_BAD_INPUT_DATA );
 
     /* Copy key to W0 (and potential remainder to W1) */
-    MBEDTLS_GET_UINT32_LE( w[0][0], key,  0 );
-    MBEDTLS_GET_UINT32_LE( w[0][1], key,  4 );
-    MBEDTLS_GET_UINT32_LE( w[0][2], key,  8 );
-    MBEDTLS_GET_UINT32_LE( w[0][3], key, 12 );
+    w[0][0] = MBEDTLS_GET_UINT32_LE( key,  0 );
+    w[0][1] = MBEDTLS_GET_UINT32_LE( key,  4 );
+    w[0][2] = MBEDTLS_GET_UINT32_LE( key,  8 );
+    w[0][3] = MBEDTLS_GET_UINT32_LE( key, 12 );
 
     memset( w[1], 0, 16 );
     if( keybits >= 192 )
     {
-        MBEDTLS_GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
-        MBEDTLS_GET_UINT32_LE( w[1][1], key, 20 );
+        w[1][0] = MBEDTLS_GET_UINT32_LE( key, 16 );  // 192 bit key
+        w[1][1] = MBEDTLS_GET_UINT32_LE( key, 20 );
     }
     if( keybits == 256 )
     {
-        MBEDTLS_GET_UINT32_LE( w[1][2], key, 24 );  // 256 bit key
-        MBEDTLS_GET_UINT32_LE( w[1][3], key, 28 );
+        w[1][2] = MBEDTLS_GET_UINT32_LE( key, 24 );  // 256 bit key
+        w[1][3] = MBEDTLS_GET_UINT32_LE( key, 28 );
     }
 
     i = ( keybits - 128 ) >> 6;             // index: 0, 1, 2
@@ -524,10 +524,10 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
     ARIA_VALIDATE_RET( input != NULL );
     ARIA_VALIDATE_RET( output != NULL );
 
-    MBEDTLS_GET_UINT32_LE( a, input,  0 );
-    MBEDTLS_GET_UINT32_LE( b, input,  4 );
-    MBEDTLS_GET_UINT32_LE( c, input,  8 );
-    MBEDTLS_GET_UINT32_LE( d, input, 12 );
+    a = MBEDTLS_GET_UINT32_LE( input,  0 );
+    b = MBEDTLS_GET_UINT32_LE( input,  4 );
+    c = MBEDTLS_GET_UINT32_LE( input,  8 );
+    d = MBEDTLS_GET_UINT32_LE( input, 12 );
 
     i = 0;
     while( 1 )

--- a/library/aria.c
+++ b/library/aria.c
@@ -215,19 +215,19 @@ static inline void aria_sl( uint32_t *a, uint32_t *b,
     *a = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *a ) ]       ) ^
          (((uint32_t) sb[ MBEDTLS_BYTE_1( *a ) ]) <<  8) ^
          (((uint32_t) sc[ MBEDTLS_BYTE_2( *a ) ]) << 16) ^
-         (((uint32_t) sd[ *a >> 24             ]) << 24);
+         (((uint32_t) sd[ MBEDTLS_BYTE_3( *a ) ]) << 24);
     *b = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *b ) ]       ) ^
          (((uint32_t) sb[ MBEDTLS_BYTE_1( *b ) ]) <<  8) ^
          (((uint32_t) sc[ MBEDTLS_BYTE_2( *b ) ]) << 16) ^
-         (((uint32_t) sd[ *b >> 24             ]) << 24);
+         (((uint32_t) sd[ MBEDTLS_BYTE_3( *b ) ]) << 24);
     *c = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *c ) ]       ) ^
          (((uint32_t) sb[ MBEDTLS_BYTE_1( *c ) ]) <<  8) ^
          (((uint32_t) sc[ MBEDTLS_BYTE_2( *c ) ]) << 16) ^
-         (((uint32_t) sd[ *c >> 24             ]) << 24);
+         (((uint32_t) sd[ MBEDTLS_BYTE_3( *c ) ]) << 24);
     *d = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *d ) ]       ) ^
          (((uint32_t) sb[ MBEDTLS_BYTE_1( *d ) ]) <<  8) ^
          (((uint32_t) sc[ MBEDTLS_BYTE_2( *d ) ]) << 16) ^
-         (((uint32_t) sd[ *d >> 24        ]) << 24);
+         (((uint32_t) sd[ MBEDTLS_BYTE_3( *d ) ]) << 24);
 }
 
 /*

--- a/library/aria.c
+++ b/library/aria.c
@@ -385,7 +385,7 @@ static void aria_fe_xor( uint32_t r[4], const uint32_t p[4],
  * Big endian 128-bit rotation: r = a ^ (b <<< n), used only in key setup.
  *
  * We chose to store bytes into 32-bit words in little-endian format (see
- * GET/MBEDTLS_PUT_UINT32_LE) so we need to reverse bytes here.
+ * MBEDTLS_GET_UINT32_LE / MBEDTLS_PUT_UINT32_LE) so we need to reverse bytes here.
  */
 static void aria_rot128( uint32_t r[4], const uint32_t a[4],
                          const uint32_t b[4], uint8_t n )

--- a/library/aria.c
+++ b/library/aria.c
@@ -56,29 +56,6 @@
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
 /*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE( n, b, i )                \
-{                                               \
-    (n) = ( (uint32_t) (b)[(i)    ]       )     \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )     \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )     \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );    \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE( n, b, i )                                \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
-/*
  * modify byte order: ( A B C D ) -> ( B A D C ), i.e. swap pairs of bytes
  *
  * This is submatrix P1 in [1] Appendix B.1
@@ -408,7 +385,7 @@ static void aria_fe_xor( uint32_t r[4], const uint32_t p[4],
  * Big endian 128-bit rotation: r = a ^ (b <<< n), used only in key setup.
  *
  * We chose to store bytes into 32-bit words in little-endian format (see
- * GET/PUT_UINT32_LE) so we need to reverse bytes here.
+ * GET/MBEDTLS_PUT_UINT32_LE) so we need to reverse bytes here.
  */
 static void aria_rot128( uint32_t r[4], const uint32_t a[4],
                          const uint32_t b[4], uint8_t n )
@@ -456,21 +433,21 @@ int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
         return( MBEDTLS_ERR_ARIA_BAD_INPUT_DATA );
 
     /* Copy key to W0 (and potential remainder to W1) */
-    GET_UINT32_LE( w[0][0], key,  0 );
-    GET_UINT32_LE( w[0][1], key,  4 );
-    GET_UINT32_LE( w[0][2], key,  8 );
-    GET_UINT32_LE( w[0][3], key, 12 );
+    MBEDTLS_GET_UINT32_LE( w[0][0], key,  0 );
+    MBEDTLS_GET_UINT32_LE( w[0][1], key,  4 );
+    MBEDTLS_GET_UINT32_LE( w[0][2], key,  8 );
+    MBEDTLS_GET_UINT32_LE( w[0][3], key, 12 );
 
     memset( w[1], 0, 16 );
     if( keybits >= 192 )
     {
-        GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
-        GET_UINT32_LE( w[1][1], key, 20 );
+        MBEDTLS_GET_UINT32_LE( w[1][0], key, 16 );  // 192 bit key
+        MBEDTLS_GET_UINT32_LE( w[1][1], key, 20 );
     }
     if( keybits == 256 )
     {
-        GET_UINT32_LE( w[1][2], key, 24 );  // 256 bit key
-        GET_UINT32_LE( w[1][3], key, 28 );
+        MBEDTLS_GET_UINT32_LE( w[1][2], key, 24 );  // 256 bit key
+        MBEDTLS_GET_UINT32_LE( w[1][3], key, 28 );
     }
 
     i = ( keybits - 128 ) >> 6;             // index: 0, 1, 2
@@ -547,10 +524,10 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
     ARIA_VALIDATE_RET( input != NULL );
     ARIA_VALIDATE_RET( output != NULL );
 
-    GET_UINT32_LE( a, input,  0 );
-    GET_UINT32_LE( b, input,  4 );
-    GET_UINT32_LE( c, input,  8 );
-    GET_UINT32_LE( d, input, 12 );
+    MBEDTLS_GET_UINT32_LE( a, input,  0 );
+    MBEDTLS_GET_UINT32_LE( b, input,  4 );
+    MBEDTLS_GET_UINT32_LE( c, input,  8 );
+    MBEDTLS_GET_UINT32_LE( d, input, 12 );
 
     i = 0;
     while( 1 )
@@ -582,10 +559,10 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
     c ^= ctx->rk[i][2];
     d ^= ctx->rk[i][3];
 
-    PUT_UINT32_LE( a, output,  0 );
-    PUT_UINT32_LE( b, output,  4 );
-    PUT_UINT32_LE( c, output,  8 );
-    PUT_UINT32_LE( d, output, 12 );
+    MBEDTLS_PUT_UINT32_LE( a, output,  0 );
+    MBEDTLS_PUT_UINT32_LE( b, output,  4 );
+    MBEDTLS_PUT_UINT32_LE( c, output,  8 );
+    MBEDTLS_PUT_UINT32_LE( d, output, 12 );
 
     return( 0 );
 }

--- a/library/aria.c
+++ b/library/aria.c
@@ -212,21 +212,21 @@ static inline void aria_sl( uint32_t *a, uint32_t *b,
                             const uint8_t sa[256], const uint8_t sb[256],
                             const uint8_t sc[256], const uint8_t sd[256] )
 {
-    *a = ( (uint32_t) sa[ *a        & 0xFF]       ) ^
-         (((uint32_t) sb[(*a >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*a >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *a >> 24        ]) << 24);
-    *b = ( (uint32_t) sa[ *b        & 0xFF]       ) ^
-         (((uint32_t) sb[(*b >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*b >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *b >> 24        ]) << 24);
-    *c = ( (uint32_t) sa[ *c        & 0xFF]       ) ^
-         (((uint32_t) sb[(*c >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*c >> 16) & 0xFF]) << 16) ^
-         (((uint32_t) sd[ *c >> 24        ]) << 24);
-    *d = ( (uint32_t) sa[ *d        & 0xFF]       ) ^
-         (((uint32_t) sb[(*d >>  8) & 0xFF]) <<  8) ^
-         (((uint32_t) sc[(*d >> 16) & 0xFF]) << 16) ^
+    *a = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *a ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *a ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *a ) ]) << 16) ^
+         (((uint32_t) sd[ *a >> 24             ]) << 24);
+    *b = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *b ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *b ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *b ) ]) << 16) ^
+         (((uint32_t) sd[ *b >> 24             ]) << 24);
+    *c = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *c ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *c ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *c ) ]) << 16) ^
+         (((uint32_t) sd[ *c >> 24             ]) << 24);
+    *d = ( (uint32_t) sa[ MBEDTLS_BYTE_0( *d ) ]       ) ^
+         (((uint32_t) sb[ MBEDTLS_BYTE_1( *d ) ]) <<  8) ^
+         (((uint32_t) sc[ MBEDTLS_BYTE_2( *d ) ]) << 16) ^
          (((uint32_t) sd[ *d >> 24        ]) << 24);
 }
 

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -60,8 +60,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 3 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
+        *--(*p) = MBEDTLS_CHAR_0( len );
+        *--(*p) = MBEDTLS_CHAR_1( len );
         *--(*p) = 0x82;
         return( 3 );
     }
@@ -71,9 +71,9 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 4 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
-        *--(*p) = ( len >> 16 ) & 0xFF;
+        *--(*p) = MBEDTLS_CHAR_0( len );
+        *--(*p) = MBEDTLS_CHAR_1( len );
+        *--(*p) = MBEDTLS_CHAR_2( len );
         *--(*p) = 0x83;
         return( 4 );
     }
@@ -85,10 +85,10 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = ( len       ) & 0xFF;
-        *--(*p) = ( len >>  8 ) & 0xFF;
-        *--(*p) = ( len >> 16 ) & 0xFF;
-        *--(*p) = ( len >> 24 ) & 0xFF;
+        *--(*p) = MBEDTLS_CHAR_0( len );
+        *--(*p) = MBEDTLS_CHAR_1( len );
+        *--(*p) = MBEDTLS_CHAR_2( len );
+        *--(*p) = MBEDTLS_CHAR_3( len );
         *--(*p) = 0x84;
         return( 5 );
     }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -60,8 +60,8 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 3 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = MBEDTLS_CHAR_0( len );
-        *--(*p) = MBEDTLS_CHAR_1( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
         *--(*p) = 0x82;
         return( 3 );
     }
@@ -71,9 +71,9 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 4 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = MBEDTLS_CHAR_0( len );
-        *--(*p) = MBEDTLS_CHAR_1( len );
-        *--(*p) = MBEDTLS_CHAR_2( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
+        *--(*p) = MBEDTLS_BYTE_2( len );
         *--(*p) = 0x83;
         return( 4 );
     }
@@ -85,10 +85,10 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start, size_t len 
         if( *p - start < 5 )
             return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
-        *--(*p) = MBEDTLS_CHAR_0( len );
-        *--(*p) = MBEDTLS_CHAR_1( len );
-        *--(*p) = MBEDTLS_CHAR_2( len );
-        *--(*p) = MBEDTLS_CHAR_3( len );
+        *--(*p) = MBEDTLS_BYTE_0( len );
+        *--(*p) = MBEDTLS_BYTE_1( len );
+        *--(*p) = MBEDTLS_BYTE_2( len );
+        *--(*p) = MBEDTLS_BYTE_3( len );
         *--(*p) = 0x84;
         return( 5 );
     }

--- a/library/base64.c
+++ b/library/base64.c
@@ -319,9 +319,9 @@ int mbedtls_base64_decode( unsigned char *dst, size_t dlen, size_t *olen,
         if( ++n == 4 )
         {
             n = 0;
-            if( j > 0 ) *p++ = (unsigned char)( x >> 16 );
-            if( j > 1 ) *p++ = (unsigned char)( x >>  8 );
-            if( j > 2 ) *p++ = (unsigned char)( x       );
+            if( j > 0 ) *p++ = MBEDTLS_BYTE_2( x );
+            if( j > 1 ) *p++ = MBEDTLS_BYTE_1( x );
+            if( j > 2 ) *p++ = MBEDTLS_BYTE_0( x );
         }
     }
 

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -219,8 +219,8 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
     BLOWFISH_VALIDATE_RET( input  != NULL );
     BLOWFISH_VALIDATE_RET( output != NULL );
 
-    MBEDTLS_GET_UINT32_BE( X0, input,  0 );
-    MBEDTLS_GET_UINT32_BE( X1, input,  4 );
+    X0 = MBEDTLS_GET_UINT32_BE( input,  0 );
+    X1 = MBEDTLS_GET_UINT32_BE( input,  4 );
 
     if( mode == MBEDTLS_BLOWFISH_DECRYPT )
     {

--- a/library/blowfish.c
+++ b/library/blowfish.c
@@ -40,29 +40,6 @@
 #define BLOWFISH_VALIDATE( cond )                                           \
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
 static const uint32_t P[MBEDTLS_BLOWFISH_ROUNDS + 2] = {
         0x243F6A88L, 0x85A308D3L, 0x13198A2EL, 0x03707344L,
         0xA4093822L, 0x299F31D0L, 0x082EFA98L, 0xEC4E6C89L,
@@ -242,8 +219,8 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
     BLOWFISH_VALIDATE_RET( input  != NULL );
     BLOWFISH_VALIDATE_RET( output != NULL );
 
-    GET_UINT32_BE( X0, input,  0 );
-    GET_UINT32_BE( X1, input,  4 );
+    MBEDTLS_GET_UINT32_BE( X0, input,  0 );
+    MBEDTLS_GET_UINT32_BE( X1, input,  4 );
 
     if( mode == MBEDTLS_BLOWFISH_DECRYPT )
     {
@@ -254,8 +231,8 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
         blowfish_enc( ctx, &X0, &X1 );
     }
 
-    PUT_UINT32_BE( X0, output,  0 );
-    PUT_UINT32_BE( X1, output,  4 );
+    MBEDTLS_PUT_UINT32_BE( X0, output,  0 );
+    MBEDTLS_PUT_UINT32_BE( X1, output,  4 );
 
     return( 0 );
 }

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -278,14 +278,14 @@ static void camellia_feistel( const uint32_t x[2], const uint32_t k[2],
     I0 = x[0] ^ k[0];
     I1 = x[1] ^ k[1];
 
-    I0 = ((uint32_t) SBOX1((I0 >> 24) & 0xFF) << 24) |
-         ((uint32_t) SBOX2((I0 >> 16) & 0xFF) << 16) |
-         ((uint32_t) SBOX3((I0 >>  8) & 0xFF) <<  8) |
-         ((uint32_t) SBOX4((I0      ) & 0xFF)      );
-    I1 = ((uint32_t) SBOX2((I1 >> 24) & 0xFF) << 24) |
-         ((uint32_t) SBOX3((I1 >> 16) & 0xFF) << 16) |
-         ((uint32_t) SBOX4((I1 >>  8) & 0xFF) <<  8) |
-         ((uint32_t) SBOX1((I1      ) & 0xFF)      );
+    I0 = ((uint32_t) SBOX1( MBEDTLS_BYTE_3( I0 )) << 24) |
+         ((uint32_t) SBOX2( MBEDTLS_BYTE_2( I0 )) << 16) |
+         ((uint32_t) SBOX3( MBEDTLS_BYTE_1( I0 )) <<  8) |
+         ((uint32_t) SBOX4( MBEDTLS_BYTE_0( I0 ))      );
+    I1 = ((uint32_t) SBOX2( MBEDTLS_BYTE_3( I1 )) << 24) |
+         ((uint32_t) SBOX3( MBEDTLS_BYTE_2( I1 )) << 16) |
+         ((uint32_t) SBOX4( MBEDTLS_BYTE_1( I1 )) <<  8) |
+         ((uint32_t) SBOX1( MBEDTLS_BYTE_0( I1 ))      );
 
     I0 ^= (I1 << 8) | (I1 >> 24);
     I1 ^= (I0 << 16) | (I0 >> 16);

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -353,8 +353,8 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
      * Prepare SIGMA values
      */
     for( i = 0; i < 6; i++ ) {
-        MBEDTLS_GET_UINT32_BE( SIGMA[i][0], SIGMA_CHARS[i], 0 );
-        MBEDTLS_GET_UINT32_BE( SIGMA[i][1], SIGMA_CHARS[i], 4 );
+        SIGMA[i][0] = MBEDTLS_GET_UINT32_BE( SIGMA_CHARS[i], 0 );
+        SIGMA[i][1] = MBEDTLS_GET_UINT32_BE( SIGMA_CHARS[i], 4 );
     }
 
     /*
@@ -365,7 +365,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
 
     /* Store KL, KR */
     for( i = 0; i < 8; i++ )
-        MBEDTLS_GET_UINT32_BE( KC[i], t, i * 4 );
+        KC[i] = MBEDTLS_GET_UINT32_BE( t, i * 4 );
 
     /* Generate KA */
     for( i = 0; i < 4; ++i )
@@ -491,10 +491,10 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
     NR = ctx->nr;
     RK = ctx->rk;
 
-    MBEDTLS_GET_UINT32_BE( X[0], input,  0 );
-    MBEDTLS_GET_UINT32_BE( X[1], input,  4 );
-    MBEDTLS_GET_UINT32_BE( X[2], input,  8 );
-    MBEDTLS_GET_UINT32_BE( X[3], input, 12 );
+    X[0] = MBEDTLS_GET_UINT32_BE( input,  0 );
+    X[1] = MBEDTLS_GET_UINT32_BE( input,  4 );
+    X[2] = MBEDTLS_GET_UINT32_BE( input,  8 );
+    X[3] = MBEDTLS_GET_UINT32_BE( input, 12 );
 
     X[0] ^= *RK++;
     X[1] ^= *RK++;

--- a/library/camellia.c
+++ b/library/camellia.c
@@ -49,29 +49,6 @@
 #define CAMELLIA_VALIDATE( cond )                                           \
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
 static const unsigned char SIGMA_CHARS[6][8] =
 {
     { 0xa0, 0x9e, 0x66, 0x7f, 0x3b, 0xcc, 0x90, 0x8b },
@@ -376,8 +353,8 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
      * Prepare SIGMA values
      */
     for( i = 0; i < 6; i++ ) {
-        GET_UINT32_BE( SIGMA[i][0], SIGMA_CHARS[i], 0 );
-        GET_UINT32_BE( SIGMA[i][1], SIGMA_CHARS[i], 4 );
+        MBEDTLS_GET_UINT32_BE( SIGMA[i][0], SIGMA_CHARS[i], 0 );
+        MBEDTLS_GET_UINT32_BE( SIGMA[i][1], SIGMA_CHARS[i], 4 );
     }
 
     /*
@@ -388,7 +365,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
 
     /* Store KL, KR */
     for( i = 0; i < 8; i++ )
-        GET_UINT32_BE( KC[i], t, i * 4 );
+        MBEDTLS_GET_UINT32_BE( KC[i], t, i * 4 );
 
     /* Generate KA */
     for( i = 0; i < 4; ++i )
@@ -514,10 +491,10 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
     NR = ctx->nr;
     RK = ctx->rk;
 
-    GET_UINT32_BE( X[0], input,  0 );
-    GET_UINT32_BE( X[1], input,  4 );
-    GET_UINT32_BE( X[2], input,  8 );
-    GET_UINT32_BE( X[3], input, 12 );
+    MBEDTLS_GET_UINT32_BE( X[0], input,  0 );
+    MBEDTLS_GET_UINT32_BE( X[1], input,  4 );
+    MBEDTLS_GET_UINT32_BE( X[2], input,  8 );
+    MBEDTLS_GET_UINT32_BE( X[3], input, 12 );
 
     X[0] ^= *RK++;
     X[1] ^= *RK++;
@@ -552,10 +529,10 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
     X[0] ^= *RK++;
     X[1] ^= *RK++;
 
-    PUT_UINT32_BE( X[2], output,  0 );
-    PUT_UINT32_BE( X[3], output,  4 );
-    PUT_UINT32_BE( X[0], output,  8 );
-    PUT_UINT32_BE( X[1], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( X[2], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( X[3], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( X[0], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( X[1], output, 12 );
 
     return( 0 );
 }

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -200,7 +200,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = MBEDTLS_CHAR_0( len_left );
+        b[15-i] = MBEDTLS_BYTE_0( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
@@ -221,8 +221,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = MBEDTLS_CHAR_1( add_len );
-        b[1] = MBEDTLS_CHAR_0( add_len );
+        b[0] = MBEDTLS_BYTE_1( add_len );
+        b[1] = MBEDTLS_BYTE_0( add_len );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -221,8 +221,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = MBEDTLS_BYTE_1( add_len );
-        b[1] = MBEDTLS_BYTE_0( add_len );
+        MBEDTLS_PUT_UINT16_BE( add_len, b, 0 );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -200,7 +200,7 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     memcpy( b + 1, iv, iv_len );
 
     for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = (unsigned char)( len_left & 0xFF );
+        b[15-i] = MBEDTLS_CHAR_0( len_left );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );

--- a/library/ccm.c
+++ b/library/ccm.c
@@ -221,8 +221,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         src = add;
 
         memset( b, 0, 16 );
-        b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
-        b[1] = (unsigned char)( ( add_len      ) & 0xFF );
+        b[0] = MBEDTLS_CHAR_1( add_len );
+        b[1] = MBEDTLS_CHAR_0( add_len );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
         memcpy( b + 2, src, use_len );

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -171,10 +171,10 @@ static void chacha20_block( const uint32_t initial_state[16],
     {
         size_t offset = i * 4U;
 
-        keystream[offset     ] = (unsigned char)( working_state[i]       );
-        keystream[offset + 1U] = (unsigned char)( working_state[i] >>  8 );
-        keystream[offset + 2U] = (unsigned char)( working_state[i] >> 16 );
-        keystream[offset + 3U] = (unsigned char)( working_state[i] >> 24 );
+        keystream[offset     ] = MBEDTLS_BYTE_0( working_state[i] );
+        keystream[offset + 1U] = MBEDTLS_BYTE_1( working_state[i] );
+        keystream[offset + 2U] = MBEDTLS_BYTE_2( working_state[i] );
+        keystream[offset + 3U] = MBEDTLS_BYTE_3( working_state[i] );
     }
 
     mbedtls_platform_zeroize( working_state, sizeof( working_state ) );

--- a/library/chacha20.c
+++ b/library/chacha20.c
@@ -171,10 +171,7 @@ static void chacha20_block( const uint32_t initial_state[16],
     {
         size_t offset = i * 4U;
 
-        keystream[offset     ] = MBEDTLS_BYTE_0( working_state[i] );
-        keystream[offset + 1U] = MBEDTLS_BYTE_1( working_state[i] );
-        keystream[offset + 2U] = MBEDTLS_BYTE_2( working_state[i] );
-        keystream[offset + 3U] = MBEDTLS_BYTE_3( working_state[i] );
+        MBEDTLS_PUT_UINT32_LE(working_state[i], keystream, offset);
     }
 
     mbedtls_platform_zeroize( working_state, sizeof( working_state ) );

--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -263,22 +263,8 @@ int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
     /* The lengths of the AAD and ciphertext are processed by
      * Poly1305 as the final 128-bit block, encoded as little-endian integers.
      */
-    len_block[ 0] = MBEDTLS_BYTE_0( ctx->aad_len );
-    len_block[ 1] = MBEDTLS_BYTE_1( ctx->aad_len );
-    len_block[ 2] = MBEDTLS_BYTE_2( ctx->aad_len );
-    len_block[ 3] = MBEDTLS_BYTE_3( ctx->aad_len );
-    len_block[ 4] = MBEDTLS_BYTE_4( ctx->aad_len );
-    len_block[ 5] = MBEDTLS_BYTE_5( ctx->aad_len );
-    len_block[ 6] = MBEDTLS_BYTE_6( ctx->aad_len );
-    len_block[ 7] = MBEDTLS_BYTE_7( ctx->aad_len );
-    len_block[ 8] = MBEDTLS_BYTE_0( ctx->ciphertext_len );
-    len_block[ 9] = MBEDTLS_BYTE_1( ctx->ciphertext_len );
-    len_block[10] = MBEDTLS_BYTE_2( ctx->ciphertext_len );
-    len_block[11] = MBEDTLS_BYTE_3( ctx->ciphertext_len );
-    len_block[12] = MBEDTLS_BYTE_4( ctx->ciphertext_len );
-    len_block[13] = MBEDTLS_BYTE_5( ctx->ciphertext_len );
-    len_block[14] = MBEDTLS_BYTE_6( ctx->ciphertext_len );
-    len_block[15] = MBEDTLS_BYTE_7( ctx->ciphertext_len );
+    MBEDTLS_PUT_UINT64_LE(ctx->aad_len, len_block, 0);
+    MBEDTLS_PUT_UINT64_LE(ctx->ciphertext_len, len_block, 8);
 
     ret = mbedtls_poly1305_update( &ctx->poly1305_ctx, len_block, 16U );
     if( ret != 0 )

--- a/library/chachapoly.c
+++ b/library/chachapoly.c
@@ -263,22 +263,22 @@ int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
     /* The lengths of the AAD and ciphertext are processed by
      * Poly1305 as the final 128-bit block, encoded as little-endian integers.
      */
-    len_block[ 0] = (unsigned char)( ctx->aad_len       );
-    len_block[ 1] = (unsigned char)( ctx->aad_len >>  8 );
-    len_block[ 2] = (unsigned char)( ctx->aad_len >> 16 );
-    len_block[ 3] = (unsigned char)( ctx->aad_len >> 24 );
-    len_block[ 4] = (unsigned char)( ctx->aad_len >> 32 );
-    len_block[ 5] = (unsigned char)( ctx->aad_len >> 40 );
-    len_block[ 6] = (unsigned char)( ctx->aad_len >> 48 );
-    len_block[ 7] = (unsigned char)( ctx->aad_len >> 56 );
-    len_block[ 8] = (unsigned char)( ctx->ciphertext_len       );
-    len_block[ 9] = (unsigned char)( ctx->ciphertext_len >>  8 );
-    len_block[10] = (unsigned char)( ctx->ciphertext_len >> 16 );
-    len_block[11] = (unsigned char)( ctx->ciphertext_len >> 24 );
-    len_block[12] = (unsigned char)( ctx->ciphertext_len >> 32 );
-    len_block[13] = (unsigned char)( ctx->ciphertext_len >> 40 );
-    len_block[14] = (unsigned char)( ctx->ciphertext_len >> 48 );
-    len_block[15] = (unsigned char)( ctx->ciphertext_len >> 56 );
+    len_block[ 0] = MBEDTLS_BYTE_0( ctx->aad_len );
+    len_block[ 1] = MBEDTLS_BYTE_1( ctx->aad_len );
+    len_block[ 2] = MBEDTLS_BYTE_2( ctx->aad_len );
+    len_block[ 3] = MBEDTLS_BYTE_3( ctx->aad_len );
+    len_block[ 4] = MBEDTLS_BYTE_4( ctx->aad_len );
+    len_block[ 5] = MBEDTLS_BYTE_5( ctx->aad_len );
+    len_block[ 6] = MBEDTLS_BYTE_6( ctx->aad_len );
+    len_block[ 7] = MBEDTLS_BYTE_7( ctx->aad_len );
+    len_block[ 8] = MBEDTLS_BYTE_0( ctx->ciphertext_len );
+    len_block[ 9] = MBEDTLS_BYTE_1( ctx->ciphertext_len );
+    len_block[10] = MBEDTLS_BYTE_2( ctx->ciphertext_len );
+    len_block[11] = MBEDTLS_BYTE_3( ctx->ciphertext_len );
+    len_block[12] = MBEDTLS_BYTE_4( ctx->ciphertext_len );
+    len_block[13] = MBEDTLS_BYTE_5( ctx->ciphertext_len );
+    len_block[14] = MBEDTLS_BYTE_6( ctx->ciphertext_len );
+    len_block[15] = MBEDTLS_BYTE_7( ctx->ciphertext_len );
 
     ret = mbedtls_poly1305_update( &ctx->poly1305_ctx, len_block, 16U );
     if( ret != 0 )

--- a/library/common.h
+++ b/library/common.h
@@ -177,6 +177,40 @@
 #endif
 
 /**
+ * Get the unsigned 16 bits integer corresponding to two bytes in
+ * big-endian order (LSB first).
+ *
+ * \param   data    Base address of the memory to get the two bytes from.
+ * \param   offset  Offset from \p base of the first and most significant
+ *                  byte of the two bytes to build the 16 bits unsigned
+ *                  integer from.
+ */
+#ifndef MBEDTLS_GET_UINT16_BE
+#define MBEDTLS_GET_UINT16_BE( data, offset )              \
+    (                                                      \
+          ( (uint16_t) ( data )[( offset )    ] << 8 )     \
+        | ( (uint16_t) ( data )[( offset ) + 1]      )     \
+    )
+#endif
+
+/**
+ * Put in memory a 16 bits unsigned integer in big-endian order.
+ *
+ * \param   n       16 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 16
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the most significant
+ *                  byte of the 16 bits unsigned integer \p n.
+ */
+#ifndef MBEDTLS_PUT_UINT16_BE
+#define MBEDTLS_PUT_UINT16_BE( n, data, offset )                           \
+{                                                                          \
+    ( data )[( offset )    ] = (unsigned char) ( ( (n) >> 8 ) & 0xFF );    \
+    ( data )[( offset ) + 1] = (unsigned char) ( ( (n)      ) & 0xFF );    \
+}
+#endif
+
+/**
  * Get the unsigned 64 bits integer corresponding to eight bytes in
  * big-endian order (MSB first).
  *

--- a/library/common.h
+++ b/library/common.h
@@ -55,7 +55,7 @@
  * To tidy up code and save horizontal and vertical space, use byte
  * reading macros to cast
  */
-#define MBEDTLS_BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
 #define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
 #define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 #define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
@@ -83,20 +83,46 @@
     } while( 0 )
 #endif
 
-
-/*
- * 32-bit integer manipulation macros (big endian)
+/**
+ * 32-bit integer manipulation GET macros (big endian)
+ *
+ * \brief   Use this to assign an unsigned 32 bit integer
+ *          by taking data stored adjacent in memory that
+ *          can be accessed via on offset
+ *          Big Endian is used when wanting to
+ *          transmit the most signifcant bits first
+ *
+ * \param   data    The data used to translate to a 32 bit
+ *                  integer
+ * \param   offset  the shift in bytes to access the next byte
+ *                  of data
  */
 #ifndef MBEDTLS_GET_UINT32_BE
-#define MBEDTLS_GET_UINT32_BE(n,b,i)                    \
-    do {                                                \
-        (n) = ( (uint32_t) (b)[(i)    ] << 24 )         \
-            | ( (uint32_t) (b)[(i) + 1] << 16 )         \
-            | ( (uint32_t) (b)[(i) + 2] <<  8 )         \
-            | ( (uint32_t) (b)[(i) + 3]       );        \
-    } while( 0 )
+#define MBEDTLS_GET_UINT32_BE( data , offset )              \
+    (                                                       \
+          ( (uint32_t) ( data )[( offset )    ] << 24 )     \
+        | ( (uint32_t) ( data )[( offset ) + 1] << 16 )     \
+        | ( (uint32_t) ( data )[( offset ) + 2] <<  8 )     \
+        | ( (uint32_t) ( data )[( offset ) + 3]       )     \
+    )
 #endif
 
+/**
+ * 32-bit integer manipulation PUT macros (big endian)
+ *
+ * \brief   Read from a 32 bit integer and store each byte
+ *          in memory, offset by a specified amount, resulting
+ *          in each byte being adjacent in memory.
+ *          Big Endian is used when wanting to
+ *          transmit the most signifcant bits first
+ *
+ * \param   n   32 bit integer where data is accessed
+ * \param   b   const unsigned char array of data to be
+ *              manipulated
+ * \param   i   offset in bytes, In the case of UINT32, i
+ *              would increment by 4 every use assuming
+ *              the data is being stored in the same location
+ */
 #ifndef MBEDTLS_PUT_UINT32_BE
 #define MBEDTLS_PUT_UINT32_BE(n,b,i)                    \
     do {                                                \
@@ -107,17 +133,94 @@
     } while( 0 )
 #endif
 
-/*
- * 16-bit integer manipulation macros (little endian)
+/**
+ * 32-bit integer manipulation GET macros (little endian)
+ *
+ * \brief   Use this to assign an unsigned 32 bit integer
+ *          by taking data stored adjacent in memory that
+ *          can be accessed via on offset
+ *          Little Endian is used when wanting to
+ *          transmit the least signifcant bits first
+ *
+ * \param   data    The data used to translate to a 32 bit
+ *                  integer
+ * \param   offset  the shift in bytes to access the next byte
+ *                  of data
  */
-#ifndef MBEDTLS_GET_UINT16_LE
-#define MBEDTLS_GET_UINT16_LE( n, b, i )                \
-{                                                       \
-    (n) = ( (uint16_t) (b)[(i)    ]       )             \
-        | ( (uint16_t) (b)[(i) + 1] <<  8 );            \
-}
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE( data, offset )              \
+    (                                                      \
+          ( (uint32_t) ( data )[( offset )    ]       )    \
+        | ( (uint32_t) ( data )[( offset ) + 1] <<  8 )    \
+        | ( (uint32_t) ( data )[( offset ) + 2] << 16 )    \
+        | ( (uint32_t) ( data )[( offset ) + 3] << 24 )    \
+    )
 #endif
 
+/**
+ * 32-bit integer manipulation PUT macros (little endian)
+ *
+ * \brief   Read from a 32 bit integer and store each byte
+ *          in memory, offset by a specified amount, resulting
+ *          in each byte being adjacent in memory.
+ *          Little Endian is used when wanting to
+ *          transmit the least signifcant bits first
+ *
+ * \param   n   32 bit integer where data is accessed
+ * \param   b   const unsigned char array of data to be
+ *              manipulated
+ * \param   i   offset in bytes, In the case of UINT32, i
+ *              would increment by 4 every use assuming
+ *              the data is being stored in the same location
+ */
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                \
+    do {                                                            \
+        (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+        (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+        (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
+        (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+    } while( 0 )
+#endif
+
+/**
+ * 16-bit integer manipulation GET macros (little endian)
+ *
+ * \brief   Use this to assign an unsigned 16 bit integer
+ *          by taking data stored adjacent in memory that
+ *          can be accessed via on offset
+ *          Little Endian is used when wanting to
+ *          transmit the least signifcant bits first
+ *
+ * \param   data    The data used to translate to a 16 bit
+ *                  integer
+ * \param   offset  the shit in bytes to access the next byte
+ *                  of data
+ */
+#ifndef MBEDTLS_GET_UINT16_LE
+#define MBEDTLS_GET_UINT16_LE( data, offset )               \
+    (                                                       \
+          ( (uint16_t) ( data )[( offset )    ]       )     \
+        | ( (uint16_t) ( data )[( offset ) + 1] <<  8 )     \
+    )
+#endif
+
+/**
+ * 16-bit integer manipulation PUT macros (little endian)
+ *
+ * \brief   Read from a 16 bit integer and store each byte
+ *          in memory, offset by a specified amount, resulting
+ *          in each byte being adjacent in memory.
+ *          Little Endian is used when wanting to
+ *          transmit the least signifcant bits first
+ *
+ * \param   n   16 bit integer where data is accessed
+ * \param   b   const unsigned char array of data to be
+ *              manipulated
+ * \param   i   offset in bytes, In the case of UINT16, i
+ *              would increment by 2 every use assuming
+ *              the data is being stored in the same location
+ */
 #ifndef MBEDTLS_PUT_UINT16_LE
 #define MBEDTLS_PUT_UINT16_LE( n, b, i )                        \
 {                                                               \

--- a/library/common.h
+++ b/library/common.h
@@ -50,4 +50,14 @@
 #define MBEDTLS_STATIC_TESTABLE static
 #endif
 
+/** Byte Reading Macros
+ *
+ * To tidy up code and save horizontal and vertical space, use byte
+ * reading macros to cast
+ */
+#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff ) )
+#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
+#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -54,7 +54,7 @@
 
 /** Byte Reading Macros
  *
- * Given a multi-byte integer \p x, MBEDTLS_BYTE_n retrieves the n-th 
+ * Given a multi-byte integer \p x, MBEDTLS_BYTE_n retrieves the n-th
  * byte from x, where byte 0 is the least significant byte.
  */
 #define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )

--- a/library/common.h
+++ b/library/common.h
@@ -60,28 +60,14 @@
 #define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 #define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
 
-/*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef MBEDTLS_GET_UINT32_LE
-#define MBEDTLS_GET_UINT32_LE(n,b,i)                    \
-    do {                                                \
-        (n) = ( (uint32_t) (b)[(i)    ]       )         \
-            | ( (uint32_t) (b)[(i) + 1] <<  8 )         \
-            | ( (uint32_t) (b)[(i) + 2] << 16 )         \
-            | ( (uint32_t) (b)[(i) + 3] << 24 );        \
-    } while( 0 )
-#endif
-
-#ifndef MBEDTLS_PUT_UINT32_LE
-#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                \
-    do {                                                            \
-        (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-        (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-        (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-        (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-    } while( 0 )
-#endif
+#define MBEDTLS_CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xff ) )
+#define MBEDTLS_CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xff ) )
+#define MBEDTLS_CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_CHAR_4( x ) ( (unsigned char) ( ( ( x ) >> 32 ) & 0xff ) )
+#define MBEDTLS_CHAR_5( x ) ( (unsigned char) ( ( ( x ) >> 40 ) & 0xff ) )
+#define MBEDTLS_CHAR_6( x ) ( (unsigned char) ( ( ( x ) >> 48 ) & 0xff ) )
+#define MBEDTLS_CHAR_7( x ) ( (unsigned char) ( ( ( x ) >> 56 ) & 0xff ) )
 
 /**
  * 32-bit integer manipulation GET macros (big endian)

--- a/library/common.h
+++ b/library/common.h
@@ -176,4 +176,96 @@
 }
 #endif
 
+/**
+ * Get the unsigned 64 bits integer corresponding to eight bytes in
+ * big-endian order (MSB first).
+ *
+ * \param   data    Base address of the memory to get the eight bytes from.
+ * \param   offset  Offset from \p base of the first and most significant
+ *                  byte of the eight bytes to build the 64 bits unsigned
+ *                  integer from.
+ */
+#ifndef MBEDTLS_GET_UINT64_BE
+#define MBEDTLS_GET_UINT64_BE( data, offset )                 \
+    (                                                         \
+          ( (uint64_t) ( data )[( offset )    ] << 56 )       \
+        | ( (uint64_t) ( data )[( offset ) + 1] << 48 )       \
+        | ( (uint64_t) ( data )[( offset ) + 2] << 40 )       \
+        | ( (uint64_t) ( data )[( offset ) + 3] << 32 )       \
+        | ( (uint64_t) ( data )[( offset ) + 4] << 24 )       \
+        | ( (uint64_t) ( data )[( offset ) + 5] << 16 )       \
+        | ( (uint64_t) ( data )[( offset ) + 6] <<  8 )       \
+        | ( (uint64_t) ( data )[( offset ) + 7]       )       \
+    )
+#endif
+
+/**
+ * Put in memory a 64 bits unsigned integer in big-endian order.
+ *
+ * \param   n       64 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 64
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the most significant
+ *                  byte of the 64 bits unsigned integer \p n.
+ */
+#ifndef MBEDTLS_PUT_UINT64_BE
+#define MBEDTLS_PUT_UINT64_BE( n, data, offset )                    \
+{                                                                   \
+    ( data )[( offset )    ] = (unsigned char) ( (n) >> 56 );       \
+    ( data )[( offset ) + 1] = (unsigned char) ( (n) >> 48 );       \
+    ( data )[( offset ) + 2] = (unsigned char) ( (n) >> 40 );       \
+    ( data )[( offset ) + 3] = (unsigned char) ( (n) >> 32 );       \
+    ( data )[( offset ) + 4] = (unsigned char) ( (n) >> 24 );       \
+    ( data )[( offset ) + 5] = (unsigned char) ( (n) >> 16 );       \
+    ( data )[( offset ) + 6] = (unsigned char) ( (n) >>  8 );       \
+    ( data )[( offset ) + 7] = (unsigned char) ( (n)       );       \
+}
+#endif
+
+/**
+ * Get the unsigned 64 bits integer corresponding to eight bytes in
+ * little-endian order (LSB first).
+ *
+ * \param   data    Base address of the memory to get the eight bytes from.
+ * \param   offset  Offset from \p base of the first and least significant
+ *                  byte of the eight bytes to build the 64 bits unsigned
+ *                  integer from.
+ */
+#ifndef MBEDTLS_GET_UINT64_LE
+#define MBEDTLS_GET_UINT64_LE( data, offset )               \
+    (                                                       \
+          ( (uint64_t) ( data )[( offset ) + 7] << 56 )     \
+        | ( (uint64_t) ( data )[( offset ) + 6] << 48 )     \
+        | ( (uint64_t) ( data )[( offset ) + 5] << 40 )     \
+        | ( (uint64_t) ( data )[( offset ) + 4] << 32 )     \
+        | ( (uint64_t) ( data )[( offset ) + 3] << 24 )     \
+        | ( (uint64_t) ( data )[( offset ) + 2] << 16 )     \
+        | ( (uint64_t) ( data )[( offset ) + 1] <<  8 )     \
+        | ( (uint64_t) ( data )[( offset )    ]       )     \
+    )
+#endif
+
+/**
+ * Put in memory a 64 bits unsigned integer in little-endian order.
+ *
+ * \param   n       64 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 64
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the least significant
+ *                  byte of the 64 bits unsigned integer \p n.
+ */
+#ifndef MBEDTLS_PUT_UINT64_LE
+#define MBEDTLS_PUT_UINT64_LE( n, data, offset )                    \
+{                                                                   \
+    ( data )[( offset ) + 7] = (unsigned char) ( (n) >> 56 );       \
+    ( data )[( offset ) + 6] = (unsigned char) ( (n) >> 48 );       \
+    ( data )[( offset ) + 5] = (unsigned char) ( (n) >> 40 );       \
+    ( data )[( offset ) + 4] = (unsigned char) ( (n) >> 32 );       \
+    ( data )[( offset ) + 3] = (unsigned char) ( (n) >> 24 );       \
+    ( data )[( offset ) + 2] = (unsigned char) ( (n) >> 16 );       \
+    ( data )[( offset ) + 1] = (unsigned char) ( (n) >>  8 );       \
+    ( data )[( offset )    ] = (unsigned char) ( (n)       );       \
+}
+#endif
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -54,9 +54,8 @@
 
 /** Byte Reading Macros
  *
- * Obtain the most significant byte of x using 0xff
- * Using MBEDTLS_BYTE_a will shift a*8 bits
- * to retrieve the next byte of information
+ * Given a multi-byte integer \p x, MBEDTLS_BYTE_n retrieves the n-th 
+ * byte from x, where byte 0 is the least significant byte.
  */
 #define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
 #define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )

--- a/library/common.h
+++ b/library/common.h
@@ -70,18 +70,13 @@
 #define MBEDTLS_CHAR_7( x ) ( (unsigned char) ( ( ( x ) >> 56 ) & 0xff ) )
 
 /**
- * 32-bit integer manipulation GET macros (big endian)
+ * Get the unsigned 32 bits integer corresponding to four bytes in
+ * big-endian order (MSB first).
  *
- * \brief   Use this to assign an unsigned 32 bit integer
- *          by taking data stored adjacent in memory that
- *          can be accessed via on offset
- *          Big Endian is used when wanting to
- *          transmit the most signifcant bits first
- *
- * \param   data    The data used to translate to a 32 bit
- *                  integer
- * \param   offset  the shift in bytes to access the next byte
- *                  of data
+ * \param   data    Base address of the memory to get the four bytes from.
+ * \param   offset  Offset from \p base of the first and most significant
+ *                  byte of the four bytes to build the 32 bits unsigned
+ *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT32_BE
 #define MBEDTLS_GET_UINT32_BE( data , offset )              \
@@ -94,44 +89,32 @@
 #endif
 
 /**
- * 32-bit integer manipulation PUT macros (big endian)
+ * Put in memory a 32 bits unsigned integer in big-endian order.
  *
- * \brief   Read from a 32 bit integer and store each byte
- *          in memory, offset by a specified amount, resulting
- *          in each byte being adjacent in memory.
- *          Big Endian is used when wanting to
- *          transmit the most signifcant bits first
- *
- * \param   n   32 bit integer where data is accessed
- * \param   b   const unsigned char array of data to be
- *              manipulated
- * \param   i   offset in bytes, In the case of UINT32, i
- *              would increment by 4 every use assuming
- *              the data is being stored in the same location
+ * \param   n       32 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 32
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the most significant
+ *                  byte of the 32 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT32_BE
-#define MBEDTLS_PUT_UINT32_BE(n,b,i)                    \
-    do {                                                \
-        (b)[(i)    ] = (unsigned char) ( (n) >> 24 );   \
-        (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );   \
-        (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );   \
-        (b)[(i) + 3] = (unsigned char) ( (n)       );   \
+#define MBEDTLS_PUT_UINT32_BE( n, data, offset )                    \
+    do {                                                            \
+        ( data )[( offset )    ] = (unsigned char) ( (n) >> 24 );   \
+        ( data )[( offset ) + 1] = (unsigned char) ( (n) >> 16 );   \
+        ( data )[( offset ) + 2] = (unsigned char) ( (n) >>  8 );   \
+        ( data )[( offset ) + 3] = (unsigned char) ( (n)       );   \
     } while( 0 )
 #endif
 
 /**
- * 32-bit integer manipulation GET macros (little endian)
+ * Get the unsigned 32 bits integer corresponding to four bytes in
+ * little-endian order (LSB first).
  *
- * \brief   Use this to assign an unsigned 32 bit integer
- *          by taking data stored adjacent in memory that
- *          can be accessed via on offset
- *          Little Endian is used when wanting to
- *          transmit the least signifcant bits first
- *
- * \param   data    The data used to translate to a 32 bit
- *                  integer
- * \param   offset  the shift in bytes to access the next byte
- *                  of data
+ * \param   data    Base address of the memory to get the four bytes from.
+ * \param   offset  Offset from \p base of the first and least significant
+ *                  byte of the four bytes to build the 32 bits unsigned
+ *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT32_LE
 #define MBEDTLS_GET_UINT32_LE( data, offset )              \
@@ -144,44 +127,32 @@
 #endif
 
 /**
- * 32-bit integer manipulation PUT macros (little endian)
+ * Put in memory a 32 bits unsigned integer in little-endian order.
  *
- * \brief   Read from a 32 bit integer and store each byte
- *          in memory, offset by a specified amount, resulting
- *          in each byte being adjacent in memory.
- *          Little Endian is used when wanting to
- *          transmit the least signifcant bits first
- *
- * \param   n   32 bit integer where data is accessed
- * \param   b   const unsigned char array of data to be
- *              manipulated
- * \param   i   offset in bytes, In the case of UINT32, i
- *              would increment by 4 every use assuming
- *              the data is being stored in the same location
+ * \param   n       32 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 32
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the least significant
+ *                  byte of the 32 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT32_LE
-#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                \
-    do {                                                            \
-        (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-        (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-        (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-        (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+#define MBEDTLS_PUT_UINT32_LE( n, data, offset )                                \
+    do {                                                                        \
+        ( data )[( offset )    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+        ( data )[( offset ) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+        ( data )[( offset ) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
+        ( data )[( offset ) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
     } while( 0 )
 #endif
 
 /**
- * 16-bit integer manipulation GET macros (little endian)
+ * Get the unsigned 16 bits integer corresponding to four bytes in
+ * little-endian order (LSB first).
  *
- * \brief   Use this to assign an unsigned 16 bit integer
- *          by taking data stored adjacent in memory that
- *          can be accessed via on offset
- *          Little Endian is used when wanting to
- *          transmit the least signifcant bits first
- *
- * \param   data    The data used to translate to a 16 bit
- *                  integer
- * \param   offset  the shit in bytes to access the next byte
- *                  of data
+ * \param   data    Base address of the memory to get the four bytes from.
+ * \param   offset  Offset from \p base of the first and least significant
+ *                  byte of the four bytes to build the 16 bits unsigned
+ *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT16_LE
 #define MBEDTLS_GET_UINT16_LE( data, offset )               \
@@ -192,26 +163,19 @@
 #endif
 
 /**
- * 16-bit integer manipulation PUT macros (little endian)
+ * Put in memory a 16 bits unsigned integer in little-endian order.
  *
- * \brief   Read from a 16 bit integer and store each byte
- *          in memory, offset by a specified amount, resulting
- *          in each byte being adjacent in memory.
- *          Little Endian is used when wanting to
- *          transmit the least signifcant bits first
- *
- * \param   n   16 bit integer where data is accessed
- * \param   b   const unsigned char array of data to be
- *              manipulated
- * \param   i   offset in bytes, In the case of UINT16, i
- *              would increment by 2 every use assuming
- *              the data is being stored in the same location
+ * \param   n       16 bits unsigned integer to put in memory.
+ * \param   data    Base address of the memory where to put the 16
+ *                  bits unsigned integer in.
+ * \param   offset  Offset from \p base where to put the least significant
+ *                  byte of the 16 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT16_LE
-#define MBEDTLS_PUT_UINT16_LE( n, b, i )                        \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+#define MBEDTLS_PUT_UINT16_LE( n, data, offset )                            \
+{                                                                           \
+    ( data )[( offset )    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+    ( data )[( offset ) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
 }
 #endif
 

--- a/library/common.h
+++ b/library/common.h
@@ -29,6 +29,8 @@
 #include "mbedtls/config.h"
 #endif
 
+#include <stdint.h>
+
 /** Helper to define a function as static except when building invasive tests.
  *
  * If a function is only used inside its own source file and should be
@@ -59,15 +61,10 @@
 #define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
 #define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
 #define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
-
-#define MBEDTLS_CHAR_0( x ) ( (unsigned char) (   ( x )         & 0xff ) )
-#define MBEDTLS_CHAR_1( x ) ( (unsigned char) ( ( ( x ) >> 8  ) & 0xff ) )
-#define MBEDTLS_CHAR_2( x ) ( (unsigned char) ( ( ( x ) >> 16 ) & 0xff ) )
-#define MBEDTLS_CHAR_3( x ) ( (unsigned char) ( ( ( x ) >> 24 ) & 0xff ) )
-#define MBEDTLS_CHAR_4( x ) ( (unsigned char) ( ( ( x ) >> 32 ) & 0xff ) )
-#define MBEDTLS_CHAR_5( x ) ( (unsigned char) ( ( ( x ) >> 40 ) & 0xff ) )
-#define MBEDTLS_CHAR_6( x ) ( (unsigned char) ( ( ( x ) >> 48 ) & 0xff ) )
-#define MBEDTLS_CHAR_7( x ) ( (unsigned char) ( ( ( x ) >> 56 ) & 0xff ) )
+#define MBEDTLS_BYTE_4( x ) ( (uint8_t) ( ( ( x ) >> 32 ) & 0xff ) )
+#define MBEDTLS_BYTE_5( x ) ( (uint8_t) ( ( ( x ) >> 40 ) & 0xff ) )
+#define MBEDTLS_BYTE_6( x ) ( (uint8_t) ( ( ( x ) >> 48 ) & 0xff ) )
+#define MBEDTLS_BYTE_7( x ) ( (uint8_t) ( ( ( x ) >> 56 ) & 0xff ) )
 
 /**
  * Get the unsigned 32 bits integer corresponding to four bytes in
@@ -146,12 +143,12 @@
 #endif
 
 /**
- * Get the unsigned 16 bits integer corresponding to four bytes in
+ * Get the unsigned 16 bits integer corresponding to two bytes in
  * little-endian order (LSB first).
  *
- * \param   data    Base address of the memory to get the four bytes from.
+ * \param   data    Base address of the memory to get the two bytes from.
  * \param   offset  Offset from \p base of the first and least significant
- *                  byte of the four bytes to build the 16 bits unsigned
+ *                  byte of the two bytes to build the 16 bits unsigned
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT16_LE

--- a/library/common.h
+++ b/library/common.h
@@ -54,8 +54,9 @@
 
 /** Byte Reading Macros
  *
- * To tidy up code and save horizontal and vertical space, use byte
- * reading macros to cast
+ * Obtain the most significant byte of x using 0xff
+ * Using MBEDTLS_BYTE_a will shift a*8 bits
+ * to retrieve the next byte of information
  */
 #define MBEDTLS_BYTE_0( x ) ( (uint8_t) (   ( x )         & 0xff ) )
 #define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
@@ -76,12 +77,12 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT32_BE
-#define MBEDTLS_GET_UINT32_BE( data , offset )              \
-    (                                                       \
-          ( (uint32_t) ( data )[( offset )    ] << 24 )     \
-        | ( (uint32_t) ( data )[( offset ) + 1] << 16 )     \
-        | ( (uint32_t) ( data )[( offset ) + 2] <<  8 )     \
-        | ( (uint32_t) ( data )[( offset ) + 3]       )     \
+#define MBEDTLS_GET_UINT32_BE( data , offset )                  \
+    (                                                           \
+          ( (uint32_t) ( data )[( offset )    ] << 24 )         \
+        | ( (uint32_t) ( data )[( offset ) + 1] << 16 )         \
+        | ( (uint32_t) ( data )[( offset ) + 2] <<  8 )         \
+        | ( (uint32_t) ( data )[( offset ) + 3]       )         \
     )
 #endif
 
@@ -95,13 +96,13 @@
  *                  byte of the 32 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT32_BE
-#define MBEDTLS_PUT_UINT32_BE( n, data, offset )                    \
-    do {                                                            \
-        ( data )[( offset )    ] = (unsigned char) ( (n) >> 24 );   \
-        ( data )[( offset ) + 1] = (unsigned char) ( (n) >> 16 );   \
-        ( data )[( offset ) + 2] = (unsigned char) ( (n) >>  8 );   \
-        ( data )[( offset ) + 3] = (unsigned char) ( (n)       );   \
-    } while( 0 )
+#define MBEDTLS_PUT_UINT32_BE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_3( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_2( n );             \
+    ( data )[( offset ) + 2] = MBEDTLS_BYTE_1( n );             \
+    ( data )[( offset ) + 3] = MBEDTLS_BYTE_0( n );             \
+}
 #endif
 
 /**
@@ -114,12 +115,12 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT32_LE
-#define MBEDTLS_GET_UINT32_LE( data, offset )              \
-    (                                                      \
-          ( (uint32_t) ( data )[( offset )    ]       )    \
-        | ( (uint32_t) ( data )[( offset ) + 1] <<  8 )    \
-        | ( (uint32_t) ( data )[( offset ) + 2] << 16 )    \
-        | ( (uint32_t) ( data )[( offset ) + 3] << 24 )    \
+#define MBEDTLS_GET_UINT32_LE( data, offset )                   \
+    (                                                           \
+          ( (uint32_t) ( data )[( offset )    ]       )         \
+        | ( (uint32_t) ( data )[( offset ) + 1] <<  8 )         \
+        | ( (uint32_t) ( data )[( offset ) + 2] << 16 )         \
+        | ( (uint32_t) ( data )[( offset ) + 3] << 24 )         \
     )
 #endif
 
@@ -133,13 +134,13 @@
  *                  byte of the 32 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT32_LE
-#define MBEDTLS_PUT_UINT32_LE( n, data, offset )                                \
-    do {                                                                        \
-        ( data )[( offset )    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-        ( data )[( offset ) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-        ( data )[( offset ) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-        ( data )[( offset ) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-    } while( 0 )
+#define MBEDTLS_PUT_UINT32_LE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_0( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_1( n );             \
+    ( data )[( offset ) + 2] = MBEDTLS_BYTE_2( n );             \
+    ( data )[( offset ) + 3] = MBEDTLS_BYTE_3( n );             \
+}
 #endif
 
 /**
@@ -152,10 +153,10 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT16_LE
-#define MBEDTLS_GET_UINT16_LE( data, offset )               \
-    (                                                       \
-          ( (uint16_t) ( data )[( offset )    ]       )     \
-        | ( (uint16_t) ( data )[( offset ) + 1] <<  8 )     \
+#define MBEDTLS_GET_UINT16_LE( data, offset )                   \
+    (                                                           \
+          ( (uint16_t) ( data )[( offset )    ]       )         \
+        | ( (uint16_t) ( data )[( offset ) + 1] <<  8 )         \
     )
 #endif
 
@@ -169,16 +170,16 @@
  *                  byte of the 16 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT16_LE
-#define MBEDTLS_PUT_UINT16_LE( n, data, offset )                            \
-{                                                                           \
-    ( data )[( offset )    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    ( data )[( offset ) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+#define MBEDTLS_PUT_UINT16_LE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_0( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_1( n );             \
 }
 #endif
 
 /**
  * Get the unsigned 16 bits integer corresponding to two bytes in
- * big-endian order (LSB first).
+ * big-endian order (MSB first).
  *
  * \param   data    Base address of the memory to get the two bytes from.
  * \param   offset  Offset from \p base of the first and most significant
@@ -186,10 +187,10 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT16_BE
-#define MBEDTLS_GET_UINT16_BE( data, offset )              \
-    (                                                      \
-          ( (uint16_t) ( data )[( offset )    ] << 8 )     \
-        | ( (uint16_t) ( data )[( offset ) + 1]      )     \
+#define MBEDTLS_GET_UINT16_BE( data, offset )                   \
+    (                                                           \
+          ( (uint16_t) ( data )[( offset )    ] << 8 )          \
+        | ( (uint16_t) ( data )[( offset ) + 1]      )          \
     )
 #endif
 
@@ -203,10 +204,10 @@
  *                  byte of the 16 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT16_BE
-#define MBEDTLS_PUT_UINT16_BE( n, data, offset )                           \
-{                                                                          \
-    ( data )[( offset )    ] = (unsigned char) ( ( (n) >> 8 ) & 0xFF );    \
-    ( data )[( offset ) + 1] = (unsigned char) ( ( (n)      ) & 0xFF );    \
+#define MBEDTLS_PUT_UINT16_BE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_1( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_0( n );             \
 }
 #endif
 
@@ -220,16 +221,16 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT64_BE
-#define MBEDTLS_GET_UINT64_BE( data, offset )                 \
-    (                                                         \
-          ( (uint64_t) ( data )[( offset )    ] << 56 )       \
-        | ( (uint64_t) ( data )[( offset ) + 1] << 48 )       \
-        | ( (uint64_t) ( data )[( offset ) + 2] << 40 )       \
-        | ( (uint64_t) ( data )[( offset ) + 3] << 32 )       \
-        | ( (uint64_t) ( data )[( offset ) + 4] << 24 )       \
-        | ( (uint64_t) ( data )[( offset ) + 5] << 16 )       \
-        | ( (uint64_t) ( data )[( offset ) + 6] <<  8 )       \
-        | ( (uint64_t) ( data )[( offset ) + 7]       )       \
+#define MBEDTLS_GET_UINT64_BE( data, offset )                   \
+    (                                                           \
+          ( (uint64_t) ( data )[( offset )    ] << 56 )         \
+        | ( (uint64_t) ( data )[( offset ) + 1] << 48 )         \
+        | ( (uint64_t) ( data )[( offset ) + 2] << 40 )         \
+        | ( (uint64_t) ( data )[( offset ) + 3] << 32 )         \
+        | ( (uint64_t) ( data )[( offset ) + 4] << 24 )         \
+        | ( (uint64_t) ( data )[( offset ) + 5] << 16 )         \
+        | ( (uint64_t) ( data )[( offset ) + 6] <<  8 )         \
+        | ( (uint64_t) ( data )[( offset ) + 7]       )         \
     )
 #endif
 
@@ -243,16 +244,16 @@
  *                  byte of the 64 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT64_BE
-#define MBEDTLS_PUT_UINT64_BE( n, data, offset )                    \
-{                                                                   \
-    ( data )[( offset )    ] = (unsigned char) ( (n) >> 56 );       \
-    ( data )[( offset ) + 1] = (unsigned char) ( (n) >> 48 );       \
-    ( data )[( offset ) + 2] = (unsigned char) ( (n) >> 40 );       \
-    ( data )[( offset ) + 3] = (unsigned char) ( (n) >> 32 );       \
-    ( data )[( offset ) + 4] = (unsigned char) ( (n) >> 24 );       \
-    ( data )[( offset ) + 5] = (unsigned char) ( (n) >> 16 );       \
-    ( data )[( offset ) + 6] = (unsigned char) ( (n) >>  8 );       \
-    ( data )[( offset ) + 7] = (unsigned char) ( (n)       );       \
+#define MBEDTLS_PUT_UINT64_BE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_7( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_6( n );             \
+    ( data )[( offset ) + 2] = MBEDTLS_BYTE_5( n );             \
+    ( data )[( offset ) + 3] = MBEDTLS_BYTE_4( n );             \
+    ( data )[( offset ) + 4] = MBEDTLS_BYTE_3( n );             \
+    ( data )[( offset ) + 5] = MBEDTLS_BYTE_2( n );             \
+    ( data )[( offset ) + 6] = MBEDTLS_BYTE_1( n );             \
+    ( data )[( offset ) + 7] = MBEDTLS_BYTE_0( n );             \
 }
 #endif
 
@@ -266,16 +267,16 @@
  *                  integer from.
  */
 #ifndef MBEDTLS_GET_UINT64_LE
-#define MBEDTLS_GET_UINT64_LE( data, offset )               \
-    (                                                       \
-          ( (uint64_t) ( data )[( offset ) + 7] << 56 )     \
-        | ( (uint64_t) ( data )[( offset ) + 6] << 48 )     \
-        | ( (uint64_t) ( data )[( offset ) + 5] << 40 )     \
-        | ( (uint64_t) ( data )[( offset ) + 4] << 32 )     \
-        | ( (uint64_t) ( data )[( offset ) + 3] << 24 )     \
-        | ( (uint64_t) ( data )[( offset ) + 2] << 16 )     \
-        | ( (uint64_t) ( data )[( offset ) + 1] <<  8 )     \
-        | ( (uint64_t) ( data )[( offset )    ]       )     \
+#define MBEDTLS_GET_UINT64_LE( data, offset )                   \
+    (                                                           \
+          ( (uint64_t) ( data )[( offset ) + 7] << 56 )         \
+        | ( (uint64_t) ( data )[( offset ) + 6] << 48 )         \
+        | ( (uint64_t) ( data )[( offset ) + 5] << 40 )         \
+        | ( (uint64_t) ( data )[( offset ) + 4] << 32 )         \
+        | ( (uint64_t) ( data )[( offset ) + 3] << 24 )         \
+        | ( (uint64_t) ( data )[( offset ) + 2] << 16 )         \
+        | ( (uint64_t) ( data )[( offset ) + 1] <<  8 )         \
+        | ( (uint64_t) ( data )[( offset )    ]       )         \
     )
 #endif
 
@@ -289,16 +290,16 @@
  *                  byte of the 64 bits unsigned integer \p n.
  */
 #ifndef MBEDTLS_PUT_UINT64_LE
-#define MBEDTLS_PUT_UINT64_LE( n, data, offset )                    \
-{                                                                   \
-    ( data )[( offset ) + 7] = (unsigned char) ( (n) >> 56 );       \
-    ( data )[( offset ) + 6] = (unsigned char) ( (n) >> 48 );       \
-    ( data )[( offset ) + 5] = (unsigned char) ( (n) >> 40 );       \
-    ( data )[( offset ) + 4] = (unsigned char) ( (n) >> 32 );       \
-    ( data )[( offset ) + 3] = (unsigned char) ( (n) >> 24 );       \
-    ( data )[( offset ) + 2] = (unsigned char) ( (n) >> 16 );       \
-    ( data )[( offset ) + 1] = (unsigned char) ( (n) >>  8 );       \
-    ( data )[( offset )    ] = (unsigned char) ( (n)       );       \
+#define MBEDTLS_PUT_UINT64_LE( n, data, offset )                \
+{                                                               \
+    ( data )[( offset )    ] = MBEDTLS_BYTE_0( n );             \
+    ( data )[( offset ) + 1] = MBEDTLS_BYTE_1( n );             \
+    ( data )[( offset ) + 2] = MBEDTLS_BYTE_2( n );             \
+    ( data )[( offset ) + 3] = MBEDTLS_BYTE_3( n );             \
+    ( data )[( offset ) + 4] = MBEDTLS_BYTE_4( n );             \
+    ( data )[( offset ) + 5] = MBEDTLS_BYTE_5( n );             \
+    ( data )[( offset ) + 6] = MBEDTLS_BYTE_6( n );             \
+    ( data )[( offset ) + 7] = MBEDTLS_BYTE_7( n );             \
 }
 #endif
 

--- a/library/common.h
+++ b/library/common.h
@@ -55,9 +55,56 @@
  * To tidy up code and save horizontal and vertical space, use byte
  * reading macros to cast
  */
-#define BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff ) )
-#define BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
-#define BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
-#define BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+#define MBEDTLS_BYTE_0( x ) ( (uint8_t) ( ( x ) & 0xff ) )
+#define MBEDTLS_BYTE_1( x ) ( (uint8_t) ( ( ( x ) >> 8  ) & 0xff ) )
+#define MBEDTLS_BYTE_2( x ) ( (uint8_t) ( ( ( x ) >> 16 ) & 0xff ) )
+#define MBEDTLS_BYTE_3( x ) ( (uint8_t) ( ( ( x ) >> 24 ) & 0xff ) )
+
+/*
+ * 32-bit integer manipulation macros (little endian)
+ */
+#ifndef MBEDTLS_GET_UINT32_LE
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
+    do {                                                \
+        (n) = ( (uint32_t) (b)[(i)    ]       )         \
+            | ( (uint32_t) (b)[(i) + 1] <<  8 )         \
+            | ( (uint32_t) (b)[(i) + 2] << 16 )         \
+            | ( (uint32_t) (b)[(i) + 3] << 24 );        \
+    } while( 0 )
+#endif
+
+#ifndef MBEDTLS_PUT_UINT32_LE
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                        \
+    do {                                                            \
+        (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+        (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+        (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
+        (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+    } while( 0 )
+#endif
+
+
+/*
+ * 32-bit integer manipulation macros (big endian)
+ */
+#ifndef MBEDTLS_GET_UINT32_BE
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
+    do {                                                \
+        (n) = ( (uint32_t) (b)[(i)    ] << 24 )         \
+            | ( (uint32_t) (b)[(i) + 1] << 16 )         \
+            | ( (uint32_t) (b)[(i) + 2] <<  8 )         \
+            | ( (uint32_t) (b)[(i) + 3]       );        \
+    } while( 0 )
+#endif
+
+#ifndef MBEDTLS_PUT_UINT32_BE
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
+    do {                                                \
+        (b)[(i)    ] = (unsigned char) ( (n) >> 24 );   \
+        (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );   \
+        (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );   \
+        (b)[(i) + 3] = (unsigned char) ( (n)       );   \
+    } while( 0 )
+#endif
 
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/common.h
+++ b/library/common.h
@@ -64,7 +64,7 @@
  * 32-bit integer manipulation macros (little endian)
  */
 #ifndef MBEDTLS_GET_UINT32_LE
-#define MBEDTLS_GET_UINT32_LE(n,b,i)                            \
+#define MBEDTLS_GET_UINT32_LE(n,b,i)                    \
     do {                                                \
         (n) = ( (uint32_t) (b)[(i)    ]       )         \
             | ( (uint32_t) (b)[(i) + 1] <<  8 )         \
@@ -74,7 +74,7 @@
 #endif
 
 #ifndef MBEDTLS_PUT_UINT32_LE
-#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                        \
+#define MBEDTLS_PUT_UINT32_LE(n,b,i)                                \
     do {                                                            \
         (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
         (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
@@ -88,7 +88,7 @@
  * 32-bit integer manipulation macros (big endian)
  */
 #ifndef MBEDTLS_GET_UINT32_BE
-#define MBEDTLS_GET_UINT32_BE(n,b,i)                            \
+#define MBEDTLS_GET_UINT32_BE(n,b,i)                    \
     do {                                                \
         (n) = ( (uint32_t) (b)[(i)    ] << 24 )         \
             | ( (uint32_t) (b)[(i) + 1] << 16 )         \
@@ -98,13 +98,32 @@
 #endif
 
 #ifndef MBEDTLS_PUT_UINT32_BE
-#define MBEDTLS_PUT_UINT32_BE(n,b,i)                            \
+#define MBEDTLS_PUT_UINT32_BE(n,b,i)                    \
     do {                                                \
         (b)[(i)    ] = (unsigned char) ( (n) >> 24 );   \
         (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );   \
         (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );   \
         (b)[(i) + 3] = (unsigned char) ( (n)       );   \
     } while( 0 )
+#endif
+
+/*
+ * 16-bit integer manipulation macros (little endian)
+ */
+#ifndef MBEDTLS_GET_UINT16_LE
+#define MBEDTLS_GET_UINT16_LE( n, b, i )                \
+{                                                       \
+    (n) = ( (uint16_t) (b)[(i)    ]       )             \
+        | ( (uint16_t) (b)[(i) + 1] <<  8 );            \
+}
+#endif
+
+#ifndef MBEDTLS_PUT_UINT16_LE
+#define MBEDTLS_PUT_UINT16_LE( n, b, i )                        \
+{                                                               \
+    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+}
 #endif
 
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -152,10 +152,10 @@ static int block_cipher_df( unsigned char *output,
      *     (Total is padded to a multiple of 16-bytes with zeroes)
      */
     p = buf + MBEDTLS_CTR_DRBG_BLOCKSIZE;
-    *p++ = ( data_len >> 24 ) & 0xff;
-    *p++ = ( data_len >> 16 ) & 0xff;
-    *p++ = ( data_len >> 8  ) & 0xff;
-    *p++ = ( data_len       ) & 0xff;
+    *p++ = BYTE_3( data_len );
+    *p++ = BYTE_2( data_len );
+    *p++ = BYTE_1( data_len );
+    *p++ = BYTE_0( data_len );
     p += 3;
     *p++ = MBEDTLS_CTR_DRBG_SEEDLEN;
     memcpy( p, data, data_len );

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -152,10 +152,10 @@ static int block_cipher_df( unsigned char *output,
      *     (Total is padded to a multiple of 16-bytes with zeroes)
      */
     p = buf + MBEDTLS_CTR_DRBG_BLOCKSIZE;
-    *p++ = BYTE_3( data_len );
-    *p++ = BYTE_2( data_len );
-    *p++ = BYTE_1( data_len );
-    *p++ = BYTE_0( data_len );
+    *p++ = MBEDTLS_BYTE_3( data_len );
+    *p++ = MBEDTLS_BYTE_2( data_len );
+    *p++ = MBEDTLS_BYTE_1( data_len );
+    *p++ = MBEDTLS_BYTE_0( data_len );
     p += 3;
     *p++ = MBEDTLS_CTR_DRBG_SEEDLEN;
     memcpy( p, data, data_len );

--- a/library/des.c
+++ b/library/des.c
@@ -400,8 +400,8 @@ void mbedtls_des_setkey( uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KE
     int i;
     uint32_t X, Y, T;
 
-    MBEDTLS_GET_UINT32_BE( X, key, 0 );
-    MBEDTLS_GET_UINT32_BE( Y, key, 4 );
+    X = MBEDTLS_GET_UINT32_BE( key, 0 );
+    Y = MBEDTLS_GET_UINT32_BE( key, 4 );
 
     /*
      * Permuted Choice 1
@@ -610,8 +610,8 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
 
     SK = ctx->sk;
 
-    MBEDTLS_GET_UINT32_BE( X, input, 0 );
-    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
+    X = MBEDTLS_GET_UINT32_BE( input, 0 );
+    Y = MBEDTLS_GET_UINT32_BE( input, 4 );
 
     DES_IP( X, Y );
 
@@ -697,8 +697,8 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
 
     SK = ctx->sk;
 
-    MBEDTLS_GET_UINT32_BE( X, input, 0 );
-    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
+    X = MBEDTLS_GET_UINT32_BE( input, 0 );
+    Y = MBEDTLS_GET_UINT32_BE( input, 4 );
 
     DES_IP( X, Y );
 

--- a/library/des.c
+++ b/library/des.c
@@ -44,29 +44,6 @@
 #if !defined(MBEDTLS_DES_ALT)
 
 /*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
-/*
  * Expanded DES S-boxes
  */
 static const uint32_t SB1[64] =
@@ -423,8 +400,8 @@ void mbedtls_des_setkey( uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KE
     int i;
     uint32_t X, Y, T;
 
-    GET_UINT32_BE( X, key, 0 );
-    GET_UINT32_BE( Y, key, 4 );
+    MBEDTLS_GET_UINT32_BE( X, key, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, key, 4 );
 
     /*
      * Permuted Choice 1
@@ -633,8 +610,8 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
 
     SK = ctx->sk;
 
-    GET_UINT32_BE( X, input, 0 );
-    GET_UINT32_BE( Y, input, 4 );
+    MBEDTLS_GET_UINT32_BE( X, input, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
 
     DES_IP( X, Y );
 
@@ -646,8 +623,8 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
 
     DES_FP( Y, X );
 
-    PUT_UINT32_BE( Y, output, 0 );
-    PUT_UINT32_BE( X, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( Y, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( X, output, 4 );
 
     return( 0 );
 }
@@ -720,8 +697,8 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
 
     SK = ctx->sk;
 
-    GET_UINT32_BE( X, input, 0 );
-    GET_UINT32_BE( Y, input, 4 );
+    MBEDTLS_GET_UINT32_BE( X, input, 0 );
+    MBEDTLS_GET_UINT32_BE( Y, input, 4 );
 
     DES_IP( X, Y );
 
@@ -745,8 +722,8 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
 
     DES_FP( Y, X );
 
-    PUT_UINT32_BE( Y, output, 0 );
-    PUT_UINT32_BE( X, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( Y, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( X, output, 4 );
 
     return( 0 );
 }

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -231,8 +231,8 @@ int mbedtls_dhm_make_params( mbedtls_dhm_context *ctx, int x_size,
         MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( ( X ),               \
                                                    p + 2,               \
                                                    ( n ) ) );           \
-        *p++ = (unsigned char)( ( n ) >> 8 );                           \
-        *p++ = (unsigned char)( ( n )      );                           \
+        *p++ = MBEDTLS_BYTE_1( n );                                     \
+        *p++ = MBEDTLS_BYTE_0( n );                                     \
         p += ( n );                                                     \
     } while( 0 )
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -166,10 +166,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = MBEDTLS_CHAR_3( len );
-    (*p)[1] = MBEDTLS_CHAR_2( len );
-    (*p)[2] = MBEDTLS_CHAR_1( len );
-    (*p)[3] = MBEDTLS_CHAR_0( len );
+    (*p)[0] = MBEDTLS_BYTE_3( len );
+    (*p)[1] = MBEDTLS_BYTE_2( len );
+    (*p)[2] = MBEDTLS_BYTE_1( len );
+    (*p)[3] = MBEDTLS_BYTE_0( len );
 
     *p += 4 + len;
 
@@ -209,10 +209,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = MBEDTLS_CHAR_3( id_len );
-    *p++ = MBEDTLS_CHAR_2( id_len );
-    *p++ = MBEDTLS_CHAR_1( id_len );
-    *p++ = MBEDTLS_CHAR_0( id_len );
+    *p++ = MBEDTLS_BYTE_3( id_len );
+    *p++ = MBEDTLS_BYTE_2( id_len );
+    *p++ = MBEDTLS_BYTE_1( id_len );
+    *p++ = MBEDTLS_BYTE_0( id_len );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
@@ -352,7 +352,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = MBEDTLS_CHAR_0( len );
+    *(*p)++ = MBEDTLS_BYTE_0( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -352,7 +352,7 @@ static int ecjpake_zkp_write( const mbedtls_md_info_t *md_info,
         goto cleanup;
     }
 
-    *(*p)++ = (unsigned char)( len & 0xFF );
+    *(*p)++ = MBEDTLS_CHAR_0( len );
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( &h, *p, len ) ); /* r */
     *p += len;
 

--- a/library/ecjpake.c
+++ b/library/ecjpake.c
@@ -166,10 +166,10 @@ static int ecjpake_write_len_point( unsigned char **p,
     if( ret != 0 )
         return( ret );
 
-    (*p)[0] = (unsigned char)( ( len >> 24 ) & 0xFF );
-    (*p)[1] = (unsigned char)( ( len >> 16 ) & 0xFF );
-    (*p)[2] = (unsigned char)( ( len >>  8 ) & 0xFF );
-    (*p)[3] = (unsigned char)( ( len       ) & 0xFF );
+    (*p)[0] = MBEDTLS_CHAR_3( len );
+    (*p)[1] = MBEDTLS_CHAR_2( len );
+    (*p)[2] = MBEDTLS_CHAR_1( len );
+    (*p)[3] = MBEDTLS_CHAR_0( len );
 
     *p += 4 + len;
 
@@ -209,10 +209,10 @@ static int ecjpake_hash( const mbedtls_md_info_t *md_info,
     if( end - p < 4 )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );
 
-    *p++ = (unsigned char)( ( id_len >> 24 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >> 16 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len >>  8 ) & 0xFF );
-    *p++ = (unsigned char)( ( id_len       ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_3( id_len );
+    *p++ = MBEDTLS_CHAR_2( id_len );
+    *p++ = MBEDTLS_CHAR_1( id_len );
+    *p++ = MBEDTLS_CHAR_0( id_len );
 
     if( end < p || (size_t)( end - p ) < id_len )
         return( MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1159,8 +1159,8 @@ int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp, size_t *olen,
     /*
      * Next two bytes are the namedcurve value
      */
-    buf[0] = curve_info->tls_id >> 8;
-    buf[1] = curve_info->tls_id & 0xFF;
+    buf[0] = MBEDTLS_BYTE_1( curve_info->tls_id );
+    buf[1] = MBEDTLS_BYTE_0( curve_info->tls_id );
 
     return( 0 );
 }

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1159,8 +1159,7 @@ int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp, size_t *olen,
     /*
      * Next two bytes are the namedcurve value
      */
-    buf[0] = MBEDTLS_BYTE_1( curve_info->tls_id );
-    buf[1] = MBEDTLS_BYTE_0( curve_info->tls_id );
+    MBEDTLS_PUT_UINT16_BE( curve_info->tls_id, buf, 0 );
 
     return( 0 );
 }

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -88,12 +88,12 @@ static int gcm_gen_table( mbedtls_gcm_context *ctx )
         return( ret );
 
     /* pack h as two 64-bits ints, big-endian */
-    MBEDTLS_GET_UINT32_BE( hi, h,  0  );
-    MBEDTLS_GET_UINT32_BE( lo, h,  4  );
+    hi = MBEDTLS_GET_UINT32_BE( h,  0  );
+    lo = MBEDTLS_GET_UINT32_BE( h,  4  );
     vh = (uint64_t) hi << 32 | lo;
 
-    MBEDTLS_GET_UINT32_BE( hi, h,  8  );
-    MBEDTLS_GET_UINT32_BE( lo, h,  12 );
+    hi = MBEDTLS_GET_UINT32_BE( h,  8  );
+    lo = MBEDTLS_GET_UINT32_BE( h,  12 );
     vl = (uint64_t) hi << 32 | lo;
 
     /* 8 = 1000 corresponds to 1 in GF(2^128) */

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -59,29 +59,6 @@
     MBEDTLS_INTERNAL_VALIDATE( cond )
 
 /*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
-/*
  * Initialize a context
  */
 void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
@@ -111,12 +88,12 @@ static int gcm_gen_table( mbedtls_gcm_context *ctx )
         return( ret );
 
     /* pack h as two 64-bits ints, big-endian */
-    GET_UINT32_BE( hi, h,  0  );
-    GET_UINT32_BE( lo, h,  4  );
+    MBEDTLS_GET_UINT32_BE( hi, h,  0  );
+    MBEDTLS_GET_UINT32_BE( lo, h,  4  );
     vh = (uint64_t) hi << 32 | lo;
 
-    GET_UINT32_BE( hi, h,  8  );
-    GET_UINT32_BE( lo, h,  12 );
+    MBEDTLS_GET_UINT32_BE( hi, h,  8  );
+    MBEDTLS_GET_UINT32_BE( lo, h,  12 );
     vl = (uint64_t) hi << 32 | lo;
 
     /* 8 = 1000 corresponds to 1 in GF(2^128) */
@@ -223,10 +200,10 @@ static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
     if( mbedtls_aesni_has_support( MBEDTLS_AESNI_CLMUL ) ) {
         unsigned char h[16];
 
-        PUT_UINT32_BE( ctx->HH[8] >> 32, h,  0 );
-        PUT_UINT32_BE( ctx->HH[8],       h,  4 );
-        PUT_UINT32_BE( ctx->HL[8] >> 32, h,  8 );
-        PUT_UINT32_BE( ctx->HL[8],       h, 12 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HH[8] >> 32, h,  0 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HH[8],       h,  4 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HL[8] >> 32, h,  8 );
+        MBEDTLS_PUT_UINT32_BE( ctx->HL[8],       h, 12 );
 
         mbedtls_aesni_gcm_mult( output, x, h );
         return;
@@ -262,10 +239,10 @@ static void gcm_mult( mbedtls_gcm_context *ctx, const unsigned char x[16],
         zl ^= ctx->HL[hi];
     }
 
-    PUT_UINT32_BE( zh >> 32, output, 0 );
-    PUT_UINT32_BE( zh, output, 4 );
-    PUT_UINT32_BE( zl >> 32, output, 8 );
-    PUT_UINT32_BE( zl, output, 12 );
+    MBEDTLS_PUT_UINT32_BE( zh >> 32, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( zh, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( zl >> 32, output, 8 );
+    MBEDTLS_PUT_UINT32_BE( zl, output, 12 );
 }
 
 int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
@@ -309,7 +286,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     else
     {
         memset( work_buf, 0x00, 16 );
-        PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
+        MBEDTLS_PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
 
         p = iv;
         while( iv_len > 0 )
@@ -442,10 +419,10 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
     {
         memset( work_buf, 0x00, 16 );
 
-        PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
-        PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );
-        PUT_UINT32_BE( ( orig_len     >> 32 ), work_buf, 8  );
-        PUT_UINT32_BE( ( orig_len           ), work_buf, 12 );
+        MBEDTLS_PUT_UINT32_BE( ( orig_add_len >> 32 ), work_buf, 0  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_add_len       ), work_buf, 4  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_len     >> 32 ), work_buf, 8  );
+        MBEDTLS_PUT_UINT32_BE( ( orig_len           ), work_buf, 12 );
 
         for( i = 0; i < 16; i++ )
             ctx->buf[i] ^= work_buf[i];

--- a/library/md4.c
+++ b/library/md4.c
@@ -44,29 +44,6 @@
 
 #if !defined(MBEDTLS_MD4_ALT)
 
-/*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
 void mbedtls_md4_init( mbedtls_md4_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_md4_context ) );
@@ -118,22 +95,22 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
@@ -333,8 +310,8 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  msglen, 0 );
-    PUT_UINT32_LE( high, msglen, 4 );
+    MBEDTLS_PUT_UINT32_LE( low,  msglen, 0 );
+    MBEDTLS_PUT_UINT32_LE( high, msglen, 4 );
 
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
@@ -347,10 +324,10 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
         return( ret );
 
 
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
 
     return( 0 );
 }

--- a/library/md4.c
+++ b/library/md4.c
@@ -95,22 +95,22 @@ int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
-    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
-    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
-    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
-    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
-    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
-    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
+    local.X[ 0] = MBEDTLS_GET_UINT32_LE( data,  0 );
+    local.X[ 1] = MBEDTLS_GET_UINT32_LE( data,  4 );
+    local.X[ 2] = MBEDTLS_GET_UINT32_LE( data,  8 );
+    local.X[ 3] = MBEDTLS_GET_UINT32_LE( data, 12 );
+    local.X[ 4] = MBEDTLS_GET_UINT32_LE( data, 16 );
+    local.X[ 5] = MBEDTLS_GET_UINT32_LE( data, 20 );
+    local.X[ 6] = MBEDTLS_GET_UINT32_LE( data, 24 );
+    local.X[ 7] = MBEDTLS_GET_UINT32_LE( data, 28 );
+    local.X[ 8] = MBEDTLS_GET_UINT32_LE( data, 32 );
+    local.X[ 9] = MBEDTLS_GET_UINT32_LE( data, 36 );
+    local.X[10] = MBEDTLS_GET_UINT32_LE( data, 40 );
+    local.X[11] = MBEDTLS_GET_UINT32_LE( data, 44 );
+    local.X[12] = MBEDTLS_GET_UINT32_LE( data, 48 );
+    local.X[13] = MBEDTLS_GET_UINT32_LE( data, 52 );
+    local.X[14] = MBEDTLS_GET_UINT32_LE( data, 56 );
+    local.X[15] = MBEDTLS_GET_UINT32_LE( data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 

--- a/library/md5.c
+++ b/library/md5.c
@@ -94,22 +94,22 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
-    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
-    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
-    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
-    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
-    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
-    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
+    local.X[ 0] = MBEDTLS_GET_UINT32_LE( data,  0 );
+    local.X[ 1] = MBEDTLS_GET_UINT32_LE( data,  4 );
+    local.X[ 2] = MBEDTLS_GET_UINT32_LE( data,  8 );
+    local.X[ 3] = MBEDTLS_GET_UINT32_LE( data, 12 );
+    local.X[ 4] = MBEDTLS_GET_UINT32_LE( data, 16 );
+    local.X[ 5] = MBEDTLS_GET_UINT32_LE( data, 20 );
+    local.X[ 6] = MBEDTLS_GET_UINT32_LE( data, 24 );
+    local.X[ 7] = MBEDTLS_GET_UINT32_LE( data, 28 );
+    local.X[ 8] = MBEDTLS_GET_UINT32_LE( data, 32 );
+    local.X[ 9] = MBEDTLS_GET_UINT32_LE( data, 36 );
+    local.X[10] = MBEDTLS_GET_UINT32_LE( data, 40 );
+    local.X[11] = MBEDTLS_GET_UINT32_LE( data, 44 );
+    local.X[12] = MBEDTLS_GET_UINT32_LE( data, 48 );
+    local.X[13] = MBEDTLS_GET_UINT32_LE( data, 52 );
+    local.X[14] = MBEDTLS_GET_UINT32_LE( data, 56 );
+    local.X[15] = MBEDTLS_GET_UINT32_LE( data, 60 );
 
 #define S(x,n)                                                          \
     ( ( (x) << (n) ) | ( ( (x) & 0xFFFFFFFF) >> ( 32 - (n) ) ) )

--- a/library/md5.c
+++ b/library/md5.c
@@ -43,29 +43,6 @@
 
 #if !defined(MBEDTLS_MD5_ALT)
 
-/*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
 void mbedtls_md5_init( mbedtls_md5_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_md5_context ) );
@@ -117,22 +94,22 @@ int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
         uint32_t X[16], A, B, C, D;
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
 #define S(x,n)                                                          \
     ( ( (x) << (n) ) | ( ( (x) & 0xFFFFFFFF) >> ( 32 - (n) ) ) )
@@ -353,8 +330,8 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  ctx->buffer, 56 );
-    PUT_UINT32_LE( high, ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_LE( low,  ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_LE( high, ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_md5_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -362,10 +339,10 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
 
     return( 0 );
 }

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -454,7 +454,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
         }
 
-        MBEDTLS_GET_UINT32_BE( Plen, A, KW_SEMIBLOCK_LENGTH / 2 );
+        Plen = MBEDTLS_GET_UINT32_BE( A, KW_SEMIBLOCK_LENGTH / 2 );
 
         /*
          * Plen is the length of the plaintext, when the input is valid.

--- a/library/nist_kw.c
+++ b/library/nist_kw.c
@@ -77,26 +77,6 @@ static const unsigned char NIST_KW_ICV1[] = {0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
 /*! The 32-bit default integrity check value (ICV) for KWP mode. */
 static const  unsigned char NIST_KW_ICV2[] = {0xA6, 0x59, 0x59, 0xA6};
 
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-do {                                                    \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-} while( 0 )
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-do {                                                    \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-} while( 0 )
-#endif
-
 /*
  * Initialize context
  */
@@ -243,7 +223,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx,
         }
 
         memcpy( output, NIST_KW_ICV2, KW_SEMIBLOCK_LENGTH / 2 );
-        PUT_UINT32_BE( ( in_len & 0xffffffff ), output,
+        MBEDTLS_PUT_UINT32_BE( ( in_len & 0xffffffff ), output,
                        KW_SEMIBLOCK_LENGTH / 2 );
 
         memcpy( output + KW_SEMIBLOCK_LENGTH, input, in_len );
@@ -474,7 +454,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx,
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
         }
 
-        GET_UINT32_BE( Plen, A, KW_SEMIBLOCK_LENGTH / 2 );
+        MBEDTLS_GET_UINT32_BE( Plen, A, KW_SEMIBLOCK_LENGTH / 2 );
 
         /*
          * Plen is the length of the plaintext, when the input is valid.

--- a/library/pkcs12.c
+++ b/library/pkcs12.c
@@ -330,8 +330,8 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
         for( i = v; i > 0; i-- )
         {
             j = salt_block[i - 1] + hash_block[i - 1] + c;
-            c = (unsigned char) (j >> 8);
-            salt_block[i - 1] = j & 0xFF;
+            c = MBEDTLS_BYTE_1( j );
+            salt_block[i - 1] = MBEDTLS_BYTE_0( j );
         }
 
         // pwd_block  += B
@@ -339,8 +339,8 @@ int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
         for( i = v; i > 0; i-- )
         {
             j = pwd_block[i - 1] + hash_block[i - 1] + c;
-            c = (unsigned char) (j >> 8);
-            pwd_block[i - 1] = j & 0xFF;
+            c = MBEDTLS_BYTE_1( j );
+            pwd_block[i - 1] = MBEDTLS_BYTE_0( j );
         }
     }
 

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -257,22 +257,22 @@ static void poly1305_compute_mac( const mbedtls_poly1305_context *ctx,
     acc3 += ctx->s[3] + (uint32_t) ( d >> 32U );
 
     /* Compute MAC (128 least significant bits of the accumulator) */
-    mac[ 0] = (unsigned char)( acc0       );
-    mac[ 1] = (unsigned char)( acc0 >>  8 );
-    mac[ 2] = (unsigned char)( acc0 >> 16 );
-    mac[ 3] = (unsigned char)( acc0 >> 24 );
-    mac[ 4] = (unsigned char)( acc1       );
-    mac[ 5] = (unsigned char)( acc1 >>  8 );
-    mac[ 6] = (unsigned char)( acc1 >> 16 );
-    mac[ 7] = (unsigned char)( acc1 >> 24 );
-    mac[ 8] = (unsigned char)( acc2       );
-    mac[ 9] = (unsigned char)( acc2 >>  8 );
-    mac[10] = (unsigned char)( acc2 >> 16 );
-    mac[11] = (unsigned char)( acc2 >> 24 );
-    mac[12] = (unsigned char)( acc3       );
-    mac[13] = (unsigned char)( acc3 >>  8 );
-    mac[14] = (unsigned char)( acc3 >> 16 );
-    mac[15] = (unsigned char)( acc3 >> 24 );
+    mac[ 0] = MBEDTLS_BYTE_0( acc0 );
+    mac[ 1] = MBEDTLS_BYTE_1( acc0 );
+    mac[ 2] = MBEDTLS_BYTE_2( acc0 );
+    mac[ 3] = MBEDTLS_BYTE_3( acc0 );
+    mac[ 4] = MBEDTLS_BYTE_0( acc1 );
+    mac[ 5] = MBEDTLS_BYTE_1( acc1 );
+    mac[ 6] = MBEDTLS_BYTE_2( acc1 );
+    mac[ 7] = MBEDTLS_BYTE_3( acc1 );
+    mac[ 8] = MBEDTLS_BYTE_0( acc2 );
+    mac[ 9] = MBEDTLS_BYTE_1( acc2 );
+    mac[10] = MBEDTLS_BYTE_2( acc2 );
+    mac[11] = MBEDTLS_BYTE_3( acc2 );
+    mac[12] = MBEDTLS_BYTE_0( acc3 );
+    mac[13] = MBEDTLS_BYTE_1( acc3 );
+    mac[14] = MBEDTLS_BYTE_2( acc3 );
+    mac[15] = MBEDTLS_BYTE_3( acc3 );
 }
 
 void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx )

--- a/library/poly1305.c
+++ b/library/poly1305.c
@@ -257,22 +257,10 @@ static void poly1305_compute_mac( const mbedtls_poly1305_context *ctx,
     acc3 += ctx->s[3] + (uint32_t) ( d >> 32U );
 
     /* Compute MAC (128 least significant bits of the accumulator) */
-    mac[ 0] = MBEDTLS_BYTE_0( acc0 );
-    mac[ 1] = MBEDTLS_BYTE_1( acc0 );
-    mac[ 2] = MBEDTLS_BYTE_2( acc0 );
-    mac[ 3] = MBEDTLS_BYTE_3( acc0 );
-    mac[ 4] = MBEDTLS_BYTE_0( acc1 );
-    mac[ 5] = MBEDTLS_BYTE_1( acc1 );
-    mac[ 6] = MBEDTLS_BYTE_2( acc1 );
-    mac[ 7] = MBEDTLS_BYTE_3( acc1 );
-    mac[ 8] = MBEDTLS_BYTE_0( acc2 );
-    mac[ 9] = MBEDTLS_BYTE_1( acc2 );
-    mac[10] = MBEDTLS_BYTE_2( acc2 );
-    mac[11] = MBEDTLS_BYTE_3( acc2 );
-    mac[12] = MBEDTLS_BYTE_0( acc3 );
-    mac[13] = MBEDTLS_BYTE_1( acc3 );
-    mac[14] = MBEDTLS_BYTE_2( acc3 );
-    mac[15] = MBEDTLS_BYTE_3( acc3 );
+    MBEDTLS_PUT_UINT32_LE( acc0, mac, 0 );
+    MBEDTLS_PUT_UINT32_LE( acc1, mac, 4 );
+    MBEDTLS_PUT_UINT32_LE( acc2, mac, 8 );
+    MBEDTLS_PUT_UINT32_LE( acc3, mac, 12 );
 }
 
 void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx )

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4396,8 +4396,8 @@ static psa_status_t psa_tls12_prf_psk_to_ms_set_key(
      * uint16 with the value N, and the PSK itself.
      */
 
-    *cur++ = BYTE_1( data_length );
-    *cur++ = BYTE_0( data_length );
+    *cur++ = MBEDTLS_BYTE_1( data_length );
+    *cur++ = MBEDTLS_BYTE_0( data_length );
     memset( cur, 0, data_length );
     cur += data_length;
     *cur++ = pms[0];

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4396,8 +4396,8 @@ static psa_status_t psa_tls12_prf_psk_to_ms_set_key(
      * uint16 with the value N, and the PSK itself.
      */
 
-    *cur++ = ( data_length >> 8 ) & 0xff;
-    *cur++ = ( data_length >> 0 ) & 0xff;
+    *cur++ = BYTE_1( data_length );
+    *cur++ = BYTE_0( data_length );
     memset( cur, 0, data_length );
     cur += data_length;
     *cur++ = pms[0];

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -24,6 +24,8 @@
 #include "mbedtls/config.h"
 #endif
 
+#include "common.h"
+
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 
 #include <stdlib.h>
@@ -236,29 +238,6 @@ static psa_status_t psa_crypto_storage_get_data_length(
 }
 
 /*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE( n, b, i )                        \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE( n, b, i )                                \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
-/*
  * 16-bit integer manipulation macros (little endian)
  */
 #ifndef GET_UINT16_LE
@@ -303,14 +282,14 @@ void psa_format_key_data_for_storage( const uint8_t *data,
         (psa_persistent_key_storage_format *) storage_data;
 
     memcpy( storage_format->magic, PSA_KEY_STORAGE_MAGIC_HEADER, PSA_KEY_STORAGE_MAGIC_HEADER_LENGTH );
-    PUT_UINT32_LE( 0, storage_format->version, 0 );
-    PUT_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
+    MBEDTLS_PUT_UINT32_LE( 0, storage_format->version, 0 );
+    MBEDTLS_PUT_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
     PUT_UINT16_LE( (uint16_t) attr->type, storage_format->type, 0 );
     PUT_UINT16_LE( (uint16_t) attr->bits, storage_format->bits, 0 );
-    PUT_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
-    PUT_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
-    PUT_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
-    PUT_UINT32_LE( data_length, storage_format->data_len, 0 );
+    MBEDTLS_PUT_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
+    MBEDTLS_PUT_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
+    MBEDTLS_PUT_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
+    MBEDTLS_PUT_UINT32_LE( data_length, storage_format->data_len, 0 );
     memcpy( storage_format->key_data, data, data_length );
 }
 
@@ -340,11 +319,11 @@ psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
     if( status != PSA_SUCCESS )
         return( status );
 
-    GET_UINT32_LE( version, storage_format->version, 0 );
+    MBEDTLS_GET_UINT32_LE( version, storage_format->version, 0 );
     if( version != 0 )
         return( PSA_ERROR_DATA_INVALID );
 
-    GET_UINT32_LE( *key_data_length, storage_format->data_len, 0 );
+    MBEDTLS_GET_UINT32_LE( *key_data_length, storage_format->data_len, 0 );
     if( *key_data_length > ( storage_data_length - sizeof(*storage_format) ) ||
         *key_data_length > PSA_CRYPTO_MAX_STORAGE_SIZE )
         return( PSA_ERROR_DATA_INVALID );
@@ -361,12 +340,12 @@ psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
         memcpy( *key_data, storage_format->key_data, *key_data_length );
     }
 
-    GET_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
+    MBEDTLS_GET_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
     GET_UINT16_LE( attr->type, storage_format->type, 0 );
     GET_UINT16_LE( attr->bits, storage_format->bits, 0 );
-    GET_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
-    GET_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
-    GET_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
+    MBEDTLS_GET_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
+    MBEDTLS_GET_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
+    MBEDTLS_GET_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
 
     return( PSA_SUCCESS );
 }

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -300,11 +300,11 @@ psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
     if( status != PSA_SUCCESS )
         return( status );
 
-    MBEDTLS_GET_UINT32_LE( version, storage_format->version, 0 );
+    version = MBEDTLS_GET_UINT32_LE( storage_format->version, 0 );
     if( version != 0 )
         return( PSA_ERROR_DATA_INVALID );
 
-    MBEDTLS_GET_UINT32_LE( *key_data_length, storage_format->data_len, 0 );
+    *key_data_length = MBEDTLS_GET_UINT32_LE( storage_format->data_len, 0 );
     if( *key_data_length > ( storage_data_length - sizeof(*storage_format) ) ||
         *key_data_length > PSA_CRYPTO_MAX_STORAGE_SIZE )
         return( PSA_ERROR_DATA_INVALID );
@@ -321,13 +321,12 @@ psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
         memcpy( *key_data, storage_format->key_data, *key_data_length );
     }
 
-    MBEDTLS_GET_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
-    MBEDTLS_GET_UINT16_LE( attr->type, storage_format->type, 0 );
-    MBEDTLS_GET_UINT16_LE( attr->bits, storage_format->bits, 0 );
-    MBEDTLS_GET_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
-    MBEDTLS_GET_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
-    MBEDTLS_GET_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
-
+    attr->lifetime = MBEDTLS_GET_UINT32_LE( storage_format->lifetime, 0 );
+    attr->type = MBEDTLS_GET_UINT16_LE( storage_format->type, 0 );
+    attr->bits = MBEDTLS_GET_UINT16_LE( storage_format->bits, 0 );
+    attr->policy.usage = MBEDTLS_GET_UINT32_LE( storage_format->policy, 0 );
+    attr->policy.alg = MBEDTLS_GET_UINT32_LE( storage_format->policy, sizeof( uint32_t ) );
+    attr->policy.alg2 = MBEDTLS_GET_UINT32_LE( storage_format->policy, 2 * sizeof( uint32_t ) );
     return( PSA_SUCCESS );
 }
 

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -237,25 +237,6 @@ static psa_status_t psa_crypto_storage_get_data_length(
     return( PSA_SUCCESS );
 }
 
-/*
- * 16-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT16_LE
-#define GET_UINT16_LE( n, b, i )                        \
-{                                                       \
-    (n) = ( (uint16_t) (b)[(i)    ]       )             \
-        | ( (uint16_t) (b)[(i) + 1] <<  8 );            \
-}
-#endif
-
-#ifndef PUT_UINT16_LE
-#define PUT_UINT16_LE( n, b, i )                                \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-}
-#endif
-
 /**
  * Persistent key storage magic header.
  */
@@ -284,8 +265,8 @@ void psa_format_key_data_for_storage( const uint8_t *data,
     memcpy( storage_format->magic, PSA_KEY_STORAGE_MAGIC_HEADER, PSA_KEY_STORAGE_MAGIC_HEADER_LENGTH );
     MBEDTLS_PUT_UINT32_LE( 0, storage_format->version, 0 );
     MBEDTLS_PUT_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
-    PUT_UINT16_LE( (uint16_t) attr->type, storage_format->type, 0 );
-    PUT_UINT16_LE( (uint16_t) attr->bits, storage_format->bits, 0 );
+    MBEDTLS_PUT_UINT16_LE( (uint16_t) attr->type, storage_format->type, 0 );
+    MBEDTLS_PUT_UINT16_LE( (uint16_t) attr->bits, storage_format->bits, 0 );
     MBEDTLS_PUT_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
     MBEDTLS_PUT_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
     MBEDTLS_PUT_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );
@@ -341,8 +322,8 @@ psa_status_t psa_parse_key_data_from_storage( const uint8_t *storage_data,
     }
 
     MBEDTLS_GET_UINT32_LE( attr->lifetime, storage_format->lifetime, 0 );
-    GET_UINT16_LE( attr->type, storage_format->type, 0 );
-    GET_UINT16_LE( attr->bits, storage_format->bits, 0 );
+    MBEDTLS_GET_UINT16_LE( attr->type, storage_format->type, 0 );
+    MBEDTLS_GET_UINT16_LE( attr->bits, storage_format->bits, 0 );
     MBEDTLS_GET_UINT32_LE( attr->policy.usage, storage_format->policy, 0 );
     MBEDTLS_GET_UINT32_LE( attr->policy.alg, storage_format->policy, sizeof( uint32_t ) );
     MBEDTLS_GET_UINT32_LE( attr->policy.alg2, storage_format->policy, 2 * sizeof( uint32_t ) );

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -197,14 +197,14 @@ psa_status_t psa_its_set( psa_storage_uid_t uid,
     size_t n;
 
     memcpy( header.magic, PSA_ITS_MAGIC_STRING, PSA_ITS_MAGIC_LENGTH );
-    header.size[0] = BYTE_0( data_length );
-    header.size[1] = BYTE_1( data_length );
-    header.size[2] = BYTE_2( data_length );
-    header.size[3] = BYTE_3( data_length );
-    header.flags[0] = BYTE_0( create_flags );
-    header.flags[1] = BYTE_1( create_flags );
-    header.flags[2] = BYTE_2( create_flags );
-    header.flags[3] = BYTE_3( create_flags );
+    header.size[0] = MBEDTLS_BYTE_0( data_length );
+    header.size[1] = MBEDTLS_BYTE_1( data_length );
+    header.size[2] = MBEDTLS_BYTE_2( data_length );
+    header.size[3] = MBEDTLS_BYTE_3( data_length );
+    header.flags[0] = MBEDTLS_BYTE_0( create_flags );
+    header.flags[1] = MBEDTLS_BYTE_1( create_flags );
+    header.flags[2] = MBEDTLS_BYTE_2( create_flags );
+    header.flags[3] = MBEDTLS_BYTE_3( create_flags );
 
     psa_its_fill_filename( uid, filename );
     stream = fopen( PSA_ITS_STORAGE_TEMP, "wb" );

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -197,14 +197,8 @@ psa_status_t psa_its_set( psa_storage_uid_t uid,
     size_t n;
 
     memcpy( header.magic, PSA_ITS_MAGIC_STRING, PSA_ITS_MAGIC_LENGTH );
-    header.size[0] = MBEDTLS_BYTE_0( data_length );
-    header.size[1] = MBEDTLS_BYTE_1( data_length );
-    header.size[2] = MBEDTLS_BYTE_2( data_length );
-    header.size[3] = MBEDTLS_BYTE_3( data_length );
-    header.flags[0] = MBEDTLS_BYTE_0( create_flags );
-    header.flags[1] = MBEDTLS_BYTE_1( create_flags );
-    header.flags[2] = MBEDTLS_BYTE_2( create_flags );
-    header.flags[3] = MBEDTLS_BYTE_3( create_flags );
+    MBEDTLS_PUT_UINT32_LE( data_length, header.size, 0 );
+    MBEDTLS_PUT_UINT32_LE( create_flags, header.flags, 0 );
 
     psa_its_fill_filename( uid, filename );
     stream = fopen( PSA_ITS_STORAGE_TEMP, "wb" );

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -38,6 +38,8 @@
 
 #include "psa_crypto_its.h"
 
+#include "common.h"
+
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -195,14 +197,14 @@ psa_status_t psa_its_set( psa_storage_uid_t uid,
     size_t n;
 
     memcpy( header.magic, PSA_ITS_MAGIC_STRING, PSA_ITS_MAGIC_LENGTH );
-    header.size[0] = data_length & 0xff;
-    header.size[1] = ( data_length >> 8 ) & 0xff;
-    header.size[2] = ( data_length >> 16 ) & 0xff;
-    header.size[3] = ( data_length >> 24 ) & 0xff;
-    header.flags[0] = create_flags & 0xff;
-    header.flags[1] = ( create_flags >> 8 ) & 0xff;
-    header.flags[2] = ( create_flags >> 16 ) & 0xff;
-    header.flags[3] = ( create_flags >> 24 ) & 0xff;
+    header.size[0] = BYTE_0( data_length );
+    header.size[1] = BYTE_1( data_length );
+    header.size[2] = BYTE_2( data_length );
+    header.size[3] = BYTE_3( data_length );
+    header.flags[0] = BYTE_0( create_flags );
+    header.flags[1] = BYTE_1( create_flags );
+    header.flags[2] = BYTE_2( create_flags );
+    header.flags[3] = BYTE_3( create_flags );
 
     psa_its_fill_filename( uid, filename );
     stream = fopen( PSA_ITS_STORAGE_TEMP, "wb" );

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -44,29 +44,6 @@
 
 #if !defined(MBEDTLS_RIPEMD160_ALT)
 
-/*
- * 32-bit integer manipulation macros (little endian)
- */
-#ifndef GET_UINT32_LE
-#define GET_UINT32_LE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-#endif
-
-#ifndef PUT_UINT32_LE
-#define PUT_UINT32_LE(n,b,i)                                    \
-{                                                               \
-    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
-    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
-    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
-    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
-}
-#endif
-
 void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_ripemd160_context ) );
@@ -122,22 +99,22 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
         uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
     } local;
 
-    GET_UINT32_LE( local.X[ 0], data,  0 );
-    GET_UINT32_LE( local.X[ 1], data,  4 );
-    GET_UINT32_LE( local.X[ 2], data,  8 );
-    GET_UINT32_LE( local.X[ 3], data, 12 );
-    GET_UINT32_LE( local.X[ 4], data, 16 );
-    GET_UINT32_LE( local.X[ 5], data, 20 );
-    GET_UINT32_LE( local.X[ 6], data, 24 );
-    GET_UINT32_LE( local.X[ 7], data, 28 );
-    GET_UINT32_LE( local.X[ 8], data, 32 );
-    GET_UINT32_LE( local.X[ 9], data, 36 );
-    GET_UINT32_LE( local.X[10], data, 40 );
-    GET_UINT32_LE( local.X[11], data, 44 );
-    GET_UINT32_LE( local.X[12], data, 48 );
-    GET_UINT32_LE( local.X[13], data, 52 );
-    GET_UINT32_LE( local.X[14], data, 56 );
-    GET_UINT32_LE( local.X[15], data, 60 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
+    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
+    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
+    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
+    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
+    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
 
     local.A = local.Ap = ctx->state[0];
     local.B = local.Bp = ctx->state[1];
@@ -400,8 +377,8 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_LE( low,  msglen, 0 );
-    PUT_UINT32_LE( high, msglen, 4 );
+    MBEDTLS_PUT_UINT32_LE( low,  msglen, 0 );
+    MBEDTLS_PUT_UINT32_LE( high, msglen, 4 );
 
     last = ctx->total[0] & 0x3F;
     padn = ( last < 56 ) ? ( 56 - last ) : ( 120 - last );
@@ -414,11 +391,11 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
     if( ret != 0 )
         return( ret );
 
-    PUT_UINT32_LE( ctx->state[0], output,  0 );
-    PUT_UINT32_LE( ctx->state[1], output,  4 );
-    PUT_UINT32_LE( ctx->state[2], output,  8 );
-    PUT_UINT32_LE( ctx->state[3], output, 12 );
-    PUT_UINT32_LE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_LE( ctx->state[4], output, 16 );
 
     return( 0 );
 }

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -99,22 +99,22 @@ int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
         uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
     } local;
 
-    MBEDTLS_GET_UINT32_LE( local.X[ 0], data,  0 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 1], data,  4 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 2], data,  8 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 3], data, 12 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 4], data, 16 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 5], data, 20 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 6], data, 24 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 7], data, 28 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 8], data, 32 );
-    MBEDTLS_GET_UINT32_LE( local.X[ 9], data, 36 );
-    MBEDTLS_GET_UINT32_LE( local.X[10], data, 40 );
-    MBEDTLS_GET_UINT32_LE( local.X[11], data, 44 );
-    MBEDTLS_GET_UINT32_LE( local.X[12], data, 48 );
-    MBEDTLS_GET_UINT32_LE( local.X[13], data, 52 );
-    MBEDTLS_GET_UINT32_LE( local.X[14], data, 56 );
-    MBEDTLS_GET_UINT32_LE( local.X[15], data, 60 );
+    local.X[ 0] = MBEDTLS_GET_UINT32_LE( data,  0 );
+    local.X[ 1] = MBEDTLS_GET_UINT32_LE( data,  4 );
+    local.X[ 2] = MBEDTLS_GET_UINT32_LE( data,  8 );
+    local.X[ 3] = MBEDTLS_GET_UINT32_LE( data, 12 );
+    local.X[ 4] = MBEDTLS_GET_UINT32_LE( data, 16 );
+    local.X[ 5] = MBEDTLS_GET_UINT32_LE( data, 20 );
+    local.X[ 6] = MBEDTLS_GET_UINT32_LE( data, 24 );
+    local.X[ 7] = MBEDTLS_GET_UINT32_LE( data, 28 );
+    local.X[ 8] = MBEDTLS_GET_UINT32_LE( data, 32 );
+    local.X[ 9] = MBEDTLS_GET_UINT32_LE( data, 36 );
+    local.X[10] = MBEDTLS_GET_UINT32_LE( data, 40 );
+    local.X[11] = MBEDTLS_GET_UINT32_LE( data, 44 );
+    local.X[12] = MBEDTLS_GET_UINT32_LE( data, 48 );
+    local.X[13] = MBEDTLS_GET_UINT32_LE( data, 52 );
+    local.X[14] = MBEDTLS_GET_UINT32_LE( data, 56 );
+    local.X[15] = MBEDTLS_GET_UINT32_LE( data, 60 );
 
     local.A = local.Ap = ctx->state[0];
     local.B = local.Bp = ctx->state[1];

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -110,22 +110,22 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     SHA1_VALIDATE_RET( ctx != NULL );
     SHA1_VALIDATE_RET( (const unsigned char *)data != NULL );
 
-    MBEDTLS_GET_UINT32_BE( local.W[ 0], data,  0 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 1], data,  4 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 2], data,  8 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 3], data, 12 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 4], data, 16 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 5], data, 20 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 6], data, 24 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 7], data, 28 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 8], data, 32 );
-    MBEDTLS_GET_UINT32_BE( local.W[ 9], data, 36 );
-    MBEDTLS_GET_UINT32_BE( local.W[10], data, 40 );
-    MBEDTLS_GET_UINT32_BE( local.W[11], data, 44 );
-    MBEDTLS_GET_UINT32_BE( local.W[12], data, 48 );
-    MBEDTLS_GET_UINT32_BE( local.W[13], data, 52 );
-    MBEDTLS_GET_UINT32_BE( local.W[14], data, 56 );
-    MBEDTLS_GET_UINT32_BE( local.W[15], data, 60 );
+    local.W[ 0] = MBEDTLS_GET_UINT32_BE( data,  0 );
+    local.W[ 1] = MBEDTLS_GET_UINT32_BE( data,  4 );
+    local.W[ 2] = MBEDTLS_GET_UINT32_BE( data,  8 );
+    local.W[ 3] = MBEDTLS_GET_UINT32_BE( data, 12 );
+    local.W[ 4] = MBEDTLS_GET_UINT32_BE( data, 16 );
+    local.W[ 5] = MBEDTLS_GET_UINT32_BE( data, 20 );
+    local.W[ 6] = MBEDTLS_GET_UINT32_BE( data, 24 );
+    local.W[ 7] = MBEDTLS_GET_UINT32_BE( data, 28 );
+    local.W[ 8] = MBEDTLS_GET_UINT32_BE( data, 32 );
+    local.W[ 9] = MBEDTLS_GET_UINT32_BE( data, 36 );
+    local.W[10] = MBEDTLS_GET_UINT32_BE( data, 40 );
+    local.W[11] = MBEDTLS_GET_UINT32_BE( data, 44 );
+    local.W[12] = MBEDTLS_GET_UINT32_BE( data, 48 );
+    local.W[13] = MBEDTLS_GET_UINT32_BE( data, 52 );
+    local.W[14] = MBEDTLS_GET_UINT32_BE( data, 56 );
+    local.W[15] = MBEDTLS_GET_UINT32_BE( data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 

--- a/library/sha1.c
+++ b/library/sha1.c
@@ -48,29 +48,6 @@
 
 #if !defined(MBEDTLS_SHA1_ALT)
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
 {
     SHA1_VALIDATE( ctx != NULL );
@@ -133,22 +110,22 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     SHA1_VALIDATE_RET( ctx != NULL );
     SHA1_VALIDATE_RET( (const unsigned char *)data != NULL );
 
-    GET_UINT32_BE( local.W[ 0], data,  0 );
-    GET_UINT32_BE( local.W[ 1], data,  4 );
-    GET_UINT32_BE( local.W[ 2], data,  8 );
-    GET_UINT32_BE( local.W[ 3], data, 12 );
-    GET_UINT32_BE( local.W[ 4], data, 16 );
-    GET_UINT32_BE( local.W[ 5], data, 20 );
-    GET_UINT32_BE( local.W[ 6], data, 24 );
-    GET_UINT32_BE( local.W[ 7], data, 28 );
-    GET_UINT32_BE( local.W[ 8], data, 32 );
-    GET_UINT32_BE( local.W[ 9], data, 36 );
-    GET_UINT32_BE( local.W[10], data, 40 );
-    GET_UINT32_BE( local.W[11], data, 44 );
-    GET_UINT32_BE( local.W[12], data, 48 );
-    GET_UINT32_BE( local.W[13], data, 52 );
-    GET_UINT32_BE( local.W[14], data, 56 );
-    GET_UINT32_BE( local.W[15], data, 60 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 0], data,  0 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 1], data,  4 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 2], data,  8 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 3], data, 12 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 4], data, 16 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 5], data, 20 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 6], data, 24 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 7], data, 28 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 8], data, 32 );
+    MBEDTLS_GET_UINT32_BE( local.W[ 9], data, 36 );
+    MBEDTLS_GET_UINT32_BE( local.W[10], data, 40 );
+    MBEDTLS_GET_UINT32_BE( local.W[11], data, 44 );
+    MBEDTLS_GET_UINT32_BE( local.W[12], data, 48 );
+    MBEDTLS_GET_UINT32_BE( local.W[13], data, 52 );
+    MBEDTLS_GET_UINT32_BE( local.W[14], data, 56 );
+    MBEDTLS_GET_UINT32_BE( local.W[15], data, 60 );
 
 #define S(x,n) (((x) << (n)) | (((x) & 0xFFFFFFFF) >> (32 - (n))))
 
@@ -408,8 +385,8 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_BE( high, ctx->buffer, 56 );
-    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_BE( high, ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_BE( low,  ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_sha1_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -417,11 +394,11 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_BE( ctx->state[0], output,  0 );
-    PUT_UINT32_BE( ctx->state[1], output,  4 );
-    PUT_UINT32_BE( ctx->state[2], output,  8 );
-    PUT_UINT32_BE( ctx->state[3], output, 12 );
-    PUT_UINT32_BE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[4], output, 16 );
 
     return( 0 );
 }

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -191,7 +191,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     for( i = 0; i < 64; i++ )
     {
         if( i < 16 )
-            MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
+            local.W[i] = MBEDTLS_GET_UINT32_BE( data, 4 * i );
         else
             R( i );
 
@@ -206,7 +206,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     }
 #else /* MBEDTLS_SHA256_SMALLER */
     for( i = 0; i < 16; i++ )
-        MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
+        local.W[i] = MBEDTLS_GET_UINT32_BE( data, 4 * i );
 
     for( i = 0; i < 16; i += 8 )
     {

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -50,29 +50,6 @@
 
 #if !defined(MBEDTLS_SHA256_ALT)
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-do {                                                    \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-} while( 0 )
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-do {                                                    \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-} while( 0 )
-#endif
-
 void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
     SHA256_VALIDATE( ctx != NULL );
@@ -214,7 +191,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     for( i = 0; i < 64; i++ )
     {
         if( i < 16 )
-            GET_UINT32_BE( local.W[i], data, 4 * i );
+            MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
         else
             R( i );
 
@@ -229,7 +206,7 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
     }
 #else /* MBEDTLS_SHA256_SMALLER */
     for( i = 0; i < 16; i++ )
-        GET_UINT32_BE( local.W[i], data, 4 * i );
+        MBEDTLS_GET_UINT32_BE( local.W[i], data, 4 * i );
 
     for( i = 0; i < 16; i += 8 )
     {
@@ -395,8 +372,8 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
          | ( ctx->total[1] <<  3 );
     low  = ( ctx->total[0] <<  3 );
 
-    PUT_UINT32_BE( high, ctx->buffer, 56 );
-    PUT_UINT32_BE( low,  ctx->buffer, 60 );
+    MBEDTLS_PUT_UINT32_BE( high, ctx->buffer, 56 );
+    MBEDTLS_PUT_UINT32_BE( low,  ctx->buffer, 60 );
 
     if( ( ret = mbedtls_internal_sha256_process( ctx, ctx->buffer ) ) != 0 )
         return( ret );
@@ -404,16 +381,16 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
     /*
      * Output final state
      */
-    PUT_UINT32_BE( ctx->state[0], output,  0 );
-    PUT_UINT32_BE( ctx->state[1], output,  4 );
-    PUT_UINT32_BE( ctx->state[2], output,  8 );
-    PUT_UINT32_BE( ctx->state[3], output, 12 );
-    PUT_UINT32_BE( ctx->state[4], output, 16 );
-    PUT_UINT32_BE( ctx->state[5], output, 20 );
-    PUT_UINT32_BE( ctx->state[6], output, 24 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[0], output,  0 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[1], output,  4 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[2], output,  8 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[3], output, 12 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[4], output, 16 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[5], output, 20 );
+    MBEDTLS_PUT_UINT32_BE( ctx->state[6], output, 24 );
 
     if( ctx->is224 == 0 )
-        PUT_UINT32_BE( ctx->state[7], output, 28 );
+        MBEDTLS_PUT_UINT32_BE( ctx->state[7], output, 28 );
 
     return( 0 );
 }

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -56,44 +56,13 @@
 
 #if !defined(MBEDTLS_SHA512_ALT)
 
-/*
- * 64-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT64_BE
-#define GET_UINT64_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
-        | ( (uint64_t) (b)[(i) + 1] << 48 )       \
-        | ( (uint64_t) (b)[(i) + 2] << 40 )       \
-        | ( (uint64_t) (b)[(i) + 3] << 32 )       \
-        | ( (uint64_t) (b)[(i) + 4] << 24 )       \
-        | ( (uint64_t) (b)[(i) + 5] << 16 )       \
-        | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
-        | ( (uint64_t) (b)[(i) + 7]       );      \
-}
-#endif /* GET_UINT64_BE */
-
-#ifndef PUT_UINT64_BE
-#define PUT_UINT64_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
-    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
-}
-#endif /* PUT_UINT64_BE */
-
 #if defined(MBEDTLS_SHA512_SMALLER)
 static void sha512_put_uint64_be( uint64_t n, unsigned char *b, uint8_t i )
 {
-    PUT_UINT64_BE(n, b, i);
+    MBEDTLS_PUT_UINT64_BE(n, b, i);
 }
 #else
-#define sha512_put_uint64_be    PUT_UINT64_BE
+#define sha512_put_uint64_be    MBEDTLS_PUT_UINT64_BE
 #endif /* MBEDTLS_SHA512_SMALLER */
 
 void mbedtls_sha512_init( mbedtls_sha512_context *ctx )
@@ -269,7 +238,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     {
         if( i < 16 )
         {
-            GET_UINT64_BE( local.W[i], data, i << 3 );
+            local.W[i] = MBEDTLS_GET_UINT64_BE( data, i << 3 );
         }
         else
         {
@@ -289,7 +258,7 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 #else /* MBEDTLS_SHA512_SMALLER */
     for( i = 0; i < 16; i++ )
     {
-        GET_UINT64_BE( local.W[i], data, i << 3 );
+        local.W[i] = MBEDTLS_GET_UINT64_BE( data, i << 3 );
     }
 
     for( ; i < 80; i++ )

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -136,18 +136,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME );
 
-    *p++ = (unsigned char)( ( (hostname_len + 5) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 5)      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( hostname_len + 5);
+    *p++ = MBEDTLS_CHAR_0( hostname_len + 5);
 
-    *p++ = (unsigned char)( ( (hostname_len + 3) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( (hostname_len + 3)      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( hostname_len + 3 );
+    *p++ = MBEDTLS_CHAR_0( hostname_len + 3 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( hostname_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = MBEDTLS_CHAR_1( hostname_len );
+    *p++ = MBEDTLS_CHAR_0( hostname_len );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -181,14 +181,12 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
     *p++ = 0x00;
-    *p++ = ( ssl->verify_data_len + 1 ) & 0xFF;
-    *p++ = ssl->verify_data_len & 0xFF;
+    *p++ = MBEDTLS_CHAR_0( ssl->verify_data_len + 1 );
+    *p++ = MBEDTLS_CHAR_0( ssl->verify_data_len );
 
     memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
 
@@ -283,14 +281,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SIG_ALG      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SIG_ALG );
 
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( sig_alg_len + 2 )      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( sig_alg_len + 2 );
+    *p++ = MBEDTLS_CHAR_0( sig_alg_len + 2 );
 
-    *p++ = (unsigned char)( ( sig_alg_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( sig_alg_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( sig_alg_len );
+    *p++ = MBEDTLS_CHAR_0( sig_alg_len );
 
     *olen = 6 + sig_alg_len;
 
@@ -358,16 +356,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES      )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len + 2 )      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len + 2 );
+    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len + 2 );
 
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ( elliptic_curve_len     )      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len     );
+    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len     );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -388,10 +384,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -427,8 +421,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -470,8 +464,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( kkpp_len );
+    *p++ = MBEDTLS_CHAR_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 
@@ -510,11 +504,11 @@ static int ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, (unsigned)( ssl->own_cid_len + 5 ) );
 
     /* Add extension ID + size */
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_CID );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( ext_len );
+    *p++ = MBEDTLS_CHAR_0( ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -543,10 +537,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -577,8 +569,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -608,8 +600,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -639,10 +631,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 )
-                            & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -673,11 +663,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
-    *p++ = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( tlen      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( tlen );
+    *p++ = MBEDTLS_CHAR_0( tlen );
 
     *olen = 4;
 
@@ -717,8 +707,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ALPN );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -745,12 +735,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = MBEDTLS_CHAR_1( *olen - 6 );
+    buf[5] = MBEDTLS_CHAR_0( *olen - 6 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = MBEDTLS_CHAR_1( *olen - 4 );
+    buf[3] = MBEDTLS_CHAR_0( *olen - 4 );
 
     return( 0 );
 }
@@ -802,12 +792,12 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
      */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, ext_len + 4 );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_USE_SRTP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_USE_SRTP      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_USE_SRTP );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_USE_SRTP );
 
 
-    *p++ = (unsigned char)( ( ( ext_len & 0xFF00 ) >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ext_len & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( ext_len & 0xFF00 );
+    *p++ = MBEDTLS_CHAR_0( ext_len );
 
     /* protection profile length: 2*(ssl->conf->dtls_srtp_profile_list_len) */
     /* micro-optimization:
@@ -818,8 +808,7 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
      *                        >> 8 ) & 0xFF );
      */
     *p++ = 0;
-    *p++ = (unsigned char)( ( 2 * ssl->conf->dtls_srtp_profile_list_len )
-                            & 0xFF );
+    *p++ = MBEDTLS_CHAR_0( 2 * ssl->conf->dtls_srtp_profile_list_len );
 
     for( protection_profiles_index=0;
          protection_profiles_index < ssl->conf->dtls_srtp_profile_list_len;
@@ -831,8 +820,8 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "ssl_write_use_srtp_ext, add profile: %04x",
                                         profile_value ) );
-            *p++ = ( ( profile_value >> 8 ) & 0xFF );
-            *p++ = ( profile_value & 0xFF );
+            *p++ = MBEDTLS_BYTE_1( profile_value );
+            *p++ = MBEDTLS_BYTE_0( profile_value );
         }
         else
         {
@@ -1428,8 +1417,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_1( ext_len );
+        *p++ = MBEDTLS_CHAR_0( ext_len );
         p += ext_len;
     }
 

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -352,8 +352,8 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
          grp_id++ )
     {
         info = mbedtls_ecp_curve_info_from_grp_id( *grp_id );
-        elliptic_curve_list[elliptic_curve_len++] = info->tls_id >> 8;
-        elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
+        elliptic_curve_list[elliptic_curve_len++] = MBEDTLS_BYTE_1( info->tls_id );
+        elliptic_curve_list[elliptic_curve_len++] = MBEDTLS_BYTE_0( info->tls_id );
     }
 
     *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
@@ -889,10 +889,10 @@ static int ssl_generate_random( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_HAVE_TIME)
     t = mbedtls_time( NULL );
-    *p++ = (unsigned char)( t >> 24 );
-    *p++ = (unsigned char)( t >> 16 );
-    *p++ = (unsigned char)( t >>  8 );
-    *p++ = (unsigned char)( t       );
+    *p++ = MBEDTLS_BYTE_3( t );
+    *p++ = MBEDTLS_BYTE_2( t );
+    *p++ = MBEDTLS_BYTE_1( t );
+    *p++ = MBEDTLS_BYTE_0( t );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "client hello, current time: %" MBEDTLS_PRINTF_LONGLONG,
                                 (long long) t ) );
@@ -1182,8 +1182,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
         MBEDTLS_SSL_CHK_BUF_PTR( p, end, 2 );
 
         n++;
-        *p++ = (unsigned char)( ciphersuites[i] >> 8 );
-        *p++ = (unsigned char)( ciphersuites[i]      );
+        *p++ = MBEDTLS_BYTE_1( ciphersuites[i] );
+        *p++ = MBEDTLS_BYTE_0( ciphersuites[i] );
     }
 
     MBEDTLS_SSL_DEBUG_MSG( 3,
@@ -1198,8 +1198,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         MBEDTLS_SSL_DEBUG_MSG( 3, ( "adding EMPTY_RENEGOTIATION_INFO_SCSV" ) );
         MBEDTLS_SSL_CHK_BUF_PTR( p, end, 2 );
-        *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO >> 8 );
-        *p++ = (unsigned char)( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO      );
+        *p++ = MBEDTLS_BYTE_1( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO );
+        *p++ = MBEDTLS_BYTE_0( MBEDTLS_SSL_EMPTY_RENEGOTIATION_INFO );
         n++;
     }
 
@@ -2897,8 +2897,8 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( len_bytes == 2 )
     {
-        ssl->out_msg[offset+0] = (unsigned char)( *olen >> 8 );
-        ssl->out_msg[offset+1] = (unsigned char)( *olen      );
+        ssl->out_msg[offset+0] = MBEDTLS_BYTE_1( *olen );
+        ssl->out_msg[offset+1] = MBEDTLS_BYTE_0( *olen );
         *olen += 2;
     }
 #endif
@@ -3682,8 +3682,8 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
          */
         content_len = ssl->handshake->dhm_ctx.len;
 
-        ssl->out_msg[4] = (unsigned char)( content_len >> 8 );
-        ssl->out_msg[5] = (unsigned char)( content_len      );
+        ssl->out_msg[4] = MBEDTLS_BYTE_1( content_len );
+        ssl->out_msg[5] = MBEDTLS_BYTE_0( content_len );
         header_len = 6;
 
         ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
@@ -3898,8 +3898,8 @@ ecdh_calc_secret:
             return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
         }
 
-        ssl->out_msg[header_len++] = (unsigned char)( content_len >> 8 );
-        ssl->out_msg[header_len++] = (unsigned char)( content_len      );
+        ssl->out_msg[header_len++] = MBEDTLS_BYTE_1( content_len );
+        ssl->out_msg[header_len++] = MBEDTLS_BYTE_0( content_len );
 
         memcpy( ssl->out_msg + header_len,
                 ssl->conf->psk_identity,
@@ -3950,8 +3950,8 @@ ecdh_calc_secret:
                 return( MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL );
             }
 
-            ssl->out_msg[header_len++] = (unsigned char)( content_len >> 8 );
-            ssl->out_msg[header_len++] = (unsigned char)( content_len      );
+            ssl->out_msg[header_len++] = MBEDTLS_BYTE_1( content_len );
+            ssl->out_msg[header_len++] = MBEDTLS_BYTE_0( content_len );
 
             ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
                     (int) mbedtls_mpi_size( &ssl->handshake->dhm_ctx.P ),
@@ -4257,8 +4257,8 @@ sign:
         return( ret );
     }
 
-    ssl->out_msg[4 + offset] = (unsigned char)( n >> 8 );
-    ssl->out_msg[5 + offset] = (unsigned char)( n      );
+    ssl->out_msg[4 + offset] = MBEDTLS_BYTE_1( n );
+    ssl->out_msg[5 + offset] = MBEDTLS_BYTE_0( n );
 
     ssl->out_msglen  = 6 + n + offset;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -735,12 +735,10 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
-    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
+    MBEDTLS_PUT_UINT16_BE( *olen - 6, buf, 4 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
-    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
+    MBEDTLS_PUT_UINT16_BE( *olen - 4, buf, 2 );
 
     return( 0 );
 }
@@ -2897,8 +2895,7 @@ static int ssl_write_encrypted_pms( mbedtls_ssl_context *ssl,
     defined(MBEDTLS_SSL_PROTO_TLS1_2)
     if( len_bytes == 2 )
     {
-        ssl->out_msg[offset+0] = MBEDTLS_BYTE_1( *olen );
-        ssl->out_msg[offset+1] = MBEDTLS_BYTE_0( *olen );
+        MBEDTLS_PUT_UINT16_BE( *olen, ssl->out_msg, offset );
         *olen += 2;
     }
 #endif
@@ -3682,8 +3679,7 @@ static int ssl_write_client_key_exchange( mbedtls_ssl_context *ssl )
          */
         content_len = ssl->handshake->dhm_ctx.len;
 
-        ssl->out_msg[4] = MBEDTLS_BYTE_1( content_len );
-        ssl->out_msg[5] = MBEDTLS_BYTE_0( content_len );
+        MBEDTLS_PUT_UINT16_BE( content_len, ssl->out_msg, 4 );
         header_len = 6;
 
         ret = mbedtls_dhm_make_public( &ssl->handshake->dhm_ctx,
@@ -4257,8 +4253,7 @@ sign:
         return( ret );
     }
 
-    ssl->out_msg[4 + offset] = MBEDTLS_BYTE_1( n );
-    ssl->out_msg[5 + offset] = MBEDTLS_BYTE_0( n );
+    MBEDTLS_PUT_UINT16_BE( n, ssl->out_msg, offset + 4 );
 
     ssl->out_msglen  = 6 + n + offset;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -362,8 +362,8 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
     *p++ = MBEDTLS_CHAR_1( elliptic_curve_len + 2 );
     *p++ = MBEDTLS_CHAR_0( elliptic_curve_len + 2 );
 
-    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len     );
-    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len     );
+    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len );
+    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -570,7 +570,7 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
     *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -632,7 +632,7 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
     *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -794,7 +794,7 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
     *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_USE_SRTP );
 
 
-    *p++ = MBEDTLS_BYTE_1( ext_len & 0xFF00 );
+    *p++ = MBEDTLS_BYTE_1( ext_len );
     *p++ = MBEDTLS_BYTE_0( ext_len );
 
     /* protection profile length: 2*(ssl->conf->dtls_srtp_profile_list_len) */

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -136,18 +136,18 @@ static int ssl_write_hostname_ext( mbedtls_ssl_context *ssl,
      * } ServerNameList;
      *
      */
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SERVERNAME );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SERVERNAME );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME );
 
-    *p++ = MBEDTLS_CHAR_1( hostname_len + 5);
-    *p++ = MBEDTLS_CHAR_0( hostname_len + 5);
+    *p++ = MBEDTLS_BYTE_1( hostname_len + 5);
+    *p++ = MBEDTLS_BYTE_0( hostname_len + 5);
 
-    *p++ = MBEDTLS_CHAR_1( hostname_len + 3 );
-    *p++ = MBEDTLS_CHAR_0( hostname_len + 3 );
+    *p++ = MBEDTLS_BYTE_1( hostname_len + 3 );
+    *p++ = MBEDTLS_BYTE_0( hostname_len + 3 );
 
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
-    *p++ = MBEDTLS_CHAR_1( hostname_len );
-    *p++ = MBEDTLS_CHAR_0( hostname_len );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SERVERNAME_HOSTNAME );
+    *p++ = MBEDTLS_BYTE_1( hostname_len );
+    *p++ = MBEDTLS_BYTE_0( hostname_len );
 
     memcpy( p, ssl->hostname, hostname_len );
 
@@ -181,12 +181,12 @@ static int ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
     /*
      * Secure renegotiation
      */
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
     *p++ = 0x00;
-    *p++ = MBEDTLS_CHAR_0( ssl->verify_data_len + 1 );
-    *p++ = MBEDTLS_CHAR_0( ssl->verify_data_len );
+    *p++ = MBEDTLS_BYTE_0( ssl->verify_data_len + 1 );
+    *p++ = MBEDTLS_BYTE_0( ssl->verify_data_len );
 
     memcpy( p, ssl->own_verify_data, ssl->verify_data_len );
 
@@ -281,14 +281,14 @@ static int ssl_write_signature_algorithms_ext( mbedtls_ssl_context *ssl,
      * SignatureAndHashAlgorithm
      *   supported_signature_algorithms<2..2^16-2>;
      */
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SIG_ALG );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SIG_ALG );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SIG_ALG );
 
-    *p++ = MBEDTLS_CHAR_1( sig_alg_len + 2 );
-    *p++ = MBEDTLS_CHAR_0( sig_alg_len + 2 );
+    *p++ = MBEDTLS_BYTE_1( sig_alg_len + 2 );
+    *p++ = MBEDTLS_BYTE_0( sig_alg_len + 2 );
 
-    *p++ = MBEDTLS_CHAR_1( sig_alg_len );
-    *p++ = MBEDTLS_CHAR_0( sig_alg_len );
+    *p++ = MBEDTLS_BYTE_1( sig_alg_len );
+    *p++ = MBEDTLS_BYTE_0( sig_alg_len );
 
     *olen = 6 + sig_alg_len;
 
@@ -356,14 +356,14 @@ static int ssl_write_supported_elliptic_curves_ext( mbedtls_ssl_context *ssl,
         elliptic_curve_list[elliptic_curve_len++] = info->tls_id & 0xFF;
     }
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_ELLIPTIC_CURVES );
 
-    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len + 2 );
-    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len + 2 );
+    *p++ = MBEDTLS_BYTE_1( elliptic_curve_len + 2 );
+    *p++ = MBEDTLS_BYTE_0( elliptic_curve_len + 2 );
 
-    *p++ = MBEDTLS_CHAR_1( elliptic_curve_len );
-    *p++ = MBEDTLS_CHAR_0( elliptic_curve_len );
+    *p++ = MBEDTLS_BYTE_1( elliptic_curve_len );
+    *p++ = MBEDTLS_BYTE_0( elliptic_curve_len );
 
     *olen = 6 + elliptic_curve_len;
 
@@ -384,8 +384,8 @@ static int ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
         ( "client hello, adding supported_point_formats extension" ) );
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -421,8 +421,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     /*
      * We may need to send ClientHello multiple times for Hello verification.
@@ -464,8 +464,8 @@ static int ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         memcpy( p + 2, ssl->handshake->ecjpake_cache, kkpp_len );
     }
 
-    *p++ = MBEDTLS_CHAR_1( kkpp_len );
-    *p++ = MBEDTLS_CHAR_0( kkpp_len );
+    *p++ = MBEDTLS_BYTE_1( kkpp_len );
+    *p++ = MBEDTLS_BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 
@@ -504,11 +504,11 @@ static int ssl_write_cid_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, (unsigned)( ssl->own_cid_len + 5 ) );
 
     /* Add extension ID + size */
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_CID );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_CID );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = MBEDTLS_CHAR_1( ext_len );
-    *p++ = MBEDTLS_CHAR_0( ext_len );
+    *p++ = MBEDTLS_BYTE_1( ext_len );
+    *p++ = MBEDTLS_BYTE_0( ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -537,8 +537,8 @@ static int ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 5 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -569,8 +569,8 @@ static int ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -600,8 +600,8 @@ static int ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -631,8 +631,8 @@ static int ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -663,11 +663,11 @@ static int ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
     /* The addition is safe here since the ticket length is 16 bit. */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 4 + tlen );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
-    *p++ = MBEDTLS_CHAR_1( tlen );
-    *p++ = MBEDTLS_CHAR_0( tlen );
+    *p++ = MBEDTLS_BYTE_1( tlen );
+    *p++ = MBEDTLS_BYTE_0( tlen );
 
     *olen = 4;
 
@@ -707,8 +707,8 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, 6 + alpnlen );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ALPN );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     /*
      * opaque ProtocolName<1..2^8-1>;
@@ -735,12 +735,12 @@ static int ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
     *olen = p - buf;
 
     /* List length = olen - 2 (ext_type) - 2 (ext_len) - 2 (list_len) */
-    buf[4] = MBEDTLS_CHAR_1( *olen - 6 );
-    buf[5] = MBEDTLS_CHAR_0( *olen - 6 );
+    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
+    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
 
     /* Extension length = olen - 2 (ext_type) - 2 (ext_len) */
-    buf[2] = MBEDTLS_CHAR_1( *olen - 4 );
-    buf[3] = MBEDTLS_CHAR_0( *olen - 4 );
+    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
+    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
 
     return( 0 );
 }
@@ -792,12 +792,12 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
      */
     MBEDTLS_SSL_CHK_BUF_PTR( p, end, ext_len + 4 );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_USE_SRTP );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_USE_SRTP );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_USE_SRTP );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_USE_SRTP );
 
 
-    *p++ = MBEDTLS_CHAR_1( ext_len & 0xFF00 );
-    *p++ = MBEDTLS_CHAR_0( ext_len );
+    *p++ = MBEDTLS_BYTE_1( ext_len & 0xFF00 );
+    *p++ = MBEDTLS_BYTE_0( ext_len );
 
     /* protection profile length: 2*(ssl->conf->dtls_srtp_profile_list_len) */
     /* micro-optimization:
@@ -808,7 +808,7 @@ static int ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
      *                        >> 8 ) & 0xFF );
      */
     *p++ = 0;
-    *p++ = MBEDTLS_CHAR_0( 2 * ssl->conf->dtls_srtp_profile_list_len );
+    *p++ = MBEDTLS_BYTE_0( 2 * ssl->conf->dtls_srtp_profile_list_len );
 
     for( protection_profiles_index=0;
          protection_profiles_index < ssl->conf->dtls_srtp_profile_list_len;
@@ -1417,8 +1417,8 @@ static int ssl_write_client_hello( mbedtls_ssl_context *ssl )
     {
         /* No need to check for space here, because the extension
          * writing functions already took care of that. */
-        *p++ = MBEDTLS_CHAR_1( ext_len );
-        *p++ = MBEDTLS_CHAR_0( ext_len );
+        *p++ = MBEDTLS_BYTE_1( ext_len );
+        *p++ = MBEDTLS_BYTE_0( ext_len );
         p += ext_len;
     }
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -166,10 +166,10 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
     t = ctx->serial++;
 #endif
 
-    (*p)[0] = (unsigned char)( t >> 24 );
-    (*p)[1] = (unsigned char)( t >> 16 );
-    (*p)[2] = (unsigned char)( t >>  8 );
-    (*p)[3] = (unsigned char)( t       );
+    (*p)[0] = MBEDTLS_BYTE_3( t );
+    (*p)[1] = MBEDTLS_BYTE_2( t );
+    (*p)[2] = MBEDTLS_BYTE_1( t );
+    (*p)[3] = MBEDTLS_BYTE_0( t );
     *p += 4;
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -166,10 +166,7 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
     t = ctx->serial++;
 #endif
 
-    (*p)[0] = MBEDTLS_BYTE_3( t );
-    (*p)[1] = MBEDTLS_BYTE_2( t );
-    (*p)[2] = MBEDTLS_BYTE_1( t );
-    (*p)[3] = MBEDTLS_BYTE_0( t );
+    MBEDTLS_PUT_UINT32_BE(t, *p, 0);
     *p += 4;
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -454,15 +454,13 @@ static void ssl_extract_add_data_from_record( unsigned char* add_data,
         *cur = rec->cid_len;
         cur++;
 
-        cur[0] = MBEDTLS_BYTE_1( rec->data_len );
-        cur[1] = MBEDTLS_BYTE_0( rec->data_len );
+        MBEDTLS_PUT_UINT16_BE( rec->data_len, cur, 0 );
         cur += 2;
     }
     else
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     {
-        cur[0] = MBEDTLS_BYTE_1( rec->data_len );
-        cur[1] = MBEDTLS_BYTE_0( rec->data_len );
+        MBEDTLS_PUT_UINT16_BE( rec->data_len, cur, 0 );
         cur += 2;
     }
 
@@ -2759,8 +2757,7 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = MBEDTLS_BYTE_1( ssl->handshake->out_msg_seq );
-                ssl->out_msg[5] = MBEDTLS_BYTE_0( ssl->handshake->out_msg_seq );
+                MBEDTLS_PUT_UINT16_BE( ssl->handshake->out_msg_seq, ssl->out_msg, 4 );
                 ++( ssl->handshake->out_msg_seq );
             }
             else
@@ -2874,8 +2871,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
                            ssl->conf->transport, ssl->out_hdr + 1 );
 
         memcpy( ssl->out_ctr, ssl->cur_out_ctr, 8 );
-        ssl->out_len[0] = MBEDTLS_BYTE_1( len );
-        ssl->out_len[1] = MBEDTLS_BYTE_0( len );
+        MBEDTLS_PUT_UINT16_BE( len, ssl->out_len, 0);
 
         if( ssl->transform_out != NULL )
         {
@@ -2915,8 +2911,7 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
             memcpy( ssl->out_cid, rec.cid, rec.cid_len );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
             ssl->out_msglen = len = rec.data_len;
-            ssl->out_len[0] = MBEDTLS_BYTE_1( rec.data_len );
-            ssl->out_len[1] = MBEDTLS_BYTE_0( rec.data_len );
+            MBEDTLS_PUT_UINT16_BE( rec.data_len, ssl->out_len, 0 );
         }
 
         protected_record_size = len + mbedtls_ssl_out_hdr_len( ssl );
@@ -3492,8 +3487,7 @@ static int ssl_check_dtls_clihlo_cookie(
     obuf[15] = obuf[23] = MBEDTLS_BYTE_1( *olen - 25 );
     obuf[16] = obuf[24] = MBEDTLS_BYTE_0( *olen - 25 );
 
-    obuf[11] = (unsigned char)( ( *olen - 13 ) >>  8 );
-    obuf[12] = (unsigned char)( ( *olen - 13 )       );
+    MBEDTLS_PUT_UINT16_BE( *olen - 13, obuf, 11);
 
     return( MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED );
 }
@@ -4891,8 +4885,7 @@ static int ssl_get_next_record( mbedtls_ssl_context *ssl )
     ssl->in_hdr[0] = rec.type;
     ssl->in_msg    = rec.buf + rec.data_offset;
     ssl->in_msglen = rec.data_len;
-    ssl->in_len[0] = MBEDTLS_BYTE_1( rec.data_len );
-    ssl->in_len[1] = MBEDTLS_BYTE_0( rec.data_len );
+    MBEDTLS_PUT_UINT16_BE( rec.data_len, ssl->in_len, 0 );
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->transform_in != NULL &&

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2526,13 +2526,13 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
              * Handshake headers: type(1) len(3) seq(2) f_off(3) f_len(3) */
             memcpy( ssl->out_msg, cur->p, 6 );
 
-            ssl->out_msg[6] = ( ( frag_off >> 16 ) & 0xff );
-            ssl->out_msg[7] = ( ( frag_off >>  8 ) & 0xff );
-            ssl->out_msg[8] = ( ( frag_off       ) & 0xff );
+            ssl->out_msg[6] = BYTE_2( frag_off );
+            ssl->out_msg[7] = BYTE_1( frag_off );
+            ssl->out_msg[8] = BYTE_0( frag_off );
 
-            ssl->out_msg[ 9] = ( ( cur_hs_frag_len >> 16 ) & 0xff );
-            ssl->out_msg[10] = ( ( cur_hs_frag_len >>  8 ) & 0xff );
-            ssl->out_msg[11] = ( ( cur_hs_frag_len       ) & 0xff );
+            ssl->out_msg[ 9] = BYTE_2( cur_hs_frag_len );
+            ssl->out_msg[10] = BYTE_1( cur_hs_frag_len );
+            ssl->out_msg[11] = BYTE_0( cur_hs_frag_len );
 
             MBEDTLS_SSL_DEBUG_BUF( 3, "handshake header", ssl->out_msg, 12 );
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -454,15 +454,15 @@ static void ssl_extract_add_data_from_record( unsigned char* add_data,
         *cur = rec->cid_len;
         cur++;
 
-        cur[0] = MBEDTLS_CHAR_1( rec->data_len );
-        cur[1] = MBEDTLS_CHAR_0( rec->data_len );
+        cur[0] = MBEDTLS_BYTE_1( rec->data_len );
+        cur[1] = MBEDTLS_BYTE_0( rec->data_len );
         cur += 2;
     }
     else
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     {
-        cur[0] = MBEDTLS_CHAR_1( rec->data_len );
-        cur[1] = MBEDTLS_CHAR_0( rec->data_len );
+        cur[0] = MBEDTLS_BYTE_1( rec->data_len );
+        cur[1] = MBEDTLS_BYTE_0( rec->data_len );
         cur += 2;
     }
 
@@ -2759,8 +2759,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = MBEDTLS_CHAR_1( ssl->handshake->out_msg_seq );
-                ssl->out_msg[5] = MBEDTLS_CHAR_0( ssl->handshake->out_msg_seq );
+                ssl->out_msg[4] = MBEDTLS_BYTE_1( ssl->handshake->out_msg_seq );
+                ssl->out_msg[5] = MBEDTLS_BYTE_0( ssl->handshake->out_msg_seq );
                 ++( ssl->handshake->out_msg_seq );
             }
             else

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -454,15 +454,15 @@ static void ssl_extract_add_data_from_record( unsigned char* add_data,
         *cur = rec->cid_len;
         cur++;
 
-        cur[0] = ( rec->data_len >> 8 ) & 0xFF;
-        cur[1] = ( rec->data_len >> 0 ) & 0xFF;
+        cur[0] = MBEDTLS_CHAR_1( rec->data_len );
+        cur[1] = MBEDTLS_CHAR_0( rec->data_len );
         cur += 2;
     }
     else
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     {
-        cur[0] = ( rec->data_len >> 8 ) & 0xFF;
-        cur[1] = ( rec->data_len >> 0 ) & 0xFF;
+        cur[0] = MBEDTLS_CHAR_1( rec->data_len );
+        cur[1] = MBEDTLS_CHAR_0( rec->data_len );
         cur += 2;
     }
 
@@ -2759,8 +2759,8 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
             /* Write message_seq and update it, except for HelloRequest */
             if( hs_type != MBEDTLS_SSL_HS_HELLO_REQUEST )
             {
-                ssl->out_msg[4] = ( ssl->handshake->out_msg_seq >> 8 ) & 0xFF;
-                ssl->out_msg[5] = ( ssl->handshake->out_msg_seq      ) & 0xFF;
+                ssl->out_msg[4] = MBEDTLS_CHAR_1( ssl->handshake->out_msg_seq );
+                ssl->out_msg[5] = MBEDTLS_CHAR_0( ssl->handshake->out_msg_seq );
                 ++( ssl->handshake->out_msg_seq );
             }
             else

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -496,8 +496,8 @@ static void ssl_mac( mbedtls_md_context_t *md_ctx,
 
     memcpy( header, ctr, 8 );
     header[ 8] = (unsigned char)  type;
-    header[ 9] = (unsigned char)( len >> 8 );
-    header[10] = (unsigned char)( len      );
+    header[ 9] = MBEDTLS_BYTE_1( len );
+    header[10] = MBEDTLS_BYTE_0( len );
 
     memset( padding, 0x36, padlen );
     mbedtls_md_starts( md_ctx );
@@ -2729,9 +2729,9 @@ int mbedtls_ssl_write_handshake_msg( mbedtls_ssl_context *ssl )
      */
     if( ssl->out_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE )
     {
-        ssl->out_msg[1] = (unsigned char)( hs_len >> 16 );
-        ssl->out_msg[2] = (unsigned char)( hs_len >>  8 );
-        ssl->out_msg[3] = (unsigned char)( hs_len       );
+        ssl->out_msg[1] = MBEDTLS_BYTE_2( hs_len );
+        ssl->out_msg[2] = MBEDTLS_BYTE_1( hs_len );
+        ssl->out_msg[3] = MBEDTLS_BYTE_0( hs_len );
 
         /*
          * DTLS has additional fields in the Handshake layer,
@@ -2874,8 +2874,8 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
                            ssl->conf->transport, ssl->out_hdr + 1 );
 
         memcpy( ssl->out_ctr, ssl->cur_out_ctr, 8 );
-        ssl->out_len[0] = (unsigned char)( len >> 8 );
-        ssl->out_len[1] = (unsigned char)( len      );
+        ssl->out_len[0] = MBEDTLS_BYTE_1( len );
+        ssl->out_len[1] = MBEDTLS_BYTE_0( len );
 
         if( ssl->transform_out != NULL )
         {
@@ -2915,8 +2915,8 @@ int mbedtls_ssl_write_record( mbedtls_ssl_context *ssl, uint8_t force_flush )
             memcpy( ssl->out_cid, rec.cid, rec.cid_len );
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
             ssl->out_msglen = len = rec.data_len;
-            ssl->out_len[0] = (unsigned char)( rec.data_len >> 8 );
-            ssl->out_len[1] = (unsigned char)( rec.data_len      );
+            ssl->out_len[0] = MBEDTLS_BYTE_1( rec.data_len );
+            ssl->out_len[1] = MBEDTLS_BYTE_0( rec.data_len );
         }
 
         protected_record_size = len + mbedtls_ssl_out_hdr_len( ssl );
@@ -3488,9 +3488,9 @@ static int ssl_check_dtls_clihlo_cookie(
     /* Go back and fill length fields */
     obuf[27] = (unsigned char)( *olen - 28 );
 
-    obuf[14] = obuf[22] = (unsigned char)( ( *olen - 25 ) >> 16 );
-    obuf[15] = obuf[23] = (unsigned char)( ( *olen - 25 ) >>  8 );
-    obuf[16] = obuf[24] = (unsigned char)( ( *olen - 25 )       );
+    obuf[14] = obuf[22] = MBEDTLS_BYTE_2( *olen - 25 );
+    obuf[15] = obuf[23] = MBEDTLS_BYTE_1( *olen - 25 );
+    obuf[16] = obuf[24] = MBEDTLS_BYTE_0( *olen - 25 );
 
     obuf[11] = (unsigned char)( ( *olen - 13 ) >>  8 );
     obuf[12] = (unsigned char)( ( *olen - 13 )       );
@@ -4891,8 +4891,8 @@ static int ssl_get_next_record( mbedtls_ssl_context *ssl )
     ssl->in_hdr[0] = rec.type;
     ssl->in_msg    = rec.buf + rec.data_offset;
     ssl->in_msglen = rec.data_len;
-    ssl->in_len[0] = (unsigned char)( rec.data_len >> 8 );
-    ssl->in_len[1] = (unsigned char)( rec.data_len      );
+    ssl->in_len[0] = MBEDTLS_BYTE_1( rec.data_len );
+    ssl->in_len[1] = MBEDTLS_BYTE_0( rec.data_len );
 
 #if defined(MBEDTLS_ZLIB_SUPPORT)
     if( ssl->transform_in != NULL &&

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2526,13 +2526,13 @@ int mbedtls_ssl_flight_transmit( mbedtls_ssl_context *ssl )
              * Handshake headers: type(1) len(3) seq(2) f_off(3) f_len(3) */
             memcpy( ssl->out_msg, cur->p, 6 );
 
-            ssl->out_msg[6] = BYTE_2( frag_off );
-            ssl->out_msg[7] = BYTE_1( frag_off );
-            ssl->out_msg[8] = BYTE_0( frag_off );
+            ssl->out_msg[6] = MBEDTLS_BYTE_2( frag_off );
+            ssl->out_msg[7] = MBEDTLS_BYTE_1( frag_off );
+            ssl->out_msg[8] = MBEDTLS_BYTE_0( frag_off );
 
-            ssl->out_msg[ 9] = BYTE_2( cur_hs_frag_len );
-            ssl->out_msg[10] = BYTE_1( cur_hs_frag_len );
-            ssl->out_msg[11] = BYTE_0( cur_hs_frag_len );
+            ssl->out_msg[ 9] = MBEDTLS_BYTE_2( cur_hs_frag_len );
+            ssl->out_msg[10] = MBEDTLS_BYTE_1( cur_hs_frag_len );
+            ssl->out_msg[11] = MBEDTLS_BYTE_0( cur_hs_frag_len );
 
             MBEDTLS_SSL_DEBUG_BUF( 3, "handshake header", ssl->out_msg, 12 );
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1322,8 +1322,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     for( i = 0, p = buf + 6; i < ciph_len; i += 3, p += 3 )
     {
         if( p[0] == 0 &&
-            p[1] == MBEDTLS_CHAR_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
-            p[2] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ))
+            p[1] == MBEDTLS_BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
+            p[2] == MBEDTLS_BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ))
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
@@ -2086,8 +2086,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
     for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
-        if( p[0] == MBEDTLS_CHAR_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
-            p[1] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) )
+        if( p[0] == MBEDTLS_BYTE_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
+            p[1] == MBEDTLS_BYTE_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 
@@ -2205,8 +2205,8 @@ read_record_header:
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
 #endif
         {
-            if( p[0] != MBEDTLS_CHAR_1( ciphersuites[i] ) ||
-                p[1] != MBEDTLS_CHAR_0( ciphersuites[i] ) )
+            if( p[0] != MBEDTLS_BYTE_1( ciphersuites[i] ) ||
+                p[1] != MBEDTLS_BYTE_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2290,8 +2290,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2335,11 +2335,11 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
      *   } ConnectionId;
     */
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_CID );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_CID );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = MBEDTLS_CHAR_1( ext_len );
-    *p++ = MBEDTLS_CHAR_0( ext_len );
+    *p++ = MBEDTLS_BYTE_1( ext_len );
+    *p++ = MBEDTLS_BYTE_0( ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -2381,8 +2381,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2408,8 +2408,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2433,8 +2433,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2457,8 +2457,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2498,8 +2498,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2528,8 +2528,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2566,8 +2566,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
-    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2578,8 +2578,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = MBEDTLS_CHAR_1( kkpp_len );
-    *p++ = MBEDTLS_CHAR_0( kkpp_len );
+    *p++ = MBEDTLS_BYTE_1( kkpp_len );
+    *p++ = MBEDTLS_BYTE_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 }
@@ -2604,18 +2604,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ALPN );
-    buf[1] = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ALPN );
+    buf[0] = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ALPN );
+    buf[1] = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ALPN );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = MBEDTLS_CHAR_1( *olen - 4 );
-    buf[3] = MBEDTLS_CHAR_0( *olen - 4 );
+    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
+    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
 
-    buf[4] = MBEDTLS_CHAR_1( *olen - 6 );
-    buf[5] = MBEDTLS_CHAR_0( *olen - 6 );
+    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
+    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
 
-    buf[6] = MBEDTLS_CHAR_0( *olen - 7 );
+    buf[6] = MBEDTLS_BYTE_0( *olen - 7 );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2660,15 +2660,15 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
     }
 
     /* extension */
-    buf[0] = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_USE_SRTP );
-    buf[1] = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_USE_SRTP );
+    buf[0] = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_USE_SRTP );
+    buf[1] = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_USE_SRTP );
     /*
      * total length 5 and mki value: only one profile(2 bytes)
      *              and length(2 bytes) and srtp_mki  )
      */
     ext_len = 5 + mki_len;
-    buf[2] = MBEDTLS_CHAR_1( ext_len );
-    buf[3] = MBEDTLS_CHAR_0( ext_len );
+    buf[2] = MBEDTLS_BYTE_1( ext_len );
+    buf[3] = MBEDTLS_BYTE_0( ext_len );
 
     /* protection profile length: 2 */
     buf[4] = 0x00;
@@ -2677,8 +2677,8 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
                                 ssl->dtls_srtp_info.chosen_dtls_srtp_profile );
     if( profile_value != MBEDTLS_TLS_SRTP_UNSET )
     {
-        buf[6] = MBEDTLS_CHAR_1( profile_value );
-        buf[7] = MBEDTLS_CHAR_0( profile_value );
+        buf[6] = MBEDTLS_BYTE_1( profile_value );
+        buf[7] = MBEDTLS_BYTE_0( profile_value );
     }
     else
     {
@@ -3026,8 +3026,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = MBEDTLS_CHAR_1( ext_len );
-        *p++ = MBEDTLS_CHAR_0( ext_len );
+        *p++ = MBEDTLS_BYTE_1( ext_len );
+        *p++ = MBEDTLS_BYTE_0( ext_len );
         p += ext_len;
     }
 
@@ -4647,13 +4647,13 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = MBEDTLS_CHAR_3( lifetime );
-    ssl->out_msg[5] = MBEDTLS_CHAR_2( lifetime );
-    ssl->out_msg[6] = MBEDTLS_CHAR_1( lifetime );
-    ssl->out_msg[7] = MBEDTLS_CHAR_0( lifetime );
+    ssl->out_msg[4] = MBEDTLS_BYTE_3( lifetime );
+    ssl->out_msg[5] = MBEDTLS_BYTE_2( lifetime );
+    ssl->out_msg[6] = MBEDTLS_BYTE_1( lifetime );
+    ssl->out_msg[7] = MBEDTLS_BYTE_0( lifetime );
 
-    ssl->out_msg[8] = MBEDTLS_CHAR_1( tlen );
-    ssl->out_msg[9] = MBEDTLS_CHAR_0( tlen );
+    ssl->out_msg[8] = MBEDTLS_BYTE_1( tlen );
+    ssl->out_msg[9] = MBEDTLS_BYTE_0( tlen );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1322,8 +1322,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     for( i = 0, p = buf + 6; i < ciph_len; i += 3, p += 3 )
     {
         if( p[0] == 0 &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[2] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+            p[1] == MBEDTLS_CHAR_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
+            p[2] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 
@@ -1354,8 +1354,8 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
 #endif
         {
             if( p[0] != 0 ||
-                p[1] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
-                p[2] != ( ( ciphersuites[i]      ) & 0xFF ) )
+                p[1] != MBEDTLS_BYTE_1( ciphersuites[i] ) ||
+                p[2] != MBEDTLS_BYTE_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2086,8 +2086,8 @@ read_record_header:
 #if defined(MBEDTLS_SSL_FALLBACK_SCSV)
     for( i = 0, p = buf + ciph_offset + 2; i < ciph_len; i += 2, p += 2 )
     {
-        if( p[0] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE >> 8 ) & 0xff ) &&
-            p[1] == (unsigned char)( ( MBEDTLS_SSL_FALLBACK_SCSV_VALUE      ) & 0xff ) )
+        if( p[0] == MBEDTLS_CHAR_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
+            p[1] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "received FALLBACK_SCSV" ) );
 
@@ -2205,8 +2205,8 @@ read_record_header:
         for( j = 0, p = buf + ciph_offset + 2; j < ciph_len; j += 2, p += 2 )
 #endif
         {
-            if( p[0] != ( ( ciphersuites[i] >> 8 ) & 0xFF ) ||
-                p[1] != ( ( ciphersuites[i]      ) & 0xFF ) )
+            if( p[0] != MBEDTLS_CHAR_1( ciphersuites[i] ) ||
+                p[1] != MBEDTLS_CHAR_0( ciphersuites[i] ) )
                 continue;
 
             got_common_suite = 1;
@@ -2290,8 +2290,8 @@ static void ssl_write_truncated_hmac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding truncated hmac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_TRUNCATED_HMAC      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_TRUNCATED_HMAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2335,11 +2335,11 @@ static void ssl_write_cid_ext( mbedtls_ssl_context *ssl,
      *   } ConnectionId;
     */
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_CID      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_CID );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_CID );
     ext_len = (size_t) ssl->own_cid_len + 1;
-    *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( ext_len );
+    *p++ = MBEDTLS_CHAR_0( ext_len );
 
     *p++ = (uint8_t) ssl->own_cid_len;
     memcpy( p, ssl->own_cid, ssl->own_cid_len );
@@ -2381,8 +2381,8 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding encrypt then mac extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ENCRYPT_THEN_MAC );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2408,8 +2408,8 @@ static void ssl_write_extended_ms_ext( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding extended master secret "
                         "extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_EXTENDED_MASTER_SECRET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2433,8 +2433,8 @@ static void ssl_write_session_ticket_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, adding session ticket extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SESSION_TICKET      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SESSION_TICKET );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SESSION_TICKET );
 
     *p++ = 0x00;
     *p++ = 0x00;
@@ -2457,8 +2457,8 @@ static void ssl_write_renegotiation_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, secure renegotiation extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_RENEGOTIATION_INFO );
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if( ssl->renego_status != MBEDTLS_SSL_INITIAL_HANDSHAKE )
@@ -2498,8 +2498,8 @@ static void ssl_write_max_fragment_length_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, max_fragment_length extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_MAX_FRAGMENT_LENGTH );
 
     *p++ = 0x00;
     *p++ = 1;
@@ -2528,8 +2528,8 @@ static void ssl_write_supported_point_formats_ext( mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, supported_point_formats extension" ) );
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_SUPPORTED_POINT_FORMATS );
 
     *p++ = 0x00;
     *p++ = 2;
@@ -2566,8 +2566,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( MBEDTLS_TLS_EXT_ECJPAKE_KKPP      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
+    *p++ = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ECJPAKE_KKPP );
 
     ret = mbedtls_ecjpake_write_round_one( &ssl->handshake->ecjpake_ctx,
                                         p + 2, end - p - 2, &kkpp_len,
@@ -2578,8 +2578,8 @@ static void ssl_write_ecjpake_kkpp_ext( mbedtls_ssl_context *ssl,
         return;
     }
 
-    *p++ = (unsigned char)( ( kkpp_len >> 8 ) & 0xFF );
-    *p++ = (unsigned char)( ( kkpp_len      ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_1( kkpp_len );
+    *p++ = MBEDTLS_CHAR_0( kkpp_len );
 
     *olen = kkpp_len + 4;
 }
@@ -2604,18 +2604,18 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN >> 8 ) & 0xFF );
-    buf[1] = (unsigned char)( ( MBEDTLS_TLS_EXT_ALPN      ) & 0xFF );
+    buf[0] = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_ALPN );
+    buf[1] = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_ALPN );
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = (unsigned char)( ( ( *olen - 4 ) >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ( ( *olen - 4 )      ) & 0xFF );
+    buf[2] = MBEDTLS_CHAR_1( *olen - 4 );
+    buf[3] = MBEDTLS_CHAR_0( *olen - 4 );
 
-    buf[4] = (unsigned char)( ( ( *olen - 6 ) >> 8 ) & 0xFF );
-    buf[5] = (unsigned char)( ( ( *olen - 6 )      ) & 0xFF );
+    buf[4] = MBEDTLS_CHAR_1( *olen - 6 );
+    buf[5] = MBEDTLS_CHAR_0( *olen - 6 );
 
-    buf[6] = (unsigned char)( ( ( *olen - 7 )      ) & 0xFF );
+    buf[6] = MBEDTLS_CHAR_0( *olen - 7 );
 
     memcpy( buf + 7, ssl->alpn_chosen, *olen - 7 );
 }
@@ -2660,15 +2660,15 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
     }
 
     /* extension */
-    buf[0] = (unsigned char)( ( MBEDTLS_TLS_EXT_USE_SRTP >> 8 ) & 0xFF );
-    buf[1] = (unsigned char)( ( MBEDTLS_TLS_EXT_USE_SRTP      ) & 0xFF );
+    buf[0] = MBEDTLS_CHAR_1( MBEDTLS_TLS_EXT_USE_SRTP );
+    buf[1] = MBEDTLS_CHAR_0( MBEDTLS_TLS_EXT_USE_SRTP );
     /*
      * total length 5 and mki value: only one profile(2 bytes)
      *              and length(2 bytes) and srtp_mki  )
      */
     ext_len = 5 + mki_len;
-    buf[2] = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-    buf[3] = (unsigned char)( ext_len & 0xFF );
+    buf[2] = MBEDTLS_CHAR_1( ext_len );
+    buf[3] = MBEDTLS_CHAR_0( ext_len );
 
     /* protection profile length: 2 */
     buf[4] = 0x00;
@@ -2677,8 +2677,8 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
                                 ssl->dtls_srtp_info.chosen_dtls_srtp_profile );
     if( profile_value != MBEDTLS_TLS_SRTP_UNSET )
     {
-        buf[6] = (unsigned char)( ( profile_value >> 8 ) & 0xFF );
-        buf[7] = (unsigned char)( profile_value & 0xFF );
+        buf[6] = MBEDTLS_CHAR_1( profile_value );
+        buf[7] = MBEDTLS_CHAR_0( profile_value );
     }
     else
     {
@@ -3026,8 +3026,8 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
     if( ext_len > 0 )
     {
-        *p++ = (unsigned char)( ( ext_len >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ext_len      ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_1( ext_len );
+        *p++ = MBEDTLS_CHAR_0( ext_len );
         p += ext_len;
     }
 
@@ -3883,8 +3883,8 @@ static int ssl_decrypt_encrypted_pms( mbedtls_ssl_context *ssl,
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
         }
-        if( *p++ != ( ( len >> 8 ) & 0xFF ) ||
-            *p++ != ( ( len      ) & 0xFF ) )
+        if( *p++ != MBEDTLS_BYTE_1( len ) ||
+            *p++ != MBEDTLS_BYTE_0( len ) )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad client key exchange message" ) );
             return( MBEDTLS_ERR_SSL_BAD_HS_CLIENT_KEY_EXCHANGE );
@@ -4647,13 +4647,13 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = ( lifetime >> 24 ) & 0xFF;
-    ssl->out_msg[5] = ( lifetime >> 16 ) & 0xFF;
-    ssl->out_msg[6] = ( lifetime >>  8 ) & 0xFF;
-    ssl->out_msg[7] = ( lifetime       ) & 0xFF;
+    ssl->out_msg[4] = MBEDTLS_CHAR_3( lifetime );
+    ssl->out_msg[5] = MBEDTLS_CHAR_2( lifetime );
+    ssl->out_msg[6] = MBEDTLS_CHAR_1( lifetime );
+    ssl->out_msg[7] = MBEDTLS_CHAR_0( lifetime );
 
-    ssl->out_msg[8] = (unsigned char)( ( tlen >> 8 ) & 0xFF );
-    ssl->out_msg[9] = (unsigned char)( ( tlen      ) & 0xFF );
+    ssl->out_msg[8] = MBEDTLS_CHAR_1( tlen );
+    ssl->out_msg[9] = MBEDTLS_CHAR_0( tlen );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2861,10 +2861,10 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_HAVE_TIME)
     t = mbedtls_time( NULL );
-    *p++ = (unsigned char)( t >> 24 );
-    *p++ = (unsigned char)( t >> 16 );
-    *p++ = (unsigned char)( t >>  8 );
-    *p++ = (unsigned char)( t       );
+    *p++ = MBEDTLS_BYTE_3( t );
+    *p++ = MBEDTLS_BYTE_2( t );
+    *p++ = MBEDTLS_BYTE_1( t );
+    *p++ = MBEDTLS_BYTE_0( t );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, current time: %" MBEDTLS_PRINTF_LONGLONG,
                                 (long long) t ) );
@@ -2945,9 +2945,9 @@ static int ssl_write_server_hello( mbedtls_ssl_context *ssl )
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "%s session has been resumed",
                    ssl->handshake->resume ? "a" : "no" ) );
 
-    *p++ = (unsigned char)( ssl->session_negotiate->ciphersuite >> 8 );
-    *p++ = (unsigned char)( ssl->session_negotiate->ciphersuite      );
-    *p++ = (unsigned char)( ssl->session_negotiate->compression      );
+    *p++ = MBEDTLS_BYTE_1( ssl->session_negotiate->ciphersuite );
+    *p++ = MBEDTLS_BYTE_0( ssl->session_negotiate->ciphersuite );
+    *p++ = MBEDTLS_BYTE_0( ssl->session_negotiate->compression );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "server hello, chosen ciphersuite: %s",
            mbedtls_ssl_get_ciphersuite_name( ssl->session_negotiate->ciphersuite ) ) );
@@ -3167,8 +3167,8 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
 #endif
         }
 
-        p[0] = (unsigned char)( sa_len >> 8 );
-        p[1] = (unsigned char)( sa_len      );
+        p[0] = MBEDTLS_BYTE_1( sa_len );
+        p[1] = MBEDTLS_BYTE_0( sa_len );
         sa_len += 2;
         p += sa_len;
     }
@@ -3208,8 +3208,8 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
                 break;
             }
 
-            *p++ = (unsigned char)( dn_size >> 8 );
-            *p++ = (unsigned char)( dn_size      );
+            *p++ = MBEDTLS_BYTE_1( dn_size );
+            *p++ = MBEDTLS_BYTE_0( dn_size );
             memcpy( p, crt->subject_raw.p, dn_size );
             p += dn_size;
 
@@ -3223,8 +3223,8 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
     ssl->out_msglen  = p - buf;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_CERTIFICATE_REQUEST;
-    ssl->out_msg[4 + ct_len + sa_len] = (unsigned char)( total_dn_size  >> 8 );
-    ssl->out_msg[5 + ct_len + sa_len] = (unsigned char)( total_dn_size       );
+    ssl->out_msg[4 + ct_len + sa_len] = MBEDTLS_BYTE_1( total_dn_size );
+    ssl->out_msg[5 + ct_len + sa_len] = MBEDTLS_BYTE_0( total_dn_size );
 
     ret = mbedtls_ssl_write_handshake_msg( ssl );
 
@@ -3722,8 +3722,8 @@ static int ssl_write_server_key_exchange( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED)
     if( signature_len != 0 )
     {
-        ssl->out_msg[ssl->out_msglen++] = (unsigned char)( signature_len >> 8 );
-        ssl->out_msg[ssl->out_msglen++] = (unsigned char)( signature_len      );
+        ssl->out_msg[ssl->out_msglen++] = MBEDTLS_BYTE_1( signature_len );
+        ssl->out_msg[ssl->out_msglen++] = MBEDTLS_BYTE_0( signature_len );
 
         MBEDTLS_SSL_DEBUG_BUF( 3, "my signature",
                                ssl->out_msg + ssl->out_msglen,

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2604,16 +2604,13 @@ static void ssl_write_alpn_ext( mbedtls_ssl_context *ssl,
      * 6 . 6    protocol name length
      * 7 . 7+n  protocol name
      */
-    buf[0] = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_ALPN );
-    buf[1] = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_ALPN );
+    MBEDTLS_PUT_UINT16_BE( MBEDTLS_TLS_EXT_ALPN, buf, 0);
 
     *olen = 7 + strlen( ssl->alpn_chosen );
 
-    buf[2] = MBEDTLS_BYTE_1( *olen - 4 );
-    buf[3] = MBEDTLS_BYTE_0( *olen - 4 );
+    MBEDTLS_PUT_UINT16_BE( *olen - 4, buf, 2 );
 
-    buf[4] = MBEDTLS_BYTE_1( *olen - 6 );
-    buf[5] = MBEDTLS_BYTE_0( *olen - 6 );
+    MBEDTLS_PUT_UINT16_BE( *olen - 6, buf, 4 );
 
     buf[6] = MBEDTLS_BYTE_0( *olen - 7 );
 
@@ -2660,16 +2657,13 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
     }
 
     /* extension */
-    buf[0] = MBEDTLS_BYTE_1( MBEDTLS_TLS_EXT_USE_SRTP );
-    buf[1] = MBEDTLS_BYTE_0( MBEDTLS_TLS_EXT_USE_SRTP );
+    MBEDTLS_PUT_UINT16_BE(MBEDTLS_TLS_EXT_USE_SRTP, buf, 0 );
     /*
      * total length 5 and mki value: only one profile(2 bytes)
      *              and length(2 bytes) and srtp_mki  )
      */
     ext_len = 5 + mki_len;
-    buf[2] = MBEDTLS_BYTE_1( ext_len );
-    buf[3] = MBEDTLS_BYTE_0( ext_len );
-
+    MBEDTLS_PUT_UINT16_BE( ext_len, buf, 2 );
     /* protection profile length: 2 */
     buf[4] = 0x00;
     buf[5] = 0x02;
@@ -2677,8 +2671,7 @@ static void ssl_write_use_srtp_ext( mbedtls_ssl_context *ssl,
                                 ssl->dtls_srtp_info.chosen_dtls_srtp_profile );
     if( profile_value != MBEDTLS_TLS_SRTP_UNSET )
     {
-        buf[6] = MBEDTLS_BYTE_1( profile_value );
-        buf[7] = MBEDTLS_BYTE_0( profile_value );
+        MBEDTLS_PUT_UINT16_BE( profile_value, buf, 6 );
     }
     else
     {
@@ -3167,8 +3160,7 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
 #endif
         }
 
-        p[0] = MBEDTLS_BYTE_1( sa_len );
-        p[1] = MBEDTLS_BYTE_0( sa_len );
+        MBEDTLS_PUT_UINT16_BE( sa_len, p, 0 );
         sa_len += 2;
         p += sa_len;
     }
@@ -3223,8 +3215,7 @@ static int ssl_write_certificate_request( mbedtls_ssl_context *ssl )
     ssl->out_msglen  = p - buf;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
     ssl->out_msg[0]  = MBEDTLS_SSL_HS_CERTIFICATE_REQUEST;
-    ssl->out_msg[4 + ct_len + sa_len] = MBEDTLS_BYTE_1( total_dn_size );
-    ssl->out_msg[5 + ct_len + sa_len] = MBEDTLS_BYTE_0( total_dn_size );
+    MBEDTLS_PUT_UINT16_BE( total_dn_size, ssl->out_msg, 4 + ct_len + sa_len );
 
     ret = mbedtls_ssl_write_handshake_msg( ssl );
 
@@ -4647,13 +4638,8 @@ static int ssl_write_new_session_ticket( mbedtls_ssl_context *ssl )
         tlen = 0;
     }
 
-    ssl->out_msg[4] = MBEDTLS_BYTE_3( lifetime );
-    ssl->out_msg[5] = MBEDTLS_BYTE_2( lifetime );
-    ssl->out_msg[6] = MBEDTLS_BYTE_1( lifetime );
-    ssl->out_msg[7] = MBEDTLS_BYTE_0( lifetime );
-
-    ssl->out_msg[8] = MBEDTLS_BYTE_1( tlen );
-    ssl->out_msg[9] = MBEDTLS_BYTE_0( tlen );
+    MBEDTLS_PUT_UINT32_BE( lifetime, ssl->out_msg, 4 );
+    MBEDTLS_PUT_UINT16_BE( tlen, ssl->out_msg, 8 );
 
     ssl->out_msglen = 10 + tlen;
 

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1323,7 +1323,7 @@ static int ssl_parse_client_hello_v2( mbedtls_ssl_context *ssl )
     {
         if( p[0] == 0 &&
             p[1] == MBEDTLS_CHAR_1( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ) &&
-            p[2] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE )
+            p[2] == MBEDTLS_CHAR_0( MBEDTLS_SSL_FALLBACK_SCSV_VALUE ))
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "received FALLBACK_SCSV" ) );
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -245,8 +245,8 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-    state_len_bytes[0] = ( clear_len >> 8 ) & 0xff;
-    state_len_bytes[1] = ( clear_len      ) & 0xff;
+    state_len_bytes[0] = BYTE_1( clear_len );
+    state_len_bytes[1] = BYTE_0( clear_len );
 
     /* Encrypt and authenticate */
     if( ( ret = mbedtls_cipher_auth_encrypt_ext( &key->ctx,

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -245,8 +245,8 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-    state_len_bytes[0] = BYTE_1( clear_len );
-    state_len_bytes[1] = BYTE_0( clear_len );
+    state_len_bytes[0] = MBEDTLS_BYTE_1( clear_len );
+    state_len_bytes[1] = MBEDTLS_BYTE_0( clear_len );
 
     /* Encrypt and authenticate */
     if( ( ret = mbedtls_cipher_auth_encrypt_ext( &key->ctx,

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -245,8 +245,7 @@ int mbedtls_ssl_ticket_write( void *p_ticket,
     {
          goto cleanup;
     }
-    state_len_bytes[0] = MBEDTLS_BYTE_1( clear_len );
-    state_len_bytes[1] = MBEDTLS_BYTE_0( clear_len );
+    MBEDTLS_PUT_UINT16_BE( clear_len, state_len_bytes, 0 );
 
     /* Encrypt and authenticate */
     if( ( ret = mbedtls_cipher_auth_encrypt_ext( &key->ctx,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5278,8 +5278,8 @@ static unsigned char ssl_serialized_session_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
     MBEDTLS_VERSION_PATCH,
-    ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 8 ) & 0xFF,
-    ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 0 ) & 0xFF,
+    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
 };
 
 /*
@@ -5359,15 +5359,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     if( used <= buf_len )
     {
         start = (uint64_t) session->start;
-
-        *p++ = (unsigned char)( ( start >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( start >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( start       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_7( start );
+        *p++ = MBEDTLS_CHAR_6( start );
+        *p++ = MBEDTLS_CHAR_5( start );
+        *p++ = MBEDTLS_CHAR_4( start );
+        *p++ = MBEDTLS_CHAR_3( start );
+        *p++ = MBEDTLS_CHAR_2( start );
+        *p++ = MBEDTLS_CHAR_1( start );
+        *p++ = MBEDTLS_CHAR_0( start );
     }
 #endif /* MBEDTLS_HAVE_TIME */
 
@@ -5383,22 +5382,22 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session->ciphersuite >> 8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ciphersuite      ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_1( session->ciphersuite );
+        *p++ = MBEDTLS_CHAR_0( session->ciphersuite );
 
-        *p++ = (unsigned char)( session->compression & 0xFF );
+        *p++ = MBEDTLS_CHAR_0( session->compression );
 
-        *p++ = (unsigned char)( session->id_len & 0xFF );
+        *p++ = MBEDTLS_CHAR_0( session->id_len );
         memcpy( p, session->id, 32 );
         p += 32;
 
         memcpy( p, session->master, 48 );
         p += 48;
 
-        *p++ = (unsigned char)( ( session->verify_result >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->verify_result       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_3( session->verify_result );
+        *p++ = MBEDTLS_CHAR_2( session->verify_result );
+        *p++ = MBEDTLS_CHAR_1( session->verify_result );
+        *p++ = MBEDTLS_CHAR_0( session->verify_result );
     }
 
     /*
@@ -5415,9 +5414,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( cert_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( cert_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( cert_len       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_2( cert_len );
+        *p++ = MBEDTLS_CHAR_1( cert_len );
+        *p++ = MBEDTLS_CHAR_0( cert_len );
 
         if( session->peer_cert != NULL )
         {
@@ -5458,9 +5457,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session->ticket_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_len       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_2( session->ticket_len );
+        *p++ = MBEDTLS_CHAR_1( session->ticket_len );
+        *p++ = MBEDTLS_CHAR_0( session->ticket_len );
 
         if( session->ticket != NULL )
         {
@@ -5468,10 +5467,10 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
             p += session->ticket_len;
         }
 
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session->ticket_lifetime       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_3( session->ticket_lifetime );
+        *p++ = MBEDTLS_CHAR_2( session->ticket_lifetime );
+        *p++ = MBEDTLS_CHAR_1( session->ticket_lifetime );
+        *p++ = MBEDTLS_CHAR_0( session->ticket_lifetime );
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
@@ -5489,14 +5488,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     used += 1;
 
     if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->trunc_hmac ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_0( session->trunc_hmac );
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     used += 1;
 
     if( used <= buf_len )
-        *p++ = (unsigned char)( ( session->encrypt_then_mac ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_0( session->encrypt_then_mac );
 #endif
 
     /* Done */
@@ -6149,11 +6148,12 @@ static unsigned char ssl_serialized_context_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
     MBEDTLS_VERSION_PATCH,
-    ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 8 ) & 0xFF,
-    ( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG >> 0 ) & 0xFF,
-    ( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG >> 16 ) & 0xFF,
-    ( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG >>  8 ) & 0xFF,
-    ( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG >>  0 ) & 0xFF,
+    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_2( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+
 };
 
 /*
@@ -6294,10 +6294,10 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4 + session_len;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( session_len >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( session_len       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_3( session_len );
+        *p++ = MBEDTLS_CHAR_2( session_len );
+        *p++ = MBEDTLS_CHAR_1( session_len );
+        *p++ = MBEDTLS_CHAR_0( session_len );
 
         ret = ssl_session_save( ssl->session, 1,
                                 p, session_len, &session_len );
@@ -6339,34 +6339,33 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( ssl->badmac_seen >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->badmac_seen       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_3( ssl->badmac_seen );
+        *p++ = MBEDTLS_CHAR_2( ssl->badmac_seen );
+        *p++ = MBEDTLS_CHAR_1( ssl->badmac_seen );
+        *p++ = MBEDTLS_CHAR_0( ssl->badmac_seen );
     }
 #endif /* MBEDTLS_SSL_DTLS_BADMAC_LIMIT */
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
     used += 16;
     if( used <= buf_len )
-    {
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window_top       ) & 0xFF );
+    {   *p++ = MBEDTLS_CHAR_7( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_6( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_5( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_4( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_3( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_2( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_1( ssl->in_window_top );
+        *p++ = MBEDTLS_CHAR_0( ssl->in_window_top );
 
-        *p++ = (unsigned char)( ( ssl->in_window >> 56 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 48 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 40 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 32 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 24 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >> 16 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->in_window       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_7( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_6( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_5( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_4( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_3( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_2( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_1( ssl->in_window );
+        *p++ = MBEDTLS_CHAR_0( ssl->in_window );
     }
 #endif /* MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 
@@ -6389,8 +6388,8 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 2;
     if( used <= buf_len )
     {
-        *p++ = (unsigned char)( ( ssl->mtu >>  8 ) & 0xFF );
-        *p++ = (unsigned char)( ( ssl->mtu       ) & 0xFF );
+        *p++ = MBEDTLS_CHAR_1( ssl->mtu );
+        *p++ = MBEDTLS_CHAR_0( ssl->mtu );
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6150,10 +6150,9 @@ static unsigned char ssl_serialized_context_header[] = {
     MBEDTLS_VERSION_PATCH,
     MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
     MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_2( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-
+    MBEDTLS_CHAR_2( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_1( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
+    MBEDTLS_CHAR_0( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
 };
 
 /*
@@ -6349,7 +6348,8 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
     used += 16;
     if( used <= buf_len )
-    {   *p++ = MBEDTLS_CHAR_7( ssl->in_window_top );
+    {
+        *p++ = MBEDTLS_CHAR_7( ssl->in_window_top );
         *p++ = MBEDTLS_CHAR_6( ssl->in_window_top );
         *p++ = MBEDTLS_CHAR_5( ssl->in_window_top );
         *p++ = MBEDTLS_CHAR_4( ssl->in_window_top );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1948,8 +1948,8 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
         if( end - p < 2 )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-        *(p++) = (unsigned char)( psk_len >> 8 );
-        *(p++) = (unsigned char)( psk_len      );
+        *(p++) = MBEDTLS_BYTE_1( psk_len );
+        *(p++) = MBEDTLS_BYTE_0( psk_len );
 
         if( end < p || (size_t)( end - p ) < psk_len )
             return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -1989,8 +1989,8 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
             MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_dhm_calc_secret", ret );
             return( ret );
         }
-        *(p++) = (unsigned char)( len >> 8 );
-        *(p++) = (unsigned char)( len );
+        *(p++) = MBEDTLS_BYTE_1( len );
+        *(p++) = MBEDTLS_BYTE_0( len );
         p += len;
 
         MBEDTLS_SSL_DEBUG_MPI( 3, "DHM: K ", &ssl->handshake->dhm_ctx.K  );
@@ -2011,8 +2011,8 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
             return( ret );
         }
 
-        *(p++) = (unsigned char)( zlen >> 8 );
-        *(p++) = (unsigned char)( zlen      );
+        *(p++) = MBEDTLS_BYTE_1( zlen );
+        *(p++) = MBEDTLS_BYTE_0( zlen );
         p += zlen;
 
         MBEDTLS_SSL_DEBUG_ECDH( 3, &ssl->handshake->ecdh_ctx,
@@ -2029,8 +2029,8 @@ int mbedtls_ssl_psk_derive_premaster( mbedtls_ssl_context *ssl, mbedtls_key_exch
     if( end - p < 2 )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    *(p++) = (unsigned char)( psk_len >> 8 );
-    *(p++) = (unsigned char)( psk_len      );
+    *(p++) = MBEDTLS_BYTE_1( psk_len );
+    *(p++) = MBEDTLS_BYTE_0( psk_len );
 
     if( end < p || (size_t)( end - p ) < psk_len )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -2224,17 +2224,17 @@ int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl )
             return( MBEDTLS_ERR_SSL_CERTIFICATE_TOO_LARGE );
         }
 
-        ssl->out_msg[i    ] = (unsigned char)( n >> 16 );
-        ssl->out_msg[i + 1] = (unsigned char)( n >>  8 );
-        ssl->out_msg[i + 2] = (unsigned char)( n       );
+        ssl->out_msg[i    ] = MBEDTLS_BYTE_2( n );
+        ssl->out_msg[i + 1] = MBEDTLS_BYTE_1( n );
+        ssl->out_msg[i + 2] = MBEDTLS_BYTE_0( n );
 
         i += 3; memcpy( ssl->out_msg + i, crt->raw.p, n );
         i += n; crt = crt->next;
     }
 
-    ssl->out_msg[4]  = (unsigned char)( ( i - 7 ) >> 16 );
-    ssl->out_msg[5]  = (unsigned char)( ( i - 7 ) >>  8 );
-    ssl->out_msg[6]  = (unsigned char)( ( i - 7 )       );
+    ssl->out_msg[4]  = MBEDTLS_BYTE_2( i - 7 );
+    ssl->out_msg[5]  = MBEDTLS_BYTE_1( i - 7 );
+    ssl->out_msg[6]  = MBEDTLS_BYTE_0( i - 7 );
 
     ssl->out_msglen  = i;
     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5278,8 +5278,8 @@ static unsigned char ssl_serialized_session_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
     MBEDTLS_VERSION_PATCH,
-    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
 };
 
 /*
@@ -5359,14 +5359,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     if( used <= buf_len )
     {
         start = (uint64_t) session->start;
-        *p++ = MBEDTLS_CHAR_7( start );
-        *p++ = MBEDTLS_CHAR_6( start );
-        *p++ = MBEDTLS_CHAR_5( start );
-        *p++ = MBEDTLS_CHAR_4( start );
-        *p++ = MBEDTLS_CHAR_3( start );
-        *p++ = MBEDTLS_CHAR_2( start );
-        *p++ = MBEDTLS_CHAR_1( start );
-        *p++ = MBEDTLS_CHAR_0( start );
+        *p++ = MBEDTLS_BYTE_7( start );
+        *p++ = MBEDTLS_BYTE_6( start );
+        *p++ = MBEDTLS_BYTE_5( start );
+        *p++ = MBEDTLS_BYTE_4( start );
+        *p++ = MBEDTLS_BYTE_3( start );
+        *p++ = MBEDTLS_BYTE_2( start );
+        *p++ = MBEDTLS_BYTE_1( start );
+        *p++ = MBEDTLS_BYTE_0( start );
     }
 #endif /* MBEDTLS_HAVE_TIME */
 
@@ -5382,22 +5382,22 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_1( session->ciphersuite );
-        *p++ = MBEDTLS_CHAR_0( session->ciphersuite );
+        *p++ = MBEDTLS_BYTE_1( session->ciphersuite );
+        *p++ = MBEDTLS_BYTE_0( session->ciphersuite );
 
-        *p++ = MBEDTLS_CHAR_0( session->compression );
+        *p++ = MBEDTLS_BYTE_0( session->compression );
 
-        *p++ = MBEDTLS_CHAR_0( session->id_len );
+        *p++ = MBEDTLS_BYTE_0( session->id_len );
         memcpy( p, session->id, 32 );
         p += 32;
 
         memcpy( p, session->master, 48 );
         p += 48;
 
-        *p++ = MBEDTLS_CHAR_3( session->verify_result );
-        *p++ = MBEDTLS_CHAR_2( session->verify_result );
-        *p++ = MBEDTLS_CHAR_1( session->verify_result );
-        *p++ = MBEDTLS_CHAR_0( session->verify_result );
+        *p++ = MBEDTLS_BYTE_3( session->verify_result );
+        *p++ = MBEDTLS_BYTE_2( session->verify_result );
+        *p++ = MBEDTLS_BYTE_1( session->verify_result );
+        *p++ = MBEDTLS_BYTE_0( session->verify_result );
     }
 
     /*
@@ -5414,9 +5414,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_2( cert_len );
-        *p++ = MBEDTLS_CHAR_1( cert_len );
-        *p++ = MBEDTLS_CHAR_0( cert_len );
+        *p++ = MBEDTLS_BYTE_2( cert_len );
+        *p++ = MBEDTLS_BYTE_1( cert_len );
+        *p++ = MBEDTLS_BYTE_0( cert_len );
 
         if( session->peer_cert != NULL )
         {
@@ -5457,9 +5457,9 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
 
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_2( session->ticket_len );
-        *p++ = MBEDTLS_CHAR_1( session->ticket_len );
-        *p++ = MBEDTLS_CHAR_0( session->ticket_len );
+        *p++ = MBEDTLS_BYTE_2( session->ticket_len );
+        *p++ = MBEDTLS_BYTE_1( session->ticket_len );
+        *p++ = MBEDTLS_BYTE_0( session->ticket_len );
 
         if( session->ticket != NULL )
         {
@@ -5467,10 +5467,10 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
             p += session->ticket_len;
         }
 
-        *p++ = MBEDTLS_CHAR_3( session->ticket_lifetime );
-        *p++ = MBEDTLS_CHAR_2( session->ticket_lifetime );
-        *p++ = MBEDTLS_CHAR_1( session->ticket_lifetime );
-        *p++ = MBEDTLS_CHAR_0( session->ticket_lifetime );
+        *p++ = MBEDTLS_BYTE_3( session->ticket_lifetime );
+        *p++ = MBEDTLS_BYTE_2( session->ticket_lifetime );
+        *p++ = MBEDTLS_BYTE_1( session->ticket_lifetime );
+        *p++ = MBEDTLS_BYTE_0( session->ticket_lifetime );
     }
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
 
@@ -5488,14 +5488,14 @@ static int ssl_session_save( const mbedtls_ssl_session *session,
     used += 1;
 
     if( used <= buf_len )
-        *p++ = MBEDTLS_CHAR_0( session->trunc_hmac );
+        *p++ = MBEDTLS_BYTE_0( session->trunc_hmac );
 #endif
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     used += 1;
 
     if( used <= buf_len )
-        *p++ = MBEDTLS_CHAR_0( session->encrypt_then_mac );
+        *p++ = MBEDTLS_BYTE_0( session->encrypt_then_mac );
 #endif
 
     /* Done */
@@ -6148,11 +6148,11 @@ static unsigned char ssl_serialized_context_header[] = {
     MBEDTLS_VERSION_MAJOR,
     MBEDTLS_VERSION_MINOR,
     MBEDTLS_VERSION_PATCH,
-    MBEDTLS_CHAR_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_2( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_1( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
-    MBEDTLS_CHAR_0( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_1( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_0( SSL_SERIALIZED_SESSION_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_2( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_1( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
+    MBEDTLS_BYTE_0( SSL_SERIALIZED_CONTEXT_CONFIG_BITFLAG ),
 };
 
 /*
@@ -6293,10 +6293,10 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4 + session_len;
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_3( session_len );
-        *p++ = MBEDTLS_CHAR_2( session_len );
-        *p++ = MBEDTLS_CHAR_1( session_len );
-        *p++ = MBEDTLS_CHAR_0( session_len );
+        *p++ = MBEDTLS_BYTE_3( session_len );
+        *p++ = MBEDTLS_BYTE_2( session_len );
+        *p++ = MBEDTLS_BYTE_1( session_len );
+        *p++ = MBEDTLS_BYTE_0( session_len );
 
         ret = ssl_session_save( ssl->session, 1,
                                 p, session_len, &session_len );
@@ -6338,10 +6338,10 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 4;
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_3( ssl->badmac_seen );
-        *p++ = MBEDTLS_CHAR_2( ssl->badmac_seen );
-        *p++ = MBEDTLS_CHAR_1( ssl->badmac_seen );
-        *p++ = MBEDTLS_CHAR_0( ssl->badmac_seen );
+        *p++ = MBEDTLS_BYTE_3( ssl->badmac_seen );
+        *p++ = MBEDTLS_BYTE_2( ssl->badmac_seen );
+        *p++ = MBEDTLS_BYTE_1( ssl->badmac_seen );
+        *p++ = MBEDTLS_BYTE_0( ssl->badmac_seen );
     }
 #endif /* MBEDTLS_SSL_DTLS_BADMAC_LIMIT */
 
@@ -6349,23 +6349,23 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 16;
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_7( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_6( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_5( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_4( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_3( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_2( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_1( ssl->in_window_top );
-        *p++ = MBEDTLS_CHAR_0( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_7( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_6( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_5( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_4( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_3( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_2( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_1( ssl->in_window_top );
+        *p++ = MBEDTLS_BYTE_0( ssl->in_window_top );
 
-        *p++ = MBEDTLS_CHAR_7( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_6( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_5( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_4( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_3( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_2( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_1( ssl->in_window );
-        *p++ = MBEDTLS_CHAR_0( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_7( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_6( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_5( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_4( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_3( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_2( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_1( ssl->in_window );
+        *p++ = MBEDTLS_BYTE_0( ssl->in_window );
     }
 #endif /* MBEDTLS_SSL_DTLS_ANTI_REPLAY */
 
@@ -6388,8 +6388,8 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
     used += 2;
     if( used <= buf_len )
     {
-        *p++ = MBEDTLS_CHAR_1( ssl->mtu );
-        *p++ = MBEDTLS_CHAR_0( ssl->mtu );
+        *p++ = MBEDTLS_BYTE_1( ssl->mtu );
+        *p++ = MBEDTLS_BYTE_0( ssl->mtu );
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -112,17 +112,17 @@ static void ssl_tls1_3_hkdf_encode_label(
 #endif
 
     *p++ = 0;
-    *p++ = MBEDTLS_CHAR_0( desired_length );
+    *p++ = MBEDTLS_BYTE_0( desired_length );
 
     /* Add label incl. prefix */
-    *p++ = MBEDTLS_CHAR_0( total_label_len );
+    *p++ = MBEDTLS_BYTE_0( total_label_len );
     memcpy( p, tls1_3_label_prefix, sizeof(tls1_3_label_prefix) );
     p += sizeof(tls1_3_label_prefix);
     memcpy( p, label, llen );
     p += llen;
 
     /* Add context value */
-    *p++ = MBEDTLS_CHAR_0( clen );
+    *p++ = MBEDTLS_BYTE_0( clen );
     if( clen != 0 )
         memcpy( p, ctx, clen );
 

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -112,7 +112,7 @@ static void ssl_tls1_3_hkdf_encode_label(
 #endif
 
     *p++ = 0;
-    *p++ = (unsigned char)( ( desired_length >> 0 ) & 0xFF );
+    *p++ = MBEDTLS_CHAR_0( desired_length );
 
     /* Add label incl. prefix */
     *p++ = (unsigned char)( total_label_len & 0xFF );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -115,14 +115,14 @@ static void ssl_tls1_3_hkdf_encode_label(
     *p++ = MBEDTLS_CHAR_0( desired_length );
 
     /* Add label incl. prefix */
-    *p++ = (unsigned char)( total_label_len & 0xFF );
+    *p++ = MBEDTLS_CHAR_0( total_label_len );
     memcpy( p, tls1_3_label_prefix, sizeof(tls1_3_label_prefix) );
     p += sizeof(tls1_3_label_prefix);
     memcpy( p, label, llen );
     p += llen;
 
     /* Add context value */
-    *p++ = (unsigned char)( clen & 0xFF );
+    *p++ = MBEDTLS_CHAR_0( clen );
     if( clen != 0 )
         memcpy( p, ctx, clen );
 

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -251,8 +251,7 @@ int mbedtls_x509write_crt_set_key_usage( mbedtls_x509write_cert *ctx,
         return( MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE );
 
     c = buf + 5;
-    ku[0] = MBEDTLS_BYTE_0( key_usage );
-    ku[1] = MBEDTLS_BYTE_1( key_usage );
+    MBEDTLS_PUT_UINT16_LE( key_usage, ku, 0 );
     ret = mbedtls_asn1_write_named_bitstring( &c, buf, ku, 9 );
 
     if( ret < 0 )

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -251,8 +251,8 @@ int mbedtls_x509write_crt_set_key_usage( mbedtls_x509write_cert *ctx,
         return( MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE );
 
     c = buf + 5;
-    ku[0] = (unsigned char)( key_usage      );
-    ku[1] = (unsigned char)( key_usage >> 8 );
+    ku[0] = MBEDTLS_BYTE_0( key_usage );
+    ku[1] = MBEDTLS_BYTE_1( key_usage );
     ret = mbedtls_asn1_write_named_bitstring( &c, buf, ku, 9 );
 
     if( ret < 0 )

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -37,29 +37,6 @@
 
 #if !defined(MBEDTLS_XTEA_ALT)
 
-/*
- * 32-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT32_BE
-#define GET_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ] << 24 )             \
-        | ( (uint32_t) (b)[(i) + 1] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 2] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 3]       );            \
-}
-#endif
-
-#ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-}
-#endif
-
 void mbedtls_xtea_init( mbedtls_xtea_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_xtea_context ) );
@@ -84,7 +61,7 @@ void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] 
 
     for( i = 0; i < 4; i++ )
     {
-        GET_UINT32_BE( ctx->k[i], key, i << 2 );
+        MBEDTLS_GET_UINT32_BE( ctx->k[i], key, i << 2 );
     }
 }
 
@@ -98,8 +75,8 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx, int mode,
 
     k = ctx->k;
 
-    GET_UINT32_BE( v0, input, 0 );
-    GET_UINT32_BE( v1, input, 4 );
+    MBEDTLS_GET_UINT32_BE( v0, input, 0 );
+    MBEDTLS_GET_UINT32_BE( v1, input, 4 );
 
     if( mode == MBEDTLS_XTEA_ENCRYPT )
     {
@@ -124,8 +101,8 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx, int mode,
         }
     }
 
-    PUT_UINT32_BE( v0, output, 0 );
-    PUT_UINT32_BE( v1, output, 4 );
+    MBEDTLS_PUT_UINT32_BE( v0, output, 0 );
+    MBEDTLS_PUT_UINT32_BE( v1, output, 4 );
 
     return( 0 );
 }

--- a/library/xtea.c
+++ b/library/xtea.c
@@ -61,7 +61,7 @@ void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] 
 
     for( i = 0; i < 4; i++ )
     {
-        MBEDTLS_GET_UINT32_BE( ctx->k[i], key, i << 2 );
+        ctx->k[i] = MBEDTLS_GET_UINT32_BE( key, i << 2 );
     }
 }
 
@@ -75,8 +75,8 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx, int mode,
 
     k = ctx->k;
 
-    MBEDTLS_GET_UINT32_BE( v0, input, 0 );
-    MBEDTLS_GET_UINT32_BE( v1, input, 4 );
+    v0 = MBEDTLS_GET_UINT32_BE( input, 0 );
+    v1 = MBEDTLS_GET_UINT32_BE( input, 4 );
 
     if( mode == MBEDTLS_XTEA_ENCRYPT )
     {


### PR DESCRIPTION
## Description

Defined `MBEDTLS_BYTE_n` macros which select the nth byte of data and replaced the appropriate lines with the macro function call.

Defined the following in `library/common.h` and removed the corresponding definitions from individual files utilising them.
 - `PUT_UINT(16, 32, 64)_(BE, LE)( n, data, offset )`
 - `GET_UINT(16, 32, 64)_(BE, LE)( data, offset )`
All were prefixed with `MBEDTLS_` to match the test `tests/scripts/check-names.sh`

This was done to save space, improve readability and improve maintenance by not having to modify or implement code in multiple places.

Closes #4274

## Status
**READY**

## Requires Backporting
NO  
This is a backport from [development](https://github.com/ARMmbed/mbedtls/pull/4716)

## Migrations
NO

## Additional comments
Instances of UINT32 and & 0xff ) etc. were located using a simple bash script which just takes a given parameter and uses it to locate for all instances of a string all .c files. I can therefore say that I believe all instances of the code that could be replaced by the macros, has been.

## Todos
- [x] Tests
- No Changelog needed

## Steps to test or reproduce
As multiple files are modified in library/, running all tests with make test seems most appropriate.