### PR TITLE
Backport 2.x: Remove compiler warning if only MBEDTLS_PK_PARSE_C is d…

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1380,8 +1380,11 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
     }
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 
-    if( ( ret = pk_parse_key_pkcs8_unencrypted_der( pk, key, keylen ) ) == 0 )
+    ret = pk_parse_key_pkcs8_unencrypted_der( pk, key, keylen );
+    if( ret == 0 )
+    {
         return( 0 );
+    }
 
     mbedtls_pk_free( pk );
     mbedtls_pk_init( pk );


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/2327