### PR TITLE
Add send alert message macro

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1527,10 +1527,7 @@ struct mbedtls_ssl_context
                                      on next call to record layer? */
 
     /* The following three variables indicate if and, if yes,
-     * what kind of alert or warning is pending to be sent.
-     * They should not be set manually but through the macro
-     * MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )
-     * defined below.
+     * what kind of alert is pending to be sent.
      */
     unsigned char MBEDTLS_PRIVATE(send_alert);   /*!< Determines if a fatal alert
                                                 should be sent. Values:
@@ -1639,14 +1636,6 @@ struct mbedtls_ssl_context
     void *MBEDTLS_PRIVATE(p_export_keys);            /*!< context for key export callback    */
 #endif
 };
-
-#define MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )         \
-    do                                                                  \
-    {                                                                   \
-        ssl->send_alert = 1;                                            \
-        ssl->alert_reason = (user_return_value);                        \
-        ssl->alert_type = (type);                                       \
-    } while( 0 )
 
 /**
  * \brief               Return the name of the ciphersuite associated with the

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1532,16 +1532,15 @@ struct mbedtls_ssl_context
      * MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )
      * defined below.
      */
-    unsigned char MBEDTLS_PRIVATE(send_alert);   /*!< Determines if either a fatal error
-                                  or a warning should be sent. Values:
-                                  - \c 0 if no alert is to be sent.
-                                  - #MBEDTLS_SSL_ALERT_LEVEL_FATAL
-                                  if a fatal alert is to be sent
-                                  - #MBEDTLS_SSL_ALERT_LEVEL_WARNING
-                                  if a non-fatal alert is to be sent. */
-    unsigned char MBEDTLS_PRIVATE(alert_type);   /*!< Type of alert if send_alert != 0 */
-    int MBEDTLS_PRIVATE(alert_reason);           /*!< The error code to be returned to the
-                                 *   user once the fatal alert has been sent. */
+    unsigned char MBEDTLS_PRIVATE(send_alert);   /*!< Determines if a fatal alert
+                                                should be sent. Values:
+                                                - \c 0 , no alert is to be sent.
+                                                - \c 1 , alert is to be sent. */
+    unsigned char MBEDTLS_PRIVATE(alert_type);   /*!< Type of alert if send_alert
+                                                 != 0 */
+    int MBEDTLS_PRIVATE(alert_reason);           /*!< The error code to be returned
+                                                 to the user once the fatal alert
+                                                 has been sent. */
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     uint8_t MBEDTLS_PRIVATE(disable_datagram_packing);  /*!< Disable packing multiple records

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1526,6 +1526,23 @@ struct mbedtls_ssl_context
     int MBEDTLS_PRIVATE(keep_current_message);   /*!< drop or reuse current message
                                      on next call to record layer? */
 
+    /* The following three variables indicate if and, if yes,
+     * what kind of alert or warning is pending to be sent.
+     * They should not be set manually but through the macro
+     * MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )
+     * defined below.
+     */
+    unsigned char MBEDTLS_PRIVATE(send_alert);   /*!< Determines if either a fatal error
+                                  or a warning should be sent. Values:
+                                  - \c 0 if no alert is to be sent.
+                                  - #MBEDTLS_SSL_ALERT_LEVEL_FATAL
+                                  if a fatal alert is to be sent
+                                  - #MBEDTLS_SSL_ALERT_LEVEL_WARNING
+                                  if a non-fatal alert is to be sent. */
+    unsigned char MBEDTLS_PRIVATE(alert_type);   /*!< Type of alert if send_alert != 0 */
+    int MBEDTLS_PRIVATE(alert_reason);           /*!< The error code to be returned to the
+                                 *   user once the fatal alert has been sent. */
+
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     uint8_t MBEDTLS_PRIVATE(disable_datagram_packing);  /*!< Disable packing multiple records
                                         *   within a single datagram.  */
@@ -1623,6 +1640,14 @@ struct mbedtls_ssl_context
     void *MBEDTLS_PRIVATE(p_export_keys);            /*!< context for key export callback    */
 #endif
 };
+
+#define MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )         \
+    do                                                                  \
+    {                                                                   \
+        ssl->send_alert = 1;                                            \
+        ssl->alert_reason = (user_return_value);                        \
+        ssl->alert_type = (type);                                       \
+    } while( 0 )
 
 /**
  * \brief               Return the name of the ciphersuite associated with the

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1342,6 +1342,11 @@ void mbedtls_ssl_update_in_pointers( mbedtls_ssl_context *ssl );
 
 int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial );
 
+/*
+ * Send pending fatal alerts or warnings.
+ */
+int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl );
+
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
 void mbedtls_ssl_dtls_replay_reset( mbedtls_ssl_context *ssl );
 #endif

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1343,9 +1343,21 @@ void mbedtls_ssl_update_in_pointers( mbedtls_ssl_context *ssl );
 int mbedtls_ssl_session_reset_int( mbedtls_ssl_context *ssl, int partial );
 
 /*
- * Send pending fatal alerts or warnings.
+ * Send pending alert
  */
 int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl );
+
+/*
+ * Set pending fatal alert flag.
+ */
+void mbedtls_ssl_pend_fatal_alert( mbedtls_ssl_context *ssl,
+                                   unsigned char alert_type,
+                                   int alert_reason );
+
+/* Alias of mbedtls_ssl_pend_fatal_alert */
+#define MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )         \
+            mbedtls_ssl_pend_fatal_alert( ssl, type, user_return_value )
+
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
 void mbedtls_ssl_dtls_replay_reset( mbedtls_ssl_context *ssl );

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1358,7 +1358,6 @@ void mbedtls_ssl_pend_fatal_alert( mbedtls_ssl_context *ssl,
 #define MBEDTLS_SSL_PEND_FATAL_ALERT( type, user_return_value )         \
             mbedtls_ssl_pend_fatal_alert( ssl, type, user_return_value )
 
-
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
 void mbedtls_ssl_dtls_replay_reset( mbedtls_ssl_context *ssl );
 #endif

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5639,4 +5639,26 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
     }
 }
 
+/*
+ * Send pending fatal alerts or warnings.
+ */
+int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl )
+{
+    int ret;
+
+    /* Send alert if requested */
+    if( ssl->send_alert != 0 )
+    {
+        ret = mbedtls_ssl_send_alert_message( ssl,
+                                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                 ssl->alert_type );
+        if( ret != 0 )
+            return( ret );
+    }
+
+    ssl->send_alert = 0;
+    ssl->alert_type = 0;
+    return( 0 );
+}
+
 #endif /* MBEDTLS_SSL_TLS_C */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5640,9 +5640,10 @@ void mbedtls_ssl_read_version( int *major, int *minor, int transport,
 }
 
 /*
- * Send pending fatal alerts or warnings.
- * 0, No alert message.
- * !0, error from send_alert_message or handshake_step return
+ * Send pending fatal alert.
+ * 0,   No alert message.
+ * !0,  if mbedtls_ssl_send_alert_message() returned in error, the error code it
+ *      returned, ssl->alert_reason otherwise.
  */
 int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl )
 {
@@ -5656,8 +5657,8 @@ int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl )
                                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                 ssl->alert_type );
 
-    /* Success or send message fail, clear send_alert flag
-     * except WANT_WRITE. WANT_WRITE means need re-send message.
+    /* If mbedtls_ssl_send_alert_message() returned with MBEDTLS_ERR_SSL_WANT_WRITE,
+     * do not clear the alert to be able to send it later.
      */
     if( ret != MBEDTLS_ERR_SSL_WANT_WRITE )
     {
@@ -5665,12 +5666,8 @@ int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl )
     }
 
     if( ret != 0 )
-    {
-        /* some errors on send alert message */
         return( ret );
-    }
 
-    /* Assume alert_reason == handshake_step return */
     return( ssl->alert_reason );
 }
 

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5649,16 +5649,28 @@ int mbedtls_ssl_handle_pending_alert( mbedtls_ssl_context *ssl )
     /* Send alert if requested */
     if( ssl->send_alert != 0 )
     {
+        /* Clear send_alert to avoid infinite loop */
+        ssl->send_alert = 0;
+
         ret = mbedtls_ssl_send_alert_message( ssl,
                                  MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                  ssl->alert_type );
         if( ret != 0 )
             return( ret );
     }
-
-    ssl->send_alert = 0;
-    ssl->alert_type = 0;
     return( 0 );
+}
+
+/*
+ * Set pending fatal alert flag.
+ */
+void mbedtls_ssl_pend_fatal_alert( mbedtls_ssl_context *ssl,
+                                   unsigned char alert_type,
+                                   int alert_reason )
+{
+    ssl->send_alert = 1;
+    ssl->alert_type = alert_type;
+    ssl->alert_reason = alert_reason;
 }
 
 #endif /* MBEDTLS_SSL_TLS_C */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5170,6 +5170,10 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
     if( ret != 0 )
         return( ret );
 
+    ret = mbedtls_ssl_handle_pending_alert( ssl );
+    if( ret != 0 )
+        goto cleanup;
+
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
@@ -5199,6 +5203,18 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
     }
 #endif
 
+    if( ret != 0 )
+    {
+        int alert_ret;
+        alert_ret = mbedtls_ssl_handle_pending_alert( ssl );
+        if( alert_ret != 0 )
+        {
+            ret = alert_ret;
+            goto cleanup;
+        }
+    }
+
+cleanup:
     return( ret );
 }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5205,10 +5205,15 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
 
     if( ret != 0 )
     {
+        /* handshake_step return error. And it is same
+         * with alert_reason.
+         */
         int alert_ret;
         alert_ret = mbedtls_ssl_handle_pending_alert( ssl );
         if( alert_ret != 0 )
         {
+            /* If success send, ret == alert_ret.
+             */
             ret = alert_ret;
             goto cleanup;
         }

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5208,13 +5208,9 @@ int mbedtls_ssl_handshake_step( mbedtls_ssl_context *ssl )
         /* handshake_step return error. And it is same
          * with alert_reason.
          */
-        int alert_ret;
-        alert_ret = mbedtls_ssl_handle_pending_alert( ssl );
-        if( alert_ret != 0 )
+        if( ssl->send_alert )
         {
-            /* If success send, ret == alert_ret.
-             */
-            ret = alert_ret;
+            ret = mbedtls_ssl_handle_pending_alert( ssl );
             goto cleanup;
         }
     }


### PR DESCRIPTION
## Description
`MBEDTLS_SSL_PEND_FATAL_ALERT` is replacement of  `SSL_PEND_FATAL_ALERT` in `prototye`.

`SSL_PEND_FATAL_ALERT` is  delay sending alert message feature in `prototype`. It is defined at [`ssl.h`](https://github.com/hannestschofenig/mbedtls/blob/ae6624780fba2d9256072b73338c67b84f9b9793/include/mbedtls/ssl.h#L1841). It introduces `SSL_PEND_FATAL_ALERT` , [new members of context](https://github.com/hannestschofenig/mbedtls/blob/ae6624780fba2d9256072b73338c67b84f9b9793/include/mbedtls/ssl.h#L1693) and [new function](https://github.com/hannestschofenig/mbedtls/blob/ae6624780fba2d9256072b73338c67b84f9b9793/library/ssl_msg.c#L6205)


There are `ABI-API checking` fail in CI. Due to we add 3 members in `mbedtls_ssl_context`


## Status
**READY**

## Requires Backporting
NO  


## Migrations
NO


