### PR TITLE
Backport 2.16: Zeroize expected MAC/tag intermediate variables

### DIFF
--- a/ChangeLog.d/mac-zeroize.txt
+++ b/ChangeLog.d/mac-zeroize.txt
@@ -1,0 +1,6 @@
+Security
+   * Zeroize several intermediate variables used to calculate the expected
+     value when verifying a MAC or AEAD tag. This hardens the library in
+     case the value leaks through a memory disclosure vulnerability. For
+     example, a memory disclosure vulnerability could have allowed a
+     man-in-the-middle to inject fake ciphertext into a DTLS connection.

--- a/ChangeLog.d/ssl-mac-zeroize.txt
+++ b/ChangeLog.d/ssl-mac-zeroize.txt
@@ -1,5 +1,0 @@
-Security
-   * Zeroize intermediate variables used to calculate the MAC in CBC cipher
-     suites. This hardens the library in case stack memory leaks through a
-     memory disclosure vulnerabilty, which could formerly have allowed a
-     man-in-the-middle to inject fake ciphertext into a DTLS connection.

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -987,7 +987,10 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+        {
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+            goto exit;
+        }
     }
 #endif /* MBEDTLS_GCM_C */
 
@@ -1007,10 +1010,14 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
+        {
             ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
+            goto exit;
+        }
     }
 #endif /* MBEDTLS_CHACHAPOLY_C */
 
+exit:
     mbedtls_platform_zeroize( check_tag, tag_len );
     return( ret );
 }

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -967,6 +967,12 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
     }
 
+    /* Status to return on a non-authenticated algorithm. It would make sense
+     * to return MBEDTLS_ERR_CIPHER_INVALID_CONTEXT or perhaps
+     * MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA, but at the time I write this our
+     * unit tests assume 0. */
+    ret = 0;
+
 #if defined(MBEDTLS_GCM_C)
     if( MBEDTLS_MODE_GCM == ctx->cipher_info->mode )
     {
@@ -981,9 +987,7 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
-            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
-
-        return( 0 );
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
     }
 #endif /* MBEDTLS_GCM_C */
 
@@ -1003,13 +1007,12 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
 
         /* Check the tag in "constant-time" */
         if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
-            return( MBEDTLS_ERR_CIPHER_AUTH_FAILED );
-
-        return( 0 );
+            ret = MBEDTLS_ERR_CIPHER_AUTH_FAILED;
     }
 #endif /* MBEDTLS_CHACHAPOLY_C */
 
-    return( 0 );
+    mbedtls_platform_zeroize( check_tag, tag_len );
+    return( ret );
 }
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -2148,9 +2148,13 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
     memcpy( sig, sig_try, ctx->len );
 
 cleanup:
+    mbedtls_platform_zeroize( sig_try, ctx->len );
+    mbedtls_platform_zeroize( verif, ctx->len );
     mbedtls_free( sig_try );
     mbedtls_free( verif );
 
+    if( ret != 0 )
+        memset( sig, '!', ctx->len );
     return( ret );
 }
 #endif /* MBEDTLS_PKCS1_V15 */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -6811,6 +6811,14 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
 
     MBEDTLS_SSL_DEBUG_MSG( 2, ( "=> parse finished" ) );
 
+    /* There is currently no ciphersuite using another length with TLS 1.2 */
+#if defined(MBEDTLS_SSL_PROTO_SSL3)
+    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
+        hash_len = 36;
+    else
+#endif
+        hash_len = 12;
+
     ssl->handshake->calc_finished( ssl, buf, ssl->conf->endpoint ^ 1 );
 
     if( ( ret = mbedtls_ssl_read_record( ssl, 1 ) ) != 0 )
@@ -6827,14 +6835,6 @@ int mbedtls_ssl_parse_finished( mbedtls_ssl_context *ssl )
         ret = MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
         goto exit;
     }
-
-    /* There is currently no ciphersuite using another length with TLS 1.2 */
-#if defined(MBEDTLS_SSL_PROTO_SSL3)
-    if( ssl->minor_ver == MBEDTLS_SSL_MINOR_VERSION_0 )
-        hash_len = 36;
-    else
-#endif
-        hash_len = 12;
 
     if( ssl->in_msg[0] != MBEDTLS_SSL_HS_FINISHED ||
         ssl->in_hslen  != mbedtls_ssl_hs_hdr_len( ssl ) + hash_len )


### PR DESCRIPTION
Backport of #5325.

Audit of constant-time comparisons:
```
$ grep -n -e _memcmp *.c
cipher.c:104:static int mbedtls_constant_time_memcmp( const void *v1, const void *v2, size_t len )
cipher.c:983:        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
cipher.c:1005:        if( mbedtls_constant_time_memcmp( tag, check_tag, tag_len ) != 0 )
nist_kw.c:86:static inline unsigned char mbedtls_nist_kw_safer_memcmp( const void *a, const void *b, size_t n )
nist_kw.c:451:        diff = mbedtls_nist_kw_safer_memcmp( NIST_KW_ICV1, A, KW_SEMIBLOCK_LENGTH );
nist_kw.c:500:        diff = mbedtls_nist_kw_safer_memcmp( NIST_KW_ICV2, A, KW_SEMIBLOCK_LENGTH / 2 );
rsa.c:107:static inline int mbedtls_safer_memcmp( const void *a, const void *b, size_t n )
rsa.c:2142:    if( mbedtls_safer_memcmp( verif, sig, ctx->len ) != 0 )
rsa.c:2440:    if( ( ret = mbedtls_safer_memcmp( encoded, encoded_expected,
ssl_cli.c:1270:            mbedtls_ssl_safer_memcmp( buf + 1,
ssl_cli.c:1272:            mbedtls_ssl_safer_memcmp( buf + 1 + ssl->verify_data_len,
ssl_cookie.c:260:    if( mbedtls_ssl_safer_memcmp( cookie + 4, ref_hmac, sizeof( ref_hmac ) ) != 0 )
ssl_srv.c:187:            mbedtls_ssl_safer_memcmp( buf + 1, ssl->peer_verify_data,
ssl_srv.c:3714:            mbedtls_ssl_safer_memcmp( ssl->conf->psk_identity, *p, n ) != 0 )
ssl_tls.c:2303:            if( mbedtls_ssl_safer_memcmp( ssl->in_iv + ssl->in_msglen, mac_expect,
ssl_tls.c:2556:        if( mbedtls_ssl_safer_memcmp( mac_peer, mac_expect,
ssl_tls.c:6847:    if( mbedtls_ssl_safer_memcmp( ssl->in_msg + mbedtls_ssl_hs_hdr_len( ssl ),
```
The locations are the same as in 2.2x except that `psa_crypto.c` doesn't exist.
In each case, the zeroization or lack thereof in the existing code is the same.

Rebase notes (from the 2.2x patch set):
* Many hunks failed and had to be re-done manually by changing `return( foo );` to `ret = foo; goto exit;`.
* Git had some nonsensical conflict resolution in `mbedtls_ssl_parse_finished`, but `patch` applied the patches cleanly.
