### PR TITLE
Fix test code to can be built on alpine

### DIFF
--- a/ChangeLog.d/do-not-use-obsolete-header.txt
+++ b/ChangeLog.d/do-not-use-obsolete-header.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Don't use the obsolete header path sys/fcntl.h in unit tests.
+     These header files cause compilation errors in musl.
+     Fixes #4969.
+

--- a/tests/suites/test_suite_net.function
+++ b/tests/suites/test_suite_net.function
@@ -9,11 +9,11 @@
 #endif
 
 #if defined(MBEDTLS_PLATFORM_IS_UNIXLIKE)
-#include <sys/fcntl.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <fcntl.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Signed-off-by: joseph <joseph@jc-lab.net>

## Description

When build via cmake on alpine linux, cause the following error: This PR fix the error.

```
[ 99%] Building C object tests/CMakeFiles/test_suite_net.dir/test_suite_net.c.o
In file included from .../tests/suites/test_suite_net.function:12:
/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
cc1: all warnings being treated as errors
```

## Status
**READY**

## Requires Backporting

NO  

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Steps to test or reproduce

### Before

https://github.com/jclab-joseph/mbedtls/actions/runs/1264843158

The build succeeds in ubuntu but fails in alpine.

### After

https://github.com/jclab-joseph/mbedtls/actions/runs/1264845085

Both ubuntu and alpine builds succeed.