### PR TITLE
TLS1_3:add tls13 config check and dummy handshake

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -104,6 +104,8 @@ set(src_tls
     ssl_ticket.c
     ssl_tls.c
     ssl_tls13_keys.c
+    ssl_tls13_server.c
+    ssl_tls13_client.c
 )
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/library/Makefile
+++ b/library/Makefile
@@ -167,6 +167,8 @@ OBJS_TLS= \
 	  ssl_ticket.o \
 	  ssl_tls.o \
 	  ssl_tls13_keys.o \
+	  ssl_tls13_client.o \
+	  ssl_tls13_server.o \
 	  # This line is intentionally left blank
 
 .SILENT:

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -881,6 +881,10 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_handshake_client_step( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_handshake_server_step( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_handshake_wrapup( mbedtls_ssl_context *ssl );
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl );
+int mbedtls_ssl_handshake_server_step_tls1_3( mbedtls_ssl_context *ssl );
+#endif
 
 int mbedtls_ssl_send_fatal_handshake_failure( mbedtls_ssl_context *ssl );
 

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1259,4 +1259,50 @@ void mbedtls_ssl_buffering_free( mbedtls_ssl_context *ssl );
 void mbedtls_ssl_flight_free( mbedtls_ssl_flight_item *flight );
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
+/**
+ * ssl utils functions for checking configuration.
+ */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+static inline int mbedtls_ssl_conf_is_tls13_only( const mbedtls_ssl_config *conf )
+{
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
+    {
+        return( 1 );
+    }
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+static inline int mbedtls_ssl_conf_is_tls12_only( const mbedtls_ssl_config *conf )
+{
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 )
+    {
+        return( 1 );
+    }
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+static inline int mbedtls_ssl_conf_is_hybrid_tls12_tls13( const mbedtls_ssl_config *conf )
+{
+    if( conf->min_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->max_major_ver == MBEDTLS_SSL_MAJOR_VERSION_3 &&
+        conf->min_minor_ver == MBEDTLS_SSL_MINOR_VERSION_3 &&
+        conf->max_minor_ver == MBEDTLS_SSL_MINOR_VERSION_4 )
+    {
+        return( 1 );
+    }
+    return( 0 );
+}
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL*/
+
 #endif /* ssl_misc.h */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3142,6 +3142,53 @@ void mbedtls_ssl_init( mbedtls_ssl_context *ssl )
     memset( ssl, 0, sizeof( mbedtls_ssl_context ) );
 }
 
+static int ssl_conf_version_check( const mbedtls_ssl_context *ssl )
+{
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    if( mbedtls_ssl_conf_is_tls13_only( ssl->conf ) )
+    {
+        if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM )
+        {
+             MBEDTLS_SSL_DEBUG_MSG( 1, ( "DTLS 1.3 is not yet supported" ) );
+             return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
+        }
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "The SSL configuration is tls13 only." ) );
+        return( 0 );
+    }
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+    if( mbedtls_ssl_conf_is_tls12_only( ssl->conf ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 4, ( "The SSL configuration is tls12 only." ) );
+        return( 0 );
+    }
+#endif
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+    if( mbedtls_ssl_conf_is_hybrid_tls12_tls13( ssl->conf ) )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Hybrid TLS 1.2 + TLS 1.3 configurations are not yet supported" ) );
+        return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
+    }
+#endif
+
+    MBEDTLS_SSL_DEBUG_MSG( 1, ( "The SSL configuration is invalid." ) );
+    return( MBEDTLS_ERR_SSL_BAD_CONFIG );
+}
+
+static int ssl_conf_check(const mbedtls_ssl_context *ssl)
+{
+    int ret;
+    ret = ssl_conf_version_check( ssl );
+    if( ret != 0 )
+        return( ret );
+
+    /* Space for further checks */
+
+    return( 0 );
+}
+
 /*
  * Setup an SSL context
  */
@@ -3154,6 +3201,9 @@ int mbedtls_ssl_setup( mbedtls_ssl_context *ssl,
     size_t out_buf_len = MBEDTLS_SSL_OUT_BUFFER_LEN;
 
     ssl->conf = conf;
+
+    if( ( ret = ssl_conf_check( ssl ) ) != 0 )
+        return( ret );
 
     /*
      * Prepare base structures

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5135,11 +5135,31 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
 
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
-        ret = mbedtls_ssl_handshake_client_step( ssl );
+    {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        if( mbedtls_ssl_conf_is_tls13_only( ssl->conf ) )
+            ret = mbedtls_ssl_handshake_client_step_tls1_3( ssl );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        if( mbedtls_ssl_conf_is_tls12_only( ssl->conf ) )
+            ret = mbedtls_ssl_handshake_client_step( ssl );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+    }
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER )
-        ret = mbedtls_ssl_handshake_server_step( ssl );
+    {
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+        if( mbedtls_ssl_conf_is_tls13_only( ssl->conf ) )
+            ret = mbedtls_ssl_handshake_server_step_tls1_3( ssl );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+        if( mbedtls_ssl_conf_is_tls12_only( ssl->conf ) )
+            ret = mbedtls_ssl_handshake_server_step( ssl );
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+    }
 #endif
 
     return( ret );

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -27,7 +27,11 @@
 
 #include "ssl_misc.h"
 
-
+int mbedtls_ssl_handshake_client_step_tls1_3( mbedtls_ssl_context *ssl )
+{
+    ((void) ssl);
+    return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
+}
 
 #endif /* MBEDTLS_SSL_CLI_C */
 

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1,0 +1,34 @@
+/*
+ *  TLS 1.3 client-side functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS ( https://tls.mbed.org )
+ */
+
+#include "common.h"
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+#if defined(MBEDTLS_SSL_CLI_C)
+
+#include "ssl_misc.h"
+
+
+
+#endif /* MBEDTLS_SSL_CLI_C */
+
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1,0 +1,32 @@
+/*
+ *  TLSv1.3 server-side functions
+ *
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
+
+#include "common.h"
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+
+
+#if defined(MBEDTLS_SSL_SRV_C)
+
+#include "ssl_misc.h"
+
+
+#endif /* MBEDTLS_SSL_SRV_C */
+
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -1,5 +1,5 @@
 /*
- *  TLSv1.3 server-side functions
+ *  TLS 1.3 server-side functions
  *
  *  Copyright The Mbed TLS Contributors
  *  SPDX-License-Identifier: Apache-2.0
@@ -21,11 +21,15 @@
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
 
-
 #if defined(MBEDTLS_SSL_SRV_C)
 
 #include "ssl_misc.h"
 
+int mbedtls_ssl_handshake_server_step_tls1_3( mbedtls_ssl_context *ssl )
+{
+    ((void) ssl);
+    return( MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE );
+}
 
 #endif /* MBEDTLS_SSL_SRV_C */
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -395,13 +395,20 @@ int main( void )
     USAGE_CURVES                                            \
     USAGE_DHMLEN                                            \
     "\n"
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define TLS1_3_VERSION_OPTIONS  ", tls1_3"
+#else /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#define TLS1_3_VERSION_OPTIONS  ""
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #define USAGE4 \
     "    allow_sha1=%%d       default: 0\n"                             \
     "    min_version=%%s      default: (library default: tls1_2)\n"       \
     "    max_version=%%s      default: (library default: tls1_2)\n"     \
     "    force_version=%%s    default: \"\" (none)\n"       \
-    "                        options: tls1_2, dtls1_2\n" \
-    "\n"                                                    \
+    "                        options: tls1_2, dtls1_2" TLS1_3_VERSION_OPTIONS \
+    "\n\n"                                                    \
     "    force_ciphersuite=<name>    default: all enabled\n"\
     "    query_config=<name>         return 0 if the specified\n"       \
     "                                configuration macro is defined and 1\n"  \
@@ -1070,6 +1077,10 @@ int main( int argc, char *argv[] )
             if( strcmp( q, "tls1_2" ) == 0 ||
                      strcmp( q, "dtls1_2" ) == 0 )
                 opt.min_version = MBEDTLS_SSL_MINOR_VERSION_3;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+                opt.min_version = MBEDTLS_SSL_MINOR_VERSION_4;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }
@@ -1078,6 +1089,10 @@ int main( int argc, char *argv[] )
             if( strcmp( q, "tls1_2" ) == 0 ||
                      strcmp( q, "dtls1_2" ) == 0 )
                 opt.max_version = MBEDTLS_SSL_MINOR_VERSION_3;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+                opt.max_version = MBEDTLS_SSL_MINOR_VERSION_4;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }
@@ -1103,6 +1118,13 @@ int main( int argc, char *argv[] )
                 opt.max_version = MBEDTLS_SSL_MINOR_VERSION_3;
                 opt.transport = MBEDTLS_SSL_TRANSPORT_DATAGRAM;
             }
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+            {
+                opt.min_version = MBEDTLS_SSL_MINOR_VERSION_4;
+                opt.max_version = MBEDTLS_SSL_MINOR_VERSION_4;
+            }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1592,41 +1592,7 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
     /*
-     * 2. Start the connection
-     */
-    if( opt.server_addr == NULL)
-        opt.server_addr = opt.server_name;
-
-    mbedtls_printf( "  . Connecting to %s/%s/%s...",
-            opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ? "tcp" : "udp",
-            opt.server_addr, opt.server_port );
-    fflush( stdout );
-
-    if( ( ret = mbedtls_net_connect( &server_fd,
-                       opt.server_addr, opt.server_port,
-                       opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
-                       MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP ) ) != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_net_connect returned -0x%x\n\n",
-                        (unsigned int) -ret );
-        goto exit;
-    }
-
-    if( opt.nbio > 0 )
-        ret = mbedtls_net_set_nonblock( &server_fd );
-    else
-        ret = mbedtls_net_set_block( &server_fd );
-    if( ret != 0 )
-    {
-        mbedtls_printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n",
-                        (unsigned int) -ret );
-        goto exit;
-    }
-
-    mbedtls_printf( " ok\n" );
-
-    /*
-     * 3. Setup stuff
+     * 2. Setup stuff
      */
     mbedtls_printf( "  . Setting up the SSL/TLS structure..." );
     fflush( stdout );
@@ -1975,6 +1941,40 @@ int main( int argc, char *argv[] )
         }
     }
 #endif
+
+    mbedtls_printf( " ok\n" );
+
+    /*
+     * 3. Start the connection
+     */
+    if( opt.server_addr == NULL)
+        opt.server_addr = opt.server_name;
+
+    mbedtls_printf( "  . Connecting to %s/%s/%s...",
+            opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ? "tcp" : "udp",
+            opt.server_addr, opt.server_port );
+    fflush( stdout );
+
+    if( ( ret = mbedtls_net_connect( &server_fd,
+                       opt.server_addr, opt.server_port,
+                       opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
+                       MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! mbedtls_net_connect returned -0x%x\n\n",
+                        (unsigned int) -ret );
+        goto exit;
+    }
+
+    if( opt.nbio > 0 )
+        ret = mbedtls_net_set_nonblock( &server_fd );
+    else
+        ret = mbedtls_net_set_block( &server_fd );
+    if( ret != 0 )
+    {
+        mbedtls_printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n",
+                        (unsigned int) -ret );
+        goto exit;
+    }
 
     mbedtls_printf( " ok\n" );
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2398,26 +2398,7 @@ int main( int argc, char *argv[] )
 #endif /* SNI_OPTION */
 
     /*
-     * 2. Setup the listening TCP socket
-     */
-    mbedtls_printf( "  . Bind on %s://%s:%s/ ...",
-            opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ? "tcp" : "udp",
-            opt.server_addr ? opt.server_addr : "*",
-            opt.server_port );
-    fflush( stdout );
-
-    if( ( ret = mbedtls_net_bind( &listen_fd, opt.server_addr, opt.server_port,
-                          opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
-                          MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP ) ) != 0 )
-    {
-        mbedtls_printf( " failed\n  ! mbedtls_net_bind returned -0x%x\n\n", (unsigned int) -ret );
-        goto exit;
-    }
-
-    mbedtls_printf( " ok\n" );
-
-    /*
-     * 3. Setup stuff
+     * 2. Setup stuff
      */
     mbedtls_printf( "  . Setting up the SSL/TLS structure..." );
     fflush( stdout );
@@ -2909,6 +2890,24 @@ int main( int argc, char *argv[] )
                                             mbedtls_timing_get_delay );
 #endif
 
+    mbedtls_printf( " ok\n" );
+
+    /*
+     * 3. Setup the listening TCP socket
+     */
+    mbedtls_printf( "  . Bind on %s://%s:%s/ ...",
+            opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ? "tcp" : "udp",
+            opt.server_addr ? opt.server_addr : "*",
+            opt.server_port );
+    fflush( stdout );
+
+    if( ( ret = mbedtls_net_bind( &listen_fd, opt.server_addr, opt.server_port,
+                          opt.transport == MBEDTLS_SSL_TRANSPORT_STREAM ?
+                          MBEDTLS_NET_PROTO_TCP : MBEDTLS_NET_PROTO_UDP ) ) != 0 )
+    {
+        mbedtls_printf( " failed\n  ! mbedtls_net_bind returned -0x%x\n\n", (unsigned int) -ret );
+        goto exit;
+    }
     mbedtls_printf( " ok\n" );
 
 reset:

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -485,6 +485,13 @@ int main( void )
     USAGE_ETM                                               \
     USAGE_CURVES                                            \
     "\n"
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+#define TLS1_3_VERSION_OPTIONS  ", tls1_3"
+#else /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+#define TLS1_3_VERSION_OPTIONS  ""
+#endif /* !MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
+
 #define USAGE4 \
     USAGE_SSL_ASYNC                                         \
     USAGE_SNI                                               \
@@ -492,8 +499,8 @@ int main( void )
     "    min_version=%%s      default: (library default: tls1_2)\n"       \
     "    max_version=%%s      default: (library default: tls1_2)\n"     \
     "    force_version=%%s    default: \"\" (none)\n"       \
-    "                        options: tls1_2, dtls1_2\n" \
-    "\n"                                                                \
+    "                        options: tls1_2, dtls1_2" TLS1_3_VERSION_OPTIONS \
+    "\n\n"                                                                \
     "    force_ciphersuite=<name>    default: all enabled\n"            \
     "    query_config=<name>         return 0 if the specified\n"       \
     "                                configuration macro is defined and 1\n"  \
@@ -1712,6 +1719,10 @@ int main( int argc, char *argv[] )
             if( strcmp( q, "tls1_2" ) == 0 ||
                      strcmp( q, "dtls1_2" ) == 0 )
                 opt.min_version = MBEDTLS_SSL_MINOR_VERSION_3;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+                opt.min_version = MBEDTLS_SSL_MINOR_VERSION_4;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }
@@ -1720,6 +1731,10 @@ int main( int argc, char *argv[] )
             if( strcmp( q, "tls1_2" ) == 0 ||
                      strcmp( q, "dtls1_2" ) == 0 )
                 opt.max_version = MBEDTLS_SSL_MINOR_VERSION_3;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+                opt.max_version = MBEDTLS_SSL_MINOR_VERSION_4;
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }
@@ -1745,6 +1760,13 @@ int main( int argc, char *argv[] )
                 opt.max_version = MBEDTLS_SSL_MINOR_VERSION_3;
                 opt.transport = MBEDTLS_SSL_TRANSPORT_DATAGRAM;
             }
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL)
+            else if( strcmp( q, "tls1_3" ) == 0 )
+            {
+                opt.min_version = MBEDTLS_SSL_MINOR_VERSION_4;
+                opt.max_version = MBEDTLS_SSL_MINOR_VERSION_4;
+            }
+#endif /* MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL */
             else
                 goto usage;
         }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8501,6 +8501,15 @@ run_test    "TLS1.3: Not supported version check: tls1_2 and tls1_3" \
             -s "Hybrid TLS 1.2 + TLS 1.3 configurations are not yet supported" \
             -c "Hybrid TLS 1.2 + TLS 1.3 configurations are not yet supported"
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3_EXPERIMENTAL
+run_test    "TLS1.3: handshake dispatch test: tls1_3 only" \
+            "$P_SRV min_version=tls1_3 max_version=tls1_3" \
+            "$P_CLI min_version=tls1_3 max_version=tls1_3" \
+            1 \
+            -s "SSL - The requested feature is not available" \
+            -c "SSL - The requested feature is not available"
+
 # Test heap memory usage after handshake
 requires_config_enabled MBEDTLS_MEMORY_DEBUG
 requires_config_enabled MBEDTLS_MEMORY_BUFFER_ALLOC_C

--- a/tests/suites/test_suite_debug.function
+++ b/tests/suites/test_suite_debug.function
@@ -60,10 +60,16 @@ void debug_print_msg_threshold( int threshold, int level, char * file,
     memset( buffer.buf, 0, 2000 );
     buffer.ptr = buffer.buf;
 
+    mbedtls_ssl_config_defaults( &conf,
+                                 MBEDTLS_SSL_IS_CLIENT,
+                                 MBEDTLS_SSL_TRANSPORT_STREAM,
+                                 MBEDTLS_SSL_PRESET_DEFAULT );
+
+    mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+
     TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
     mbedtls_debug_set_threshold( threshold );
-    mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
 
     mbedtls_debug_print_msg( &ssl, level, file, line,
                              "Text message, 2 == %d", 2 );
@@ -89,9 +95,14 @@ void mbedtls_debug_print_ret( char * file, int line, char * text, int value,
     memset( buffer.buf, 0, 2000 );
     buffer.ptr = buffer.buf;
 
-    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+    mbedtls_ssl_config_defaults( &conf,
+                                 MBEDTLS_SSL_IS_CLIENT,
+                                 MBEDTLS_SSL_TRANSPORT_STREAM,
+                                 MBEDTLS_SSL_PRESET_DEFAULT );
 
     mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
     mbedtls_debug_print_ret( &ssl, 0, file, line, text, value);
 
@@ -116,10 +127,14 @@ void mbedtls_debug_print_buf( char * file, int line, char * text,
     memset( buffer.buf, 0, 2000 );
     buffer.ptr = buffer.buf;
 
-
-    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+    mbedtls_ssl_config_defaults( &conf,
+                                 MBEDTLS_SSL_IS_CLIENT,
+                                 MBEDTLS_SSL_TRANSPORT_STREAM,
+                                 MBEDTLS_SSL_PRESET_DEFAULT );
 
     mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
     mbedtls_debug_print_buf( &ssl, 0, file, line, text, data->x, data->len );
 
@@ -146,9 +161,14 @@ void mbedtls_debug_print_crt( char * crt_file, char * file, int line,
     memset( buffer.buf, 0, 2000 );
     buffer.ptr = buffer.buf;
 
-    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
+    mbedtls_ssl_config_defaults( &conf,
+                                 MBEDTLS_SSL_IS_CLIENT,
+                                 MBEDTLS_SSL_TRANSPORT_STREAM,
+                                 MBEDTLS_SSL_PRESET_DEFAULT );
 
     mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+
+    TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
     TEST_ASSERT( mbedtls_x509_crt_parse_file( &crt, crt_file ) == 0 );
     mbedtls_debug_print_crt( &ssl, 0, file, line, prefix, &crt);
@@ -177,11 +197,16 @@ void mbedtls_debug_print_mpi( int radix, char * value, char * file, int line,
     memset( buffer.buf, 0, 2000 );
     buffer.ptr = buffer.buf;
 
+    mbedtls_ssl_config_defaults( &conf,
+                                 MBEDTLS_SSL_IS_CLIENT,
+                                 MBEDTLS_SSL_TRANSPORT_STREAM,
+                                 MBEDTLS_SSL_PRESET_DEFAULT );
+
+    mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
+
     TEST_ASSERT( mbedtls_ssl_setup( &ssl, &conf ) == 0 );
 
     TEST_ASSERT( mbedtls_test_read_mpi( &val, radix, value ) == 0 );
-
-    mbedtls_ssl_conf_dbg( &conf, string_debug, &buffer);
 
     mbedtls_debug_print_mpi( &ssl, 0, file, line, prefix, &val);
 


### PR DESCRIPTION
## Description
This PR add TLS1.3 main dispatch dummy functions to verify basic flow. 
It includes below changes
- Add ssl structure setup check.
- Add dummy dispatches
- Add two test cases

Fixes #4844 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
 NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
