### PR TITLE
2.28 only: Any package used in a script must be listed in ci.requirements.txt

### DIFF
--- a/scripts/ci.requirements.txt
+++ b/scripts/ci.requirements.txt
@@ -1,5 +1,9 @@
 # Python package requirements for Mbed TLS testing.
 
+# Any package used by a script in this repository must be listed here
+# or in one of the included files. Normally there should be a minimum
+# version constraint; the CI will test with the minimum version.
+
 # Use a known version of Pylint, because new versions tend to add warnings
 # that could start rejecting our code.
 # 2.4.4 is the version in Ubuntu 20.04. It supports Python >=3.5.

--- a/scripts/maintainer.requirements.txt
+++ b/scripts/maintainer.requirements.txt
@@ -1,4 +1,5 @@
-# Python packages that are only useful to Mbed TLS maintainers.
+# Python packages that are not used by any script in this repository,
+# but are likely to be useful to Mbed TLS maintainers.
 
 -r ci.requirements.txt
 


### PR DESCRIPTION
Backport of a commit from https://github.com/ARMmbed/mbedtls/pull/5218. Documentation only, but useful to have here to facilitate future backports.