### PR TITLE
Remove redundant hash len check

### DIFF
--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2023,8 +2023,6 @@ static int rsa_rsassa_pkcs1_v15_encode( mbedtls_md_type_t md_alg,
      *                                 TAG-NULL + LEN [ NULL ] ]
      *                 TAG-OCTET + LEN [ HASH ] ]
      */
-    if( 0x08 + oid_size + hashlen >= 0x80 )
-        return( MBEDTLS_ERR_RSA_BAD_INPUT_DATA );
     *p++ = MBEDTLS_ASN1_SEQUENCE | MBEDTLS_ASN1_CONSTRUCTED;
     *p++ = (unsigned char)( 0x08 + oid_size + hashlen );
     *p++ = MBEDTLS_ASN1_SEQUENCE | MBEDTLS_ASN1_CONSTRUCTED;


### PR DESCRIPTION
Remove a check in rsa_rsassa_pkcs1_v15_encode() that
is not needed because the same check is performed
earlier. This check was added in #4707.

Signed-off-by: David Horstmann <david.horstmann@arm.com>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
This PR removes a bounds check on `hashlen` that was added in #4707. This check is already performed in line 1965 on all code paths that also reach this check. As a result, it is redundant and can be removed.


## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest
