### PR TITLE
TLS Cipher 1b: create translation function

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1258,6 +1258,22 @@ static inline psa_key_id_t mbedtls_ssl_get_opaque_psk(
 
     return( MBEDTLS_SVC_KEY_ID_INIT );
 }
+
+/* Corresponding PSA algorithm for MBEDTLS_CIPHER_NULL */
+#define MBEDTLS_SSL_NULL_CIPHER 0x04000000
+
+/**
+ * Translate mbedtls cipher type/mode pair to psa: algorithm, key type and
+ * key size.
+ *
+ * Return PSA_SUCCESS on success or PSA_ERROR_NOT_SUPPORTED if
+ * conversion is not supported.
+ */
+psa_status_t mbedtls_cipher_to_psa( mbedtls_cipher_type_t mbedtls_cipher_type,
+                                    size_t taglen,
+                                    psa_algorithm_t *alg,
+                                    psa_key_type_t *key_type,
+                                    size_t *key_size );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3914,6 +3914,151 @@ int mbedtls_ssl_conf_psk_opaque( mbedtls_ssl_config *conf,
     return( ret );
 }
 
+psa_status_t mbedtls_cipher_to_psa( mbedtls_cipher_type_t mbedtls_cipher_type,
+                                    size_t taglen,
+                                    psa_algorithm_t *alg,
+                                    psa_key_type_t *key_type,
+                                    size_t *key_size )
+{
+    switch ( mbedtls_cipher_type )
+    {
+        case MBEDTLS_CIPHER_AES_128_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_AES_128_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_AES_128_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_AES_192_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_AES_192_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_AES_256_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_AES_256_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_AES_256_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_AES;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_ARIA_128_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_ARIA_128_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_ARIA_128_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_ARIA_192_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_ARIA_192_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_ARIA_256_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_ARIA_256_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_ARIA_256_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_ARIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_128_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_128_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_128_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 128;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_192_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_192_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 192;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_256_CBC:
+            *alg = PSA_ALG_CBC_NO_PADDING;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_256_CCM:
+            *alg = taglen ? PSA_ALG_AEAD_WITH_SHORTENED_TAG( PSA_ALG_CCM, taglen ) : PSA_ALG_CCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_CAMELLIA_256_GCM:
+            *alg = PSA_ALG_GCM;
+            *key_type = PSA_KEY_TYPE_CAMELLIA;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_CHACHA20_POLY1305:
+            *alg = PSA_ALG_CHACHA20_POLY1305;
+            *key_type = PSA_KEY_TYPE_CHACHA20;
+            *key_size = 256;
+            break;
+        case MBEDTLS_CIPHER_NULL:
+            *alg = MBEDTLS_SSL_NULL_CIPHER;
+            *key_type = 0;
+            *key_size = 0;
+            break;
+        default:
+            return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    return PSA_SUCCESS;
+}
+
 int mbedtls_ssl_set_hs_psk_opaque( mbedtls_ssl_context *ssl,
                                    psa_key_id_t psk )
 {


### PR DESCRIPTION
## Description
Implements issue: https://github.com/ARMmbed/mbedtls/issues/5182
Related: PR https://github.com/ARMmbed/mbedtls/pull/5418

Add function to translate mbedtls cipher type/mode pair to psa: algorithm, key type and key size.

Returns `PSA_SUCCESS` on success or `PSA_ERROR_NOT_SUPPORTED` if conversion is not supported.

## Status
**READY**

## Requires Backporting
Yes?
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

NO