### PR TITLE
Backport 2.16: Fix GCM calculation with very long IV

### DIFF
--- a/ChangeLog.d/bugfix-for-gcm-long-iv-size.txt
+++ b/ChangeLog.d/bugfix-for-gcm-long-iv-size.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a bug in mbedtls_gcm_starts() when bits of iv are longer than 2^32.
+   * Fix #4884.

--- a/library/gcm.c
+++ b/library/gcm.c
@@ -111,6 +111,20 @@
 }
 #endif
 
+#ifndef PUT_UINT64_BE
+#define PUT_UINT64_BE( n, b, i )                                 \
+{                                                                \
+    ( b )[( i )    ] = (unsigned char) ( ( (n) >> 56 ) & 0xff ); \
+    ( b )[( i ) + 1] = (unsigned char) ( ( (n) >> 48 ) & 0xff ); \
+    ( b )[( i ) + 2] = (unsigned char) ( ( (n) >> 40 ) & 0xff ); \
+    ( b )[( i ) + 3] = (unsigned char) ( ( (n) >> 32 ) & 0xff ); \
+    ( b )[( i ) + 4] = (unsigned char) ( ( (n) >> 24 ) & 0xff ); \
+    ( b )[( i ) + 5] = (unsigned char) ( ( (n) >> 16 ) & 0xff ); \
+    ( b )[( i ) + 6] = (unsigned char) ( ( (n) >> 8  ) & 0xff ); \
+    ( b )[( i ) + 7] = (unsigned char) ( ( (n)       ) & 0xff ); \
+}
+#endif
+
 /*
  * Initialize a context
  */
@@ -309,6 +323,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     size_t i;
     const unsigned char *p;
     size_t use_len, olen = 0;
+    uint64_t iv_bits;
 
     GCM_VALIDATE_RET( ctx != NULL );
     GCM_VALIDATE_RET( iv != NULL );
@@ -338,7 +353,8 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
     else
     {
         memset( work_buf, 0x00, 16 );
-        PUT_UINT32_BE( iv_len * 8, work_buf, 12 );
+        iv_bits = (uint64_t)iv_len * 8;
+        PUT_UINT64_BE( iv_bits, work_buf, 8 );
 
         p = iv;
         while( iv_len > 0 )


### PR DESCRIPTION
Fixes #4884
An initialization vector IV can have any number of bits between 1 and
2^64. So it should be filled to the lower 64-bit in the last step
when computing ghash.

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
A few sentences describing the overall goals of the pull request's commits.


## Status
**READY/IN DEVELOPMENT/HOLD**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

Yes | NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

YES | NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
