### PR TITLE
Work around bad code generation with clang at -O2

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1635,10 +1635,10 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
  * \param b             A scalar to multiply.
  */
 static
-#if defined(__APPLE__) && defined(__arm__)
+#if defined(__clang__)
 /*
- * Apple LLVM version 4.2 (clang-425.0.24) (based on LLVM 3.2svn)
- * appears to need this to prevent bad ARM code generation at -O3.
+ * This is required to prevent bad code generation with various
+ * versions of clang at -O2 and -O3.
  */
 __attribute__ ((noinline))
 #endif


### PR DESCRIPTION
Versions of clang from around 12 seem to generate code
badly in `mpi_mul_hlp()`, causing the mpi tests to fail.
Setting `__attribute__ ((noinline))` fixes this issue.

Signed-off-by: David Horstmann <david.horstmann@arm.com>

## Description
Fixes #4786 
This works around bad code generation with clang-12 onwards, in `mpi_mul_hlp()`. We already work around code generation issues with clang on some platforms using `__attribute__ ((noinline))`, so this PR extends that workaround to all versions of clang.
## Status
**READY**

## Requires Backporting
Yes

Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported