### PR TITLE
doc improvements in aes and sha256 includes

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -511,10 +511,6 @@ int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
  * \brief      This function performs an AES-CTR encryption or decryption
  *             operation.
  *
- *             This function performs the operation defined in the \p mode
- *             parameter (encrypt/decrypt), on the input data buffer
- *             defined in the \p input parameter.
- *
  *             Due to the nature of CTR, you must use the same key schedule
  *             for both encryption and decryption operations. Therefore, you
  *             must use the context initialized with mbedtls_aes_setkey_enc()

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -167,6 +167,9 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
  *                 for SHA-256, \c 28 bytes for SHA-224.
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
  */
 int mbedtls_sha256( const unsigned char *input,
                     size_t ilen,


### PR DESCRIPTION
## Minor doc improvements

1. Add return value description to the docs of `mbedtls_sha256`
2. Remove description of non-existing "mode" parameter from the docs of `mbedtls_aes_crypt_ctr`  