### PR TITLE
Backport 2.x: Reorder structure fields to maximize usage of immediate offset access

### DIFF
--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -317,11 +317,29 @@ typedef struct mbedtls_cipher_info_t
  */
 typedef struct mbedtls_cipher_context_t
 {
-    /** Information about the associated cipher. */
-    const mbedtls_cipher_info_t *cipher_info;
+    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
+     * for XTS-mode. */
+    unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
+    
+    /** Buffer for input that has not been processed yet. */
+    unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
+
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    /** Indicates whether the cipher operations should be performed
+     *  by Mbed TLS' own crypto library or an external implementation
+     *  of the PSA Crypto API.
+     *  This is unset if the cipher context was established through
+     *  mbedtls_cipher_setup(), and set if it was established through
+     *  mbedtls_cipher_setup_psa().
+     */
+    unsigned char psa_enabled;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     /** Key length to use. */
     int key_bitlen;
+
+    /** Information about the associated cipher. */
+    const mbedtls_cipher_info_t *cipher_info;
 
     /** Operation that the key of the context has been
      * initialized for.
@@ -336,15 +354,8 @@ typedef struct mbedtls_cipher_context_t
     int (*get_padding)( unsigned char *input, size_t ilen, size_t *data_len );
 #endif
 
-    /** Buffer for input that has not been processed yet. */
-    unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
-
     /** Number of Bytes that have not been processed yet. */
     size_t unprocessed_len;
-
-    /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
-     * for XTS-mode. */
-    unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
 
     /** IV size in Bytes, for ciphers with variable-length IVs. */
     size_t iv_size;
@@ -356,17 +367,6 @@ typedef struct mbedtls_cipher_context_t
     /** CMAC-specific context. */
     mbedtls_cmac_context_t *cmac_ctx;
 #endif
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    /** Indicates whether the cipher operations should be performed
-     *  by Mbed TLS' own crypto library or an external implementation
-     *  of the PSA Crypto API.
-     *  This is unset if the cipher context was established through
-     *  mbedtls_cipher_setup(), and set if it was established through
-     *  mbedtls_cipher_setup_psa().
-     */
-    unsigned char psa_enabled;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 } mbedtls_cipher_context_t;
 

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -320,7 +320,7 @@ typedef struct mbedtls_cipher_context_t
     /** Current IV or NONCE_COUNTER for CTR-mode, data unit (or sector) number
      * for XTS-mode. */
     unsigned char iv[MBEDTLS_MAX_IV_LENGTH];
-    
+
     /** Buffer for input that has not been processed yet. */
     unsigned char unprocessed_data[MBEDTLS_MAX_BLOCK_LENGTH];
 

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -65,17 +65,18 @@ extern "C" {
  */
 typedef struct mbedtls_gcm_context
 {
-    mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
-    uint64_t HL[16];                      /*!< Precalculated HTable low. */
-    uint64_t HH[16];                      /*!< Precalculated HTable high. */
-    uint64_t len;                         /*!< The total length of the encrypted data. */
-    uint64_t add_len;                     /*!< The total length of the additional data. */
     unsigned char base_ectr[16];          /*!< The first ECTR for tag. */
     unsigned char y[16];                  /*!< The Y working value. */
     unsigned char buf[16];                /*!< The buf working value. */
     int mode;                             /*!< The operation to perform:
                                                #MBEDTLS_GCM_ENCRYPT or
                                                #MBEDTLS_GCM_DECRYPT. */
+
+    uint64_t HL[16];                      /*!< Precalculated HTable low. */
+    uint64_t HH[16];                      /*!< Precalculated HTable high. */
+    uint64_t len;                         /*!< The total length of the encrypted data. */
+    uint64_t add_len;                     /*!< The total length of the additional data. */
+    mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
 }
 mbedtls_gcm_context;
 

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -65,18 +65,18 @@ extern "C" {
  */
 typedef struct mbedtls_gcm_context
 {
-    unsigned char base_ectr[16];          /*!< The first ECTR for tag. */
     unsigned char y[16];                  /*!< The Y working value. */
     unsigned char buf[16];                /*!< The buf working value. */
     int mode;                             /*!< The operation to perform:
                                                #MBEDTLS_GCM_ENCRYPT or
                                                #MBEDTLS_GCM_DECRYPT. */
 
-    uint64_t HL[16];                      /*!< Precalculated HTable low. */
-    uint64_t HH[16];                      /*!< Precalculated HTable high. */
     uint64_t len;                         /*!< The total length of the encrypted data. */
     uint64_t add_len;                     /*!< The total length of the additional data. */
     mbedtls_cipher_context_t cipher_ctx;  /*!< The cipher context used. */
+    uint64_t HL[16];                      /*!< Precalculated HTable low. */
+    uint64_t HH[16];                      /*!< Precalculated HTable high. */
+    unsigned char base_ectr[16];          /*!< The first ECTR for tag. */
 }
 mbedtls_gcm_context;
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -57,9 +57,9 @@ extern "C" {
  */
 typedef struct mbedtls_md5_context
 {
+    unsigned char buffer[64];   /*!< data block being processed */
     uint32_t total[2];          /*!< number of bytes processed  */
     uint32_t state[4];          /*!< intermediate digest state  */
-    unsigned char buffer[64];   /*!< data block being processed */
 }
 mbedtls_md5_context;
 

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -62,10 +62,10 @@ extern "C" {
 
 typedef struct mbedtls_poly1305_context
 {
+    uint8_t queue[16];  /** The current partial block of data. */
     uint32_t r[4];      /** The value for 'r' (low 128 bits of the key). */
     uint32_t s[4];      /** The value for 's' (high 128 bits of the key). */
     uint32_t acc[5];    /** The accumulator number. */
-    uint8_t queue[16];  /** The current partial block of data. */
     size_t queue_len;   /** The number of bytes stored in 'queue'. */
 }
 mbedtls_poly1305_context;

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -67,10 +67,11 @@ mbedtls_x509_crl_entry;
  */
 typedef struct mbedtls_x509_crl
 {
+    int version;                    /**< CRL version (1=v1, 2=v2) */
+
     mbedtls_x509_buf raw;           /**< The raw certificate data (DER). */
     mbedtls_x509_buf tbs;           /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int version;            /**< CRL version (1=v1, 2=v2) */
     mbedtls_x509_buf sig_oid;       /**< CRL signature type identifier */
 
     mbedtls_x509_buf issuer_raw;    /**< The raw issuer data (DER). */

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -51,12 +51,22 @@ extern "C" {
  */
 typedef struct mbedtls_x509_crt
 {
+    unsigned char ns_cert_type;         /**< Optional Netscape certificate type extension value: See the values in x509.h */
+
     int own_buffer;                     /**< Indicates if \c raw is owned
                                          *   by the structure or not.        */
+
+    int ext_types;                      /**< Bit string containing detected and parsed extensions */
+    int ca_istrue;                      /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
+    int max_pathlen;                    /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
+
+    int version;                        /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
+
+    unsigned int key_usage;             /**< Optional key usage extension value: See the values in x509.h */
+
     mbedtls_x509_buf raw;               /**< The raw certificate data (DER). */
     mbedtls_x509_buf tbs;               /**< The raw certificate body (DER). The part that is To Be Signed. */
 
-    int version;                /**< The X.509 version. (1=v1, 2=v2, 3=v3) */
     mbedtls_x509_buf serial;            /**< Unique id for certificate issued by a specific CA. */
     mbedtls_x509_buf sig_oid;           /**< Signature algorithm, e.g. sha1RSA */
 
@@ -79,15 +89,7 @@ typedef struct mbedtls_x509_crt
 
     mbedtls_x509_sequence certificate_policies; /**< Optional list of certificate policies (Only anyPolicy is printed and enforced, however the rest of the policies are still listed). */
 
-    int ext_types;              /**< Bit string containing detected and parsed extensions */
-    int ca_istrue;              /**< Optional Basic Constraint extension value: 1 if this certificate belongs to a CA, 0 otherwise. */
-    int max_pathlen;            /**< Optional Basic Constraint extension value: The maximum path length to the root certificate. Path length is 1 higher than RFC 5280 'meaning', so 1+ */
-
-    unsigned int key_usage;     /**< Optional key usage extension value: See the values in x509.h */
-
     mbedtls_x509_sequence ext_key_usage; /**< Optional list of extended key usage OIDs. */
-
-    unsigned char ns_cert_type; /**< Optional Netscape certificate type extension value: See the values in x509.h */
 
     mbedtls_x509_buf sig;               /**< Signature: hash of the tbs part signed with the private key. */
     mbedtls_md_type_t sig_md;           /**< Internal representation of the MD algorithm of the signature algorithm, e.g. MBEDTLS_MD_SHA256 */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -48,10 +48,10 @@ extern "C" {
  */
 typedef struct mbedtls_x509_csr
 {
+    int version;                    /**< CSR version (1=v1). */
+    
     mbedtls_x509_buf raw;           /**< The raw CSR data (DER). */
     mbedtls_x509_buf cri;           /**< The raw CertificateRequestInfo body (DER). */
-
-    int version;            /**< CSR version (1=v1). */
 
     mbedtls_x509_buf  subject_raw;  /**< The raw subject data (DER). */
     mbedtls_x509_name subject;      /**< The parsed subject data (named information object). */

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -49,7 +49,7 @@ extern "C" {
 typedef struct mbedtls_x509_csr
 {
     int version;                    /**< CSR version (1=v1). */
-    
+
     mbedtls_x509_buf raw;           /**< The raw CSR data (DER). */
     mbedtls_x509_buf cri;           /**< The raw CertificateRequestInfo body (DER). */
 

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -175,9 +175,6 @@ typedef struct
 {
     uint8_t *info;
     size_t info_length;
-    psa_mac_operation_t hmac;
-    uint8_t prk[PSA_HASH_MAX_SIZE];
-    uint8_t output_block[PSA_HASH_MAX_SIZE];
 #if PSA_HASH_MAX_SIZE > 0xff
 #error "PSA_HASH_MAX_SIZE does not fit in uint8_t"
 #endif
@@ -185,6 +182,9 @@ typedef struct
     uint8_t block_number;
     unsigned int state : 2;
     unsigned int info_set : 1;
+    uint8_t output_block[PSA_HASH_MAX_SIZE];
+    uint8_t prk[PSA_HASH_MAX_SIZE];
+    psa_mac_operation_t hmac;
 } psa_hkdf_key_derivation_t;
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_HKDF */
 

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -108,9 +108,9 @@ static int key_type_is_raw_bytes( psa_key_type_t type )
 
 typedef struct
 {
-    mbedtls_psa_random_context_t rng;
     unsigned initialized : 1;
     unsigned rng_state : 2;
+    mbedtls_psa_random_context_t rng;
 } psa_global_data_t;
 
 static psa_global_data_t global_data;

--- a/library/psa_crypto_aead.c
+++ b/library/psa_crypto_aead.c
@@ -32,6 +32,8 @@
 
 typedef struct
 {
+    psa_algorithm_t core_alg;
+    uint8_t tag_length;
     union
     {
         unsigned dummy; /* Make the union non-empty even with no supported algorithms. */
@@ -45,11 +47,9 @@ typedef struct
         mbedtls_chachapoly_context chachapoly;
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_CHACHA20_POLY1305 */
     } ctx;
-    psa_algorithm_t core_alg;
-    uint8_t tag_length;
 } aead_operation_t;
 
-#define AEAD_OPERATION_INIT {{0}, 0, 0}
+#define AEAD_OPERATION_INIT {0, 0, {0}}
 
 static void psa_aead_abort_internal( aead_operation_t *operation )
 {


### PR DESCRIPTION
Resolve #4747 for 2.x, i.e. without breaking the API.

This is a backport of https://github.com/ARMmbed/mbedtls/pull/4821. The two currently differ significantly; I propose to rework https://github.com/ARMmbed/mbedtls/pull/4821 to be a forward-port of this plus the crypto parts that are not suitable for 2.x due to being API breaks.

----

Code size for  2290afc2d4419c34fd58f0894670d01cb756ac3c → c0656b43f1e1489f247777be336ae57121efe99f (arm-none-eabi-gcc 7.3.1, build_arm_none_eabi_gcc_m0plus build):

* `baremetal` config: 435089 → 433521 (save 1568 bytes)
* `config-suite-b.h` + `MBEDTLS_ECDH_LEGACY_CONTEXT` + `MBEDTLS_ECP_RESTARTABLE` + `MBEDTLS_NO_PLATFORM_ENTROPY` - `MBEDTLS_NET_C`: 131083 → 130555 (save 528 bytes)

