### PR TITLE
Add an accessor for mbedtls_net_context to set a file descriptor directly

### DIFF
--- a/ChangeLog.d/net_context_fd_accessor.txt
+++ b/ChangeLog.d/net_context_fd_accessor.txt
@@ -1,0 +1,3 @@
+Features
+   * Add an accessor to set the file descriptor for mbedtls_net_context.
+

--- a/include/mbedtls/net_sockets.h
+++ b/include/mbedtls/net_sockets.h
@@ -107,6 +107,23 @@ mbedtls_net_context;
 void mbedtls_net_init( mbedtls_net_context *ctx );
 
 /**
+ * \brief          Set file descriptor for given context
+ *
+ * \param ctx      The context to configure
+ * \param fd       The file descriptor
+ *
+ * \return         O if succesful, or MBEDTLS_ERR_NET_INVALID_CONTEXT
+ *
+ * \note           The file descriptor set by this function will be overwritten by
+ *                 calling any of the the following functions:
+ *                 mbedtls_net_connect(), mbedtls_net_bind(), mbedtls_net_accept()
+ *                 mbedtls_net_close() and mbedtls_net_free().
+ *                 Additionally, mbedtls_net_close() and mbedtls_net_free() will alter the state
+ *                 of the file descriptor before overwriting it.
+ */
+int mbedtls_net_set_fd( mbedtls_net_context *ctx, int fd );
+
+/**
  * \brief          Initiate a connection with host:port in the given protocol
  *
  * \param ctx      Socket to use

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -169,6 +169,21 @@ void mbedtls_net_init( mbedtls_net_context *ctx )
 }
 
 /*
+ * Set file descriptor
+ */
+int mbedtls_net_set_fd( mbedtls_net_context *ctx, int fd )
+{
+    int ret = check_fd( fd, 0 );
+
+    if( ret != 0 )
+        return ( ret );
+
+    ctx->fd = fd;
+
+    return ( ret );
+}
+
+/*
  * Initiate a TCP connection with host:port and the given protocol
  */
 int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host,

--- a/tests/suites/test_suite_net.data
+++ b/tests/suites/test_suite_net.data
@@ -4,5 +4,11 @@ context_init_free:0
 Context init-free-init-free
 context_init_free:1
 
+Context init-set-fd
+context_set_fd:1:0
+
+Context init-set-fd-invalid
+context_set_fd:-1:MBEDTLS_ERR_NET_INVALID_CONTEXT
+
 net_poll beyond FD_SETSIZE
 poll_beyond_fd_setsize:

--- a/tests/suites/test_suite_net.function
+++ b/tests/suites/test_suite_net.function
@@ -71,6 +71,22 @@ void context_init_free( int reinit )
 }
 /* END_CASE */
 
+/* BEGIN_CASE */
+void context_set_fd( int fd, int result )
+{
+    mbedtls_net_context ctx;
+
+    mbedtls_net_init( &ctx );
+
+    /* Test mbedtls_net_set_fd with a "valid" file descriptor and an invalid
+     * one. */
+    TEST_ASSERT( mbedtls_net_set_fd( &ctx, fd ) == result );
+
+exit:
+    mbedtls_net_free(&ctx);
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_PLATFORM_IS_UNIXLIKE */
 void poll_beyond_fd_setsize( )
 {


### PR DESCRIPTION
<!--Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things-->

## Description
resolve #4868 
This is an attempt to provide an accessor which set the file descriptor from `mbebtls_net_context`.


## Status
**READY<!--/IN DEVELOPMENT/HOLD-->**

## Requires Backporting
<!--When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | -->NO  
<!--Which branch?-->

## Migrations
<!--If there is any API change, what's the incentive and logic for it.

YES | -->NO

## Additional comments
- I don't know if a test is needed for this.
- I tried to use `check_fd` rather than just put the `fd` in `ctx->fd` (eg https://github.com/tytan652/mbedtls/commit/37bac90f2424d01a84c05cb6aa7eee9ad5eac0ad)
- Sorry if I made a mistake

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
<!-- - [ ] Backported-->


<!--## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.-->
