### PR TITLE
Fix unused variable warning for "status" variable in library/psa_cryp…

### DIFF
--- a/library/psa_crypto_aead.c
+++ b/library/psa_crypto_aead.c
@@ -52,7 +52,7 @@ static psa_status_t psa_aead_setup(
     size_t full_tag_length = 0;
 
     ( void ) key_buffer_size;
-
+    ( void ) status;
     key_bits = attributes->core.bits;
 
     cipher_info = mbedtls_cipher_info_from_psa( alg,


### PR DESCRIPTION
Fix unused variable warning for "status" variable in library/psa_crypto_aead.c

* when the function "psa_aead_setup" is not supported.


## Description
The MR resolves the warning if  `status` variable is not used when the underlying CIPHERs are not selected.


## Status
**READY**

## Requires Backporting
NO

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

