### PR TITLE
Backport 2.x: Fix x86_64 assembly for bignum multiplication

### DIFF
--- a/ChangeLog.d/muladdc-amd64-memory.txt
+++ b/ChangeLog.d/muladdc-amd64-memory.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix missing constraints on x86_64 assembly code for bignum multiplication
+     that broke some bignum operations with (at least) Clang 12. Fixes #4786.

--- a/ChangeLog.d/muladdc-amd64-memory.txt
+++ b/ChangeLog.d/muladdc-amd64-memory.txt
@@ -1,3 +1,4 @@
 Bugfix
    * Fix missing constraints on x86_64 assembly code for bignum multiplication
-     that broke some bignum operations with (at least) Clang 12. Fixes #4786.
+     that broke some bignum operations with (at least) Clang 12.
+     Fixes #4116, #4786, #4917.

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -189,9 +189,9 @@
         "addq   $8, %%rdi\n"
 
 #define MULADDC_STOP                        \
-        : "+c" (c), "+D" (d), "+S" (s)      \
-        : "b" (b)                           \
-        : "rax", "rdx", "r8"                \
+        : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
+        : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
+        : "rax", "rdx", "r8"                                         \
     );
 
 #endif /* AMD64 */


### PR DESCRIPTION
Backport of #4947