### PR TITLE
Fix the multipart AEAD compliance tests

### DIFF
--- a/tests/scripts/test_psa_compliance.py
+++ b/tests/scripts/test_psa_compliance.py
@@ -33,10 +33,6 @@ import sys
 # Test number 2xx corresponds to the files in the folder
 # psa-arch-tests/api-tests/dev_apis/crypto/test_c0xx
 EXPECTED_FAILURES = {
-    # Multipart CCM is not supported.
-    # - Tracked in issue #3721
-    252, 253, 254, 255, 256, 257, 258, 259, 261,
-
     # psa_hash_suspend() and psa_hash_resume() are not supported.
     # - Tracked in issue #3274
     262, 263
@@ -51,7 +47,7 @@ EXPECTED_FAILURES = {
 #
 # Web URL: https://github.com/bensze01/psa-arch-tests/tree/fixes-for-mbedtls-3
 PSA_ARCH_TESTS_REPO = 'https://github.com/bensze01/psa-arch-tests.git'
-PSA_ARCH_TESTS_REF = 'fixes-for-mbedtls-3'
+PSA_ARCH_TESTS_REF = 'fix-multipart-aead'
 
 #pylint: disable=too-many-branches,too-many-statements
 def main():


### PR DESCRIPTION
## Description
This PR [updates our fork of psa-arch-tests](https://github.com/bensze01/psa-arch-tests/compare/fixes-for-mbedtls-2..fix-multipart-aead) to a version that fixes several defects in the multipart AEAD tests, and removes these tests from the expected  failures list.

## Status
**READY**

## Requires Backporting

No, Mbed TLS 2.28 does not support multipart AEAD