### PR TITLE
[session] fix a session copy bug

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -183,6 +183,10 @@ int mbedtls_ssl_session_copy( mbedtls_ssl_session *dst,
     mbedtls_ssl_session_free( dst );
     memcpy( dst, src, sizeof( mbedtls_ssl_session ) );
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
+    dst->ticket = NULL;
+#endif
+
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)


### PR DESCRIPTION
fix a possible double reference on 'ticket'
when peer_cert/peer_cert_digest calloc failed.