### PR TITLE
Backport 2.16: Facilitate reproducing unit tests from all.sh

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,6 +6,9 @@ CFLAGS	?= -O2
 WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -Wunused
 LDFLAGS ?=
 
+# Set this to -v to see the details of failing test cases
+TEST_FLAGS ?= $(if $(filter-out 0 OFF Off off NO No no FALSE False false N n,$(CTEST_OUTPUT_ON_FAILURE)),-v,)
+
 LOCAL_CFLAGS = $(WARNING_CFLAGS) -I../include -D_FILE_OFFSET_BITS=64
 LOCAL_LDFLAGS = -L../library			\
 		-lmbedtls$(SHARED_SUFFIX)	\
@@ -119,7 +122,7 @@ endif
 
 # Test suites caught by SKIP_TEST_SUITES are built but not executed.
 check: $(BINARIES)
-	perl scripts/run-test-suites.pl --skip=$(SKIP_TEST_SUITES)
+	perl scripts/run-test-suites.pl $(TEST_FLAGS) --skip=$(SKIP_TEST_SUITES)
 
 test: check
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -186,7 +186,7 @@ pre_initialize_variables () {
         export MAKEFLAGS="-j"
     fi
 
-    # Include more verbose output for failing tests run by CMake
+    # Include more verbose output for failing tests run by CMake or make
     export CTEST_OUTPUT_ON_FAILURE=1
 
     # CFLAGS and LDFLAGS for Asan builds that don't use CMake


### PR DESCRIPTION
Backport of #4955 (just the `make test` part, not the PSA part which doesn't apply to 2.16).
