### PR TITLE
Add fetch_hand_message in generic

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1493,9 +1493,9 @@ static inline void mbedtls_ssl_handshake_set_state( mbedtls_ssl_context *ssl,
  * Fetch TLS 1.3 handshake message header
  */
 int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
-                                       unsigned hs_type,
-                                       unsigned char **buf,
-                                       size_t *buf_len );
+                                            unsigned hs_type,
+                                            unsigned char **buf,
+                                            size_t *buf_len );
 
 /*
  * Write TLS 1.3 handshake message header

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1490,6 +1490,14 @@ static inline void mbedtls_ssl_handshake_set_state( mbedtls_ssl_context *ssl,
 }
 
 /*
+ * Fetch TLS 1.3 handshake message header
+ */
+int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
+                                       unsigned hs_type,
+                                       unsigned char **buf,
+                                       size_t *buf_len );
+
+/*
  * Write TLS 1.3 handshake message header
  */
 int mbedtls_ssl_tls13_start_handshake_msg( mbedtls_ssl_context *ssl,

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -29,9 +29,9 @@
 #include "ssl_misc.h"
 
 int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
-                                     unsigned hs_type,
-                                     unsigned char **buf,
-                                     size_t *buflen )
+                                            unsigned hs_type,
+                                            unsigned char **buf,
+                                            size_t *buflen )
 {
     int ret;
 
@@ -41,10 +41,10 @@ int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
         goto cleanup;
     }
 
-    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE         ||
+    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE ||
         ssl->in_msg[0]  != hs_type )
     {
-        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate verify message" ) );
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "Receive unexpected handshake message." ) );
         MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
                               MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
         ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
@@ -53,7 +53,6 @@ int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
 
     *buf    = ssl->in_msg   + 4;
     *buflen = ssl->in_hslen - 4;
-
 
 cleanup:
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -46,11 +46,18 @@ int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
     {
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Receive unexpected handshake message." ) );
         MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
-                              MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
+                                      MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
         ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
         goto cleanup;
     }
 
+    /*
+     * Jump handshake header (4 bytes, see Section 4 of RFC 8446).
+     *    ...
+     *    HandshakeType msg_type;
+     *    uint24 length;
+     *    ...
+     */
     *buf    = ssl->in_msg   + 4;
     *buflen = ssl->in_hslen - 4;
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -28,6 +28,38 @@
 
 #include "ssl_misc.h"
 
+int mbedtls_ssl_tls1_3_fetch_handshake_msg( mbedtls_ssl_context *ssl,
+                                     unsigned hs_type,
+                                     unsigned char **buf,
+                                     size_t *buflen )
+{
+    int ret;
+
+    if( ( ret = mbedtls_ssl_read_record( ssl, 0 ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
+        goto cleanup;
+    }
+
+    if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE         ||
+        ssl->in_msg[0]  != hs_type )
+    {
+        MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad certificate verify message" ) );
+        MBEDTLS_SSL_PEND_FATAL_ALERT( MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
+                              MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
+        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+        goto cleanup;
+    }
+
+    *buf    = ssl->in_msg   + 4;
+    *buflen = ssl->in_hslen - 4;
+
+
+cleanup:
+
+    return( ret );
+}
+
 int mbedtls_ssl_tls13_start_handshake_msg( mbedtls_ssl_context *ssl,
                                            unsigned hs_type,
                                            unsigned char **buf,


### PR DESCRIPTION
This function is one common function in generic file, get it from
the encrypted extension and submit one patch independently.
Extracted from the PR #4937

Signed-off-by: XiaokangQian <xiaokang.qian@arm.com>

