### PR TITLE
Additional cipher_info getters

### DIFF
--- a/ChangeLog.d/additional_cipher_info_getters.txt
+++ b/ChangeLog.d/additional_cipher_info_getters.txt
@@ -1,0 +1,3 @@
+Features
+   * Add functions to get the IV and block size from cipher_info structs.
+   * Add functions to check if a cipher supports variable IV or key size.

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -527,11 +527,13 @@ static inline size_t mbedtls_cipher_info_get_iv_size(
 
 /**
  * \brief        This function returns the block size of the given
- *               cipher info structure.
+ *               cipher info structure in bytes.
  *
  * \param info   The cipher info structure. This may be \c NULL.
  *
  * \return       The block size of the cipher.
+ * \return       \c 1 if the cipher is a stream cipher.
+ * \return       \c 0 if \p info is \c NULL.
  */
 static inline size_t mbedtls_cipher_info_get_block_size(
     const mbedtls_cipher_info_t *info )
@@ -654,11 +656,13 @@ int mbedtls_cipher_setup_psa( mbedtls_cipher_context_t *ctx,
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /**
- * \brief        This function returns the block size of the given cipher.
+ * \brief        This function returns the block size of the given cipher
+ *               in bytes.
  *
- * \param ctx    The context of the cipher. This must be initialized.
+ * \param ctx    The context of the cipher.
  *
  * \return       The block size of the underlying cipher.
+ * \return       \c 1 if the cipher is a stream cipher.
  * \return       \c 0 if \p ctx has not been initialized.
  */
 static inline unsigned int mbedtls_cipher_get_block_size(

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -543,6 +543,42 @@ static inline unsigned int mbedtls_cipher_info_get_block_size(
 }
 
 /**
+ * \brief        This function returns a non-zero value if the key length for
+ *               the given cipher is variable.
+ *
+ * \param info   The cipher info structure. This may be \c NULL.
+ *
+ * \return       Non-zero if the key length is variable, \c 0 otherwise.
+ * \return       \c 0 if the given pointer is \c NULL.
+ */
+static inline int mbedtls_cipher_info_has_variable_key_bitlen(
+    const mbedtls_cipher_info_t *info )
+{
+    if( info == NULL )
+        return( 0 );
+
+    return( info->MBEDTLS_PRIVATE(flags) & MBEDTLS_CIPHER_VARIABLE_KEY_LEN );
+}
+
+/**
+ * \brief        This function returns a non-zero value if the IV size for
+ *               the given cipher is variable.
+ *
+ * \param info   The cipher info structure. This may be \c NULL.
+ *
+ * \return       Non-zero if the IV size is variable, \c 0 otherwise.
+ * \return       \c 0 if the given pointer is \c NULL.
+ */
+static inline int mbedtls_cipher_info_has_variable_iv_size(
+    const mbedtls_cipher_info_t *info )
+{
+    if( info == NULL )
+        return( 0 );
+
+    return( info->MBEDTLS_PRIVATE(flags) & MBEDTLS_CIPHER_VARIABLE_IV_LEN );
+}
+
+/**
  * \brief               This function initializes a \p cipher_context as NONE.
  *
  * \param ctx           The context to be initialized. This must not be \c NULL.

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -508,6 +508,41 @@ static inline const char *mbedtls_cipher_info_get_name(
 }
 
 /**
+ * \brief       This function returns the size of the IV or nonce
+ *              for the cipher info structure, in bytes.
+ *
+ * \param info  The cipher info structure. This may be \c NULL.
+ *
+ * \return      The recommended IV size.
+ * \return      \c 0 for ciphers not using an IV or a nonce.
+ */
+static inline int mbedtls_cipher_info_get_iv_size(
+    const mbedtls_cipher_info_t *info )
+{
+    if( info == NULL )
+        return( 0 );
+
+    return( (int) info->MBEDTLS_PRIVATE(iv_size) );
+}
+
+/**
+ * \brief        This function returns the block size of the given
+ *               cipher info structure.
+ *
+ * \param info   The cipher info structure. This may be \c NULL.
+ *
+ * \return       The block size of the cipher.
+ */
+static inline unsigned int mbedtls_cipher_info_get_block_size(
+    const mbedtls_cipher_info_t *info )
+{
+    if( info == NULL )
+        return( 0 );
+
+    return( info->MBEDTLS_PRIVATE(block_size) );
+}
+
+/**
  * \brief               This function initializes a \p cipher_context as NONE.
  *
  * \param ctx           The context to be initialized. This must not be \c NULL.

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -516,13 +516,13 @@ static inline const char *mbedtls_cipher_info_get_name(
  * \return      The recommended IV size.
  * \return      \c 0 for ciphers not using an IV or a nonce.
  */
-static inline int mbedtls_cipher_info_get_iv_size(
+static inline size_t mbedtls_cipher_info_get_iv_size(
     const mbedtls_cipher_info_t *info )
 {
     if( info == NULL )
         return( 0 );
 
-    return( (int) info->MBEDTLS_PRIVATE(iv_size) );
+    return( (size_t) info->MBEDTLS_PRIVATE(iv_size) );
 }
 
 /**
@@ -533,13 +533,13 @@ static inline int mbedtls_cipher_info_get_iv_size(
  *
  * \return       The block size of the cipher.
  */
-static inline unsigned int mbedtls_cipher_info_get_block_size(
+static inline size_t mbedtls_cipher_info_get_block_size(
     const mbedtls_cipher_info_t *info )
 {
     if( info == NULL )
         return( 0 );
 
-    return( info->MBEDTLS_PRIVATE(block_size) );
+    return( (size_t) info->MBEDTLS_PRIVATE(block_size) );
 }
 
 /**

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -515,6 +515,7 @@ static inline const char *mbedtls_cipher_info_get_name(
  *
  * \return      The recommended IV size.
  * \return      \c 0 for ciphers not using an IV or a nonce.
+ * \return      \c 0 if \p info is \c NULL.
  */
 static inline size_t mbedtls_cipher_info_get_iv_size(
     const mbedtls_cipher_info_t *info )

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -18,8 +18,7 @@
 static int check_cipher_info( mbedtls_cipher_type_t type,
                               const mbedtls_cipher_info_t *info )
 {
-    size_t key_bitlen;
-    int block_size, iv_size;
+    size_t key_bitlen, block_size, iv_size;
 
     TEST_ASSERT( info != NULL );
     TEST_EQUAL( type, mbedtls_cipher_info_get_type( info ) );

--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -19,6 +19,7 @@ static int check_cipher_info( mbedtls_cipher_type_t type,
                               const mbedtls_cipher_info_t *info )
 {
     size_t key_bitlen;
+    int block_size, iv_size;
 
     TEST_ASSERT( info != NULL );
     TEST_EQUAL( type, mbedtls_cipher_info_get_type( info ) );
@@ -33,8 +34,14 @@ static int check_cipher_info( mbedtls_cipher_type_t type,
     TEST_ASSERT( mbedtls_cipher_info_from_string( info->name ) == info );
 
     key_bitlen = mbedtls_cipher_info_get_key_bitlen( info );
+    block_size = mbedtls_cipher_info_get_block_size( info );
+    iv_size = mbedtls_cipher_info_get_iv_size( info );
     if( info->type == MBEDTLS_CIPHER_NULL )
+    {
         TEST_ASSERT( key_bitlen == 0 );
+        TEST_ASSERT( block_size == 1 );
+        TEST_ASSERT( iv_size == 0 );
+    }
     else if( info->mode == MBEDTLS_MODE_XTS )
     {
         TEST_ASSERT( key_bitlen == 256 ||
@@ -44,20 +51,51 @@ static int check_cipher_info( mbedtls_cipher_type_t type,
     else if( ! strncmp( info->name, "DES-EDE3-", 9 ) )
     {
         TEST_ASSERT( key_bitlen == 192 );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_key_bitlen( info ) );
+        TEST_ASSERT( block_size == 8 );
     }
     else if( ! strncmp( info->name, "DES-EDE-", 8 ) )
     {
         TEST_ASSERT( key_bitlen == 128 );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_key_bitlen( info ) );
+        TEST_ASSERT( block_size == 8 );
     }
     else if( ! strncmp( info->name, "DES-", 4 ) )
     {
         TEST_ASSERT( key_bitlen == 64 );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_key_bitlen( info ) );
+        TEST_ASSERT( block_size == 8 );
+    }
+    else if( ! strncmp( info->name, "AES", 3 ) )
+    {
+        TEST_ASSERT( key_bitlen == 128 ||
+                     key_bitlen == 192 ||
+                     key_bitlen == 256 );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_key_bitlen( info ) );
+        TEST_ASSERT( block_size == 16 );
     }
     else
     {
         TEST_ASSERT( key_bitlen == 128 ||
                      key_bitlen == 192 ||
                      key_bitlen == 256 );
+    }
+
+    if( strstr( info->name, "-ECB" ) != NULL )
+    {
+        TEST_ASSERT( iv_size == 0 );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_iv_size( info ) );
+    }
+    else if( strstr( info->name, "-CBC" ) != NULL ||
+             strstr( info->name, "-CTR" ) != NULL )
+    {
+        TEST_ASSERT( iv_size == block_size );
+        TEST_ASSERT( ! mbedtls_cipher_info_has_variable_iv_size( info ) );
+    }
+    else if( strstr( info->name, "-GCM" ) != NULL )
+    {
+        TEST_ASSERT( iv_size == block_size - 4 );
+        TEST_ASSERT( mbedtls_cipher_info_has_variable_iv_size( info ) );
     }
 
     return( 1 );


### PR DESCRIPTION
## Description
While trying to add mbedtls 3 support to OpenVPN, we found that we need some additional getter functions that are not yet in the dev branch. This pull request adds functions that get the IV and block size from a `cipher_info` struct and functions that check if the IV or key size of a cipher are variable.

We also need some more getter functions in other parts of the library, but I figured it's easier if I keep the pull requests small.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated