### PR TITLE
Explicitly mark fields as private via MBEDTLS_PRIVATE(...)

### DIFF
--- a/ChangeLog.d/session_export_private.txt
+++ b/ChangeLog.d/session_export_private.txt
@@ -1,0 +1,5 @@
+Changes
+    * Explicitly mark the fields mbedtls_ssl_session.exported and
+      mbedtls_ssl_config.respect_cli_pref as private. This was an
+      oversight during the run-up to the release of Mbed TLS 3.0.
+      The fields were never intended to be public.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1214,7 +1214,7 @@ struct mbedtls_ssl_config
 #if defined(MBEDTLS_SSL_SRV_C)
     unsigned int MBEDTLS_PRIVATE(cert_req_ca_list) : 1;  /*!< enable sending CA list in
                                           Certificate Request messages?     */
-    unsigned int respect_cli_pref : 1;  /*!< pick the ciphersuite according to
+    unsigned int MBEDTLS_PRIVATE(respect_cli_pref) : 1;  /*!< pick the ciphersuite according to
                                           the client's preferences rather
                                           than ours                         */
 #endif

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -925,7 +925,7 @@ struct mbedtls_ssl_session
     unsigned char MBEDTLS_PRIVATE(id)[32];       /*!< session identifier */
     unsigned char MBEDTLS_PRIVATE(master)[48];   /*!< the master secret  */
 
-    unsigned char exported;
+    unsigned char MBEDTLS_PRIVATE(exported);
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)


### PR DESCRIPTION
The fact that those fields were not explicitly marked private currently is an oversight due to concurrent merging of PRs during the run-up to the release of Mbed TLS 3.0.