### PR TITLE
Upgrade gnutls next

### DIFF
--- a/tests/compat-in-docker.sh
+++ b/tests/compat-in-docker.sh
@@ -42,13 +42,13 @@ esac
 
 case "${GNUTLS_CLI:-default}" in
     "legacy")  export GNUTLS_CLI="/usr/local/gnutls-3.3.8/bin/gnutls-cli";;
-    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.6.5/bin/gnutls-cli";;
+    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.7.2/bin/gnutls-cli";;
     *) ;;
 esac
 
 case "${GNUTLS_SERV:-default}" in
     "legacy")  export GNUTLS_SERV="/usr/local/gnutls-3.3.8/bin/gnutls-serv";;
-    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.6.5/bin/gnutls-serv";;
+    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.7.2/bin/gnutls-serv";;
     *) ;;
 esac
 

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -137,29 +137,29 @@ RUN cd /tmp \
 ENV GNUTLS_CLI=/usr/local/gnutls-3.4.10/bin/gnutls-cli
 ENV GNUTLS_SERV=/usr/local/gnutls-3.4.10/bin/gnutls-serv
 
-# Build libnettle 3.4 (needed by gnutls next)
+# Build libnettle 3.7.3 (needed by gnutls next)
 RUN cd /tmp \
-    && wget https://ftp.gnu.org/gnu/nettle/nettle-3.4.1.tar.gz -qO- | tar xz \
-    && cd nettle-3.4.1 \
+    && wget https://ftp.gnu.org/gnu/nettle/nettle-3.7.3.tar.gz -qO- | tar xz \
+    && cd nettle-3.7.3 \
     && ./configure --disable-documentation \
     && make ${MAKEFLAGS_PARALLEL} \
     && make install \
     && /sbin/ldconfig \
     && rm -rf /tmp/nettle*
 
-# Build gnutls next (3.6.5)
+# Build gnutls next (3.7.2)
 RUN cd /tmp \
-    && wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.5.tar.xz -qO- | tar xJ \
-    && cd gnutls-3.6.5 \
-    && ./configure --prefix=/usr/local/gnutls-3.6.5 --exec_prefix=/usr/local/gnutls-3.6.5 \
+    && wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.2.tar.xz -qO- | tar xJ \
+    && cd gnutls-3.7.2 \
+    && ./configure --prefix=/usr/local/gnutls-3.7.2 --exec_prefix=/usr/local/gnutls-3.7.2 \
         --with-included-libtasn1 --with-included-unistring --without-p11-kit \
         --disable-shared --disable-guile --disable-doc \
     && make ${MAKEFLAGS_PARALLEL} \
     && make install \
     && rm -rf /tmp/gnutls*
 
-ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.6.5/bin/gnutls-cli
-ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.6.5/bin/gnutls-serv
+ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
+ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 
 RUN pip3 install --no-cache-dir \
     mbed-host-tests \

--- a/tests/ssl-opt-in-docker.sh
+++ b/tests/ssl-opt-in-docker.sh
@@ -42,13 +42,13 @@ esac
 
 case "${GNUTLS_CLI:-default}" in
     "legacy")  export GNUTLS_CLI="/usr/local/gnutls-3.3.8/bin/gnutls-cli";;
-    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.6.5/bin/gnutls-cli";;
+    "next")  export GNUTLS_CLI="/usr/local/gnutls-3.7.2/bin/gnutls-cli";;
     *) ;;
 esac
 
 case "${GNUTLS_SERV:-default}" in
     "legacy")  export GNUTLS_SERV="/usr/local/gnutls-3.3.8/bin/gnutls-serv";;
-    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.6.5/bin/gnutls-serv";;
+    "next")  export GNUTLS_SERV="/usr/local/gnutls-3.7.2/bin/gnutls-serv";;
     *) ;;
 esac
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -405,6 +405,44 @@ requires_gnutls_tls1_3() {
     fi
 }
 
+# check %NO_TICKETS option
+requires_gnutls_next_no_ticket() {
+    requires_gnutls_next
+    if [ "$GNUTLS_NEXT_AVAILABLE" = "NO" ]; then
+        GNUTLS_NO_TICKETS_AVAILABLE="NO"
+    fi
+    if [ -z "${GNUTLS_NO_TICKETS_AVAILABLE:-}" ]; then
+        if $GNUTLS_NEXT_CLI --priority-list 2>&1 | grep NO_TICKETS >/dev/null
+        then
+            GNUTLS_NO_TICKETS_AVAILABLE="YES"
+        else
+            GNUTLS_NO_TICKETS_AVAILABLE="NO"
+        fi
+    fi
+    if [ "$GNUTLS_NO_TICKETS_AVAILABLE" = "NO" ]; then
+        SKIP_NEXT="YES"
+    fi
+}
+
+# check %%DISABLE_TLS13_COMPAT_MODE option
+requires_gnutls_next_disable_tls13_compat() {
+    requires_gnutls_next
+    if [ "$GNUTLS_NEXT_AVAILABLE" = "NO" ]; then
+        GNUTLS_DISABLE_TLS13_COMPAT_MODE_AVAILABLE="NO"
+    fi
+    if [ -z "${GNUTLS_DISABLE_TLS13_COMPAT_MODE_AVAILABLE:-}" ]; then
+        if $GNUTLS_NEXT_CLI --priority-list 2>&1 | grep DISABLE_TLS13_COMPAT_MODE >/dev/null
+        then
+            GNUTLS_DISABLE_TLS13_COMPAT_MODE_AVAILABLE="YES"
+        else
+            GNUTLS_DISABLE_TLS13_COMPAT_MODE_AVAILABLE="NO"
+        fi
+    fi
+    if [ "$GNUTLS_DISABLE_TLS13_COMPAT_MODE_AVAILABLE" = "NO" ]; then
+        SKIP_NEXT="YES"
+    fi
+}
+
 # skip next test if IPv6 isn't available on this host
 requires_ipv6() {
     if [ -z "${HAS_IPV6:-}" ]; then
@@ -8589,11 +8627,13 @@ run_test    "TLS1.3: Test openssl tls1_3 feature" \
             -c "TLS 1.3" \
             -s "TLS 1.3"
 
-# gnutls feature tests: check if tls1.3 exists.
+# gnutls feature tests: check if tls1.3,NO_TICKETS and DISABLE_TLS13_COMPAT_MODE exist.
 requires_gnutls_tls1_3
+requires_gnutls_next_no_ticket
+requires_gnutls_next_disable_tls13_compat
 run_test    "TLS1.3: Test gnutls tls1_3 feature" \
-            "$G_NEXT_SRV --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3" \
-            "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3 -V" \
+            "$G_NEXT_SRV --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE" \
+            "$G_NEXT_CLI localhost --priority=NORMAL:-VERS-ALL:+VERS-TLS1.3:%NO_TICKETS:%DISABLE_TLS13_COMPAT_MODE -V" \
             0 \
             -s "Version: TLS1.3" \
             -c "Version: TLS1.3"

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -405,7 +405,7 @@ requires_gnutls_tls1_3() {
     fi
 }
 
-# check %NO_TICKETS option
+# Check %NO_TICKETS option
 requires_gnutls_next_no_ticket() {
     requires_gnutls_next
     if [ "$GNUTLS_NEXT_AVAILABLE" = "NO" ]; then
@@ -424,7 +424,7 @@ requires_gnutls_next_no_ticket() {
     fi
 }
 
-# check %%DISABLE_TLS13_COMPAT_MODE option
+# Check %DISABLE_TLS13_COMPAT_MODE option
 requires_gnutls_next_disable_tls13_compat() {
     requires_gnutls_next
     if [ "$GNUTLS_NEXT_AVAILABLE" = "NO" ]; then
@@ -8627,7 +8627,7 @@ run_test    "TLS1.3: Test openssl tls1_3 feature" \
             -c "TLS 1.3" \
             -s "TLS 1.3"
 
-# gnutls feature tests: check if tls1.3,NO_TICKETS and DISABLE_TLS13_COMPAT_MODE exist.
+# gnutls feature tests: check if TLS 1.3 is supported as well as the NO_TICKETS and DISABLE_TLS13_COMPAT_MODE options.
 requires_gnutls_tls1_3
 requires_gnutls_next_no_ticket
 requires_gnutls_next_disable_tls13_compat


### PR DESCRIPTION
## Description

Upgrade gnutls-next from 3.6.5 to 3.7.2.
TLS1.3 tests depend on new features in 3.7.2. 
v3.7.2 introduce DISABLE_TLS13_COMPAT_MODE, that can disable compatible middle box. And we will add options for same purpose. That will need test cases for it.

Also, in our development progress, SESSION TICKET and TLS13 COMPATIBLE will not be available at beginning. and the issue target is finish client flow first. we should prepare a well configured server for test

issues: #4417 

## Status
**READY**

## Requires Backporting
NO  


## Migrations
NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
