### PR TITLE
Fix psa_generate_key_internal returning wrong error code

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5708,7 +5708,6 @@ psa_status_t psa_generate_key_internal(
 #endif /* MBEDTLS_PSA_BUILTIN_KEY_TYPE_DES */
     }
     else
-
 #if defined(MBEDTLS_PSA_BUILTIN_KEY_TYPE_RSA_KEY_PAIR) && \
     defined(MBEDTLS_GENPRIME)
     if ( type == PSA_KEY_TYPE_RSA_KEY_PAIR )
@@ -5721,7 +5720,6 @@ psa_status_t psa_generate_key_internal(
     else
 #endif /* defined(MBEDTLS_PSA_BUILTIN_KEY_TYPE_RSA_KEY_PAIR)
         * defined(MBEDTLS_GENPRIME) */
-
 #if defined(MBEDTLS_PSA_BUILTIN_KEY_TYPE_ECC_KEY_PAIR)
     if ( PSA_KEY_TYPE_IS_ECC( type ) && PSA_KEY_TYPE_IS_KEY_PAIR( type ) )
     {


### PR DESCRIPTION
## Description
The psa_generate_key_internal has a bug where it will always execute a block of code which was intended to be used as an else statement. The problem is that it contains two spaces which effectively make the "else" statement having an empty body. As a result the block of code which was intended to be used as the "else" body is executed every time returning a false error code. This only applies to "raw" key types, like the symmetric ones. ECC and RSA keys are not affected.

## Status
READY

## Requires Backporting
Yes

## Migrations
No

## Steps to test or reproduce

Execute psa_generate_key for a symmetric (i.e AES) key without any drivers enabled. This will always result to an error with error code "PSA_ERROR_NOT_SUPPORTED" even if the call to the psa_generate_random was successful. 

