### PR TITLE
Minor improvements to ECC arithmetic subroutines

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1927,6 +1927,8 @@ static int ecp_select_comb( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     /* Safely invert result if i is "negative" */
     MBEDTLS_MPI_CHK( ecp_safe_invert_jac( grp, R, i >> 7 ) );
 
+    MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &R->Z, 1 ) );
+
 cleanup:
     return( ret );
 }
@@ -1979,7 +1981,6 @@ static int ecp_mul_comb_core( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R
         /* Start with a non-zero point and randomize its coordinates */
         i = d;
         MBEDTLS_MPI_CHK( ecp_select_comb( grp, R, T, T_size, x[i] ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_lset( &R->Z, 1 ) );
         if( f_rng != 0 )
             MBEDTLS_MPI_CHK( ecp_randomize_jac( grp, R, f_rng, p_rng ) );
     }

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1279,7 +1279,7 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t i;
-    mbedtls_mpi *c, u, Zi, ZZi;
+    mbedtls_mpi *c, u, Zi;
 
     if( ( c = mbedtls_calloc( T_size, sizeof( mbedtls_mpi ) ) ) == NULL )
         return( MBEDTLS_ERR_ECP_ALLOC_FAILED );
@@ -1287,7 +1287,7 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
     for( i = 0; i < T_size; i++ )
         mbedtls_mpi_init( &c[i] );
 
-    mbedtls_mpi_init( &u ); mbedtls_mpi_init( &Zi ); mbedtls_mpi_init( &ZZi );
+    mbedtls_mpi_init( &u ); mbedtls_mpi_init( &Zi );
 
     /*
      * c[i] = Z_0 * ... * Z_i
@@ -1322,10 +1322,10 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
         /*
          * proceed as in normalize()
          */
-        MPI_ECP_MUL( &ZZi,     &Zi,      &Zi  );
-        MPI_ECP_MUL( &T[i]->X, &T[i]->X, &ZZi );
-        MPI_ECP_MUL( &T[i]->Y, &T[i]->Y, &ZZi );
-        MPI_ECP_MUL( &T[i]->Y, &T[i]->Y, &Zi  );
+        MPI_ECP_MUL( &T[i]->Y, &T[i]->Y, &Zi );
+        MPI_ECP_MUL( &Zi,      &Zi,      &Zi );
+        MPI_ECP_MUL( &T[i]->X, &T[i]->X, &Zi );
+        MPI_ECP_MUL( &T[i]->Y, &T[i]->Y, &Zi );
 
         /*
          * Post-precessing: reclaim some memory by shrinking coordinates
@@ -1343,7 +1343,7 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
 
 cleanup:
 
-    mbedtls_mpi_free( &u ); mbedtls_mpi_free( &Zi ); mbedtls_mpi_free( &ZZi );
+    mbedtls_mpi_free( &u ); mbedtls_mpi_free( &Zi );
     for( i = 0; i < T_size; i++ )
         mbedtls_mpi_free( &c[i] );
     mbedtls_free( c );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -342,13 +342,13 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
 
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
-static void mpi_init_many( mbedtls_mpi *arr, unsigned size )
+static void mpi_init_many( mbedtls_mpi *arr, size_t size )
 {
     while( size-- )
         mbedtls_mpi_init( arr++ );
 }
 
-static void mpi_free_many( mbedtls_mpi *arr, unsigned size )
+static void mpi_free_many( mbedtls_mpi *arr, size_t size )
 {
     while( size-- )
         mbedtls_mpi_free( arr++ );
@@ -1340,11 +1340,9 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
     if( ( c = mbedtls_calloc( T_size, sizeof( mbedtls_mpi ) ) ) == NULL )
         return( MBEDTLS_ERR_ECP_ALLOC_FAILED );
 
-    for( i = 0; i < T_size; i++ )
-        mbedtls_mpi_init( &c[i] );
-
     mbedtls_mpi_init( &t );
 
+    mpi_init_many( c, T_size );
     /*
      * c[i] = Z_0 * ... * Z_i,   i = 0,..,n := T_size-1
      */
@@ -1408,8 +1406,7 @@ static int ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
 cleanup:
 
     mbedtls_mpi_free( &t );
-    for( i = 0; i < T_size; i++ )
-        mbedtls_mpi_free( &c[i] );
+    mpi_free_many( c, T_size );
     mbedtls_free( c );
 
     return( ret );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1464,7 +1464,10 @@ static int ecp_add_mixed( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_mpi T1, T2, T3, T4, X, Y, Z;
+    mbedtls_mpi T1, T2, T3, T4;
+    mbedtls_mpi * const X = &R->X;
+    mbedtls_mpi * const Y = &R->Y;
+    mbedtls_mpi * const Z = &R->Z;
 
     /*
      * Trivial cases: P == 0 or Q == 0 (case 1)
@@ -1482,7 +1485,6 @@ static int ecp_add_mixed( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
 
     mbedtls_mpi_init( &T1 ); mbedtls_mpi_init( &T2 ); mbedtls_mpi_init( &T3 ); mbedtls_mpi_init( &T4 );
-    mbedtls_mpi_init( &X ); mbedtls_mpi_init( &Y ); mbedtls_mpi_init( &Z );
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T1,  &P->Z,  &P->Z ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T2,  &T1,    &P->Z ) );
@@ -1506,28 +1508,23 @@ static int ecp_add_mixed( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
         }
     }
 
-    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &Z,   &P->Z,  &T1   ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, Z,    &P->Z,  &T1   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T3,  &T1,    &T1   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T4,  &T3,    &T1   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T3,  &T3,    &P->X ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &T1, &T3 ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l_mod( grp, &T1,  1     ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &X,   &T2,    &T2   ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &X,   &X,     &T1   ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &X,   &X,     &T4   ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &T3,  &T3,    &X    ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, X,    &T2,    &T2   ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, X,    X,      &T1   ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, X,    X,      &T4   ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &T3,  &T3,    X     ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T3,  &T3,    &T2   ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &T4,  &T4,    &P->Y ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &Y,   &T3,    &T4   ) );
-
-    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R->X, &X ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R->Y, &Y ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R->Z, &Z ) );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, Y,    &T3,    &T4   ) );
 
 cleanup:
 
     mbedtls_mpi_free( &T1 ); mbedtls_mpi_free( &T2 ); mbedtls_mpi_free( &T3 ); mbedtls_mpi_free( &T4 );
-    mbedtls_mpi_free( &X ); mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &Z );
 
     return( ret );
 #endif /* !defined(MBEDTLS_ECP_NO_FALLBACK) || !defined(MBEDTLS_ECP_ADD_MIXED_ALT) */

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1138,6 +1138,19 @@ cleanup:
     return( ret );
 }
 
+static inline int mbedtls_mpi_mul_int_mod( const mbedtls_ecp_group *grp,
+                                           mbedtls_mpi *X,
+                                           const mbedtls_mpi *A,
+                                           mbedtls_mpi_uint c )
+{
+    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( X, A, c ) );
+    MOD_ADD( *X );
+cleanup:
+    return( ret );
+}
+
 #if defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED) && \
     !( defined(MBEDTLS_ECP_NO_FALLBACK) && \
        defined(MBEDTLS_ECP_DOUBLE_JAC_ALT) && \
@@ -1372,17 +1385,17 @@ static int ecp_double_jac( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     if( grp->A.p == NULL )
     {
         /* M = 3(X + Z^2)(X - Z^2) */
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &S,  &P->Z,  &P->Z   ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mod( grp, &T,  &P->X,  &S      ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod( grp, &U,  &P->X,  &S      ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &S,  &T,     &U      ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &M,  &S,     3       ) ); MOD_ADD( M );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod(     grp, &S,  &P->Z,  &P->Z   ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_add_mod(     grp, &T,  &P->X,  &S      ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_sub_mod(     grp, &U,  &P->X,  &S      ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod(     grp, &S,  &T,     &U      ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int_mod( grp, &M,  &S,     3       ) );
     }
     else
     {
         /* M = 3.X^2 */
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod( grp, &S,  &P->X,  &P->X   ) );
-        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int( &M,  &S,     3       ) ); MOD_ADD( M );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mod    ( grp, &S,  &P->X,  &P->X   ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mul_int_mod( grp, &M,  &S,     3       ) );
 
         /* Optimize away for "koblitz" curves with A = 0 */
         if( mbedtls_mpi_cmp_int( &grp->A, 0 ) != 0 )

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2402,22 +2402,22 @@ static int ecp_double_add_mxz( const mbedtls_ecp_group *grp,
     mbedtls_mpi_init( &D ); mbedtls_mpi_init( &DA ); mbedtls_mpi_init( &CB );
 
     MPI_ECP_ADD( &A,    &P->X,   &P->Z );
-    MPI_ECP_SQR( &AA,   &A             );
     MPI_ECP_SUB( &B,    &P->X,   &P->Z );
-    MPI_ECP_SQR( &BB,   &B             );
-    MPI_ECP_SUB( &E,    &AA,     &BB   );
     MPI_ECP_ADD( &C,    &Q->X,   &Q->Z );
     MPI_ECP_SUB( &D,    &Q->X,   &Q->Z );
-    MPI_ECP_MUL( &DA,   &D,      &A    );
-    MPI_ECP_MUL( &CB,   &C,      &B    );
+    MPI_ECP_MUL( &DA,   &D,      &A    ); /* D no longer needed */
+    MPI_ECP_MUL( &CB,   &C,      &B    ); /* C no longer needed */
+    MPI_ECP_SQR( &AA,   &A             ); /* A no longer needed */
+    MPI_ECP_SQR( &BB,   &B             ); /* B no longer needed */
+    MPI_ECP_MUL( &R->X, &AA,     &BB   );
+    MPI_ECP_SUB( &E,    &AA,     &BB   ); /* AA no longer needed */
+    MPI_ECP_MUL( &R->Z, &grp->A, &E    );
+    MPI_ECP_ADD( &R->Z, &BB,     &R->Z ); /* BB no longer needed */
     MPI_ECP_ADD( &S->X, &DA,     &CB   );
     MPI_ECP_SQR( &S->X, &S->X          );
     MPI_ECP_SUB( &S->Z, &DA,     &CB   );
     MPI_ECP_SQR( &S->Z, &S->Z          );
     MPI_ECP_MUL( &S->Z, d,       &S->Z );
-    MPI_ECP_MUL( &R->X, &AA,     &BB   );
-    MPI_ECP_MUL( &R->Z, &grp->A, &E    );
-    MPI_ECP_ADD( &R->Z, &BB,     &R->Z );
     MPI_ECP_MUL( &R->Z, &E,      &R->Z );
 
 cleanup:

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -342,6 +342,18 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
 
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
+static void mpi_init_many( mbedtls_mpi *arr, unsigned size )
+{
+    while( size-- )
+        mbedtls_mpi_init( arr++ );
+}
+
+static void mpi_free_many( mbedtls_mpi *arr, unsigned size )
+{
+    while( size-- )
+        mbedtls_mpi_free( arr++ );
+}
+
 /*
  * List of supported curves:
  *  - internal ID
@@ -1812,10 +1824,7 @@ static int ecp_precompute_comb( const mbedtls_ecp_group *grp,
 
     mbedtls_mpi tmp[4];
 
-    mbedtls_mpi_init( &tmp[0] );
-    mbedtls_mpi_init( &tmp[1] );
-    mbedtls_mpi_init( &tmp[2] );
-    mbedtls_mpi_init( &tmp[3] );
+    mpi_init_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if( rs_ctx != NULL && rs_ctx->rsm != NULL )
@@ -1938,10 +1947,7 @@ norm_add:
 
 cleanup:
 
-    mbedtls_mpi_free( &tmp[0] );
-    mbedtls_mpi_free( &tmp[1] );
-    mbedtls_mpi_free( &tmp[2] );
-    mbedtls_mpi_free( &tmp[3] );
+    mpi_free_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if( rs_ctx != NULL && rs_ctx->rsm != NULL &&
@@ -2005,10 +2011,7 @@ static int ecp_mul_comb_core( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R
     size_t i;
 
     mbedtls_ecp_point_init( &Txi );
-    mbedtls_mpi_init( &tmp[0] );
-    mbedtls_mpi_init( &tmp[1] );
-    mbedtls_mpi_init( &tmp[2] );
-    mbedtls_mpi_init( &tmp[3] );
+    mpi_init_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
 #if !defined(MBEDTLS_ECP_RESTARTABLE)
     (void) rs_ctx;
@@ -2051,11 +2054,7 @@ static int ecp_mul_comb_core( const mbedtls_ecp_group *grp, mbedtls_ecp_point *R
 cleanup:
 
     mbedtls_ecp_point_free( &Txi );
-
-    mbedtls_mpi_free( &tmp[0] );
-    mbedtls_mpi_free( &tmp[1] );
-    mbedtls_mpi_free( &tmp[2] );
-    mbedtls_mpi_free( &tmp[3] );
+    mpi_free_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if( rs_ctx != NULL && rs_ctx->rsm != NULL &&
@@ -2509,10 +2508,7 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
     mbedtls_mpi tmp[4];
     mbedtls_ecp_point_init( &RP ); mbedtls_mpi_init( &PX );
 
-    mbedtls_mpi_init( &tmp[0] );
-    mbedtls_mpi_init( &tmp[1] );
-    mbedtls_mpi_init( &tmp[2] );
-    mbedtls_mpi_init( &tmp[3] );
+    mpi_init_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
     if( f_rng == NULL )
         return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
@@ -2568,11 +2564,7 @@ static int ecp_mul_mxz( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 cleanup:
     mbedtls_ecp_point_free( &RP ); mbedtls_mpi_free( &PX );
 
-    mbedtls_mpi_free( &tmp[0] );
-    mbedtls_mpi_free( &tmp[1] );
-    mbedtls_mpi_free( &tmp[2] );
-    mbedtls_mpi_free( &tmp[3] );
-
+    mpi_free_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
     return( ret );
 }
 
@@ -2797,11 +2789,7 @@ int mbedtls_ecp_muladd_restartable(
         return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
 
     mbedtls_ecp_point_init( &mP );
-
-    mbedtls_mpi_init( &tmp[0] );
-    mbedtls_mpi_init( &tmp[1] );
-    mbedtls_mpi_init( &tmp[2] );
-    mbedtls_mpi_init( &tmp[3] );
+    mpi_init_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
     ECP_RS_ENTER( ma );
 
@@ -2860,10 +2848,7 @@ norm:
 
 cleanup:
 
-    mbedtls_mpi_free( &tmp[0] );
-    mbedtls_mpi_free( &tmp[1] );
-    mbedtls_mpi_free( &tmp[2] );
-    mbedtls_mpi_free( &tmp[3] );
+    mpi_free_many( tmp, sizeof( tmp ) / sizeof( mbedtls_mpi ) );
 
 #if defined(MBEDTLS_ECP_INTERNAL_ALT)
     if( is_grp_capable )

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1611,26 +1611,28 @@ static int ecp_randomize_jac( const mbedtls_ecp_group *grp, mbedtls_ecp_point *p
     return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_mpi l, ll;
+    mbedtls_mpi l;
 
-    mbedtls_mpi_init( &l ); mbedtls_mpi_init( &ll );
+    mbedtls_mpi_init( &l );
 
     /* Generate l such that 1 < l < p */
     MBEDTLS_MPI_CHK( mbedtls_mpi_random( &l, 2, &grp->P, f_rng, p_rng ) );
 
     /* Z = l * Z */
-    MPI_ECP_MUL( &pt->Z,   &pt->Z,     &l  );
+    MPI_ECP_MUL( &pt->Z,   &pt->Z,     &l );
+
+    /* Y = l * Z */
+    MPI_ECP_MUL( &pt->Y,   &pt->Y,     &l );
 
     /* X = l^2 * X */
-    MPI_ECP_SQR( &ll,      &l              );
-    MPI_ECP_MUL( &pt->X,   &pt->X,     &ll );
+    MPI_ECP_SQR( &l,       &l             );
+    MPI_ECP_MUL( &pt->X,   &pt->X,     &l );
 
     /* Y = l^3 * Y */
-    MPI_ECP_MUL( &ll,      &ll,        &l  );
-    MPI_ECP_MUL( &pt->Y,   &pt->Y,     &ll );
+    MPI_ECP_MUL( &pt->Y,   &pt->Y,     &l );
 
 cleanup:
-    mbedtls_mpi_free( &l ); mbedtls_mpi_free( &ll );
+    mbedtls_mpi_free( &l );
 
     if( ret == MBEDTLS_ERR_MPI_NOT_ACCEPTABLE )
         ret = MBEDTLS_ERR_ECP_RANDOM_FAILED;

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2395,35 +2395,39 @@ static int ecp_double_add_mxz( const mbedtls_ecp_group *grp,
     return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
 #else
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    mbedtls_mpi A, AA, B, BB, E, C, D, DA, CB;
 
-    mbedtls_mpi_init( &A ); mbedtls_mpi_init( &AA ); mbedtls_mpi_init( &B );
-    mbedtls_mpi_init( &BB ); mbedtls_mpi_init( &E ); mbedtls_mpi_init( &C );
-    mbedtls_mpi_init( &D ); mbedtls_mpi_init( &DA ); mbedtls_mpi_init( &CB );
+    mbedtls_mpi T0,T1,T2,T3;
 
-    MPI_ECP_ADD( &A,    &P->X,   &P->Z );
-    MPI_ECP_SUB( &B,    &P->X,   &P->Z );
-    MPI_ECP_ADD( &C,    &Q->X,   &Q->Z );
-    MPI_ECP_SUB( &D,    &Q->X,   &Q->Z );
-    MPI_ECP_MUL( &DA,   &D,      &A    ); /* D no longer needed */
-    MPI_ECP_MUL( &CB,   &C,      &B    ); /* C no longer needed */
-    MPI_ECP_SQR( &AA,   &A             ); /* A no longer needed */
-    MPI_ECP_SQR( &BB,   &B             ); /* B no longer needed */
-    MPI_ECP_MUL( &R->X, &AA,     &BB   );
-    MPI_ECP_SUB( &E,    &AA,     &BB   ); /* AA no longer needed */
-    MPI_ECP_MUL( &R->Z, &grp->A, &E    );
-    MPI_ECP_ADD( &R->Z, &BB,     &R->Z ); /* BB no longer needed */
-    MPI_ECP_ADD( &S->X, &DA,     &CB   );
+    mbedtls_mpi_init( &T0 );
+    mbedtls_mpi_init( &T1 );
+    mbedtls_mpi_init( &T2 );
+    mbedtls_mpi_init( &T3 );
+
+    MPI_ECP_ADD( &T0,   &P->X,   &P->Z );
+    MPI_ECP_SUB( &T1,   &P->X,   &P->Z );
+    MPI_ECP_ADD( &T2,   &Q->X,   &Q->Z );
+    MPI_ECP_SUB( &T3,   &Q->X,   &Q->Z );
+    MPI_ECP_MUL( &T3,   &T3,     &T0   );
+    MPI_ECP_MUL( &T2,   &T2,     &T1   );
+    MPI_ECP_SQR( &T0,   &T0            );
+    MPI_ECP_SQR( &T1,   &T1            );
+    MPI_ECP_MUL( &R->X, &T0,     &T1   );
+    MPI_ECP_SUB( &T0,   &T0,     &T1   );
+    MPI_ECP_MUL( &R->Z, &grp->A, &T0   );
+    MPI_ECP_ADD( &R->Z, &T1,     &R->Z );
+    MPI_ECP_ADD( &S->X, &T3,     &T2   );
     MPI_ECP_SQR( &S->X, &S->X          );
-    MPI_ECP_SUB( &S->Z, &DA,     &CB   );
+    MPI_ECP_SUB( &S->Z, &T3,     &T2   );
     MPI_ECP_SQR( &S->Z, &S->Z          );
     MPI_ECP_MUL( &S->Z, d,       &S->Z );
-    MPI_ECP_MUL( &R->Z, &E,      &R->Z );
+    MPI_ECP_MUL( &R->Z, &T0,     &R->Z );
 
 cleanup:
-    mbedtls_mpi_free( &A ); mbedtls_mpi_free( &AA ); mbedtls_mpi_free( &B );
-    mbedtls_mpi_free( &BB ); mbedtls_mpi_free( &E ); mbedtls_mpi_free( &C );
-    mbedtls_mpi_free( &D ); mbedtls_mpi_free( &DA ); mbedtls_mpi_free( &CB );
+
+    mbedtls_mpi_free( &T0 );
+    mbedtls_mpi_free( &T1 );
+    mbedtls_mpi_free( &T2 );
+    mbedtls_mpi_free( &T3 );
 
     return( ret );
 #endif /* !defined(MBEDTLS_ECP_NO_FALLBACK) || !defined(MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT) */


### PR DESCRIPTION
This PR makes a number of small improvements to ECC arithmetic subroutines:
* https://github.com/ARMmbed/mbedtls/pull/5377/commits/5c8ea307b878a9860996972c5890c53d8655c525, https://github.com/ARMmbed/mbedtls/pull/5377/commits/76f897d6994ca95c64edf527127ecb9b82a0d071, https://github.com/ARMmbed/mbedtls/pull/5377/commits/0d629791e9143056d9b2c2eca793a02256054211, https://github.com/ARMmbed/mbedtls/pull/5377/commits/28ccb1cc90101bed8befcdfbdb961b5413975a2e, https://github.com/ARMmbed/mbedtls/pull/5377/commits/02a999b91a02144ba34ca9352d297408d37c67e8 and https://github.com/ARMmbed/mbedtls/pull/5377/commits/b8442cd9c6323a6a8255eecc94617becee5056ae remove local MPIs from ECP arithmetic subroutines
* https://github.com/ARMmbed/mbedtls/pull/5377/commits/ce29ae84dd425877178b81ee9fdf1491ef623943,  https://github.com/ARMmbed/mbedtls/pull/5377/commits/02b35bd00a0b2c100975b0b0575a74ec5250324b and https://github.com/ARMmbed/mbedtls/pull/5377/commits/885ed403c954eebe5c16abec2c6bc99091073193 improve readability of ECP code by introducing macros for low-level modular arithmetic.
* https://github.com/ARMmbed/mbedtls/pull/5377/commits/a7f8edd709e7df569b22ce5f5a3648669e577699 and https://github.com/ARMmbed/mbedtls/pull/5377/commits/3b29f2194b924acec282d31d19c8c15da22b7814 reduce heap allocations by using temporary MPIs across iterated calls to the same ECC arithmetic routines

Edit: avoid merging until we're confident #5383 will also be merged before the next release.