### PR TITLE
Document platform architecture portability constraints

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -488,8 +488,6 @@ New deprecations
      deprecated.
    * PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH and PSA_ALG_AEAD_WITH_TAG_LENGTH
      have been renamed, and the old names deprecated.
-   * Sign-magnitude and one's complement representations for signed integers are
-     not supported. Two's complement is the only supported representation.
 
 Features
    * The PSA crypto subsystem can now use HMAC_DRBG instead of CTR_DRBG.
@@ -596,6 +594,8 @@ API changes
 Requirement changes
    * Update the minimum required CMake version to 2.8.12.  This silences a
      warning on CMake 3.19.0. #3801
+   * Sign-magnitude and one's complement representations for signed integers are
+     not supported. Two's complement is the only supported representation.
 
 New deprecations
    * PSA_ALG_CHACHA20 and PSA_ALG_ARC4 have been deprecated.

--- a/ChangeLog
+++ b/ChangeLog
@@ -488,6 +488,9 @@ New deprecations
      deprecated.
    * PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH and PSA_ALG_AEAD_WITH_TAG_LENGTH
      have been renamed, and the old names deprecated.
+   * Signed magnitude and one's complement implementations for signed integers are
+     are now officially not supported. Two's Complement is the only supported
+     implementation going forward.
 
 Features
    * The PSA crypto subsystem can now use HMAC_DRBG instead of CTR_DRBG.

--- a/ChangeLog
+++ b/ChangeLog
@@ -594,8 +594,6 @@ API changes
 Requirement changes
    * Update the minimum required CMake version to 2.8.12.  This silences a
      warning on CMake 3.19.0. #3801
-   * Sign-magnitude and one's complement representations for signed integers are
-     not supported. Two's complement is the only supported representation.
 
 New deprecations
    * PSA_ALG_CHACHA20 and PSA_ALG_ARC4 have been deprecated.

--- a/ChangeLog
+++ b/ChangeLog
@@ -488,8 +488,8 @@ New deprecations
      deprecated.
    * PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH and PSA_ALG_AEAD_WITH_TAG_LENGTH
      have been renamed, and the old names deprecated.
-   * Signed magnitude and one's complement implementations for signed integers are
-     not supported. Two's complement is the only supported implementation.
+   * Signed magnitude and one's complement representations for signed integers are
+     not supported. Two's complement is the only supported representation.
 
 Features
    * The PSA crypto subsystem can now use HMAC_DRBG instead of CTR_DRBG.

--- a/ChangeLog
+++ b/ChangeLog
@@ -489,8 +489,7 @@ New deprecations
    * PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH and PSA_ALG_AEAD_WITH_TAG_LENGTH
      have been renamed, and the old names deprecated.
    * Signed magnitude and one's complement implementations for signed integers are
-     are now officially not supported. Two's Complement is the only supported
-     implementation going forward.
+     not supported. Two's complement is the only supported implementation.
 
 Features
    * The PSA crypto subsystem can now use HMAC_DRBG instead of CTR_DRBG.

--- a/ChangeLog
+++ b/ChangeLog
@@ -488,7 +488,7 @@ New deprecations
      deprecated.
    * PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH and PSA_ALG_AEAD_WITH_TAG_LENGTH
      have been renamed, and the old names deprecated.
-   * Signed magnitude and one's complement representations for signed integers are
+   * Sign-magnitude and one's complement representations for signed integers are
      not supported. Two's complement is the only supported representation.
 
 Features

--- a/ChangeLog.d/twos_complement_representation.txt
+++ b/ChangeLog.d/twos_complement_representation.txt
@@ -1,0 +1,3 @@
+Requirement changes
+   * Sign-magnitude and one's complement representations for signed integers are
+     not supported. Two's complement is the only supported representation.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Mbed TLS can be ported to many different architectures, OS's and platforms. Befo
 Mbed TLS is mostly written in portable C99; however, it has a few platform requirements that go beyond the standard, but are met by most modern architectures:
 
 - Bytes must be 8 bits.
-- `all-bits-zero` must be a valid representation of a null pointer.
+- All-bits-zero must be a valid representation of a null pointer.
 - Signed integers must be represented using two's complement.
 - `int` and `size_t` must be at least 32 bits wide.
 - The types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.

--- a/README.md
+++ b/README.md
@@ -254,12 +254,11 @@ Mbed TLS can be ported to many different architectures, OS's and platforms. Befo
 
 Mbed TLS is mostly written in portable C99; however, it has a few platform requirements that go beyond the standard, but are met by most modern architectures:
 
-- bytes must be 8 bits
-- all-bits-zero must be a valid representation of the NULL pointer
-- signed integers must be represented using two's complement
-- integers must not have padding bits in their representation
-- `int` and `size_t` must be at least 32 bits wide
-- the types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.
+- Bytes must be 8 bits.
+- `all-bits-zero` must be a valid representation of a null pointer.
+- Signed integers must be represented using two's complement.
+- `int` and `size_t` must be at least 32 bits wide.
+- The types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.
 
 PSA cryptography API
 --------------------

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ Mbed TLS can be ported to many different architectures, OS's and platforms. Befo
 -   [What external dependencies does Mbed TLS rely on?](https://tls.mbed.org/kb/development/what-external-dependencies-does-mbedtls-rely-on)
 -   [How do I configure Mbed TLS](https://tls.mbed.org/kb/compiling-and-building/how-do-i-configure-mbedtls)
 
+Mbed TLS is mostly written in portable C99; however, it has a few platform requirements that go beyond the standard, but are met by most modern architectures:
+
+- bytes must be 8 bits
+- all-bits-zero must be a valid representation of the NULL pointer
+- signed integers must be represented using two's complement
+- integers must not have padding bits in their representation
+- `int` and `size_t` must be at least 32 bits wide
+- the types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.
+
 PSA cryptography API
 --------------------
 


### PR DESCRIPTION
# Description
Aligning documentation changes with the ask for #5264. This change is adding wording to state expliciticly what has already been assumed in the code before. 

There are no functional changes in the code-base

# Status
**Ready**

[2.x backport](https://github.com/ARMmbed/mbedtls/pull/5308) (not applicable to 2.16 LTS)