### PR TITLE
Add missing config check for PKCS5.

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -149,6 +149,10 @@
 #error "MBEDTLS_PK_PARSE_C defined, but not all prerequesites"
 #endif
 
+#if defined(MBEDTLS_PKCS5_C) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_PKCS5_C defined, but not all prerequesites"
+#endif
+
 #if defined(MBEDTLS_ENTROPY_C) && (!defined(MBEDTLS_SHA512_C) &&      \
                                     !defined(MBEDTLS_SHA256_C))
 #error "MBEDTLS_ENTROPY_C defined, but not all prerequisites"


### PR DESCRIPTION
PKCS5 depends on MD, but is missing a config check resulting in
obscure errors on invalid configurations.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>

Backport: #5439