### PR TITLE
Backport 2.16: Prevent triggering Clang 12 -Wstring-concatenation warning

### DIFF
--- a/library/md2.c
+++ b/library/md2.c
@@ -320,8 +320,7 @@ static const unsigned char md2_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md2_test_strlen[7] =

--- a/library/md2.c
+++ b/library/md2.c
@@ -320,8 +320,8 @@ static const unsigned char md2_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md2_test_strlen[7] =

--- a/library/md4.c
+++ b/library/md4.c
@@ -444,8 +444,7 @@ static const unsigned char md4_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md4_test_strlen[7] =

--- a/library/md4.c
+++ b/library/md4.c
@@ -444,8 +444,8 @@ static const unsigned char md4_test_str[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md4_test_strlen[7] =

--- a/library/md5.c
+++ b/library/md5.c
@@ -458,8 +458,7 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") }
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" }
 };
 
 static const size_t md5_test_buflen[7] =

--- a/library/md5.c
+++ b/library/md5.c
@@ -458,8 +458,8 @@ static const unsigned char md5_test_buf[7][81] =
     { "message digest" },
     { "abcdefghijklmnopqrstuvwxyz" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" }
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") }
 };
 
 static const size_t md5_test_buflen[7] =

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -514,8 +514,8 @@ static const unsigned char ripemd160_test_str[TESTS][81] =
     { "abcdefghijklmnopqrstuvwxyz" },
     { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { "12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890" },
+    { ("12345678901234567890123456789012345678901234567890123456789012"
+      "345678901234567890") },
 };
 
 static const size_t ripemd160_test_strlen[TESTS] =

--- a/library/ripemd160.c
+++ b/library/ripemd160.c
@@ -514,8 +514,7 @@ static const unsigned char ripemd160_test_str[TESTS][81] =
     { "abcdefghijklmnopqrstuvwxyz" },
     { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" },
     { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" },
-    { ("12345678901234567890123456789012345678901234567890123456789012"
-      "345678901234567890") },
+    { "12345678901234567890123456789012345678901234567890123456789012345678901234567890" },
 };
 
 static const size_t ripemd160_test_strlen[TESTS] =

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -527,8 +527,8 @@ void mbedtls_sha512( const unsigned char *input,
 static const unsigned char sha512_test_buf[3][113] =
 {
     { "abc" },
-    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
+    { ("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") },
     { "" }
 };
 

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -527,8 +527,7 @@ void mbedtls_sha512( const unsigned char *input,
 static const unsigned char sha512_test_buf[3][113] =
 {
     { "abc" },
-    { ("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu") },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
     { "" }
 };
 


### PR DESCRIPTION
Trivial backport of https://github.com/ARMmbed/mbedtls/pull/3588. Closes https://github.com/ARMmbed/mbedtls/issues/3666.
