### PR TITLE
Reset dhm_P and dhm_G if config call repeated; avoid memory leak

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_comfig_defaults-memleak.txt
+++ b/ChangeLog.d/mbedtls_ssl_comfig_defaults-memleak.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix memory leak if mbedtls_ssl_config_defaults() call is repeated

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3944,6 +3944,9 @@ int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+    mbedtls_mpi_free( &conf->dhm_P );
+    mbedtls_mpi_free( &conf->dhm_G );
+
     if( ( ret = mbedtls_mpi_read_binary( &conf->dhm_P, dhm_P, P_len ) ) != 0 ||
         ( ret = mbedtls_mpi_read_binary( &conf->dhm_G, dhm_G, G_len ) ) != 0 )
     {
@@ -3958,6 +3961,9 @@ int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
 int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context *dhm_ctx )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    mbedtls_mpi_free( &conf->dhm_P );
+    mbedtls_mpi_free( &conf->dhm_G );
 
     if( ( ret = mbedtls_dhm_get_value( dhm_ctx, MBEDTLS_DHM_PARAM_P,
                                        &conf->dhm_P ) ) != 0 ||


### PR DESCRIPTION
## Description
Reset dhm_P and dhm_G if call to mbedtls_ssl_config_defaults() repeated
to avoid leaking memory.

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

## Status
**READY**

## Requires Backporting
Not required, IMHO, but could be backported.  In mbedtls 3.0.0, `mbedtls_ssl_config` members `dhm_P` and `dhm_G` are private, so routines underlying `mbedtls_ssl_config_defaults()` should avoid leaking memory if `mbedtls_ssl_config_defaults()` is called more than once.  If `mbedtls_ssl_config_defaults()` is called more than once by an application, then with earlier versions of mbedtls, the application could call `mbedtls_mpi_free()` on `dhm_P` and `dhm_G`.

## Todos
- [x] Changelog updated  (Changelog.d/xxxxx.txt file provided)
- [x] Backport to 2.28 (#5416)

## Other
Test for memory leak not provided.

Observe that `mbedtls_ssl_config_free()` calls `mbedtls_mpi_free()` on `dhm_P` and `dhm_G` conf members.
Observe that `mbedtls_ssl_config_defaults()` calls `mbedtls_ssl_conf_dh_param_bin()`, and if `mbedtls_ssl_config_defaults()` is called more than once, then `mbedtls_ssl_conf_dh_param_bin()` is called more than once, and inside `mbedtls_ssl_conf_dh_param_bin()`, conf members `dhm_P` and `dhm_G` are overwritten.  They should be freed before being overwritten.  Observer in `mbedtls_ssl_conf_dh_param_bin()` that if there is an error, then `mbedtls_mpi_free()` is called on `dhm_P` and `dhm_G` conf members.  This patch calls `mbedtls_mpi_free()` on those members before overwriting them, so that memory is not leaked if the members had previously been allocated.