### PR TITLE
Backport 2.x: Limit make parallelism to the number of CPUs in all.sh

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -165,7 +165,7 @@ pre_initialize_variables () {
 
     # if MAKEFLAGS is not set add the -j option to speed up invocations of make
     if [ -z "${MAKEFLAGS+set}" ]; then
-        export MAKEFLAGS="-j"
+        export MAKEFLAGS="-j$(all_sh_nproc)"
     fi
 
     # Include more verbose output for failing tests run by CMake or make
@@ -312,6 +312,18 @@ fatal_signal () {
 trap 'fatal_signal HUP' HUP
 trap 'fatal_signal INT' INT
 trap 'fatal_signal TERM' TERM
+
+# Number of processors on this machine. Used as the default setting
+# for parallel make.
+all_sh_nproc ()
+{
+    {
+        nproc || # Linux
+        sysctl -n hw.ncpuonline || # NetBSD, OpenBSD
+        sysctl -n hw.ncpu || # FreeBSD
+        echo 1
+    } 2>/dev/null
+}
 
 msg()
 {


### PR DESCRIPTION
Trivial backport of #5003.
