### PR TITLE
Add contact information directly on the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,10 @@ Contributing
 ------------
 
 We gratefully accept bug reports and contributions from the community. Please see the [contributing guidelines](CONTRIBUTING.md) for details on how to do this.
+
+Contact
+-------
+
+* To report a security vulnerability in Mbed TLS, please email <mbed-tls-security@lists.trustedfirmware.org>. For more information, see [`SECURITY.md`](SECURITY.md).
+* To report a bug or request a feature in Mbed TLS, please [file an issue on GitHub](https://github.com/ARMmbed/mbedtls/issues/new/choose).
+* Please see [`SUPPORT.md`](SUPPORT.md) for other channels for discussion and support about Mbed TLS.


### PR DESCRIPTION
This information was already present in SECURITY.md and SUPPORT.md, but that
wasn't very apparent.
