### PR TITLE
Add mbedtls_ssl_get_cipher_info() accessor

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_get_cipher_info.txt
+++ b/ChangeLog.d/mbedtls_ssl_get_cipher_info.txt
@@ -1,0 +1,2 @@
+Features
+   * Add mbedtls_ssl_get_cipher_info() accessor.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3898,6 +3898,15 @@ uint32_t mbedtls_ssl_get_verify_result( const mbedtls_ssl_context *ssl );
 const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl );
 
 /**
+ * \brief          Return the current cipher information
+ *
+ * \param ssl      SSL context
+ *
+ * \return         a cipher information structure
+ */
+const mbedtls_cipher_info_t *mbedtls_ssl_get_cipher_info( const mbedtls_ssl_context *ssl );
+
+/**
  * \brief          Return the current TLS version
  *
  * \param ssl      SSL context

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4366,6 +4366,19 @@ const char *mbedtls_ssl_get_ciphersuite( const mbedtls_ssl_context *ssl )
     return mbedtls_ssl_get_ciphersuite_name( ssl->session->ciphersuite );
 }
 
+const mbedtls_cipher_info_t *mbedtls_ssl_get_cipher_info( const mbedtls_ssl_context *ssl )
+{
+    if( ssl == NULL || ssl->session == NULL )
+        return( NULL );
+
+    const mbedtls_ssl_ciphersuite_t * const ciphersuite_info =
+      mbedtls_ssl_ciphersuite_from_id( ssl->session->ciphersuite );
+    if( ciphersuite_info == NULL )
+        return( NULL );
+
+    return( mbedtls_cipher_info_from_type( ciphersuite_info->cipher ) );
+}
+
 const char *mbedtls_ssl_get_version( const mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)


### PR DESCRIPTION
## Description
Add `mbedtls_ssl_get_cipher_info()` accessor for mbedtls 3.0

This is a follow-up to an item in #5331

## Status
**READY**

## Requires Backporting
NO

## Migrations
Yes: adds accessor to retrieve `(const mbedtls_cipher_info_t *)` from session

## Todos
- [x] Changelog updated