### PR TITLE
Backport 2.x: Retry a test case if it fails due to an unexpected resend

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -485,6 +485,32 @@ record_outcome() {
     fi
 }
 
+# True if the presence of the given pattern in a log definitely indicates
+# that the test has failed. False if the presence is inconclusive.
+#
+# Inputs:
+# * $1: pattern found in the logs
+# * $TIMES_LEFT: >0 if retrying is an option
+#
+# Outputs:
+# * $outcome: set to a retry reason if the pattern is inconclusive,
+#             unchanged otherwise.
+# * Return value: 1 if the pattern is inconclusive,
+#                 0 if the failure is definitive.
+log_pattern_presence_is_conclusive() {
+    # If we've run out of attempts, then don't retry no matter what.
+    if [ $TIMES_LEFT -eq 0 ]; then
+        return 0
+    fi
+    case $1 in
+        "resend")
+            # An undesired resend may have been caused by the OS dropping or
+            # delaying a packet at an inopportune time.
+            outcome="RETRY(resend)"
+            return 1;;
+    esac
+}
+
 # fail <message>
 fail() {
     record_outcome "FAIL" "$1"
@@ -863,9 +889,7 @@ check_test_failure() {
 
             "-S")
                 if grep -v '^==' $SRV_OUT | grep -v 'Serious error when reading debug info' | grep "$2" >/dev/null; then
-                    if [ "$2" = "resend" ] && [ $TIMES_LEFT -gt 0 ]; then
-                        outcome="RETRY(resend)"
-                    else
+                    if log_pattern_presence_is_conclusive "$2"; then
                         fail "pattern '$2' MUST NOT be present in the Server output"
                     fi
                     return
@@ -874,9 +898,7 @@ check_test_failure() {
 
             "-C")
                 if grep -v '^==' $CLI_OUT | grep -v 'Serious error when reading debug info' | grep "$2" >/dev/null; then
-                    if [ "$2" = "resend" ] && [ $TIMES_LEFT -gt 0 ]; then
-                        outcome="RETRY(resend)"
-                    else
+                    if log_pattern_presence_is_conclusive "$2"; then
                         fail "pattern '$2' MUST NOT be present in the Client output"
                     fi
                     return


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/5090. Mostly straightforward, just need to pay attention that the two commits that move code are indeed moving code and not introducing 3.x code.

Cherry-pick https://github.com/gilles-peskine-arm/mbedtls/tree/ssl-opt-resend-retry-3.0-demo (33756b785d46eb0403d2bb79cbb6ec4b00c7d3bb) to see retries and failures in action.
