### PR TITLE
Align function parameter names for mbedtls_set_key_owner_id

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -153,10 +153,10 @@ static void psa_set_key_id( psa_key_attributes_t *attributes,
  * the owner of a key.
  *
  * \param[out] attributes  The attribute structure to write to.
- * \param owner_id         The key owner identifier.
+ * \param owner            The key owner identifier.
  */
 static void mbedtls_set_key_owner_id( psa_key_attributes_t *attributes,
-                                      mbedtls_key_owner_id_t owner_id );
+                                      mbedtls_key_owner_id_t owner );
 #endif
 
 /** Set the location of a persistent key.


### PR DESCRIPTION
## Description
`psa/crypto.h` and `psa/crypto_struct.h` have a declaration and a definition of static function `mbedtls_set_key_owner_id` using a different parameter name as second parameter (`owner` vs `owner_id`). This can be picked by static analysis code checking tools that might trigger [funcArgNamesDifferent], for example in latest versions of cppcheck.


## Status
READY

## Requires Backporting

Yes 

Which branch?
`development_2.x`

## Todos
- [x] Documentation
- [x] Backported


## Steps to test or reproduce
Run cppcheck (e.g. version 2.7-dev) with --enable=all --inconclusive
