### PR TITLE
Generate test cases for PSA key generation

### DIFF
--- a/scripts/mbedtls_dev/test_case.py
+++ b/scripts/mbedtls_dev/test_case.py
@@ -42,6 +42,7 @@ class TestCase:
         self.dependencies = [] #type: List[str]
         self.function = None #type: Optional[str]
         self.arguments = [] #type: List[str]
+        self.result = '' #type: str
 
     def add_comment(self, *lines: str) -> None:
         self.comments += lines
@@ -57,6 +58,9 @@ class TestCase:
 
     def set_arguments(self, arguments: List[str]) -> None:
         self.arguments = arguments
+
+    def set_result(self, result: str) -> None:
+        self.result = result
 
     def check_completeness(self) -> None:
         if self.description is None:
@@ -81,9 +85,11 @@ class TestCase:
         out.write(self.description + '\n')
         if self.dependencies:
             out.write('depends_on:' + ':'.join(self.dependencies) + '\n')
-        out.write(self.function + ':' + ':'.join(self.arguments) + '\n')
-
-
+        out.write(self.function + ':' + ':'.join(self.arguments))
+        if self.result:
+            out.write(':' + self.result + '\n')
+        else:
+            out.write('\n')
 
 def write_data_file(filename: str,
                     test_cases: Iterable[TestCase],

--- a/scripts/mbedtls_dev/test_case.py
+++ b/scripts/mbedtls_dev/test_case.py
@@ -42,7 +42,6 @@ class TestCase:
         self.dependencies = [] #type: List[str]
         self.function = None #type: Optional[str]
         self.arguments = [] #type: List[str]
-        self.result = '' #type: str
 
     def add_comment(self, *lines: str) -> None:
         self.comments += lines
@@ -58,9 +57,6 @@ class TestCase:
 
     def set_arguments(self, arguments: List[str]) -> None:
         self.arguments = arguments
-
-    def set_result(self, result: str) -> None:
-        self.result = result
 
     def check_completeness(self) -> None:
         if self.description is None:
@@ -86,10 +82,6 @@ class TestCase:
         if self.dependencies:
             out.write('depends_on:' + ':'.join(self.dependencies) + '\n')
         out.write(self.function + ':' + ':'.join(self.arguments))
-        if self.result:
-            out.write(':' + self.result + '\n')
-        else:
-            out.write('\n')
 
 def write_data_file(filename: str,
                     test_cases: Iterable[TestCase],

--- a/scripts/mbedtls_dev/test_case.py
+++ b/scripts/mbedtls_dev/test_case.py
@@ -81,7 +81,7 @@ class TestCase:
         out.write(self.description + '\n')
         if self.dependencies:
             out.write('depends_on:' + ':'.join(self.dependencies) + '\n')
-        out.write(self.function + ':' + ':'.join(self.arguments))
+        out.write(self.function + ':' + ':'.join(self.arguments) + '\n')
 
 def write_data_file(filename: str,
                     test_cases: Iterable[TestCase],

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -155,30 +155,8 @@ def test_case_for_key_type_not_supported(
     tc.set_arguments([key_type] + list(args))
     return tc
 
-def test_case_for_key_type_invalid_argument(
-        verb: str, key_type: str, bits: int,
-        dependencies: List[str],
-        *args: str,
-        param_descr: str = ''
-) -> test_case.TestCase:
-    """Return one test case exercising a key creation method
-    for an invalid argument when key is public.
-    """
-    hack_dependencies_not_implemented(dependencies)
-    tc = test_case.TestCase()
-    short_key_type = re.sub(r'PSA_(KEY_TYPE|ECC_FAMILY)_', r'', key_type)
-    adverb = 'not' if dependencies else 'never'
-    if param_descr:
-        adverb = param_descr + ' ' + adverb
-    tc.set_description('PSA {} {} {}-bit invalid argument'
-                       .format(verb, short_key_type, bits))
-    tc.set_function(verb + '_invalid_argument')
-    tc.set_dependencies(dependencies)
-    tc.set_arguments([key_type] + list(args))
-    return tc
-
 class NotSupported:
-    """Generate test cases for when something is not supported or argument is inavlid."""
+    """Generate test cases for when something is not supported."""
 
     def __init__(self, info: Information) -> None:
         self.constructors = info.constructors
@@ -193,13 +171,11 @@ class NotSupported:
             param: Optional[int] = None,
             param_descr: str = '',
     ) -> Iterator[test_case.TestCase]:
-        """Return test cases exercising key creation when the given type is unsupported
-        or argument is invalid.
+        """Return test cases exercising key creation when the given type is unsupported.
 
         If param is present and not None, emit test cases conditioned on this
         parameter not being supported. If it is absent or None, emit test cases
-        conditioned on the base type not being supported. If key is public emit test
-        case for invalid argument.
+        conditioned on the base type not being supported.
         """
         if kt.name in self.ALWAYS_SUPPORTED:
             # Don't generate test cases for key types that are always supported.
@@ -227,14 +203,8 @@ class NotSupported:
                 # supported or not depending on implementation capabilities,
                 # only generate the test case once.
                 continue
-            if kt.name.endswith('_PUBLIC_KEY'):
-                yield test_case_for_key_type_invalid_argument(
-                    'generate', kt.expression, bits,
-                    finish_family_dependencies(generate_dependencies, bits),
-                    str(bits),
-                    param_descr=param_descr,
-                )
-            else:
+                # Public key cannot be generated
+            if not kt.name.endswith('_PUBLIC_KEY'):
                 yield test_case_for_key_type_not_supported(
                     'generate', kt.expression, bits,
                     finish_family_dependencies(generate_dependencies, bits),
@@ -266,7 +236,7 @@ def test_case_for_key_generation(
         dependencies: List[str],
         *args: str,
         result: str = '',
-        param_descr: str = '',
+        param_descr: str = ''
 ) -> test_case.TestCase:
     """Return one test case exercising a key generation.
     """

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -96,7 +96,7 @@ def hack_dependencies_not_implemented(dependencies: List[str]) -> None:
     if _implemented_dependencies is None:
         _implemented_dependencies = \
             read_implemented_dependencies('include/psa/crypto_config.h')
-    if not all(dep.lstrip('!') in _implemented_dependencies
+    if not all((dep.lstrip('!') in _implemented_dependencies or 'PSA_WANT' not in dep)
                for dep in dependencies):
         dependencies.append('DEPENDENCY_NOT_IMPLEMENTED_YET')
 
@@ -260,8 +260,11 @@ class KeyGenerate:
     ECC_KEY_TYPES = ('PSA_KEY_TYPE_ECC_KEY_PAIR',
                      'PSA_KEY_TYPE_ECC_PUBLIC_KEY')
 
-    @staticmethod
+    RSA_KEY_TYPES = ('PSA_KEY_TYPE_RSA_KEY_PAIR',
+                     'PSA_KEY_TYPE_RSA_PUBLIC_KEY')
+
     def test_cases_for_key_type_key_generation(
+            self,
             kt: crypto_knowledge.KeyType
     ) -> Iterator[test_case.TestCase]:
         """Return test cases exercising key generation.
@@ -280,6 +283,8 @@ class KeyGenerate:
             result = 'PSA_ERROR_INVALID_ARGUMENT'
         else:
             generate_dependencies = import_dependencies
+            if kt.name in self.RSA_KEY_TYPES:
+                generate_dependencies.append("MBEDTLS_GENPRIME")
         for bits in kt.sizes_to_test():
             yield test_case_for_key_generation(
                 kt.expression, bits,

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -235,8 +235,7 @@ def test_case_for_key_generation(
         key_type: str, bits: int,
         dependencies: List[str],
         *args: str,
-        result: str = '',
-        param_descr: str = ''
+        result: str = ''
 ) -> test_case.TestCase:
     """Return one test case exercising a key generation.
     """
@@ -244,7 +243,7 @@ def test_case_for_key_generation(
     tc = test_case.TestCase()
     short_key_type = re.sub(r'PSA_(KEY_TYPE|ECC_FAMILY)_', r'', key_type)
     tc.set_description('PSA {} {}-bit'
-                       .format( short_key_type, bits))
+                       .format(short_key_type, bits))
     tc.set_dependencies(dependencies)
     tc.set_function('generate_key')
     tc.set_arguments([key_type] + list(args))
@@ -258,11 +257,12 @@ class KeyGenerate:
     def __init__(self, info: Information) -> None:
         self.constructors = info.constructors
 
+    ECC_KEY_TYPES = ('PSA_KEY_TYPE_ECC_KEY_PAIR',
+                     'PSA_KEY_TYPE_ECC_PUBLIC_KEY')
+
+    @staticmethod
     def test_cases_for_key_type_key_generation(
-            self,
-            kt: crypto_knowledge.KeyType,
-            param: Optional[int] = None,
-            param_descr: str = '',
+            kt: crypto_knowledge.KeyType
     ) -> Iterator[test_case.TestCase]:
         """Return test cases exercising key generation.
 
@@ -285,12 +285,8 @@ class KeyGenerate:
                 kt.expression, bits,
                 finish_family_dependencies(generate_dependencies, bits),
                 str(bits),
-                result,
-                param_descr=param_descr
+                result
             )
-
-    ECC_KEY_TYPES = ('PSA_KEY_TYPE_ECC_KEY_PAIR',
-                     'PSA_KEY_TYPE_ECC_PUBLIC_KEY')
 
     def test_cases_for_key_generation(self) -> Iterator[test_case.TestCase]:
         """Generate test cases that exercise the generation of keys."""
@@ -302,11 +298,7 @@ class KeyGenerate:
         for curve_family in sorted(self.constructors.ecc_curves):
             for constr in self.ECC_KEY_TYPES:
                 kt = crypto_knowledge.KeyType(constr, [curve_family])
-                yield from self.test_cases_for_key_type_key_generation(
-                    kt, param_descr='type')
-                yield from self.test_cases_for_key_type_key_generation(
-                    kt, 0, param_descr='curve')
-
+                yield from self.test_cases_for_key_type_key_generation(kt)
 
 class StorageKey(psa_storage.Key):
     """Representation of a key for storage format testing."""

--- a/tests/suites/test_suite_psa_crypto_generate_key.function
+++ b/tests/suites/test_suite_psa_crypto_generate_key.function
@@ -13,41 +13,36 @@
  */
 
 /* BEGIN_CASE */
-void generate_key( int key_type, int bits, int result)
+void generate_key( int key_type_arg, int bits_arg, int expected_status_arg)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     mbedtls_svc_key_id_t key_id = INVALID_KEY_ID;
 
     // key lifetiem, usage flags, algorithm are irrelevant for this test
-    psa_key_lifetime_t _key_life_time = (psa_key_lifetime_t) 0;
-    psa_key_usage_t _key_usage_flags = (psa_key_usage_t) 0;
-    psa_algorithm_t _key_algorithm = (psa_algorithm_t) 0;
-    psa_key_type_t _key_type = (psa_key_type_t) key_type;
-    size_t _key_bits = (size_t) bits;
-    psa_status_t _result = (psa_status_t) result;
+    psa_key_type_t key_type = key_type_arg;
+    size_t bits = bits_arg;
+    psa_status_t expected_status = expected_status_arg;
 
     PSA_ASSERT( psa_crypto_init( ) );
-    psa_set_key_lifetime( &attributes, _key_life_time );
-    psa_set_key_usage_flags( &attributes, _key_usage_flags );
-    psa_set_key_algorithm( &attributes, _key_algorithm );
-    psa_set_key_type( &attributes, _key_type );
-    psa_set_key_bits( &attributes, _key_bits );
+    psa_set_key_type( &attributes, key_type );
+    psa_set_key_bits( &attributes, bits );
     TEST_EQUAL( psa_generate_key( &attributes, &key_id ),
-                _result );
+                expected_status );
 
     // Verify attributes of the created key on success
-    if (_result == PSA_SUCCESS)
+    if ( expected_status == PSA_SUCCESS )
     {
-        psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
-        PSA_ASSERT( psa_get_key_attributes( key_id, &key_attributes ) );
-        TEST_EQUAL( psa_get_key_lifetime( &key_attributes ), 0 );
-        TEST_EQUAL( psa_get_key_usage_flags( &key_attributes ), 0 );
-        TEST_EQUAL( psa_get_key_algorithm( &key_attributes ), 0 );
-        TEST_EQUAL( psa_get_key_type( &key_attributes ), _key_type );
-        TEST_EQUAL( psa_get_key_bits( &key_attributes ), _key_bits );
+        psa_reset_key_attributes(&attributes);
+        PSA_ASSERT( psa_get_key_attributes( key_id, &attributes ) );
+        TEST_EQUAL( psa_get_key_lifetime( &attributes ), PSA_KEY_LIFETIME_VOLATILE );
+        TEST_EQUAL( psa_get_key_usage_flags( &attributes ), 0 );
+        TEST_EQUAL( psa_get_key_algorithm( &attributes ), 0 );
+        TEST_EQUAL( psa_get_key_type( &attributes ), key_type );
+        TEST_EQUAL( psa_get_key_bits( &attributes ), bits );
     }
 
 exit:
+    psa_reset_key_attributes(&attributes);
     psa_destroy_key( key_id );
     PSA_DONE( );
 }

--- a/tests/suites/test_suite_psa_crypto_generate_key.function
+++ b/tests/suites/test_suite_psa_crypto_generate_key.function
@@ -1,0 +1,54 @@
+/* BEGIN_HEADER */
+
+#include "psa/crypto.h"
+#include "test/psa_crypto_helpers.h"
+
+#define INVALID_KEY_ID mbedtls_svc_key_id_make( 0, 0xfedcba98 )
+
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C
+ * END_DEPENDENCIES
+ */
+
+/* BEGIN_CASE */
+void generate_key( int key_type, int bits, int result)
+{
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    mbedtls_svc_key_id_t key_id = INVALID_KEY_ID;
+
+    // key lifetiem, usage flags, algorithm are irrelevant for this test
+    psa_key_lifetime_t _key_life_time = (psa_key_lifetime_t) 0;
+    psa_key_usage_t _key_usage_flags = (psa_key_usage_t) 0;
+    psa_algorithm_t _key_algorithm = (psa_algorithm_t) 0;
+    psa_key_type_t _key_type = (psa_key_type_t) key_type;
+    size_t _key_bits = (size_t) bits;
+    psa_status_t _result = (psa_status_t) result;
+
+    PSA_ASSERT( psa_crypto_init( ) );
+    psa_set_key_lifetime( &attributes, _key_life_time );
+    psa_set_key_usage_flags( &attributes, _key_usage_flags );
+    psa_set_key_algorithm( &attributes, _key_algorithm );
+    psa_set_key_type( &attributes, _key_type );
+    psa_set_key_bits( &attributes, _key_bits );
+    TEST_EQUAL( psa_generate_key( &attributes, &key_id ),
+                _result );
+
+    // Verify attributes of the created key on success
+    if (_result == PSA_SUCCESS)
+    {
+        psa_key_attributes_t key_attributes = {0};
+        PSA_ASSERT( psa_get_key_attributes( key_id, &key_attributes ) );
+        TEST_EQUAL( psa_get_key_lifetime( &key_attributes ), 0 );
+        TEST_EQUAL( psa_get_key_usage_flags( &key_attributes ), 0 );
+        TEST_EQUAL( psa_get_key_algorithm( &key_attributes ), 0 );
+        TEST_EQUAL( psa_get_key_type( &key_attributes ), _key_type );
+        TEST_EQUAL( psa_get_key_bits( &key_attributes ), _key_bits );
+    }
+
+exit:
+    psa_destroy_key( key_id );
+    PSA_DONE( );
+}
+/* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_generate_key.function
+++ b/tests/suites/test_suite_psa_crypto_generate_key.function
@@ -38,7 +38,7 @@ void generate_key( int key_type, int bits, int result)
     // Verify attributes of the created key on success
     if (_result == PSA_SUCCESS)
     {
-        psa_key_attributes_t key_attributes = {0};
+        psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
         PSA_ASSERT( psa_get_key_attributes( key_id, &key_attributes ) );
         TEST_EQUAL( psa_get_key_lifetime( &key_attributes ), 0 );
         TEST_EQUAL( psa_get_key_usage_flags( &key_attributes ), 0 );

--- a/tests/suites/test_suite_psa_crypto_not_supported.function
+++ b/tests/suites/test_suite_psa_crypto_not_supported.function
@@ -50,22 +50,3 @@ exit:
     PSA_DONE( );
 }
 /* END_CASE */
-
-/* BEGIN_CASE */
-void generate_invalid_argument( int key_type, int bits )
-{
-    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    mbedtls_svc_key_id_t key_id = INVALID_KEY_ID;
-
-    PSA_ASSERT( psa_crypto_init( ) );
-    psa_set_key_type( &attributes, key_type );
-    psa_set_key_bits( &attributes, bits );
-    TEST_EQUAL( psa_generate_key( &attributes, &key_id ),
-                PSA_ERROR_INVALID_ARGUMENT );
-    TEST_ASSERT( mbedtls_svc_key_id_equal( key_id, MBEDTLS_SVC_KEY_ID_INIT ) );
-
-exit:
-    psa_destroy_key( key_id );
-    PSA_DONE( );
-}
-/* END_CASE */


### PR DESCRIPTION
## Description
- add another family of test cases: attempting to generate key. Positive and negaive (generation is impossible for public key types) test cases,
- move the existing support for key generation for public key types from `NotSupported` class

Resolves https://github.com/ARMmbed/mbedtls/issues/5060

## Status
**READY**

## Requires Backporting
2.x PR #5142


## Migrations
NO
