### PR TITLE
Backport 2.28: Reset dhm_P and dhm_G if config call repeated

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_config_defaults-memleak.txt
+++ b/ChangeLog.d/mbedtls_ssl_config_defaults-memleak.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Fix memory leak if mbedtls_ssl_config_defaults() call is repeated

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4632,6 +4632,9 @@ int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+    mbedtls_mpi_free( &conf->dhm_P );
+    mbedtls_mpi_free( &conf->dhm_G );
+
     if( ( ret = mbedtls_mpi_read_binary( &conf->dhm_P, dhm_P, P_len ) ) != 0 ||
         ( ret = mbedtls_mpi_read_binary( &conf->dhm_G, dhm_G, G_len ) ) != 0 )
     {
@@ -4646,6 +4649,9 @@ int mbedtls_ssl_conf_dh_param_bin( mbedtls_ssl_config *conf,
 int mbedtls_ssl_conf_dh_param_ctx( mbedtls_ssl_config *conf, mbedtls_dhm_context *dhm_ctx )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
+    mbedtls_mpi_free( &conf->dhm_P );
+    mbedtls_mpi_free( &conf->dhm_G );
 
     if( ( ret = mbedtls_mpi_copy( &conf->dhm_P, &dhm_ctx->P ) ) != 0 ||
         ( ret = mbedtls_mpi_copy( &conf->dhm_G, &dhm_ctx->G ) ) != 0 )


### PR DESCRIPTION
## Description
Reset dhm_P and dhm_G if call to mbedtls_ssl_config_defaults() repeated
to avoid leaking memory.

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

## Status
**READY**

## Requires Backporting
Branch 2.28 (this PR)
Development PR (#5353)

## Todos
- [x] Changelog updated  (Changelog.d/xxxxx.txt file provided)
- [x] Backport to 2.28

## Other
Test for memory leak not provided.

Observe that `mbedtls_ssl_config_free()` calls `mbedtls_mpi_free()` on `dhm_P` and `dhm_G` conf members.
Observe that `mbedtls_ssl_config_defaults()` calls `mbedtls_ssl_conf_dh_param_bin()`, and if `mbedtls_ssl_config_defaults()` is called more than once, then `mbedtls_ssl_conf_dh_param_bin()` is called more than once, and inside `mbedtls_ssl_conf_dh_param_bin()`, conf members `dhm_P` and `dhm_G` are overwritten.  They should be freed before being overwritten.  Observer in `mbedtls_ssl_conf_dh_param_bin()` that if there is an error, then `mbedtls_mpi_free()` is called on `dhm_P` and `dhm_G` conf members.  This patch calls `mbedtls_mpi_free()` on those members before overwriting them, so that memory is not leaked if the members had previously been allocated.