### PR TITLE
List ssl_debug_helpers_generated.h in generated files

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -147,6 +147,7 @@ if(GEN_FILES)
 
     add_custom_command(
         OUTPUT
+            ${CMAKE_CURRENT_BINARY_DIR}/ssl_debug_helpers_generated.h
             ${CMAKE_CURRENT_BINARY_DIR}/ssl_debug_helpers_generated.c
         COMMAND
             ${MBEDTLS_PYTHON_EXECUTABLE}
@@ -161,6 +162,7 @@ else()
     link_to_source(error.c)
     link_to_source(version_features.c)
     link_to_source(ssl_debug_helpers_generated.c)
+    link_to_source(ssl_debug_helpers_generated.h)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/library/Makefile
+++ b/library/Makefile
@@ -288,7 +288,9 @@ libmbedcrypto.dll: $(OBJS_CRYPTO)
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) -o $@ -c $<
 
 .PHONY: generated_files
-GENERATED_FILES = error.c version_features.c ssl_debug_helpers_generated.c
+GENERATED_FILES = \
+	error.c version_features.c \
+	ssl_debug_helpers_generated.c ssl_debug_helpers_generated.h
 generated_files: $(GENERATED_FILES)
 
 error.c: ../scripts/generate_errors.pl
@@ -298,9 +300,10 @@ error.c:
 	echo "  Gen   $@"
 	$(PERL) ../scripts/generate_errors.pl
 
-ssl_debug_helpers_generated.c: ../scripts/generate_ssl_debug_helpers.py
-ssl_debug_helpers_generated.c: $(filter-out %config%,$(wildcard ../include/mbedtls/*.h))
-ssl_debug_helpers_generated.c:
+ssl_debug_helpers_generated.c: | ssl_debug_helpers_generated.h
+ssl_debug_helpers_generated.h: ../scripts/generate_ssl_debug_helpers.py
+ssl_debug_helpers_generated.h: $(filter-out %config%,$(wildcard ../include/mbedtls/*.h))
+ssl_debug_helpers_generated.h:
 	echo "  Gen   $@"
 	$(PYTHON) ../scripts/generate_ssl_debug_helpers.py --mbedtls-root .. .
 

--- a/tests/scripts/check-generated-files.sh
+++ b/tests/scripts/check-generated-files.sh
@@ -118,7 +118,7 @@ check()
 check scripts/generate_errors.pl library/error.c
 check scripts/generate_query_config.pl programs/test/query_config.c
 check scripts/generate_features.pl library/version_features.c
-check scripts/generate_ssl_debug_helpers.py library/ssl_debug_helpers_generated.c
+check scripts/generate_ssl_debug_helpers.py library/ssl_debug_helpers_generated.h library/ssl_debug_helpers_generated.c
 # generate_visualc_files enumerates source files (library/*.c). It doesn't
 # care about their content, but the files must exist. So it must run after
 # the step that creates or updates these files.


### PR DESCRIPTION
Fix intermittent failure of parallel builds from a fresh checkout, as seen recently in the `code-coverage` nightly CI job (https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-nightly-tests/2281/, https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-nightly-tests/2284/).

A few code-coverage runs to test: [1](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-new/781/) [2](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-new/782/) [3](https://jenkins-mbedtls.oss.arm.com/job/mbedtls-release-new/783/)

Not applicable to older branches.
