### PR TITLE
Add check_config checks for AEAD

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -178,7 +178,7 @@
 #undef MBEDTLS_HAS_MEMSAN
 
 #if defined(MBEDTLS_CCM_C) && (                                        \
-        !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) && !defined(MBEDTLS_ARIA_C) )
+    !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) && !defined(MBEDTLS_ARIA_C) )
 #error "MBEDTLS_CCM_C defined, but not all prerequisites"
 #endif
 
@@ -187,7 +187,7 @@
 #endif
 
 #if defined(MBEDTLS_GCM_C) && (                                        \
-        !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) && !defined(MBEDTLS_ARIA_C) )
+    !defined(MBEDTLS_AES_C) && !defined(MBEDTLS_CAMELLIA_C) && !defined(MBEDTLS_ARIA_C) )
 #error "MBEDTLS_GCM_C defined, but not all prerequisites"
 #endif
 


### PR DESCRIPTION
CCM requires one of the 128-bit-block block ciphers to be useful, just like GCM.

GCM and CCM need the cipher module.

ChaChaPoly needs ChaCha20 and Poly1305.

Backport: [2.28](https://github.com/ARMmbed/mbedtls/pull/5540)