### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1989,9 +1989,10 @@ static void mpi_montred( mbedtls_mpi *A, const mbedtls_mpi *N,
  */
 static int mpi_select( mbedtls_mpi *R, const mbedtls_mpi *T, size_t T_size, size_t idx )
 {
+    size_t i;
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-    for( size_t i = 0; i < T_size; i++ )
+    for( i = 0; i < T_size; i++ )
     {
         MBEDTLS_MPI_CHK( mbedtls_mpi_safe_cond_assign( R, &T[i],
                         (unsigned char) mbedtls_ct_size_bool_eq( i, idx ) ) );

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -412,12 +412,13 @@ void mbedtls_ct_memcpy_if_eq( unsigned char *dest,
                               size_t c1,
                               size_t c2 )
 {
+    size_t i;
     /* mask = c1 == c2 ? 0xff : 0x00 */
     const size_t equal = mbedtls_ct_size_bool_eq( c1, c2 );
     const unsigned char mask = (unsigned char) mbedtls_ct_size_mask( equal );
 
     /* dest[i] = c1 == c2 ? src[i] : dest[i] */
-    for( size_t i = 0; i < len; i++ )
+    for( i = 0; i < len; i++ )
         dest[i] = ( src[i] & mask ) | ( dest[i] & ~mask );
 }
 


### PR DESCRIPTION
Fix the following build failure with gcc 4.8:

```
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/build/mbedtls-2.28.0/library/bignum.c: In function 'mpi_select':
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/build/mbedtls-2.28.0/library/bignum.c:1994:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for( size_t i = 0; i < T_size; i++ )
     ^
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output-1/build/mbedtls-2.28.0/library/bignum.c:1994:5: note: use option -std=c99 or -std=gnu99 to compile your code
```

Fixes:
 - http://autobuild.buildroot.org/results/56ac0a8726d09eed8f45f865934fa7781a0e667a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>