### PR TITLE
Backport 2.16: Build with -O2 when running ssl-opt

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1266,7 +1266,7 @@ component_test_memory_buffer_allocator_backtrace () {
     scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
     scripts/config.pl set MBEDTLS_MEMORY_BACKTRACE
     scripts/config.pl set MBEDTLS_MEMORY_DEBUG
-    CC=gcc cmake .
+    CC=gcc cmake -DCMAKE_BUILD_TYPE:String=Release .
     make
 
     msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C and MBEDTLS_MEMORY_BACKTRACE"
@@ -1277,7 +1277,7 @@ component_test_memory_buffer_allocator () {
     msg "build: default config with memory buffer allocator"
     scripts/config.pl set MBEDTLS_MEMORY_BUFFER_ALLOC_C
     scripts/config.pl set MBEDTLS_PLATFORM_MEMORY
-    CC=gcc cmake .
+    CC=gcc cmake -DCMAKE_BUILD_TYPE:String=Release .
     make
 
     msg "test: MBEDTLS_MEMORY_BUFFER_ALLOC_C"


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/5011. Similar to [the 2.x backport](https://github.com/ARMmbed/mbedtls/pull/5087), differing mainly in the context: `config.pl` instead of `config.py`, additional calls to `if_build_succeeded`.