### PR TITLE
Backport 2.16: Use newer OpenSSL for tests failing with the old

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -988,22 +988,24 @@ SRV_DELAY_SECONDS=0
 
 # fix commands to use this port, force IPv4 while at it
 # +SRV_PORT will be replaced by either $SRV_PORT or $PXY_PORT later
+# Note: Using 'localhost' rather than 127.0.0.1 here is unwise, as on many
+# machines that will resolve to ::1, and we don't want ipv6 here.
 P_SRV="$P_SRV server_addr=127.0.0.1 server_port=$SRV_PORT"
 P_CLI="$P_CLI server_addr=127.0.0.1 server_port=+SRV_PORT"
 P_PXY="$P_PXY server_addr=127.0.0.1 server_port=$SRV_PORT listen_addr=127.0.0.1 listen_port=$PXY_PORT ${SEED:+"seed=$SEED"}"
 O_SRV="$O_SRV -accept $SRV_PORT"
-O_CLI="$O_CLI -connect localhost:+SRV_PORT"
+O_CLI="$O_CLI -connect 127.0.0.1:+SRV_PORT"
 G_SRV="$G_SRV -p $SRV_PORT"
 G_CLI="$G_CLI -p +SRV_PORT"
 
 if [ -n "${OPENSSL_LEGACY:-}" ]; then
     O_LEGACY_SRV="$O_LEGACY_SRV -accept $SRV_PORT -dhparam data_files/dhparams.pem"
-    O_LEGACY_CLI="$O_LEGACY_CLI -connect localhost:+SRV_PORT"
+    O_LEGACY_CLI="$O_LEGACY_CLI -connect 127.0.0.1:+SRV_PORT"
 fi
 
 if [ -n "${OPENSSL_NEXT:-}" ]; then
     O_NEXT_SRV="$O_NEXT_SRV -accept $SRV_PORT"
-    O_NEXT_CLI="$O_NEXT_CLI -connect localhost:+SRV_PORT"
+    O_NEXT_CLI="$O_NEXT_CLI -connect 127.0.0.1:+SRV_PORT"
 fi
 
 if [ -n "${GNUTLS_NEXT_SERV:-}" ]; then


### PR DESCRIPTION
## Description
See #5012. Whether this is a proper fix or just a stop-gap measure is yet to be determined.

Fixes I found whilst trying to get ssl-opt to run clean locally, whilst looking for the issues surrounding the tls renegotiation bug (#5022):

1.An incorrect check for DTLS. Due to missing wildcards this wasn't detecting certain server starts as being DTLS, and as a result would check for a TCP port becoming owned by the server rather than UDP, which would result in the server being marked as "Failed to start", and the test skipped.
2. When specifying the -connect string for openssl s_client, we were using localhost rather than 127.0.0.1, which would cause a failure for the client to connect to the server. I suspect this is because on many machines now, localhost resolves to ::1 rather than 127.0.0.1. Note that this failure would not be logged, and would be seen as a failure to create the session pointed to by -sess_out. This was not happening on the CI, only on local machines, however this feels brittle, as any change of AMI could break this.

Lastly @mpg's proposed fix for the failing CI tests, using a newer version of OpenSSL for the tests that fail. The above changes are to facilitate this.

This is a backport to 2.16 of #5070 

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests


## Steps to test or reproduce
ssl-opt.sh should run clean.
