### PR TITLE
Fix memory leak on failure path in test code

### DIFF
--- a/programs/ssl/ssl_test_common_source.c
+++ b/programs/ssl/ssl_test_common_source.c
@@ -167,7 +167,8 @@ int ssl_check_record( mbedtls_ssl_context const *ssl,
         if( ret != ret_repeated )
         {
             mbedtls_printf( "mbedtls_ssl_check_record() returned inconsistent results.\n" );
-            return( -1 );
+            ret = -1;
+            goto cleanup;
         }
 
         switch( ret )
@@ -178,29 +179,34 @@ int ssl_check_record( mbedtls_ssl_context const *ssl,
             case MBEDTLS_ERR_SSL_INVALID_RECORD:
                 if( opt.debug_level > 1 )
                     mbedtls_printf( "mbedtls_ssl_check_record() detected invalid record.\n" );
+                ret = 0;
                 break;
 
             case MBEDTLS_ERR_SSL_INVALID_MAC:
                 if( opt.debug_level > 1 )
                     mbedtls_printf( "mbedtls_ssl_check_record() detected unauthentic record.\n" );
+                ret = 0;
                 break;
 
             case MBEDTLS_ERR_SSL_UNEXPECTED_RECORD:
                 if( opt.debug_level > 1 )
                     mbedtls_printf( "mbedtls_ssl_check_record() detected unexpected record.\n" );
+                ret = 0;
                 break;
 
             default:
                 mbedtls_printf( "mbedtls_ssl_check_record() failed fatally with -%#04x.\n", (unsigned int) -ret );
-                return( -1 );
+                ret = -1;
+                goto cleanup;
         }
 
         /* Regardless of the outcome, forward the record to the stack. */
     }
 
+cleanup:
     mbedtls_free( tmp_buf );
 
-    return( 0 );
+    return( ret );
 }
 
 int recv_cb( void *ctx, unsigned char *buf, size_t len )


### PR DESCRIPTION
Found by @mstarzyk-mobica in the process of developing #4708, but this is an independent bug.

Needs backporting: 
- [x] 2.x #4761 
- [x] 2.16 doesn't have `check_record()` so it's not affected
