### PR TITLE
Fix the PSA_ALG_RSA_PSS salt length documentation

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1345,10 +1345,15 @@
  *
  * This is the signature scheme defined by RFC 8017
  * (PKCS#1: RSA Cryptography Specifications) under the name
- * RSASSA-PSS, with the message generation function MGF1, and with
- * a salt length equal to the length of the hash. The specified
- * hash algorithm is used to hash the input message, to create the
- * salted hash, and for the mask generation.
+ * RSASSA-PSS, with the message generation function MGF1.
+ * The specified hash algorithm is used to hash the input message, to create
+ * the salted hash, and for the mask generation.
+ *
+ * When creating a signature, the salt length is equal to the length of
+ * the hash, or the largest possible salt length for the algorithm and key
+ * size if that is smaller than the hash length.
+ * When verifying a signature, any salt length permitted by the RSASSA-PSS
+ * signature algorithm is accepted.
  *
  * \param hash_alg      A hash algorithm (\c PSA_ALG_XXX value such that
  *                      #PSA_ALG_IS_HASH(\p hash_alg) is true).


### PR DESCRIPTION
Modify the documentation of the salt length for `PSA_ALG_RSA_PSS`. The new documentation matches the actual behavior of the library. It also matches the upcoming version (1.0.2) of the PSA Crypto API specification (internal link: https://github.com/ARM-software/psa-crypto-api/pull/505).

Needs backport: 2.2x
