### PR TITLE
Remove expected failure from test_psa_compliance

### DIFF
--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -33,11 +33,6 @@ import sys
 # Test number 2xx corresponds to the files in the folder
 # psa-arch-tests/api-tests/dev_apis/crypto/test_c0xx
 EXPECTED_FAILURES = {
-    # psa_key_derivation_output_key() returns PSA_ERROR_NOT_PERMITTED instead of
-    # PSA_ERROR_BAD_STATE when called after the operation was aborted.
-    # - Tracked in issue #5143
-    221,
-
     # psa_aead_[encrypt/decrypt]() returns PSA_ERROR_NOT_SUPPORTED instead of
     # PSA_ERROR_INVALID_ARGUMENT when called with an invalid nonce.
     # - Tracked in issue #5144


### PR DESCRIPTION
## Description
The PRs #5180 and #5094 merged recently had an unhandled cross-dependency that will cause failures in our CI.

This PR removes the now-superfluous expected failure in `test_psa_crypto.py` that is causing the CI failures.
Signed-off-by: Bence Szépkúti <bence.szepkuti@arm.com>

## Status
**READY**

## Requires Backporting
Yes, development_2.x

## Todos
- [ ] Backported