### PR TITLE
Retry a test case if it fails due to an unexpected resend

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -552,6 +552,32 @@ record_outcome() {
     fi
 }
 
+# True if the presence of the given pattern in a log definitely indicates
+# that the test has failed. False if the presence is inconclusive.
+#
+# Inputs:
+# * $1: pattern found in the logs
+# * $TIMES_LEFT: >0 if retrying is an option
+#
+# Outputs:
+# * $outcome: set to a retry reason if the pattern is inconclusive,
+#             unchanged otherwise.
+# * Return value: 1 if the pattern is inconclusive,
+#                 0 if the failure is definitive.
+log_pattern_presence_is_conclusive() {
+    # If we've run out of attempts, then don't retry no matter what.
+    if [ $TIMES_LEFT -eq 0 ]; then
+        return 0
+    fi
+    case $1 in
+        "resend")
+            # An undesired resend may have been caused by the OS dropping or
+            # delaying a packet at an inopportune time.
+            outcome="RETRY(resend)"
+            return 1;;
+    esac
+}
+
 # fail <message>
 fail() {
     record_outcome "FAIL" "$1"
@@ -939,9 +965,7 @@ check_test_failure() {
 
             "-S")
                 if grep -v '^==' $SRV_OUT | grep -v 'Serious error when reading debug info' | grep "$2" >/dev/null; then
-                    if [ "$2" = "resend" ] && [ $TIMES_LEFT -gt 0 ]; then
-                        outcome="RETRY(resend)"
-                    else
+                    if log_pattern_presence_is_conclusive "$2"; then
                         fail "pattern '$2' MUST NOT be present in the Server output"
                     fi
                     return
@@ -950,9 +974,7 @@ check_test_failure() {
 
             "-C")
                 if grep -v '^==' $CLI_OUT | grep -v 'Serious error when reading debug info' | grep "$2" >/dev/null; then
-                    if [ "$2" = "resend" ] && [ $TIMES_LEFT -gt 0 ]; then
-                        outcome="RETRY(resend)"
-                    else
+                    if log_pattern_presence_is_conclusive "$2"; then
                         fail "pattern '$2' MUST NOT be present in the Client output"
                     fi
                     return


### PR DESCRIPTION
In ssl-opt.sh, if a test case fails due to an unexpected resend, retry that test case (like we do on a client timeout). The goal is to avoid spurious test failures when the OS decides to delay or drop a packet, causing a necessary resend. These failures are rare, so hopefully the probability that they'll happen multiple times in a row is low enough to be acceptable.

Resolves https://github.com/ARMmbed/mbedtls/issues/3377.

To see the retry in action: https://github.com/gilles-peskine-arm/mbedtls/tree/ssl-opt-resend-retry-3.0-demo
```
$ ./tests/ssl-opt.sh -f 'DTLS client reconnect from same port: reference'
DTLS client reconnect from same port: reference ........................ PASS
DTLS client reconnect from same port: reference (forced retry) ......... RETRY(resend) PASS
DTLS client reconnect from same port: reference (forced retry-fail) .... RETRY(resend) FAIL
  ! pattern 'resend' MUST NOT be present in the Client output
  ! outputs saved to o-XXX-3.log
DTLS client reconnect from same port: reference (forced fail) .......... FAIL
  ! pattern 'a' MUST NOT be present in the Client output
  ! outputs saved to o-XXX-4.log
------------------------------------------------------------------------
FAILED (2 / 4 tests (0 skipped))
```

Backports: [2.x](https://github.com/ARMmbed/mbedtls/pull/5097), [2.16](https://github.com/ARMmbed/mbedtls/pull/5098).
