### PR TITLE
Backport 2.x : Add checked return to cipher setup in Cipher tests

### DIFF
--- a/tests/suites/test_suite_cipher.function
+++ b/tests/suites/test_suite_cipher.function
@@ -102,7 +102,7 @@ void cipher_invalid_param_unconditional( )
     (void)valid_mode; /* In some configurations this is unused */
 
     mbedtls_cipher_init( &valid_ctx );
-    mbedtls_cipher_setup( &valid_ctx, valid_info );
+    TEST_ASSERT( mbedtls_cipher_setup( &valid_ctx, valid_info ) == 0 );
     mbedtls_cipher_init( &invalid_ctx );
 
     /* mbedtls_cipher_setup() */


### PR DESCRIPTION
## Description

Found by coverity, a missed checked return on mbedtls_cipher_setup()

Backport of #5297 

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests
