### PR TITLE
Fix run_test_suites.pl when run without --verbose

### DIFF
--- a/tests/scripts/run-test-suites.pl
+++ b/tests/scripts/run-test-suites.pl
@@ -121,9 +121,6 @@ for my $suite (@suites)
         }
     }
 
-    my ($passed, $tests, $skipped) = $result =~ /([0-9]*) \/ ([0-9]*) tests.*?([0-9]*) skipped/;
-    $total_tests_run += $tests - $skipped;
-
     if( $verbose > 1 ) {
         print "(test cases passed:", $suite_cases_passed,
                 " failed:", $suite_cases_failed,
@@ -142,7 +139,7 @@ print "-" x 72, "\n";
 print $failed_suites ? "FAILED" : "PASSED";
 printf( " (%d suites, %d tests run%s)\n",
         scalar(@suites) - $suites_skipped,
-        $total_tests_run,
+        $total_cases_passed + $total_cases_failed,
         $suites_skipped ? ", $suites_skipped suites skipped" : "" );
 
 if( $verbose > 1 ) {


### PR DESCRIPTION
## Description
If --verbose is not given as parameter when running this script, the test-suites are not run with -v either.
If the test-suites are run without -v they suppress the summary line with the test case statistics.
That line is used to calculate the number of tests run in total and that calculation fails without the summary line with "uninitialised variable" error.

"$total_tests_run" was replaced by "$total_cases_passed + $total_cases_failed" and the statistics line is not needed anymore.

## Status
**READY**

## Requires Backporting

Yes | NO  
Which branch?

## Migrations
NO

## Additional comments

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

## Steps to test or reproduce
Run "perl scripts/run-test-suites.pl" from directory tests and watch most test-cases fail due to uninitialised variables $skipped and $tests. Then run "perl scripts/run-test-suites.pl -v 1" and watch all test-cases pass.
After applying this pull request even "perl scripts/run-test-suites.pl" will show all test-cases pass.

Signed-off-by: github-fschaeckermann@snkmail.com
