### PR TITLE
Backport 2.x: Test block sizes are powers of 2

### DIFF
--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -603,6 +603,28 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
     TEST_EQUAL( type & PSA_KEY_TYPE_CATEGORY_MASK,
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
+
+    /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h
+     * Requires block sizes to be a power of 2.
+     * The following creates a bit and shifts along until it finds a
+     * match or a mismatch.
+     */
+    int check = 0;
+
+    for (size_t index = 1; index > 0; index = index << 1)
+    {
+        if (index == block_size)
+        {
+            check = 0;
+            break;
+        }
+        if (index > block_size)
+        {
+            check = 1;
+            break;
+        }
+    }
+    TEST_EQUAL( check, 0);
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -604,27 +604,9 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
-    /* PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h
-     * Requires block sizes to be a power of 2.
-     * The following creates a bit and shifts along until it finds a
-     * match or a mismatch.
-     */
-    int check = 0;
-
-    for (size_t index = 1; index > 0; index = index << 1)
-    {
-        if (index == block_size)
-        {
-            check = 0;
-            break;
-        }
-        if (index > block_size)
-        {
-            check = 1;
-            break;
-        }
-    }
-    TEST_EQUAL( check, 0);
+    /* Check that the block size is a power of 2. This is required, at least, 
+    for PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h. */
+    TEST_ASSERT( ( ( block_size - 1 ) & block_size ) == 0 );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -604,7 +604,7 @@ void block_cipher_key_type( int type_arg, int block_size_arg )
                 PSA_KEY_TYPE_CATEGORY_SYMMETRIC );
     TEST_EQUAL( PSA_BLOCK_CIPHER_BLOCK_LENGTH( type ), block_size );
 
-    /* Check that the block size is a power of 2. This is required, at least, 
+    /* Check that the block size is a power of 2. This is required, at least,
     for PSA_ROUND_UP_TO_MULTIPLE(block_size, length) in crypto_sizes.h. */
     TEST_ASSERT( ( ( block_size - 1 ) & block_size ) == 0 );
 }


### PR DESCRIPTION
## Description
Extended `test_suite_psa_crypto_metadata` as per Gilles suggestion to check the block size is a power of 2.

This is done by shifting a bit repeatedly until the value of the number is greater than or equal to the `block_size` to evaluate if it is a power of 2 or not

Closes #4228

## Status
**READY**

## Requires Backporting
NO
This is a backport from [development](https://github.com/ARMmbed/mbedtls/pull/4753)

## Migrations
NO

## Todos
- [x] Tests

## Steps to test or reproduce
Run `test_suite_psa_crypto_metadata` and it will pass. 
If you insert `block_size = 12` (or any non power of 2 number) above the power of 2 check, then it will fail.