### PR TITLE
Fix aarch64 assembly for bignum multiplication

### DIFF
--- a/ChangeLog.d/muladdc-aarch64-memory.txt
+++ b/ChangeLog.d/muladdc-aarch64-memory.txt
@@ -1,0 +1,4 @@
+Bugfix
+    * Add missing memory constraints in aarch64 inline assembly for
+      bignum multiplication.
+      Fixes #4962.

--- a/ChangeLog.d/muladdc-aarch64-memory.txt
+++ b/ChangeLog.d/muladdc-aarch64-memory.txt
@@ -1,4 +1,0 @@
-Bugfix
-    * Add missing memory constraints in aarch64 inline assembly for
-      bignum multiplication.
-      Fixes #4962.

--- a/ChangeLog.d/muladdc-amd64-memory.txt
+++ b/ChangeLog.d/muladdc-amd64-memory.txt
@@ -1,4 +1,0 @@
-Bugfix
-   * Fix missing constraints on x86_64 assembly code for bignum multiplication
-     that broke some bignum operations with (at least) Clang 12.
-     Fixes #4116, #4786, #4917.

--- a/ChangeLog.d/muladdc-memory.txt
+++ b/ChangeLog.d/muladdc-memory.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix missing constraints on x86_64 and aarch64 assembly code
+     for bignum multiplication that broke some bignum operations with
+     (at least) Clang 12.
+     Fixes #4116, #4786, #4917, #4962.

--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -224,7 +224,7 @@
         "adcq   %%rdx, %%rcx\n"             \
         "addq   $8, %%rdi\n"
 
-#define MULADDC_STOP                        \
+#define MULADDC_STOP                                                 \
         : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
         : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
         : "rax", "rdx", "r8"                                         \
@@ -240,18 +240,18 @@
 #define MULADDC_CORE                \
         "ldr x4, [%2], #8   \n\t"   \
         "ldr x5, [%1]       \n\t"   \
-        "mul x6, x4, %3     \n\t"   \
-        "umulh x7, x4, %3   \n\t"   \
+        "mul x6, x4, %4     \n\t"   \
+        "umulh x7, x4, %4   \n\t"   \
         "adds x5, x5, x6    \n\t"   \
         "adc x7, x7, xzr    \n\t"   \
         "adds x5, x5, %0    \n\t"   \
         "adc %0, x7, xzr    \n\t"   \
         "str x5, [%1], #8   \n\t"
 
-#define MULADDC_STOP                        \
-         : "+r" (c),  "+r" (d), "+r" (s)    \
-         : "r" (b)                          \
-         : "x4", "x5", "x6", "x7", "cc"     \
+#define MULADDC_STOP                                                    \
+         : "+r" (c),  "+r" (d), "+r" (s), "+m" (*(uint64_t (*)[16]) d)  \
+         : "r" (b), "m" (*(const uint64_t (*)[16]) s)                   \
+         : "x4", "x5", "x6", "x7", "cc"                                 \
     );
 
 #endif /* Aarch64 */


### PR DESCRIPTION
Add missing memory constraint in aarch64 bignum multiplication code to remedy Clang 12+ issues. Fixes #4962.
Part of the larger super-issue #4943.

Tested with the following steps:
```
mkdir build && cd build
CC=clang CFLAGS="--target=aarch64-linux-gnu" cmake -DCMAKE_BUILD_TYPE=Release ..
make -j8
cd tests
qemu-aarch64 -L /usr/aarch64-linux-gnu ./test_suite_mpi
```

## Status
**READY**

## Requires Backporting
Yes
Only to [2.x](https://github.com/ARMmbed/mbedtls/pull/4978) as `2.16` does not have this aarch64 assembly
