### PR TITLE
Fix test suite name reporting of opt-testcases/tls13-compat.sh

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -7,7 +7,6 @@ less likely to be useful.
 """
 
 import argparse
-import re
 import sys
 import traceback
 
@@ -51,29 +50,9 @@ class TestCaseOutcomes:
         """
         return len(self.successes) + len(self.failures)
 
-class TestDescriptions(check_test_cases.TestDescriptionExplorer):
-    """Collect the available test cases."""
-
-    def __init__(self):
-        super().__init__()
-        self.descriptions = set()
-
-    def process_test_case(self, _per_file_state,
-                          file_name, _line_number, description):
-        """Record an available test case."""
-        base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
-        key = ';'.join([base_name, description.decode('utf-8')])
-        self.descriptions.add(key)
-
-def collect_available_test_cases():
-    """Collect the available test cases."""
-    explorer = TestDescriptions()
-    explorer.walk_all()
-    return sorted(explorer.descriptions)
-
 def analyze_coverage(results, outcomes):
     """Check that all available test cases are executed at least once."""
-    available = collect_available_test_cases()
+    available = check_test_cases.collect_available_test_cases()
     for key in available:
         hits = outcomes[key].hits() if key in outcomes else 0
         if hits == 0:

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -196,6 +196,9 @@ class DescriptionChecker(TestDescriptionExplorer):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--list-all',
+                        action='store_true',
+                        help='List all test cases, without doing checks')
     parser.add_argument('--quiet', '-q',
                         action='store_true',
                         help='Hide warnings')
@@ -203,6 +206,10 @@ def main():
                         action='store_false', dest='quiet',
                         help='Show warnings (default: on; undoes --quiet)')
     options = parser.parse_args()
+    if options.list_all:
+        descriptions = collect_available_test_cases()
+        sys.stdout.write('\n'.join(descriptions + ['']))
+        return
     results = Results(options)
     checker = DescriptionChecker(results)
     checker.walk_all()

--- a/tests/scripts/check_test_cases.py
+++ b/tests/scripts/check_test_cases.py
@@ -137,6 +137,26 @@ state may override this method.
                                                             '*.sh')):
                 self.walk_ssl_opt_sh(ssl_opt_file_name)
 
+class TestDescriptions(TestDescriptionExplorer):
+    """Collect the available test cases."""
+
+    def __init__(self):
+        super().__init__()
+        self.descriptions = set()
+
+    def process_test_case(self, _per_file_state,
+                          file_name, _line_number, description):
+        """Record an available test case."""
+        base_name = re.sub(r'\.[^.]*$', '', re.sub(r'.*/', '', file_name))
+        key = ';'.join([base_name, description.decode('utf-8')])
+        self.descriptions.add(key)
+
+def collect_available_test_cases():
+    """Collect the available test cases."""
+    explorer = TestDescriptions()
+    explorer.walk_all()
+    return sorted(explorer.descriptions)
+
 class DescriptionChecker(TestDescriptionExplorer):
     """Check all test case descriptions.
 

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -543,16 +543,18 @@ print_name() {
 
 # record_outcome <outcome> [<failure-reason>]
 # The test name must be in $NAME.
+# Use $TEST_SUITE_NAME as the test suite name if set.
 record_outcome() {
     echo "$1"
     if [ -n "$MBEDTLS_TEST_OUTCOME_FILE" ]; then
         printf '%s;%s;%s;%s;%s;%s\n' \
                "$MBEDTLS_TEST_PLATFORM" "$MBEDTLS_TEST_CONFIGURATION" \
-               "ssl-opt" "$NAME" \
+               "${TEST_SUITE_NAME:-ssl-opt}" "$NAME" \
                "$1" "${2-}" \
                >>"$MBEDTLS_TEST_OUTCOME_FILE"
     fi
 }
+unset TEST_SUITE_NAME
 
 # True if the presence of the given pattern in a log definitely indicates
 # that the test has failed. False if the presence is inconclusive.
@@ -9015,8 +9017,11 @@ run_test    "TLS 1.3: HelloRetryRequest check - gnutls" \
 
 for i in opt-testcases/*.sh
 do
-    . $i
+    TEST_SUITE_NAME=${i##*/}
+    TEST_SUITE_NAME=${TEST_SUITE_NAME%.*}
+    . "$i"
 done
+unset TEST_SUITE_NAME
 
 requires_openssl_tls1_3
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -9013,7 +9013,7 @@ run_test    "TLS 1.3: HelloRetryRequest check - gnutls" \
             -c "Last error was: -0x6E00 - SSL - The handshake negotiation failed" \
             -s "HELLO RETRY REQUEST was queued"
 
-for i in $(ls opt-testcases/*.sh)
+for i in opt-testcases/*.sh
 do
     . $i
 done


### PR DESCRIPTION
Test cases in `tests/opt-testcases` report themselves in the outcome file as being from the test suite `ssl-opt`. But the outcome analysis bases the test suite name on the file that the test case is in. (https://github.com/ARMmbed/mbedtls/issues/5391#issuecomment-1007453643) Reconcile the two.

https://jenkins-mbedtls.oss.arm.com/job/mbed-tls-pr-head/job/PR-5393-head/2/execution/node/5326/log/ shows that all of the not-executed TLS 1.3 test cases were false positives due to the test suite name mismatch. Thus this fixes #5391.

Also fix a potential bug in `ssl-opt.sh` whereby an error while listing `opt-testcases/*.sh` was ignored. This could lead to silently skipping test cases in an insufficiently populated out-of-tree build where `opt-testcases` isn't available.

Needs backports: for the new option `tests/scripts/check_test_cases.py --list-all` → https://github.com/ARMmbed/mbedtls/pull/5459. Support for sub-scripts of `ssl-opt` doesn't apply in 2.28.
