### PR TITLE
Backport 2.x: Remove superfluous expected failure from test_psa_compliance

### DIFF
--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -33,11 +33,6 @@ import sys
 # Test number 2xx corresponds to the files in the folder
 # psa-arch-tests/api-tests/dev_apis/crypto/test_c0xx
 EXPECTED_FAILURES = {
-    # psa_key_derivation_output_key() returns PSA_ERROR_NOT_PERMITTED instead of
-    # PSA_ERROR_BAD_STATE when called after the operation was aborted.
-    # - Tracked in issue #5143
-    221,
-
     # Multipart AEAD is not supported in Mbed TLS 2.x.
     252, 253, 254, 255, 256, 257, 258, 259, 260, 261,
 


### PR DESCRIPTION
This PR is the trivial development_2.x backport of #5195.