### PR TITLE
Backport 2.16: Serialise builds of the .a files on Windows

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -110,6 +110,14 @@ static: libmbedcrypto.a libmbedx509.a libmbedtls.a
 
 shared: libmbedcrypto.$(DLEXT) libmbedx509.$(DLEXT) libmbedtls.$(DLEXT)
 
+# Windows builds under Mingw can fail if make tries to create archives in the same
+# directory at the same time - see https://bugs.launchpad.net/gcc-arm-embedded/+bug/1848002.
+# This forces builds of the .a files to be serialised.
+ifdef WINDOWS
+libmbedtls.a: | libmbedx509.a
+libmbedx509.a: | libmbedcrypto.a
+endif
+
 # tls
 libmbedtls.a: $(OBJS_TLS)
 	echo "  AR    $@"


### PR DESCRIPTION
This is a workaround for an issue with mkstemp() in older MinGW releases that
causes simultaneous creation of .a files in the same directory to fail.

Fixes #5146

Backport of #5147