### PR TITLE
Fix copypasta in #endif comment

### DIFF
--- a/library/base64_invasive.h
+++ b/library/base64_invasive.h
@@ -52,4 +52,4 @@ unsigned char mbedtls_base64_enc_char( unsigned char val );
 signed char mbedtls_base64_dec_value( unsigned char c );
 #endif /* MBEDTLS_TEST_HOOKS */
 
-#endif /* MBEDTLS_SSL_INVASIVE_H */
+#endif /* MBEDTLS_BASE64_INVASIVE_H */


### PR DESCRIPTION
This mistake will cause `check_names.py` to fail when https://github.com/ARMmbed/mbedtls/pull/4866 is merged. Let's fix it first.

Backports: [2.x](https://github.com/ARMmbed/mbedtls/pull/5129); not applicable to 2.16.
