### PR TITLE
Remove redundant write operation in Montgomery multiplication

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1931,7 +1931,7 @@ static void mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi
         mpi_mul_hlp( m, B->p, d, u0 );
         mpi_mul_hlp( n, N->p, d, u1 );
 
-        *d++ = u0; d[n + 1] = 0;
+        d++; d[n + 1] = 0;
     }
 
     /* At this point, d is either the desired result or the desired result


### PR DESCRIPTION
This PR removes code from the Montgomery multiplication routine
`mpi_montmul()` which seems to serve no purpose.

Details: `mpi_montmul()` uses a temporary storage `T` for intermediate
results which is assumed to be of twice the size as the inputs to be
multiplied, and which is used as follows: After the i-th (i=0,1,...)
iteration, the n-limb word starting at `T->p + i + 1` contains the
Montgomery multiplication of B with the limbs 0,..,i of A, and the
variable `d` points to `T->p + i + 1`. In particular, after `n` iterations,
`T->p + n` holds the full multiplication
(subject to conditional subtraction).

As a consequence of this way of using the temporary `T`, the contents
of `{T->p, ..., T->p + i}` are irrelevant after the i-th iteration. Nonetheless, 
the code copies `A[i]` to `T->p[i]` at the end of the i-th iterations, which is
redundant and can be removed.
