### PR TITLE
Added MBEDTLS_BIGNUM_ALT & related macros for custom bignum functions.

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -109,6 +109,7 @@
 #define MBEDTLS_LN_2_DIV_LN_10_SCALE100                 332
 #define MBEDTLS_MPI_RW_BUFFER_SIZE             ( ((MBEDTLS_MPI_MAX_BITS_SCALE100 + MBEDTLS_LN_2_DIV_LN_10_SCALE100 - 1) / MBEDTLS_LN_2_DIV_LN_10_SCALE100) + 10 + 6 )
 
+#if !defined(MBEDTLS_BIGNUM_ALT)
 /*
  * Define the base integer type, architecture-wise.
  *
@@ -1010,6 +1011,9 @@ typedef enum {
 int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
                    int (*f_rng)(void *, unsigned char *, size_t),
                    void *p_rng );
+#else /* MBEDTLS_BIGNUM_ALT */
+#include "bignum_alt.h"
+#endif /* MBEDTLS_BIGNUM_ALT */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -54,6 +54,8 @@
 #define mbedtls_free       free
 #endif
 
+#if !defined(MBEDTLS_BIGNUM_ALT)
+
 #define MPI_VALIDATE_RET( cond )                                       \
     MBEDTLS_INTERNAL_VALIDATE_RET( cond, MBEDTLS_ERR_MPI_BAD_INPUT_DATA )
 #define MPI_VALIDATE( cond )                                           \
@@ -1618,6 +1620,8 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_sint 
     return( mbedtls_mpi_sub_mpi( X, A, &B ) );
 }
 
+#if !defined(MBEDTLS_MPI_MUL_MPI_ALT) || !defined(MBEDTLS_MPI_EXP_MOD_ALT)
+
 /** Helper for mbedtls_mpi multiplication.
  *
  * Add \p b * \p s to \p d.
@@ -1706,6 +1710,10 @@ void mpi_mul_hlp( size_t i,
     }
 }
 
+#endif /* !defined(MBEDTLS_MPI_MUL_MPI_ALT) || !defined(MBEDTLS_MPI_EXP_MOD_ALT) */
+
+#if !defined(MBEDTLS_MPI_MUL_MPI_ALT)
+
 /*
  * Baseline multiplication: X = A * B  (HAC 14.12)
  */
@@ -1757,6 +1765,7 @@ cleanup:
 
     return( ret );
 }
+#endif /* !defined(MBEDTLS_MPI_MUL_MPI_ALT) */
 
 /*
  * Baseline multiplication: X = A * b
@@ -2123,6 +2132,8 @@ int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A, mbedtls_mpi_
 
     return( 0 );
 }
+
+#if !defined(MBEDTLS_MPI_EXP_MOD_ALT)
 
 /*
  * Fast Montgomery initialization (thanks to Tom St Denis)
@@ -2528,7 +2539,7 @@ cleanup:
 
     return( ret );
 }
-
+#endif
 /*
  * Greatest common divisor: G = gcd(A, B)  (HAC 14.54)
  */


### PR DESCRIPTION
Added the support for `MBEDTLS_BIGNUM_ALT` and other macros.
This would enables users to use a custom implementation for the lignum API's