### PR TITLE
mbedtls_pk_parse_key: don't allocate if not needed

### DIFF
--- a/ChangeLog.d/pkparse-pkcs8-unencrypted-no-alloc.txt
+++ b/ChangeLog.d/pkparse-pkcs8-unencrypted-no-alloc.txt
@@ -1,0 +1,3 @@
+Changes
+   * In mbedtls_pk_parse_key(), if no password is provided, don't allocate a
+     temporary variable on the heap. Suggested by Sergey Kanatov in #5304.

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -1343,6 +1343,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *pk,
      * error
      */
 #if defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
+    if( pwdlen != 0 )
     {
         unsigned char *key_copy;
 


### PR DESCRIPTION
Resolve #5304.

This is an optimization, so I don't think we should backport to 2.28 LTS.