### PR TITLE
Reorder structure fields to maximize usage of immediate offset access

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -303,11 +303,29 @@ typedef struct mbedtls_cipher_info_t
  */
 typedef struct mbedtls_cipher_context_t
 {
-    /** Information about the associated cipher. */
-    const mbedtls_cipher_info_t *MBEDTLS_PRIVATE(cipher_info);
+    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
+     * for XTS-mode. */
+    unsigned char MBEDTLS_PRIVATE(iv)[MBEDTLS_MAX_IV_LENGTH];
+
+    /** Buffer for input that has not been processed yet. */
+    unsigned char MBEDTLS_PRIVATE(unprocessed_data)[MBEDTLS_MAX_BLOCK_LENGTH];
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    /** Indicates whether the cipher operations should be performed
+     *  by Mbed TLS' own crypto library or an external implementation
+     *  of the PSA Crypto API.
+     *  This is unset if the cipher context was established through
+     *  mbedtls_cipher_setup(), and set if it was established through
+     *  mbedtls_cipher_setup_psa().
+     */
+    unsigned char MBEDTLS_PRIVATE(psa_enabled);
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /** Key length to use. */
     int MBEDTLS_PRIVATE(key_bitlen);
+
+    /** Information about the associated cipher. */
+    const mbedtls_cipher_info_t *MBEDTLS_PRIVATE(cipher_info);
 
     /** Operation that the key of the context has been
      * initialized for.
@@ -322,15 +340,8 @@ typedef struct mbedtls_cipher_context_t
     int (*MBEDTLS_PRIVATE(get_padding))( unsigned char *input, size_t ilen, size_t *data_len );
 #endif
 
-    /** Buffer for input that has not been processed yet. */
-    unsigned char MBEDTLS_PRIVATE(unprocessed_data)[MBEDTLS_MAX_BLOCK_LENGTH];
-
     /** Number of Bytes that have not been processed yet. */
     size_t MBEDTLS_PRIVATE(unprocessed_len);
-
-    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
-     * for XTS-mode. */
-    unsigned char MBEDTLS_PRIVATE(iv)[MBEDTLS_MAX_IV_LENGTH];
 
     /** IV size in Bytes, for ciphers with variable-length IVs. */
     size_t MBEDTLS_PRIVATE(iv_size);
@@ -342,17 +353,6 @@ typedef struct mbedtls_cipher_context_t
     /** CMAC-specific context. */
     mbedtls_cmac_context_t *MBEDTLS_PRIVATE(cmac_ctx);
 #endif
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    /** Indicates whether the cipher operations should be performed
-     *  by Mbed TLS' own crypto library or an external implementation
-     *  of the PSA Crypto API.
-     *  This is unset if the cipher context was established through
-     *  mbedtls_cipher_setup(), and set if it was established through
-     *  mbedtls_cipher_setup_psa().
-     */
-    unsigned char MBEDTLS_PRIVATE(psa_enabled);
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 } mbedtls_cipher_context_t;
 

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -57,17 +57,17 @@ extern "C" {
  */
 typedef struct mbedtls_gcm_context
 {
-    mbedtls_cipher_context_t MBEDTLS_PRIVATE(cipher_ctx);  /*!< The cipher context used. */
-    uint64_t MBEDTLS_PRIVATE(HL)[16];                      /*!< Precalculated HTable low. */
-    uint64_t MBEDTLS_PRIVATE(HH)[16];                      /*!< Precalculated HTable high. */
-    uint64_t MBEDTLS_PRIVATE(len);                         /*!< The total length of the encrypted data. */
-    uint64_t MBEDTLS_PRIVATE(add_len);                     /*!< The total length of the additional data. */
     unsigned char MBEDTLS_PRIVATE(base_ectr)[16];          /*!< The first ECTR for tag. */
     unsigned char MBEDTLS_PRIVATE(y)[16];                  /*!< The Y working value. */
     unsigned char MBEDTLS_PRIVATE(buf)[16];                /*!< The buf working value. */
     int MBEDTLS_PRIVATE(mode);                             /*!< The operation to perform:
                                                #MBEDTLS_GCM_ENCRYPT or
                                                #MBEDTLS_GCM_DECRYPT. */
+    uint64_t MBEDTLS_PRIVATE(HL)[16];                      /*!< Precalculated HTable low. */
+    uint64_t MBEDTLS_PRIVATE(HH)[16];                      /*!< Precalculated HTable high. */
+    uint64_t MBEDTLS_PRIVATE(len);                         /*!< The total length of the encrypted data. */
+    uint64_t MBEDTLS_PRIVATE(add_len);                     /*!< The total length of the additional data. */
+    mbedtls_cipher_context_t MBEDTLS_PRIVATE(cipher_ctx);  /*!< The cipher context used. */
 }
 mbedtls_gcm_context;
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -50,9 +50,9 @@ extern "C" {
  */
 typedef struct mbedtls_md5_context
 {
+    unsigned char MBEDTLS_PRIVATE(buffer)[64];   /*!< data block being processed */
     uint32_t MBEDTLS_PRIVATE(total)[2];          /*!< number of bytes processed  */
     uint32_t MBEDTLS_PRIVATE(state)[4];          /*!< intermediate digest state  */
-    unsigned char MBEDTLS_PRIVATE(buffer)[64];   /*!< data block being processed */
 }
 mbedtls_md5_context;
 

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -49,10 +49,10 @@ extern "C" {
 
 typedef struct mbedtls_poly1305_context
 {
+    uint8_t MBEDTLS_PRIVATE(queue)[16];  /** The current partial block of data. */
     uint32_t MBEDTLS_PRIVATE(r)[4];      /** The value for 'r' (low 128 bits of the key). */
     uint32_t MBEDTLS_PRIVATE(s)[4];      /** The value for 's' (high 128 bits of the key). */
     uint32_t MBEDTLS_PRIVATE(acc)[5];    /** The accumulator number. */
-    uint8_t MBEDTLS_PRIVATE(queue)[16];  /** The current partial block of data. */
     size_t MBEDTLS_PRIVATE(queue_len);   /** The number of bytes stored in 'queue'. */
 }
 mbedtls_poly1305_context;

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -966,6 +966,12 @@ mbedtls_dtls_srtp_info;
  */
 struct mbedtls_ssl_session
 {
+#if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
+    unsigned char MBEDTLS_PRIVATE(mfl_code);     /*!< MaxFragmentLength negotiated by peer */
+#endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
+
+    unsigned char MBEDTLS_PRIVATE(exported);
+
 #if defined(MBEDTLS_HAVE_TIME)
     mbedtls_time_t MBEDTLS_PRIVATE(start);       /*!< starting time      */
 #endif
@@ -974,8 +980,6 @@ struct mbedtls_ssl_session
     size_t MBEDTLS_PRIVATE(id_len);              /*!< session id length  */
     unsigned char MBEDTLS_PRIVATE(id)[32];       /*!< session identifier */
     unsigned char MBEDTLS_PRIVATE(master)[48];   /*!< the master secret  */
-
-    unsigned char MBEDTLS_PRIVATE(exported);
 
     /* This field is temporarily duplicated with mbedtls_ssl_context.minor_ver.
      * Once runtime negotiation of TLS 1.2 and TLS 1.3 is implemented, it needs
@@ -1000,10 +1004,6 @@ struct mbedtls_ssl_session
     size_t MBEDTLS_PRIVATE(ticket_len);          /*!< session ticket length   */
     uint32_t MBEDTLS_PRIVATE(ticket_lifetime);   /*!< ticket lifetime hint    */
 #endif /* MBEDTLS_SSL_SESSION_TICKETS && MBEDTLS_SSL_CLI_C */
-
-#if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    unsigned char MBEDTLS_PRIVATE(mfl_code);     /*!< MaxFragmentLength negotiated by peer */
-#endif /* MBEDTLS_SSL_MAX_FRAGMENT_LENGTH */
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     int MBEDTLS_PRIVATE(encrypt_then_mac);       /*!< flag for EtM activation                */
@@ -1066,7 +1066,86 @@ typedef void mbedtls_ssl_export_keys_t( void *p_expkey,
  */
 struct mbedtls_ssl_config
 {
-    /* Group items by size (largest first) to minimize padding overhead */
+     /* Group items by size and reorder them to maximize usage of immediate offset access.    */
+
+
+    /*
+     * Numerical settings (char)
+     */
+
+    unsigned char MBEDTLS_PRIVATE(max_major_ver);    /*!< max. major version used            */
+    unsigned char MBEDTLS_PRIVATE(max_minor_ver);    /*!< max. minor version used            */
+    unsigned char MBEDTLS_PRIVATE(min_major_ver);    /*!< min. major version used            */
+    unsigned char MBEDTLS_PRIVATE(min_minor_ver);    /*!< min. minor version used            */
+
+   /*
+     * Flags (bitfields)
+     */
+
+    unsigned int MBEDTLS_PRIVATE(endpoint) : 1;      /*!< 0: client, 1: server               */
+    unsigned int MBEDTLS_PRIVATE(transport) : 1;     /*!< stream (TLS) or datagram (DTLS)    */
+    unsigned int MBEDTLS_PRIVATE(authmode) : 2;      /*!< MBEDTLS_SSL_VERIFY_XXX             */
+    /* needed even with renego disabled for LEGACY_BREAK_HANDSHAKE          */
+    unsigned int MBEDTLS_PRIVATE(allow_legacy_renegotiation) : 2 ; /*!< MBEDTLS_LEGACY_XXX   */
+#if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
+    unsigned int MBEDTLS_PRIVATE(mfl_code) : 3;      /*!< desired fragment length            */
+#endif
+#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
+    unsigned int MBEDTLS_PRIVATE(encrypt_then_mac) : 1 ; /*!< negotiate encrypt-then-mac?    */
+#endif
+#if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
+    unsigned int MBEDTLS_PRIVATE(extended_ms) : 1;   /*!< negotiate extended master secret?  */
+#endif
+#if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
+    unsigned int MBEDTLS_PRIVATE(anti_replay) : 1;   /*!< detect and prevent replay?         */
+#endif
+#if defined(MBEDTLS_SSL_RENEGOTIATION)
+    unsigned int MBEDTLS_PRIVATE(disable_renegotiation) : 1; /*!< disable renegotiation?     */
+#endif
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+    unsigned int MBEDTLS_PRIVATE(session_tickets) : 1;   /*!< use session tickets?           */
+#endif
+#if defined(MBEDTLS_SSL_SRV_C)
+    unsigned int MBEDTLS_PRIVATE(cert_req_ca_list) : 1;  /*!< enable sending CA list in
+                                          Certificate Request messages?     */
+    unsigned int MBEDTLS_PRIVATE(respect_cli_pref) : 1;  /*!< pick the ciphersuite according to
+                                          the client's preferences rather
+                                          than ours                         */
+#endif
+#if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
+    unsigned int MBEDTLS_PRIVATE(ignore_unexpected_cid) : 1; /*!< Determines whether DTLS
+                                             *   record with unexpected CID
+                                             *   should lead to failure.    */
+#endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
+#if defined(MBEDTLS_SSL_DTLS_SRTP)
+    unsigned int MBEDTLS_PRIVATE(dtls_srtp_mki_support) : 1; /* support having mki_value
+                                               in the use_srtp extension     */
+#endif
+
+    /*
+     * Numerical settings (int)
+     */
+
+    uint32_t MBEDTLS_PRIVATE(read_timeout);          /*!< timeout for mbedtls_ssl_read (ms)  */
+
+#if defined(MBEDTLS_SSL_PROTO_DTLS)
+    uint32_t MBEDTLS_PRIVATE(hs_timeout_min);        /*!< initial value of the handshake
+                                         retransmission timeout (ms)        */
+    uint32_t MBEDTLS_PRIVATE(hs_timeout_max);        /*!< maximum value of the handshake
+                                         retransmission timeout (ms)        */
+#endif
+
+    unsigned int MBEDTLS_PRIVATE(badmac_limit);      /*!< limit of records with a bad MAC    */
+
+#if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_CLI_C)
+    unsigned int MBEDTLS_PRIVATE(dhm_min_bitlen);    /*!< min. bit length of the DHM prime   */
+#endif
+
+#if defined(MBEDTLS_SSL_RENEGOTIATION)
+    int MBEDTLS_PRIVATE(renego_max_records);         /*!< grace period for renegotiation     */
+    unsigned char MBEDTLS_PRIVATE(renego_period)[8]; /*!< value of the record counters
+                                        that triggers renegotiation        */
+#endif
 
     /*
      * Pointers
@@ -1208,80 +1287,6 @@ struct mbedtls_ssl_config
     /*! number of supported profiles */
     size_t MBEDTLS_PRIVATE(dtls_srtp_profile_list_len);
 #endif /* MBEDTLS_SSL_DTLS_SRTP */
-
-    /*
-     * Numerical settings (int then char)
-     */
-
-    uint32_t MBEDTLS_PRIVATE(read_timeout);          /*!< timeout for mbedtls_ssl_read (ms)  */
-
-#if defined(MBEDTLS_SSL_PROTO_DTLS)
-    uint32_t MBEDTLS_PRIVATE(hs_timeout_min);        /*!< initial value of the handshake
-                                         retransmission timeout (ms)        */
-    uint32_t MBEDTLS_PRIVATE(hs_timeout_max);        /*!< maximum value of the handshake
-                                         retransmission timeout (ms)        */
-#endif
-
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-    int MBEDTLS_PRIVATE(renego_max_records);         /*!< grace period for renegotiation     */
-    unsigned char MBEDTLS_PRIVATE(renego_period)[8]; /*!< value of the record counters
-                                         that triggers renegotiation        */
-#endif
-
-    unsigned int MBEDTLS_PRIVATE(badmac_limit);      /*!< limit of records with a bad MAC    */
-
-#if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_SSL_CLI_C)
-    unsigned int MBEDTLS_PRIVATE(dhm_min_bitlen);    /*!< min. bit length of the DHM prime   */
-#endif
-
-    unsigned char MBEDTLS_PRIVATE(max_major_ver);    /*!< max. major version used            */
-    unsigned char MBEDTLS_PRIVATE(max_minor_ver);    /*!< max. minor version used            */
-    unsigned char MBEDTLS_PRIVATE(min_major_ver);    /*!< min. major version used            */
-    unsigned char MBEDTLS_PRIVATE(min_minor_ver);    /*!< min. minor version used            */
-
-    /*
-     * Flags (bitfields)
-     */
-
-    unsigned int MBEDTLS_PRIVATE(endpoint) : 1;      /*!< 0: client, 1: server               */
-    unsigned int MBEDTLS_PRIVATE(transport) : 1;     /*!< stream (TLS) or datagram (DTLS)    */
-    unsigned int MBEDTLS_PRIVATE(authmode) : 2;      /*!< MBEDTLS_SSL_VERIFY_XXX             */
-    /* needed even with renego disabled for LEGACY_BREAK_HANDSHAKE          */
-    unsigned int MBEDTLS_PRIVATE(allow_legacy_renegotiation) : 2 ; /*!< MBEDTLS_LEGACY_XXX   */
-#if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
-    unsigned int MBEDTLS_PRIVATE(mfl_code) : 3;      /*!< desired fragment length            */
-#endif
-#if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
-    unsigned int MBEDTLS_PRIVATE(encrypt_then_mac) : 1 ; /*!< negotiate encrypt-then-mac?    */
-#endif
-#if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
-    unsigned int MBEDTLS_PRIVATE(extended_ms) : 1;   /*!< negotiate extended master secret?  */
-#endif
-#if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
-    unsigned int MBEDTLS_PRIVATE(anti_replay) : 1;   /*!< detect and prevent replay?         */
-#endif
-#if defined(MBEDTLS_SSL_RENEGOTIATION)
-    unsigned int MBEDTLS_PRIVATE(disable_renegotiation) : 1; /*!< disable renegotiation?     */
-#endif
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
-    unsigned int MBEDTLS_PRIVATE(session_tickets) : 1;   /*!< use session tickets?           */
-#endif
-#if defined(MBEDTLS_SSL_SRV_C)
-    unsigned int MBEDTLS_PRIVATE(cert_req_ca_list) : 1;  /*!< enable sending CA list in
-                                          Certificate Request messages?     */
-    unsigned int MBEDTLS_PRIVATE(respect_cli_pref) : 1;  /*!< pick the ciphersuite according to
-                                          the client's preferences rather
-                                          than ours                         */
-#endif
-#if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-    unsigned int MBEDTLS_PRIVATE(ignore_unexpected_cid) : 1; /*!< Determines whether DTLS
-                                             *   record with unexpected CID
-                                             *   should lead to failure.    */
-#endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
-#if defined(MBEDTLS_SSL_DTLS_SRTP)
-    unsigned int MBEDTLS_PRIVATE(dtls_srtp_mki_support) : 1; /* support having mki_value
-                                               in the use_srtp extension     */
-#endif
 };
 
 struct mbedtls_ssl_context

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1066,7 +1066,7 @@ typedef void mbedtls_ssl_export_keys_t( void *p_expkey,
  */
 struct mbedtls_ssl_config
 {
-     /* Group items by size and reorder them to maximize usage of immediate offset access.    */
+    /* Group items by size and reorder them to maximize usage of immediate offset access.    */
 
 
     /*
@@ -1078,7 +1078,7 @@ struct mbedtls_ssl_config
     unsigned char MBEDTLS_PRIVATE(min_major_ver);    /*!< min. major version used            */
     unsigned char MBEDTLS_PRIVATE(min_minor_ver);    /*!< min. minor version used            */
 
-   /*
+    /*
      * Flags (bitfields)
      */
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1292,7 +1292,7 @@ struct mbedtls_ssl_config
 struct mbedtls_ssl_context
 {
     /*
-     * Secure renegotiation
+     * DTLS connection ID
      */
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     /* CID configuration to use in subsequent handshakes. */
@@ -1490,7 +1490,7 @@ struct mbedtls_ssl_context
 #endif /* MBEDTLS_SSL_DTLS_HELLO_VERIFY && MBEDTLS_SSL_SRV_C */
 
     /*
-     * Secure renegotiation (continued)
+     * Secure renegotiation
      */
     /* needed to know when to send extension on server */
     int MBEDTLS_PRIVATE(secure_renegotiation);           /*!<  does peer support legacy or

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -64,10 +64,11 @@ mbedtls_x509_crl_entry;
  */
 typedef struct mbedtls_x509_crl
 {
+    int MBEDTLS_PRIVATE(version);            /**< CRL version (1=v1, 2=v2) */
+    
     mbedtls_x509_buf MBEDTLS_PRIVATE(raw);           /**< The raw certificate data (DER). */
     mbedtls_x509_buf MBEDTLS_PRIVATE(tbs);           /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int MBEDTLS_PRIVATE(version);            /**< CRL version (1=v1, 2=v2) */
     mbedtls_x509_buf MBEDTLS_PRIVATE(sig_oid);       /**< CRL signature type identifier */
 
     mbedtls_x509_buf MBEDTLS_PRIVATE(issuer_raw);    /**< The raw issuer data (DER). */

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -65,7 +65,7 @@ mbedtls_x509_crl_entry;
 typedef struct mbedtls_x509_crl
 {
     int MBEDTLS_PRIVATE(version);            /**< CRL version (1=v1, 2=v2) */
-    
+
     mbedtls_x509_buf MBEDTLS_PRIVATE(raw);           /**< The raw certificate data (DER). */
     mbedtls_x509_buf MBEDTLS_PRIVATE(tbs);           /**< The raw certificate body (DER). The part that is To Be Signed. */
 

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -48,12 +48,21 @@ extern "C" {
  */
 typedef struct mbedtls_x509_crt
 {
+    unsigned char MBEDTLS_PRIVATE(ns_cert_type); /**< Optional Netscape certificate type extension value: See the values in x509.h */
+
     int MBEDTLS_PRIVATE(own_buffer);                     /**< Indicates if \c raw is owned
                                          *   by the structure or not.        */
+    int MBEDTLS_PRIVATE(ext_types);              /**< Bit string containing detected and parsed extensions */
+    int MBEDTLS_PRIVATE(ca_istrue);              /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
+    int MBEDTLS_PRIVATE(max_pathlen);            /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
+
+    int MBEDTLS_PRIVATE(version);                /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
+
+    unsigned int MBEDTLS_PRIVATE(key_usage);     /**< Optional key usage extension value: See the values in x509.h */
+
     mbedtls_x509_buf MBEDTLS_PRIVATE(raw);               /**< The raw certificate data (DER). */
     mbedtls_x509_buf MBEDTLS_PRIVATE(tbs);               /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int MBEDTLS_PRIVATE(version);                /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
     mbedtls_x509_buf MBEDTLS_PRIVATE(serial);            /**< Unique id for certificate issued by a specific CA. */
     mbedtls_x509_buf MBEDTLS_PRIVATE(sig_oid);           /**< Signature algorithm, e.g. sha1RSA */
 
@@ -76,15 +85,7 @@ typedef struct mbedtls_x509_crt
 
     mbedtls_x509_sequence MBEDTLS_PRIVATE(certificate_policies); /**< Optional list of certificate policies (Only anyPolicy is printed and enforced, however the rest of the policies are still listed). */
 
-    int MBEDTLS_PRIVATE(ext_types);              /**< Bit string containing detected and parsed extensions */
-    int MBEDTLS_PRIVATE(ca_istrue);              /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
-    int MBEDTLS_PRIVATE(max_pathlen);            /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
-
-    unsigned int MBEDTLS_PRIVATE(key_usage);     /**< Optional key usage extension value: See the values in x509.h */
-
     mbedtls_x509_sequence MBEDTLS_PRIVATE(ext_key_usage); /**< Optional list of extended key usage OIDs. */
-
-    unsigned char MBEDTLS_PRIVATE(ns_cert_type); /**< Optional Netscape certificate type extension value: See the values in x509.h */
 
     mbedtls_x509_buf MBEDTLS_PRIVATE(sig);               /**< Signature: hash of the tbs part signed with the private key. */
     mbedtls_md_type_t MBEDTLS_PRIVATE(sig_md);           /**< Internal representation of the MD algorithm of the signature algorithm, e.g. MBEDTLS_MD_SHA256 */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -45,10 +45,10 @@ extern "C" {
  */
 typedef struct mbedtls_x509_csr
 {
+    int MBEDTLS_PRIVATE(version);            /**< CSR version (1=v1). */
+    
     mbedtls_x509_buf MBEDTLS_PRIVATE(raw);           /**< The raw CSR data (DER). */
     mbedtls_x509_buf MBEDTLS_PRIVATE(cri);           /**< The raw CertificateRequestInfo body (DER). */
-
-    int MBEDTLS_PRIVATE(version);            /**< CSR version (1=v1). */
 
     mbedtls_x509_buf  MBEDTLS_PRIVATE(subject_raw);  /**< The raw subject data (DER). */
     mbedtls_x509_name MBEDTLS_PRIVATE(subject);      /**< The parsed subject data (named information object). */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -46,7 +46,7 @@ extern "C" {
 typedef struct mbedtls_x509_csr
 {
     int MBEDTLS_PRIVATE(version);            /**< CSR version (1=v1). */
-    
+
     mbedtls_x509_buf MBEDTLS_PRIVATE(raw);           /**< The raw CSR data (DER). */
     mbedtls_x509_buf MBEDTLS_PRIVATE(cri);           /**< The raw CertificateRequestInfo body (DER). */
 


### PR DESCRIPTION
## Description 

According to #4747 description, we should expect output files size decrease when mentioned rules in #4747 will be applied to structures from `ssl.h` file. The `mbedtls_ssl_context` and `mbedtls_ssl_config` has been proposed as a good start point for the initial evaluation.

As a first step I tried to reorder structure fields (smallest first) to maximize usage of immediate offset access.

Here are results after reordering some of structure fields:

| filename | old size | new size | difference (old - new) |
| ----------- | ----------  | ----------- | ------------- |
| library/cipher.o | 3516 | 3496 |  20 |
| library/gcm.o | 6403 | 6351 | 52 |
| library/md5.o | 3830 | 3826 | 4 |
| library/poly1305.o | 2290 | 2270 | 20 |
| library/ssl_cli.o | 19768 | 19572 | 196 |
| library/ssl_msg.o | 25283 | 25171 | 112 |
| library/ssl_srv.o | 20867 | 20711 | 156 |
| library/ssl_tls.o | 20957 | 20797 | 160 |
| library/x509_crl.o | 2328 | 2324 | 4 |
| library/x509_crt.o | 10159 | 10127 | 32 |
| library/x509_csr.o | 1275 | 1271 | 4 |



Based on `tests/scripts/all.sh build_arm_none_eabi_gcc_m0plus`.

## Fix
#4747

## Status
Needs review

## Requires Backporting
Yes - 2.x only (ABI change): #4880

## Migrations
NO
