### PR TITLE
Create ChangeLog entry correcting the record on #4044

### DIFF
--- a/ChangeLog.d/issue4870.txt
+++ b/ChangeLog.d/issue4870.txt
@@ -1,0 +1,10 @@
+Bugfix
+   * Mark basic constraints critical as appropriate. Note that the previous
+     entry for this fix in the 2.16.10 changelog was in error, and it was not
+     included in the 2.16.10 release as was stated.
+     Make 'mbedtls_x509write_crt_set_basic_constraints' consistent with RFC
+     5280 4.2.1.9 which says: "Conforming CAs MUST include this extension in
+     all CA certificates that contain public keys used to validate digital
+     signatures on certificates and MUST mark the extension as critical in
+     such certificates." Previous to this change, the extension was always
+     marked as non-critical. This was fixed by #4044.


### PR DESCRIPTION
NOTE: Do not merge this PR before #4044 is merged! (Lest we have to do this a second time.)
Partial fix for #4870.

A ChangeLog entry was created for #4044 by mistake in the 2.16.10 release, without #4044 having been merged. This PR creates a new ChangeLog entry explaining that the previous ChangeLog entry was incorrect, but that the fix has now been merged.

## Status
**READY**

## Requires Backporting
NO  


## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported
