### PR TITLE
Backport 2.x: doc improvements in aes and sha256 includes

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -522,10 +522,6 @@ int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
  * \brief      This function performs an AES-CTR encryption or decryption
  *             operation.
  *
- *             This function performs the operation defined in the \p mode
- *             parameter (encrypt/decrypt), on the input data buffer
- *             defined in the \p input parameter.
- *
  *             Due to the nature of CTR, you must use the same key schedule
  *             for both encryption and decryption operations. Therefore, you
  *             must use the context initialized with mbedtls_aes_setkey_enc()

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -269,6 +269,9 @@ int mbedtls_sha256_ret( const unsigned char *input,
  *                 a writable buffer of length \c 32 Bytes.
  * \param is224    Determines which function to use. This must be either
  *                 \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
  */
 MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
                                         size_t ilen,

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -237,6 +237,9 @@ MBEDTLS_DEPRECATED void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
  *                 be a writable buffer of length \c 32 Bytes.
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
+ *
+ * \return         \c 0 on success.
+ * \return         A negative error code on failure.
  */
 int mbedtls_sha256_ret( const unsigned char *input,
                         size_t ilen,
@@ -269,9 +272,6 @@ int mbedtls_sha256_ret( const unsigned char *input,
  *                 a writable buffer of length \c 32 Bytes.
  * \param is224    Determines which function to use. This must be either
  *                 \c 0 for SHA-256, or \c 1 for SHA-224.
- *
- * \return         \c 0 on success.
- * \return         A negative error code on failure.
  */
 MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
                                         size_t ilen,


### PR DESCRIPTION
- Add return value description to the docs of mbedtls_sha256
- Remove description of non-existing "mode" parameter from the docs of mbedtls_aes_crypt_ctr

Backport of #5105