### PR TITLE
Fix builds when config.h only defines MBEDTLS_BIGNUM_C

### DIFF
--- a/ChangeLog.d/build-without-sha.txt
+++ b/ChangeLog.d/build-without-sha.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build when no SHA2 module is included. Fixes #4930.
+   * Fix the build when only the bignum module is included. Fixes #4929.

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -124,7 +124,7 @@ typedef struct mbedtls_entropy_context
                               * -1 after free. */
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     mbedtls_sha512_context  MBEDTLS_PRIVATE(accumulator);
-#else
+#elif defined(MBEDTLS_ENTROPY_SHA256_ACCUMULATOR)
     mbedtls_sha256_context  MBEDTLS_PRIVATE(accumulator);
 #endif
     int             MBEDTLS_PRIVATE(source_count); /* Number of entries used in source. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -43,6 +43,7 @@
 #include "mbedtls/error.h"
 #include "constant_time_internal.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes #4929 and #4930

Backports: #5167, #5271.