### PR TITLE
In-tree Python package requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: c
-compiler: gcc
+# Declare python as our language. This way we get our chosen Python version,
+# and pip is available. Gcc and clang are available anyway.
+language: python
+python: 3.5
 sudo: false
 cache: ccache
 
@@ -16,8 +18,6 @@ jobs:
           - libnewlib-arm-none-eabi
           - gcc-arm-linux-gnueabi
           - libc6-dev-armel-cross
-      language: python # Needed to get pip for Python 3
-      python: 3.5 # version from Ubuntu 16.04
       script:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
@@ -30,6 +30,10 @@ jobs:
 
     - name: Windows
       os: windows
+      # The language 'python' is currently unsupported on the
+      # Windows Build Environment. And 'generic' causes the job to get stuck
+      # on "Booting virtual machine".
+      language: c
       before_install:
         - choco install python --version=3.5.4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ jobs:
           - libc6-dev-armel-cross
       language: python # Needed to get pip for Python 3
       python: 3.5 # version from Ubuntu 16.04
-      install:
-        - pip install mypy==0.780 pylint==2.4.4
       script:
         - tests/scripts/all.sh -k 'check_*'
         - tests/scripts/all.sh -k test_default_out_of_box
@@ -52,6 +50,9 @@ env:
   global:
     - SEED=1
     - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
+
+install:
+  - scripts/min_requirements.py
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
       env:
         # Add the directory where the Choco packages go
         - PATH=/c/Python35:/c/Python35/Scripts:$PATH
+        - PYTHON=python.exe
       script:
         - type perl; perl --version
         - type python; python --version
@@ -56,7 +57,7 @@ env:
     - secure: "FrI5d2s+ckckC17T66c8jm2jV6i2DkBPU5nyWzwbedjmEBeocREfQLd/x8yKpPzLDz7ghOvr+/GQvsPPn0dVkGlNzm3Q+hGHc/ujnASuUtGrcuMM+0ALnJ3k4rFr9xEvjJeWb4SmhJO5UCAZYvTItW4k7+bj9L+R6lt3TzQbXzg="
 
 install:
-  - scripts/min_requirements.py
+  - $PYTHON scripts/min_requirements.py
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ The source code of Mbed TLS includes some files that are automatically generated
 The following tools are required:
 
 * Perl, for some library source files and for Visual Studio build files.
-* Python 3, for some sample programs and test data.
+* Python 3 and some Python packages, for some library source files, sample programs and test data. To install the necessary packages, run
+    ```
+    python -m pip install -r scripts/basic.requirements.txt
+    ```
 * A C compiler for the host platform, for some test data.
 
 If you are cross-compiling, you must set the `CC` environment variable to a C compiler for the host platform when generating the configuration-independent files.

--- a/scripts/basic.requirements.txt
+++ b/scripts/basic.requirements.txt
@@ -1,0 +1,5 @@
+# Python modules required to build Mbed TLS in ordinary conditions.
+
+# Required to (re-)generate source files. Not needed if the generated source
+# files are already present and up-to-date.
+-r driver.requirements.txt

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -1,0 +1,10 @@
+# Python package requirements for Mbed TLS testing.
+
+# Use a known version of Pylint, because new versions tend to add warnings
+# that could start rejecting our code.
+# 2.4.4 is the version in Ubuntu 20.04. It supports Python >=3.5.
+pylint == 2.4.4
+
+# Use the earliest version of mypy that works with our code base.
+# See https://github.com/ARMmbed/mbedtls/pull/3953 .
+mypy >= 0.780

--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -1,5 +1,7 @@
 # Python package requirements for Mbed TLS testing.
 
+-r driver.requirements.txt
+
 # Use a known version of Pylint, because new versions tend to add warnings
 # that could start rejecting our code.
 # 2.4.4 is the version in Ubuntu 20.04. It supports Python >=3.5.

--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -2,7 +2,8 @@
 
 # Use the version of Jinja that's in Ubuntu 20.04.
 # See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
-# Note that Jinja2 3.0 drops support for Python 3.5, so we need 2.x.
+# Note that Jinja 3.0 drops support for Python 3.5, so we need to support
+# Jinja 2.x as long as we're still using Python 3.5 anywhere.
 Jinja2 >= 2.10.1
 # Jinja2 >=2.10, <<3.0 needs a separate package for type annotations
 types-Jinja2

--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -1,0 +1,9 @@
+# Python package requirements for driver implementers.
+
+# Use the version of Jinja that's in Ubuntu 20.04.
+# See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
+# Note that Jinja2 3.0 drops support for Python 3.5, so we need 2.x.
+Jinja2 >= 2.10.1
+# Jinja2 >=2.10, <<3.0 needs a separate package for type annotations
+types-Jinja2
+

--- a/scripts/maintainer.requirements.txt
+++ b/scripts/maintainer.requirements.txt
@@ -1,0 +1,6 @@
+# Python packages that are only useful to Mbed TLS maintainers.
+
+-r ci.requirements.txt
+
+# For source code analyses
+clang

--- a/scripts/maintainer.requirements.txt
+++ b/scripts/maintainer.requirements.txt
@@ -4,3 +4,7 @@
 
 # For source code analyses
 clang
+
+# For building some test vectors
+pycryptodomex
+pycryptodome-test-vectors

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Install all the required Python packages, with the minimum Python version.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import re
+import sys
+import typing
+
+from typing import List
+from mbedtls_dev import typing_util
+
+def pylint_doesn_t_notice_that_certain_types_are_used_in_annotations(
+        _list: List[typing.Any],
+) -> None:
+    pass
+
+
+class Requirements:
+    """Collect and massage Python requirements."""
+
+    def __init__(self) -> None:
+        self.requirements = [] #type: List[str]
+
+    def adjust_requirement(self, req: str) -> str:
+        """Adjust a requirement to the minimum specified version."""
+        # allow inheritance #pylint: disable=no-self-use
+        # If a requirement specifies a minimum version, impose that version.
+        req = re.sub(r'>=|~=', r'==', req)
+        return req
+
+    def add_file(self, filename: str) -> None:
+        """Add requirements from the specified file.
+
+        This method supports a subset of pip's requirement file syntax:
+        * One requirement specifier per line, which is passed to
+          `adjust_requirement`.
+        * Comments (``#`` at the beginning of the line or after whitespace).
+        * ``-r FILENAME`` to include another file.
+        """
+        for line in open(filename):
+            line = line.strip()
+            line = re.sub(r'(\A|\s+)#.*', r'', line)
+            if not line:
+                continue
+            m = re.match(r'-r\s+', line)
+            if m:
+                nested_file = os.path.join(os.path.dirname(filename),
+                                           line[m.end(0):])
+                self.add_file(nested_file)
+                continue
+            self.requirements.append(self.adjust_requirement(line))
+
+    def write(self, out: typing_util.Writable) -> None:
+        """List the gathered requirements."""
+        for req in self.requirements:
+            out.write(req + '\n')
+
+    def install(self) -> None:
+        """Call pip to install the requirements."""
+        if not self.requirements:
+            return
+        ret = os.spawnl(os.P_WAIT, sys.executable, 'python', '-m', 'pip',
+                        'install', *self.requirements)
+        if ret != 0:
+            sys.exit(ret)
+
+
+def main() -> None:
+    """Command line entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--no-act', '-n',
+                        action='store_true',
+                        help="Don't act, just print what will be done")
+    parser.add_argument('files', nargs='*', metavar='FILE',
+                        help="Requirement files"
+                             "(default: requirements.txt in the script's directory)")
+    options = parser.parse_args()
+    if not options.files:
+        options.files = [os.path.join(os.path.dirname(__file__),
+                                      'ci.requirements.txt')]
+    reqs = Requirements()
+    for filename in options.files:
+        reqs.add_file(filename)
+    reqs.write(sys.stdout)
+    if not options.no_act:
+        reqs.install()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -99,6 +99,7 @@ class Requirements:
                                   ['install'] + pip_install_options +
                                   ['-r', req_file_name])
 
+DEFAULT_REQUIREMENTS_FILE = 'ci.requirements.txt'
 
 def main() -> None:
     """Command line entry point."""
@@ -119,11 +120,12 @@ def main() -> None:
                              " (short for --pip-install-option --user)")
     parser.add_argument('files', nargs='*', metavar='FILE',
                         help="Requirement files"
-                             " (default: requirements.txt in the script's directory)")
+                             " (default: {} in the script's directory)" \
+                             .format(DEFAULT_REQUIREMENTS_FILE))
     options = parser.parse_args()
     if not options.files:
         options.files = [os.path.join(os.path.dirname(__file__),
-                                      'ci.requirements.txt')]
+                                      DEFAULT_REQUIREMENTS_FILE)]
     reqs = Requirements()
     for filename in options.files:
         reqs.add_file(filename)

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -161,6 +161,4 @@ RUN cd /tmp \
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
 
-RUN pip3 install --no-cache-dir \
-    mbed-host-tests \
-    mock
+RUN scripts/min_requirements.py

--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -160,5 +160,3 @@ RUN cd /tmp \
 
 ENV GNUTLS_NEXT_CLI=/usr/local/gnutls-3.7.2/bin/gnutls-cli
 ENV GNUTLS_NEXT_SERV=/usr/local/gnutls-3.7.2/bin/gnutls-serv
-
-RUN scripts/min_requirements.py


### PR DESCRIPTION
Add in-tree pip `requirements.txt` files, and a script to install minimum versions of the requirements for testing.

Why do it that way: we have a single source of truth for Python package requirements, rather than have to do separate installations on Travis, each Jenkins Docker image, Jenkins FreeBSD hosts and Jenkins Windows hosts.

Rationale for having multiple `requirements.txt` files: there's one for each target audience. This helps document what each package is used for, and gives users a simple way to only install what they need.

Testing with an additional requirement (this PR plus an adjusted version of https://github.com/ARMmbed/mbedtls/pull/5193):
* Travis: see https://app.travis-ci.com/github/ARMmbed/mbedtls/branches, job on `codegen_1.0-pip`
* Jenkins: see https://github.com/ARMmbed/mbedtls-test/pull/18 (private link)

Backports: at least to 2.x, so that if we add new testing requirements, we can express them in the same way. It's probably not worth backporting to 2.16 at this point.
