### PR TITLE
Backport 2.x: Reorder structure fields to maximize usage of immediate offset access

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -317,11 +317,29 @@ typedef struct mbedtls_cipher_info_t
  */
 typedef struct mbedtls_cipher_context_t
 {
-    /** Information about the associated cipher. */
-    const mbedtls_cipher_info_t *cipher_info;
+    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
+     * for XTS-mode. */
+    unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
+    
+    /** Buffer for input that has not been processed yet. */
+    unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    /** Indicates whether the cipher operations should be performed
+     *  by Mbed TLS' own crypto library or an external implementation
+     *  of the PSA Crypto API.
+     *  This is unset if the cipher context was established through
+     *  mbedtls_cipher_setup(), and set if it was established through
+     *  mbedtls_cipher_setup_psa().
+     */
+    unsigned char psa_enabled;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /** Key length to use. */
     int key_bitlen;
+
+    /** Information about the associated cipher. */
+    const mbedtls_cipher_info_t *cipher_info;
 
     /** Operation that the key of the context has been
      * initialized for.
@@ -336,15 +354,8 @@ typedef struct mbedtls_cipher_context_t
     int (*get_padding)( unsigned char *input, size_t ilen, size_t *data_len );
 #endif
 
-    /** Buffer for input that has not been processed yet. */
-    unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
-
     /** Number of Bytes that have not been processed yet. */
     size_t unprocessed_len;
-
-    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
-     * for XTS-mode. */
-    unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
 
     /** IV size in Bytes, for ciphers with variable-length IVs. */
     size_t iv_size;
@@ -356,17 +367,6 @@ typedef struct mbedtls_cipher_context_t
     /** CMAC-specific context. */
     mbedtls_cmac_context_t *cmac_ctx;
 #endif
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    /** Indicates whether the cipher operations should be performed
-     *  by Mbed TLS' own crypto library or an external implementation
-     *  of the PSA Crypto API.
-     *  This is unset if the cipher context was established through
-     *  mbedtls_cipher_setup(), and set if it was established through
-     *  mbedtls_cipher_setup_psa().
-     */
-    unsigned char psa_enabled;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 } mbedtls_cipher_context_t;
 

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -320,7 +320,7 @@ typedef struct mbedtls_cipher_context_t
     /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
      * for XTS-mode. */
     unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
-    
+
     /** Buffer for input that has not been processed yet. */
     unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
 

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -65,17 +65,18 @@ extern "C" {
  */
 typedef struct mbedtls_gcm_context
 {
-    mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
-    uint64_t HL[16];                      /*!< Precalculated HTable low. */
-    uint64_t HH[16];                      /*!< Precalculated HTable high. */
-    uint64_t len;                         /*!< The total length of the encrypted data. */
-    uint64_t add_len;                     /*!< The total length of the additional data. */
     unsigned char base_ectr[16];          /*!< The first ECTR for tag. */
     unsigned char y[16];                  /*!< The Y working value. */
     unsigned char buf[16];                /*!< The buf working value. */
     int mode;                             /*!< The operation to perform:
                                                #MBEDTLS_GCM_ENCRYPT or
                                                #MBEDTLS_GCM_DECRYPT. */
+
+    uint64_t HL[16];                      /*!< Precalculated HTable low. */
+    uint64_t HH[16];                      /*!< Precalculated HTable high. */
+    uint64_t len;                         /*!< The total length of the encrypted data. */
+    uint64_t add_len;                     /*!< The total length of the additional data. */
+    mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
 }
 mbedtls_gcm_context;
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -57,9 +57,9 @@ extern "C" {
  */
 typedef struct mbedtls_md5_context
 {
+    unsigned char buffer[64];   /*!< data block being processed */
     uint32_t total[2];          /*!< number of bytes processed  */
     uint32_t state[4];          /*!< intermediate digest state  */
-    unsigned char buffer[64];   /*!< data block being processed */
 }
 mbedtls_md5_context;
 

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -62,10 +62,10 @@ extern "C" {
 
 typedef struct mbedtls_poly1305_context
 {
+    uint8_t queue[16];  /** The current partial block of data. */
     uint32_t r[4];      /** The value for 'r' (low 128 bits of the key). */
     uint32_t s[4];      /** The value for 's' (high 128 bits of the key). */
     uint32_t acc[5];    /** The accumulator number. */
-    uint8_t queue[16];  /** The current partial block of data. */
     size_t queue_len;   /** The number of bytes stored in 'queue'. */
 }
 mbedtls_poly1305_context;

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -67,10 +67,11 @@ mbedtls_x509_crl_entry;
  */
 typedef struct mbedtls_x509_crl
 {
+    int version;                    /**< CRL version (1=v1, 2=v2) */
+
     mbedtls_x509_buf raw;           /**< The raw certificate data (DER). */
     mbedtls_x509_buf tbs;           /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int version;            /**< CRL version (1=v1, 2=v2) */
     mbedtls_x509_buf sig_oid;       /**< CRL signature type identifier */
 
     mbedtls_x509_buf issuer_raw;    /**< The raw issuer data (DER). */

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -51,12 +51,22 @@ extern "C" {
  */
 typedef struct mbedtls_x509_crt
 {
+    unsigned char ns_cert_type;         /**< Optional Netscape certificate type extension value: See the values in x509.h */
+
     int own_buffer;                     /**< Indicates if \c raw is owned
                                          *   by the structure or not.        */
+
+    int ext_types;                      /**< Bit string containing detected and parsed extensions */
+    int ca_istrue;                      /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
+    int max_pathlen;                    /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
+
+    int version;                        /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
+
+    unsigned int key_usage;             /**< Optional key usage extension value: See the values in x509.h */
+
     mbedtls_x509_buf raw;               /**< The raw certificate data (DER). */
     mbedtls_x509_buf tbs;               /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int version;                /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
     mbedtls_x509_buf serial;            /**< Unique id for certificate issued by a specific CA. */
     mbedtls_x509_buf sig_oid;           /**< Signature algorithm, e.g. sha1RSA */
 
@@ -79,15 +89,7 @@ typedef struct mbedtls_x509_crt
 
     mbedtls_x509_sequence certificate_policies; /**< Optional list of certificate policies (Only anyPolicy is printed and enforced, however the rest of the policies are still listed). */
 
-    int ext_types;              /**< Bit string containing detected and parsed extensions */
-    int ca_istrue;              /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
-    int max_pathlen;            /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
-
-    unsigned int key_usage;     /**< Optional key usage extension value: See the values in x509.h */
-
     mbedtls_x509_sequence ext_key_usage; /**< Optional list of extended key usage OIDs. */
-
-    unsigned char ns_cert_type; /**< Optional Netscape certificate type extension value: See the values in x509.h */
 
     mbedtls_x509_buf sig;               /**< Signature: hash of the tbs part signed with the private key. */
     mbedtls_md_type_t sig_md;           /**< Internal representation of the MD algorithm of the signature algorithm, e.g. MBEDTLS_MD_SHA256 */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -48,10 +48,10 @@ extern "C" {
  */
 typedef struct mbedtls_x509_csr
 {
+    int version;                    /**< CSR version (1=v1). */
+    
     mbedtls_x509_buf raw;           /**< The raw CSR data (DER). */
     mbedtls_x509_buf cri;           /**< The raw CertificateRequestInfo body (DER). */
-
-    int version;            /**< CSR version (1=v1). */
 
     mbedtls_x509_buf  subject_raw;  /**< The raw subject data (DER). */
     mbedtls_x509_name subject;      /**< The parsed subject data (named information object). */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -49,7 +49,7 @@ extern "C" {
 typedef struct mbedtls_x509_csr
 {
     int version;                    /**< CSR version (1=v1). */
-    
+
     mbedtls_x509_buf raw;           /**< The raw CSR data (DER). */
     mbedtls_x509_buf cri;           /**< The raw CertificateRequestInfo body (DER). */
 


### PR DESCRIPTION
This is backport of #4821.

Results:

| filename | old size | new size | difference (old - new) |
| ----------- | ----------  | ----------- | ------------- |
| library/cipher.o | 6005 | 5993 |  12 |
| library/gcm.o | 6811 | 6759 | 52 |
| library/md5.o | 3870 | 3866 | 4 |
| library/poly1305.o | 2267 | 2255 | 12 |
| library/ssl_cli.o | 20341 | 20201 | 140 |
| library/ssl_msg.o | 26139 | 26003 | 136 |
| library/ssl_srv.o | 22760 | 20660 | 100 |
| library/ssl_tls.o | 23795 | 23663 | 132 |
| library/x509_crl.o | 2328 | 2324 | 4 |
| library/x509_crt.o | 10135 | 10107 | 28 |
| library/x509_csr.o | 1275 | 1271 | 4 |