### PR TITLE
Temporarily disable test cases that fail randomly on the CI

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2694,6 +2694,7 @@ run_test    "Session resume using tickets, DTLS: openssl server" \
             -c "parse new session ticket" \
             -c "a session has been resumed"
 
+requires_config_enabled TEMPORARILY_DISABLED # https://github.com/ARMmbed/mbedtls/issues/5012
 run_test    "Session resume using tickets, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=1" \
             "( $O_CLI -dtls -sess_out $SESSION; \
@@ -2894,6 +2895,7 @@ run_test    "Session resume using cache, DTLS: session copy" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
+requires_config_enabled TEMPORARILY_DISABLED # https://github.com/ARMmbed/mbedtls/issues/5012
 run_test    "Session resume using cache, DTLS: openssl client" \
             "$P_SRV dtls=1 debug_level=3 tickets=0" \
             "( $O_CLI -dtls -sess_out $SESSION; \


### PR DESCRIPTION
Temporarily disable the two `ssl-opt.sh` test cases affected by https://github.com/ARMmbed/mbedtls/issues/5012 ("Session resume using .*, DTLS: openssl client")

We're temporarily disabling these test cases so that we can have meaningful CI results until we fix the failure. At this point, we don't know whether the failures are due to an Mbed TLS bug, an OpenSSL bug or a bug in our test code.

Needs backports: 2.2x, 2.16
