### PR TITLE
Backport 2.x: Document platform architecture portability constraints

### DIFF
--- a/ChangeLog.d/twos_complement_representation.txt
+++ b/ChangeLog.d/twos_complement_representation.txt
@@ -1,0 +1,3 @@
+Requirement changes
+   * Sign-magnitude and one's complement representations for signed integers are
+     not supported. Two's complement is the only supported representation.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ Mbed TLS can be ported to many different architectures, OS's and platforms. Befo
 -   [What external dependencies does Mbed TLS rely on?](https://tls.mbed.org/kb/development/what-external-dependencies-does-mbedtls-rely-on)
 -   [How do I configure Mbed TLS](https://tls.mbed.org/kb/compiling-and-building/how-do-i-configure-mbedtls)
 
+Mbed TLS is mostly written in portable C99; however, it has a few platform requirements that go beyond the standard, but are met by most modern architectures:
+
+- Bytes must be 8 bits.
+- All-bits-zero must be a valid representation of a null pointer.
+- Signed integers must be represented using two's complement.
+- `int` and `size_t` must be at least 32 bits wide.
+- The types `uint8_t`, `uint16_t`, `uint32_t` and their signed equivalents must be available.
+
 PSA cryptography API
 --------------------
 


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/5290

### Description
Aligning documentation changes with the ask for #5264. This change is adding wording to state expliciticly what has already been assumed in the code before.

There are no functional changes in the code-base

### Status
Ready
