### PR TITLE
Test block sizes are powers of 2

### DIFF
--- a/tests/suites/test_suite_psa_crypto_metadata.data
+++ b/tests/suites/test_suite_psa_crypto_metadata.data
@@ -293,15 +293,27 @@ key_type:PSA_KEY_TYPE_DERIVE:KEY_TYPE_IS_UNSTRUCTURED
 
 Block cipher key type: AES
 depends_on:PSA_WANT_KEY_TYPE_AES
-block_cipher_key_type:PSA_KEY_TYPE_AES:16
+block_cipher_key_type:PSA_KEY_TYPE_AES:16:0
 
 Block cipher key type: DES
 depends_on:PSA_WANT_KEY_TYPE_DES
-block_cipher_key_type:PSA_KEY_TYPE_DES:8
+block_cipher_key_type:PSA_KEY_TYPE_DES:8:0
 
 Block cipher key type: Camellia
 depends_on:PSA_WANT_KEY_TYPE_CAMELLIA
-block_cipher_key_type:PSA_KEY_TYPE_CAMELLIA:16
+block_cipher_key_type:PSA_KEY_TYPE_CAMELLIA:16:0
+
+Block cipher key type: AES
+depends_on:PSA_WANT_KEY_TYPE_AES
+block_cipher_key_type:PSA_KEY_TYPE_AES:24:1
+
+Block cipher key type: AES
+depends_on:PSA_WANT_KEY_TYPE_AES
+block_cipher_key_type:PSA_KEY_TYPE_AES:12:1
+
+Block cipher key type: DES
+depends_on:PSA_WANT_KEY_TYPE_DES
+block_cipher_key_type:PSA_KEY_TYPE_DES:24:1
 
 Stream cipher key type: ChaCha20
 depends_on:PSA_WANT_KEY_TYPE_CHACHA20

--- a/tests/suites/test_suite_psa_crypto_metadata.data
+++ b/tests/suites/test_suite_psa_crypto_metadata.data
@@ -293,27 +293,15 @@ key_type:PSA_KEY_TYPE_DERIVE:KEY_TYPE_IS_UNSTRUCTURED
 
 Block cipher key type: AES
 depends_on:PSA_WANT_KEY_TYPE_AES
-block_cipher_key_type:PSA_KEY_TYPE_AES:16:0
+block_cipher_key_type:PSA_KEY_TYPE_AES:16
 
 Block cipher key type: DES
 depends_on:PSA_WANT_KEY_TYPE_DES
-block_cipher_key_type:PSA_KEY_TYPE_DES:8:0
+block_cipher_key_type:PSA_KEY_TYPE_DES:8
 
 Block cipher key type: Camellia
 depends_on:PSA_WANT_KEY_TYPE_CAMELLIA
-block_cipher_key_type:PSA_KEY_TYPE_CAMELLIA:16:0
-
-Block cipher key type: AES non power 2 block_size  (24)
-depends_on:PSA_WANT_KEY_TYPE_AES
-block_cipher_key_type:PSA_KEY_TYPE_AES:24:1
-
-Block cipher key type: AES non power 2 block_size (12)
-depends_on:PSA_WANT_KEY_TYPE_AES
-block_cipher_key_type:PSA_KEY_TYPE_AES:12:1
-
-Block cipher key type: DES non power 2 block_size (24)
-depends_on:PSA_WANT_KEY_TYPE_DES
-block_cipher_key_type:PSA_KEY_TYPE_DES:24:1
+block_cipher_key_type:PSA_KEY_TYPE_CAMELLIA:16
 
 Stream cipher key type: ChaCha20
 depends_on:PSA_WANT_KEY_TYPE_CHACHA20

--- a/tests/suites/test_suite_psa_crypto_metadata.data
+++ b/tests/suites/test_suite_psa_crypto_metadata.data
@@ -303,15 +303,15 @@ Block cipher key type: Camellia
 depends_on:PSA_WANT_KEY_TYPE_CAMELLIA
 block_cipher_key_type:PSA_KEY_TYPE_CAMELLIA:16:0
 
-Block cipher key type: AES
+Block cipher key type: AES non power 2 block_size  (24)
 depends_on:PSA_WANT_KEY_TYPE_AES
 block_cipher_key_type:PSA_KEY_TYPE_AES:24:1
 
-Block cipher key type: AES
+Block cipher key type: AES non power 2 block_size (12)
 depends_on:PSA_WANT_KEY_TYPE_AES
 block_cipher_key_type:PSA_KEY_TYPE_AES:12:1
 
-Block cipher key type: DES
+Block cipher key type: DES non power 2 block_size (24)
 depends_on:PSA_WANT_KEY_TYPE_DES
 block_cipher_key_type:PSA_KEY_TYPE_DES:24:1
 

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -619,7 +619,7 @@ void key_type( int type_arg, int classification_flags )
 /* END_CASE */
 
 /* BEGIN_CASE */
-void block_cipher_key_type( int type_arg, int block_size_arg)
+void block_cipher_key_type( int type_arg, int block_size_arg )
 {
     psa_key_type_t type = type_arg;
     size_t block_size = block_size_arg;
@@ -628,7 +628,6 @@ void block_cipher_key_type( int type_arg, int block_size_arg)
 
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
-
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
     /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -630,7 +630,7 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
-    /* Check that the block size is a power of 2. This is required, at least, 
+    /* Check that the block size is a power of 2. This is required, at least,
     for PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h. */
     TEST_ASSERT( ( ( block_size - 1 ) & block_size ) == 0 );
 }

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -619,7 +619,7 @@ void key_type( int type_arg, int classification_flags )
 /* END_CASE */
 
 /* BEGIN_CASE */
-void block_cipher_key_type( int type_arg, int block_size_arg )
+void block_cipher_key_type( int type_arg, int block_size_arg, int expecting_power_2 )
 {
     psa_key_type_t type = type_arg;
     size_t block_size = block_size_arg;
@@ -628,7 +628,27 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
 
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
-    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
+
+    if (expecting_power_2 == 0)
+        TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
+
+    /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h
+     * Requires block sizes to be a power of 2. The following test ensures
+     * the block sizes are indeed powers of 2.
+     */
+    int check = 0;
+
+    while( block_size > 1)
+    {
+        if ( block_size % 2 != 0 )
+        {
+            check = 1;
+            break;
+        }
+        block_size = block_size / 2;
+    }
+    /* expecting_power_2 should be 0 if true (e.g 16, 32 etc.) or 1 otherwise */
+    TEST_EQUAL( check, expecting_power_2 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -619,7 +619,7 @@ void key_type( int type_arg, int classification_flags )
 /* END_CASE */
 
 /* BEGIN_CASE */
-void block_cipher_key_type( int type_arg, int block_size_arg, int expecting_power_2 )
+void block_cipher_key_type( int type_arg, int block_size_arg)
 {
     psa_key_type_t type = type_arg;
     size_t block_size = block_size_arg;
@@ -629,26 +629,29 @@ void block_cipher_key_type( int type_arg, int block_size_arg, int expecting_powe
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
 
-    if (expecting_power_2 == 0)
-        TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
+    TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
     /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h
-     * Requires block sizes to be a power of 2. The following test ensures
-     * the block sizes are indeed powers of 2.
+     * Requires block sizes to be a power of 2.
+     * The following creates a bit and shifts along until it finds a
+     * match or a mismatch.
      */
     int check = 0;
 
-    while( block_size > 1)
+    for (size_t index = 1; index > 0; index = index << 1)
     {
-        if ( block_size % 2 != 0 )
+        if (index == block_size)
+        {
+            check = 0;
+            break;
+        }
+        if (index > block_size)
         {
             check = 1;
             break;
         }
-        block_size = block_size / 2;
     }
-    /* expecting_power_2 should be 0 if true (e.g 16, 32 etc.) or 1 otherwise */
-    TEST_EQUAL( check, expecting_power_2 );
+    TEST_EQUAL( check, 0);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -630,27 +630,9 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
-    /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h
-     * Requires block sizes to be a power of 2.
-     * The following creates a bit and shifts along until it finds a
-     * match or a mismatch.
-     */
-    int check = 0;
-
-    for (size_t index = 1; index > 0; index = index << 1)
-    {
-        if (index == block_size)
-        {
-            check = 0;
-            break;
-        }
-        if (index > block_size)
-        {
-            check = 1;
-            break;
-        }
-    }
-    TEST_EQUAL( check, 0);
+    /* Check that the block size is a power of 2. This is required, at least, 
+    for PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h. */
+    TEST_ASSERT( ( ( block_size - 1 ) & block_size ) == 0 );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
Extended `test_suite_psa_crypto_metadata` as per Gilles suggestion to check the block size is a power of 2.

This is done by shifting a bit repeatedly until the value of the number is greater than or equal to the block_size to evaluate if it is a power of 2 or not

Closes #4228

## Status
**READY**

## Requires Backporting
Yes
[development_2.x](https://github.com/ARMmbed/mbedtls/pull/4768)

## Migrations
NO

## Todos
- [x] Tests
- [x] Backported


## Steps to test or reproduce
Run `test_suite_psa_crypto_metadata` and it will pass. 
If you insert `block_size = 12` (or any non power of 2 number) above the power of 2 check, then it will fail.
