### PR TITLE
Zeroize expected MAC/tag intermediate variables

### DIFF
--- a/ChangeLog.d/mac-zeroize.txt
+++ b/ChangeLog.d/mac-zeroize.txt
@@ -1,0 +1,6 @@
+Security
+   * Zeroize several intermediate variables used to calculate the expected
+     value when verifying a MAC or AEAD tag. This hardens the library in
+     case the value leaks through a memory disclosure vulnerability. For
+     example, a memory disclosure vulnerability could have allowed a
+     man-in-the-middle to inject fake ciphertext into a DTLS connection.

--- a/ChangeLog.d/ssl-mac-zeroize.txt
+++ b/ChangeLog.d/ssl-mac-zeroize.txt
@@ -1,5 +1,0 @@
-Security
-   * Zeroize intermediate variables used to calculate the MAC in CBC cipher
-     suites. This hardens the library in case stack memory leaks through a
-     memory disclosure vulnerabilty, which could formerly have allowed a
-     man-in-the-middle to inject fake ciphertext into a DTLS connection.

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1175,6 +1175,12 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+    /* Status to return on a non-authenticated algorithm. It would make sense
+     * to return MBEDTLS_ERR_CIPHER_INVALID_CONTEXT or perhaps
+     * MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA, but at the time I write this our
+     * unit tests assume 0. */
+    ret = 0;
+
 #if defined(MBEDTLS_GCM_C)
     if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
     {
@@ -1195,9 +1201,7 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
-            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
-
-        return( 0 );
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
     }
 #endif /* MBEDTLS_GCM_C */
 
@@ -1217,13 +1221,12 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
-            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
-
-        return( 0 );
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
     }
 #endif /* MBEDTLS_CHACHAPOLY_C */
 
-    return( 0 );
+    mbedtls_platform_zeroize( check_tag, tag_len );
+    return( ret );
 }
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1201,7 +1201,10 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
+        {
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+            goto exit;
+        }
     }
 #endif /* MBEDTLS_GCM_C */
 
@@ -1221,10 +1224,14 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
+        {
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+            goto exit;
+        }
     }
 #endif /* MBEDTLS_CHACHAPOLY_C */
 
+exit:
     mbedtls_platform_zeroize( check_tag, tag_len );
     return( ret );
 }

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -1896,9 +1896,13 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
     memcpy( sig, sig_try, ctx->len );
 
 cleanup:
+    mbedtls_platform_zeroize( sig_try, ctx->len );
+    mbedtls_platform_zeroize( verif, ctx->len );
     mbedtls_free( sig_try );
     mbedtls_free( verif );
 
+    if( ret != 0 )
+        memset( sig, '!', ctx->len );
     return( ret );
 }
 #endif /* MBEDTLS_PKCS1_V15 */

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -217,15 +217,20 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
 
 #if defined(MBEDTLS_THREADING_C)
     if( mbedtls_mutex_unlock( &ctx->mutex ) != 0 )
-        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_SSL_INTERNAL_ERROR,
-                MBEDTLS_ERR_THREADING_MUTEX_ERROR ) );
+    {
+        ret = MBEDTLS_ERROR_ADD( MBEDTLS_ERR_SSL_INTERNAL_ERROR,
+                                 MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+    }
 #endif
 
     if( ret != 0 )
-        return( ret );
+        goto exit;
 
     if( mbedtls_ct_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
-        return( -1 );
+    {
+        ret = -1;
+        goto exit;
+    }
 
 #if defined(MBEDTLS_HAVE_TIME)
     cur_time = (unsigned long) mbedtls_time( NULL );
@@ -239,8 +244,13 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
                   ( (unsigned long) cookie[3]       );
 
     if( ctx->timeout != 0 && cur_time - cookie_time > ctx->timeout )
-        return( -1 );
+    {
+        ret = -1;
+        goto exit;
+    }
 
-    return( 0 );
+exit:
+    mbedtls_platform_zeroize( ref_hmac, sizeof( ref_hmac ) );
+    return( ret );
 }
 #endif /* MBEDTLS_SSL_COOKIE_C */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2874,7 +2874,7 @@ int mbedtls_ssl_write_finished( mbedtls_ssl_context *ssl )
 int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned int hash_len;
+    unsigned int hash_len = 12;
     unsigned char buf[SSL_MAX_HASH_LEN];
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse finished" ) );
@@ -2895,8 +2895,6 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
         goto exit;
     }
-
-    hash_len = 12;
 
     if( ssl->in_msg[0] != MBEDTLS_SSL_HS_FINISHED  )
     {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2884,7 +2884,7 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
     if( ( ret = mbedtls_ssl_read_record( ssl, 1 ) ) != 0 )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_ssl_read_record", ret );
-        return( ret );
+        goto exit;
     }
 
     if( ssl->in_msgtype != MBEDTLS_SSL_MSG_HANDSHAKE )
@@ -2892,7 +2892,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                         MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE );
-        return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
+        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+        goto exit;
     }
 
     hash_len = 12;
@@ -2901,7 +2902,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
     {
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                         MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE );
-        return( MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE );
+        ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
+        goto exit;
     }
 
     if( ssl->in_hslen  != mbedtls_ssl_hs_hdr_len( ssl ) + hash_len )
@@ -2909,7 +2911,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                         MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
-        return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+        ret = MBEDTLS_ERR_SSL_DECODE_ERROR;
+        goto exit;
     }
 
     if( mbedtls_ct_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
@@ -2918,7 +2921,8 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad finished message" ) );
         mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                         MBEDTLS_SSL_ALERT_MSG_DECRYPT_ERROR );
-        return( MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE );
+        ret = MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+        goto exit;
     }
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
@@ -2947,7 +2951,9 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= parse finished" ) );
 
-    return( 0 );
+exit:
+    mbedtls_platform_zeroize( buf, hash_len );
+    return( ret );
 }
 
 static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )


### PR DESCRIPTION
As suggested by @mpg, when we do a constant-time comparison, usually at least one of the values is sensitive and should be zeroized. Typically in `ct_memcmp(mac, expected_mac, …)`, leaking `expected_mac` through a memory disclosure vulnerability allows the attacker to send data with an invalid MAC learn the correct MAC value and send the same data again with the correct MAC.

My audit of constant-time comparisons:
```
grep -n -w -e mbedtls_ct_memcmp -e mbedtls_psa_safer_memcmp *.c
cipher.c:1197:        if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
 #1 tag: parameter
 #2 check_tag: local variable, fixed
cipher.c:1219:        if( mbedtls_ct_memcmp( tag, check_tag, tag_len ) != 0 )
 #1 tag: parameter
 #2 check_tag: local variable, fixed
constant_time.c:49:int mbedtls_ct_memcmp( const void *a,
 N/A
nist_kw.c:382:        diff = mbedtls_ct_memcmp( NIST_KW_ICV1, A, KW_SEMIBLOCK_LENGTH );
 #1 NIST_KW_ICV1: constant
 #2 A: zeroized in cleanup
nist_kw.c:431:        diff = mbedtls_ct_memcmp( NIST_KW_ICV2, A, KW_SEMIBLOCK_LENGTH / 2 );
 #1 NIST_KW_ICV2: constant
 #2 A: zeroized in cleanup
psa_crypto.c:2209:    if( mbedtls_psa_safer_memcmp( hash, actual_hash, actual_hash_length ) != 0 )
 #1 hash: parameter
 #2 actual_hash: local variable, fixed
psa_crypto.c:2250:    if( mbedtls_psa_safer_memcmp( hash, actual_hash, actual_hash_length ) != 0 )
 #1 hash: parameter
 #2 actual_hash: local variable, fixed
psa_crypto.c:2620:    if( mbedtls_psa_safer_memcmp( mac, actual_mac, actual_mac_length ) != 0 )
 #1 mac: parameter
 #2 actual_mac: zeroized in cleanup
psa_crypto_driver_wrappers.c:1923:                        mbedtls_psa_safer_memcmp( tag, check_tag, tag_length )
 #1: tag: parameter
 #2: check_tag: zeroized
psa_crypto_mac.c:451:    if( mbedtls_psa_safer_memcmp( mac, actual_mac, mac_length ) != 0 )
 #1: mac: parameter
 #2: actual_mac: zeroized in cleanup
rsa.c:1890:    if( mbedtls_ct_memcmp( verif, sig, ctx->len ) != 0 )
 #1: verif: local heap variable, fixed
 #2: sig: output parameter, fixed
rsa.c:2162:    if( ( ret = mbedtls_ct_memcmp( encoded, encoded_expected,
 #1 encoded: local heap variable, not needed?
 #2 encoded_expected: local heap variable, not needed?
ssl_cli.c:1361:            mbedtls_ct_memcmp( buf + 1,
 #1 buf: parameter
 #2 ssl->own_verify_data: parameter
ssl_cli.c:1363:            mbedtls_ct_memcmp( buf + 1 + ssl->verify_data_len,
 #1 buf: parameter
 #2 ssl->peer_verify_data: parameter
ssl_cookie.c:227:    if( mbedtls_ct_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
 #1 cookie: parameter
 #2 ref_hmac: local variable, fixed
ssl_msg.c:1199:             * mbedtls_ct_memcmp() below.
 N/A
ssl_msg.c:1223:            if( mbedtls_ct_memcmp( data + rec->data_len, mac_expect,
 Addressed in #5313
ssl_msg.c:1435:        if( mbedtls_ct_memcmp( mac_peer, mac_expect,
  Addressed in #5313
ssl_srv.c:201:            mbedtls_ct_memcmp( buf + 1, ssl->peer_verify_data,
 #1 buf: parameter
 #2 ssl->peer_verify_data: parameter
ssl_srv.c:3661:            mbedtls_ct_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
 #1 ssl->conf->psk_identity: parameter
 #2 *p: parameter
ssl_tls.c:2893:    if( mbedtls_ct_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
 #1 ssl->in_msg: parameter
 #2 buf: local variable, fixed
ssl_tls13_generic.c:932:    if( mbedtls_ct_memcmp( buf,
 #1 buf: parameter
 #2 expected_verify_data: parameter
```
When a parameter is itself a parameter of the calling function, I didn't review whether zeroization might be missing further up the call stack.

Needs backports: 2.x (#5327), 2.16 (#5328)
