### PR TITLE
Backport 2.16: Fix builds when config.h only defines MBEDTLS_BIGNUM_C

### DIFF
--- a/ChangeLog.d/build-without-sha.txt
+++ b/ChangeLog.d/build-without-sha.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix the build when no SHA2 module is included. Fixes #4930.
+   * Fix the build when only the bignum module is included. Fixes #4929.

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -157,7 +157,7 @@ typedef struct mbedtls_entropy_context
                               * -1 after free. */
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
     mbedtls_sha512_context  accumulator;
-#else
+#elif defined(MBEDTLS_ENTROPY_SHA256_ACCUMULATOR)
     mbedtls_sha256_context  accumulator;
 #endif
     int             source_count; /* Number of entries used in source. */

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -72,6 +72,7 @@
 #include "mbedtls/bn_mul.h"
 #include "mbedtls/platform_util.h"
 
+#include <limits.h>
 #include <string.h>
 
 #if defined(MBEDTLS_PLATFORM_C)


### PR DESCRIPTION
Trivial backport of https://github.com/ARMmbed/mbedtls/pull/5167 + changelog entry