### PR TITLE
TLS Cipher 2b: record: store keys and alg

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -925,6 +925,12 @@ struct mbedtls_ssl_transform
     mbedtls_cipher_context_t cipher_ctx_dec;    /*!<  decryption context      */
     int minor_ver;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    mbedtls_svc_key_id_t psa_key_enc;           /*!<  psa encryption key      */
+    mbedtls_svc_key_id_t psa_key_dec;           /*!<  psa decryption key      */
+    psa_algorithm_t psa_alg;                    /*!<  psa algorithm           */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     uint8_t in_cid_len;
     uint8_t out_cid_len;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -5404,6 +5404,11 @@ void mbedtls_ssl_transform_free( mbedtls_ssl_transform *transform )
     mbedtls_cipher_free( &transform->cipher_ctx_enc );
     mbedtls_cipher_free( &transform->cipher_ctx_dec );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_destroy_key( &transform->psa_key_enc );
+    psa_destroy_key( &transform->psa_key_dec );
+#endif
+
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
     mbedtls_md_free( &transform->md_ctx_enc );
     mbedtls_md_free( &transform->md_ctx_dec );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -52,9 +52,6 @@
 #include "mbedtls/oid.h"
 #endif
 
-/* Convert key bits to byte size */
-#define KEY_BYTES( bits ) ( ( (size_t) bits + 7 ) / 8 )
-
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -1102,7 +1099,7 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
 
     if( ( status = psa_import_key( &attributes,
                              key1,
-                             KEY_BYTES( key_bits ),
+                             PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_enc ) ) != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );
@@ -1110,7 +1107,7 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
     }
     if( ( status = psa_import_key( &attributes,
                              key2,
-                             KEY_BYTES( key_bits ),
+                             PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_dec ) ) != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3021,6 +3021,11 @@ void mbedtls_ssl_transform_init( mbedtls_ssl_transform *transform )
     mbedtls_cipher_init( &transform->cipher_ctx_enc );
     mbedtls_cipher_init( &transform->cipher_ctx_dec );
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    transform->psa_key_enc = MBEDTLS_SVC_KEY_ID_INIT;
+    transform->psa_key_dec = MBEDTLS_SVC_KEY_ID_INIT;
+#endif
+
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
     mbedtls_md_init( &transform->md_ctx_enc );
     mbedtls_md_init( &transform->md_ctx_dec );

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -922,7 +922,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
                                  &key_type,
                                  &key_bits ) ) != PSA_SUCCESS )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_cipher_to_psa", status );
+        MBEDTLS_SSL_DEBUG_RET( 1, "mbedtls_cipher_to_psa", psa_status_to_mbedtls( status ) );
         return( psa_status_to_mbedtls( status ) );
     }
 
@@ -936,7 +936,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
                              PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_enc ) ) != PSA_SUCCESS )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );
+        MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", psa_status_to_mbedtls( status ) );
         return( psa_status_to_mbedtls( status ) );
     }
     if( ( status = psa_import_key( &attributes,
@@ -944,7 +944,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
                              PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_dec ) ) != PSA_SUCCESS )
     {
-        MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );
+        MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", psa_status_to_mbedtls( status ) );
         return( psa_status_to_mbedtls( status ) );
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -31,10 +31,6 @@
 #include "ssl_misc.h"
 #include "ssl_tls13_keys.h"
 
-/* Convert key bits to byte size */
-#define KEY_BYTES( bits ) ( ( (size_t) bits + 7 ) / 8 )
-
-
 #define MBEDTLS_SSL_TLS1_3_LABEL( name, string )       \
     .name = string,
 
@@ -937,7 +933,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
 
     if( ( status = psa_import_key( &attributes,
                              key_enc,
-                             KEY_BYTES( key_bits ),
+                             PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_enc ) ) != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );
@@ -945,7 +941,7 @@ int mbedtls_ssl_tls13_populate_transform( mbedtls_ssl_transform *transform,
     }
     if( ( status = psa_import_key( &attributes,
                              key_dec,
-                             KEY_BYTES( key_bits ),
+                             PSA_BITS_TO_BYTES( key_bits ),
                              &transform->psa_key_dec ) ) != PSA_SUCCESS )
     {
         MBEDTLS_SSL_DEBUG_RET( 1, "psa_import_key", status );


### PR DESCRIPTION
## Description
Implements issue: https://github.com/ARMmbed/mbedtls/issues/5204
Needs preceding PR: https://github.com/ARMmbed/mbedtls/pull/5405

Store PSA keys and algorithm in the transform structure (in addition to the existing fields for now) in so that they can be used in later tasks.

This implementation requires `mbedtls_cipher_to_psa()` provide in PR https://github.com/ARMmbed/mbedtls/pull/5405.

## Status
**READY**

## Requires Backporting
Yes?
Which branch?

## Migrations
NO