### PR TITLE
Fix test_suite_ssl compilation errors with GCC11

### DIFF
--- a/ChangeLog.d/fix_compilation_ssl_tests.txt
+++ b/ChangeLog.d/fix_compilation_ssl_tests.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix an uninitialized variable  warning in test_suite_ssl.function with GCC
+     version 11

--- a/ChangeLog.d/fix_compilation_ssl_tests.txt
+++ b/ChangeLog.d/fix_compilation_ssl_tests.txt
@@ -1,3 +1,3 @@
 Bugfix
-   * Fix an uninitialized variable  warning in test_suite_ssl.function with GCC
-     version 11
+   * Fix an uninitialized variable warning in test_suite_ssl.function with GCC
+     version 11.

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2236,8 +2236,8 @@ exit:
 void ssl_mock_sanity( )
 {
     enum { MSGLEN = 105 };
-    unsigned char message[MSGLEN];
-    unsigned char received[MSGLEN];
+    unsigned char message[MSGLEN] = { 0 };
+    unsigned char received[MSGLEN] = { 0 };
     mbedtls_mock_socket socket;
 
     mbedtls_mock_socket_init( &socket );


### PR DESCRIPTION
## Description

Under gcc11(+) both message and received would cause errors for potentially being used uninitialised. We fixed many of these issues in another PR (fixing #3782), but this one is only seen under certain configs.

## Status
**READY**

## Requires Backporting
Yes 
[2.x](#5235 )

## Migrations
NO

## Todos
- [ ] Tests
- [ ] Changelog updated
- [ ] Backported

## Steps to test or reproduce
Run the all.sh "test_cmake_out_of_source" with GCC11
