### PR TITLE
Fix release scripts for 3.0

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -24,6 +24,8 @@
 #                           [ -v | --verbose ] [ -h | --help ]
 #
 
+set -e
+
 VERSION=""
 SOVERSION=""
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -81,6 +81,10 @@ then
   exit 1
 fi
 
+[ $VERBOSE ] && echo "Bumping VERSION in CMakeLists.txt"
+sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < CMakeLists.txt > tmp
+mv tmp CMakeLists.txt
+
 [ $VERBOSE ] && echo "Bumping VERSION in library/CMakeLists.txt"
 sed -e "s/ VERSION [0-9.]\{1,\}/ VERSION $VERSION/g" < library/CMakeLists.txt > tmp
 mv tmp library/CMakeLists.txt

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -122,10 +122,10 @@ then
   mv tmp library/Makefile
 fi
 
-[ $VERBOSE ] && echo "Bumping VERSION in include/mbedtls/version.h"
+[ $VERBOSE ] && echo "Bumping VERSION in include/mbedtls/build_info.h"
 read MAJOR MINOR PATCH <<<$(IFS="."; echo $VERSION)
 VERSION_NR="$( printf "0x%02X%02X%02X00" $MAJOR $MINOR $PATCH )"
-cat include/mbedtls/version.h |                                    \
+cat include/mbedtls/build_info.h |                                    \
     sed -e "s/_VERSION_MAJOR .\{1,\}/_VERSION_MAJOR  $MAJOR/" |    \
     sed -e "s/_VERSION_MINOR .\{1,\}/_VERSION_MINOR  $MINOR/" |    \
     sed -e "s/_VERSION_PATCH .\{1,\}/_VERSION_PATCH  $PATCH/" |    \
@@ -133,7 +133,7 @@ cat include/mbedtls/version.h |                                    \
     sed -e "s/_VERSION_STRING .\{1,\}/_VERSION_STRING         \"$VERSION\"/" |    \
     sed -e "s/_VERSION_STRING_FULL .\{1,\}/_VERSION_STRING_FULL    \"mbed TLS $VERSION\"/" \
     > tmp
-mv tmp include/mbedtls/version.h
+mv tmp include/mbedtls/build_info.h
 
 [ $VERBOSE ] && echo "Bumping version in tests/suites/test_suite_version.data"
 sed -e "s/version:\".\{1,\}/version:\"$VERSION\"/g" < tests/suites/test_suite_version.data > tmp

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -23,12 +23,13 @@ set -eu
 
 if [ $# -ne 0 ] && [ "$1" = "--help" ]; then
     cat <<EOF
-$0 [-u]
+$0 [-l | -u]
 This script checks that all generated file are up-to-date. If some aren't, by
 default the scripts reports it and exits in error; with the -u option, it just
 updates them instead.
 
   -u    Update the files rather than return an error for out-of-date files.
+  -l    List generated files, but do not update them.
 EOF
     exit
 fi
@@ -39,10 +40,13 @@ if [ -d library -a -d include -a -d tests ]; then :; else
 fi
 
 UPDATE=
-if [ $# -ne 0 ] && [ "$1" = "-u" ]; then
-    shift
-    UPDATE='y'
-fi
+LIST=
+while getopts lu OPTLET; do
+    case $OPTLET in
+      l) LIST=1;;
+      u) UPDATE=1;;
+    esac
+done
 
 # check SCRIPT FILENAME[...]
 # check SCRIPT DIRECTORY
@@ -57,6 +61,11 @@ check()
 {
     SCRIPT=$1
     shift
+
+    if [ -n "$LIST" ]; then
+        printf '%s\n' "$@"
+        return
+    fi
 
     directory=
     if [ -d "$1" ]; then


### PR DESCRIPTION
* Adapt `bump_versions.sh` for the places where the version number appears in 3.0. Fix #4744.
* `check-generated-files -l` now lists the generated files, which would have been useful when preparing the release.

No backports needed since none of the changes are required on 2.27.
