### PR TITLE
Backport 2.x: Fix GCM calculation with very long IV

### DIFF
--- a/ChangeLog.d/bugfix-for-gcm-long-iv-size.txt
+++ b/ChangeLog.d/bugfix-for-gcm-long-iv-size.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a bug in mbedtls_gcm_starts() when bits of iv are longer than 2^32.
+   * Fix #4884.
+

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -257,6 +257,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     size_t i;
     const unsigned char *p;
     size_t use_len, olen = 0;
+    uint64_t iv_bits;
 
     GCM_VALIDATE_RET( ctx != NULL );
     GCM_VALIDATE_RET( iv != NULL );
@@ -286,7 +287,8 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     else
     {
         memset( work_buf, 0x00, 16 );
-        MBEDTLS_PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
+        iv_bits = (uint64_t)iv_len * 8;
+        MBEDTLS_PUT_UINT64_BE( iv_bits, work_buf, 8 );
 
         p = iv;
         while( iv_len > 0 )


### PR DESCRIPTION
Trivial backport of https://github.com/ARMmbed/mbedtls/pull/4950