### PR TITLE
Add function to get message digest info from context

### DIFF
--- a/ChangeLog.d/md_info_from_ctx.txt
+++ b/ChangeLog.d/md_info_from_ctx.txt
@@ -1,0 +1,3 @@
+Features
+   * Add a function to extract message digest information from a message
+     digest context.

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -138,6 +138,20 @@ const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name );
 const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
 
 /**
+ * \brief           This function returns the message-digest information
+ *                  from the given context.
+ *
+ * \param ctx       The context from which to extract the information.
+ *                  This must be initialized (or \c NULL).
+ *
+ * \return          The message-digest information associated with \p ctx.
+ * \return          \c NULL if \p ctx is \c NULL.
+ */
+const mbedtls_md_info_t *mbedtls_md_info_from_ctx(
+                                        const mbedtls_md_context_t *ctx );
+
+
+/**
  * \brief           This function initializes a message-digest context without
  *                  binding it to a particular message-digest algorithm.
  *

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -150,7 +150,6 @@ const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
 const mbedtls_md_info_t *mbedtls_md_info_from_ctx(
                                         const mbedtls_md_context_t *ctx );
 
-
 /**
  * \brief           This function initializes a message-digest context without
  *                  binding it to a particular message-digest algorithm.

--- a/library/md.c
+++ b/library/md.c
@@ -227,6 +227,15 @@ const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type )
     }
 }
 
+const mbedtls_md_info_t *mbedtls_md_info_from_ctx(
+                                            const mbedtls_md_context_t *ctx )
+{
+    if( ctx == NULL )
+        return NULL;
+
+    return( ctx->MBEDTLS_PRIVATE(md_info) );
+}
+
 void mbedtls_md_init( mbedtls_md_context_t *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_md_context_t ) );

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -53,6 +53,8 @@ void md_null_args(  )
     TEST_ASSERT( mbedtls_md_get_name( NULL ) == NULL );
 
     TEST_ASSERT( mbedtls_md_info_from_string( NULL ) == NULL );
+    TEST_ASSERT( mbedtls_md_info_from_ctx( NULL ) == NULL );
+    TEST_ASSERT( mbedtls_md_info_from_ctx( &ctx ) == NULL );
 
     TEST_ASSERT( mbedtls_md_setup( &ctx, NULL, 0 ) == MBEDTLS_ERR_MD_BAD_INPUT_DATA );
     TEST_ASSERT( mbedtls_md_setup( NULL, info, 0 ) == MBEDTLS_ERR_MD_BAD_INPUT_DATA );
@@ -202,6 +204,8 @@ void md_text_multi( char * text_md_name, char * text_src_string,
     TEST_ASSERT( md_info != NULL );
     TEST_ASSERT ( 0 == mbedtls_md_setup( &ctx, md_info, 0 ) );
     TEST_ASSERT ( 0 == mbedtls_md_setup( &ctx_copy, md_info, 0 ) );
+    TEST_ASSERT ( mbedtls_md_info_from_ctx( &ctx ) == md_info );
+    TEST_ASSERT ( mbedtls_md_info_from_ctx( &ctx_copy ) == md_info );
 
     TEST_ASSERT ( 0 == mbedtls_md_starts( &ctx ) );
     TEST_ASSERT ( ctx.md_ctx != NULL );
@@ -249,6 +253,8 @@ void md_hex_multi( char * text_md_name, data_t * src_str, data_t * hash )
     TEST_ASSERT( md_info != NULL );
     TEST_ASSERT ( 0 == mbedtls_md_setup( &ctx, md_info, 0 ) );
     TEST_ASSERT ( 0 == mbedtls_md_setup( &ctx_copy, md_info, 0 ) );
+    TEST_ASSERT ( mbedtls_md_info_from_ctx( &ctx ) == md_info );
+    TEST_ASSERT ( mbedtls_md_info_from_ctx( &ctx_copy ) == md_info );
 
     halfway = src_str->len / 2;
 
@@ -321,6 +327,7 @@ void md_hmac_multi( char * text_md_name, int trunc_size, data_t * key_str,
     md_info = mbedtls_md_info_from_string( md_name );
     TEST_ASSERT( md_info != NULL );
     TEST_ASSERT ( 0 == mbedtls_md_setup( &ctx, md_info, 1 ) );
+    TEST_ASSERT ( mbedtls_md_info_from_ctx( &ctx ) == md_info );
 
     halfway = src_str->len / 2;
 


### PR DESCRIPTION
## Description
I wanted to add getter functions to get details of the message digest from a `message_digest_context_t` struct. The existing getters operate on `md_info_t`, so if you only have the context, you can't get the details of the message digest.

I figured that the simplest solution is just to add a function that extracts the `md_info` member from the context. I'm open to instead implement functions that get the name, type, size, etc. from the context individually, if you prefer that.

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated