### PR TITLE
Backport 2.16: Ssl opt fixes

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -513,6 +513,8 @@ has_mem_err() {
 # Wait for process $2 named $3 to be listening on port $1. Print error to $4.
 if type lsof >/dev/null 2>/dev/null; then
     wait_app_start() {
+        newline='
+'
         START_TIME=$(date +%s)
         if [ "$DTLS" -eq 1 ]; then
             proto=UDP
@@ -521,20 +523,14 @@ if type lsof >/dev/null 2>/dev/null; then
         fi
         # Make a tight loop, server normally takes less than 1s to start.
         while true; do
-              SERVER_PIDS=$(lsof -a -n -b -i "$proto:$1" -F p | cut -c2-)
-              SERVER_FOUND=false
-              # When proxies are used, more than one PID can be listening on
-              # the same port. Each PID will be on its own line.
-              while read -r PID; do
-                  if [[ $PID == $2 ]]; then
-                      SERVER_FOUND=true
-                      break
-                  fi
-              done <<< "$SERVER_PIDS"
-
-              if ($SERVER_FOUND == true); then
-                  break
-              fi
+              SERVER_PIDS=$(lsof -a -n -b -i "$proto:$1" -F p)
+              # When we use a proxy, it will be listening on the same port we
+              # are checking for as well as the server and lsof will list both.
+              # If multiple PIDs are returned, each one will be on a separate
+              # line, each prepended with 'p'.
+             case ${newline}${SERVER_PIDS}${newline} in
+                  *${newline}p${2}${newline}*) break;;
+              esac
               if [ $(( $(date +%s) - $START_TIME )) -gt $DOG_DELAY ]; then
                   echo "$3 START TIMEOUT"
                   echo "$3 START TIMEOUT" >> $4


### PR DESCRIPTION
## Description

Problem I found whilst trying to get ssl-opt to run clean locally, whilst looking for the issues surrounding the tls renegotiation bug (#5022)

The use of -b (non blocking) with lsof seems to break the use of -p (with PID) with lsof, on machines with newer kernels (>5.4 fgrom testing so far)This seems to be because -b forbids the usage of blocking kernel calls (which would seem potentially wise given the tight loop this is used in), however -p seems to rely on using stat() to read files in /proc, and -b forbids this. With -b on all I get is a string of warnings, and a negative result, which means that all servers are marked as 'failed to start'. This is not currently happening on the CI due to it still running kernel 5.4, but an AMI update could easily break this.

As discussed below, we are unkeen on removing -b, as blocking in a tight loop seems unwise, so instead I am parsing the output of lsof, which already contains the pids. To assist with this I am using the -F option, which allows us to format the output for reading by other tools. The only issue is that without -p, lsof can return multiple PIDs listening on the same port (especially in the case when using proxies), so I need to read multiple lines, however I avoided the use of grep at least.

This is the backport to 2.16 of #5066 

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests

## Steps to test or reproduce
ssl-opt should run clean (and not skip every test due to server not starting) on machines with kernel > 5.4
