### PR TITLE
Backport 2.28: doxygen: add missing asterisk to group closures

### DIFF
--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -122,7 +122,6 @@
 #define MBEDTLS_ASN1_TAG_VALUE_MASK          0x1F
 
 /** \} name DER constants */
-/** \} addtogroup asn1_module */
 
 /** Returns the size of the binary string, without the trailing \\0 */
 #define MBEDTLS_OID_SIZE(x) (sizeof(x) - 1)
@@ -608,6 +607,7 @@ void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
 void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
 
 /** \} name Functions to parse ASN.1 data structures */
+/** \} addtogroup asn1_module */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -61,7 +61,7 @@
 /** Buffer too small when writing ASN.1 data structure. */
 #define MBEDTLS_ERR_ASN1_BUF_TOO_SMALL                    -0x006C
 
-/* \} name */
+/** \} name ASN1 Error codes */
 
 /**
  * \name DER constants
@@ -121,8 +121,8 @@
 #define MBEDTLS_ASN1_TAG_PC_MASK             0x20
 #define MBEDTLS_ASN1_TAG_VALUE_MASK          0x1F
 
-/* \} name */
-/* \} addtogroup asn1_module */
+/** \} name DER constants */
+/** \} addtogroup asn1_module */
 
 /** Returns the size of the binary string, without the trailing \\0 */
 #define MBEDTLS_OID_SIZE(x) (sizeof(x) - 1)
@@ -606,6 +606,8 @@ void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
  *              sets \c *head to \c NULL.
  */
 void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
+
+/** \} name Functions to parse ASN.1 data structures */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -321,7 +321,7 @@
  */
 //#define MBEDTLS_CHECK_PARAMS_ASSERT
 
-/* \} name SECTION: System support */
+/** \} name SECTION: System support */
 
 /**
  * \name SECTION: mbed TLS feature support
@@ -2289,7 +2289,7 @@
  * Uncomment to enable use of ZLIB
  */
 //#define MBEDTLS_ZLIB_SUPPORT
-/* \} name SECTION: mbed TLS feature support */
+/** \} name SECTION: mbed TLS feature support */
 
 /**
  * \name SECTION: mbed TLS modules
@@ -3598,7 +3598,7 @@
  */
 #define MBEDTLS_XTEA_C
 
-/* \} name SECTION: mbed TLS modules */
+/** \} name SECTION: mbed TLS modules */
 
 /**
  * \name SECTION: Module configuration options
@@ -4002,7 +4002,7 @@
  */
 //#define MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED
 
-/* \} name SECTION: Customisation configuration options */
+/** \} name SECTION: Customisation configuration options */
 
 /* Target and application specific configurations
  *

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -138,7 +138,7 @@
 /**< The maximum size of seed or reseed buffer in bytes. */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #define MBEDTLS_CTR_DRBG_PR_OFF             0
 /**< Prediction resistance is disabled. */

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -351,7 +351,7 @@ mbedtls_ecp_group;
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM  1   /**< Enable fixed-point speed-up. */
 #endif /* MBEDTLS_ECP_FIXED_POINT_OPTIM */
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #else  /* MBEDTLS_ECP_ALT */
 #include "ecp_alt.h"

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -75,7 +75,7 @@
 #define MBEDTLS_ENTROPY_MAX_GATHER      128     /**< Maximum amount requested from entropy sources */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #if defined(MBEDTLS_ENTROPY_SHA512_ACCUMULATOR)
 #define MBEDTLS_ENTROPY_BLOCK_SIZE      64      /**< Block size of entropy accumulator (SHA-512) */

--- a/include/mbedtls/hkdf.h
+++ b/include/mbedtls/hkdf.h
@@ -39,7 +39,7 @@
  */
 /** Bad input parameters to function. */
 #define MBEDTLS_ERR_HKDF_BAD_INPUT_DATA  -0x5F80
-/* \} name */
+/** \} name */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -74,7 +74,7 @@
 #define MBEDTLS_HMAC_DRBG_MAX_SEED_INPUT    384     /**< Maximum size of (re)seed buffer */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #define MBEDTLS_HMAC_DRBG_PR_OFF   0   /**< No prediction resistance       */
 #define MBEDTLS_HMAC_DRBG_PR_ON    1   /**< Prediction resistance enabled  */

--- a/include/mbedtls/memory_buffer_alloc.h
+++ b/include/mbedtls/memory_buffer_alloc.h
@@ -42,7 +42,7 @@
 #define MBEDTLS_MEMORY_ALIGN_MULTIPLE       4 /**< Align on multiples of this value */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #define MBEDTLS_MEMORY_VERIFY_NONE         0
 #define MBEDTLS_MEMORY_VERIFY_ALLOC        (1 << 0)

--- a/include/mbedtls/pem.h
+++ b/include/mbedtls/pem.h
@@ -54,7 +54,7 @@
 #define MBEDTLS_ERR_PEM_FEATURE_UNAVAILABLE               -0x1400
 /** Bad input parameters to function. */
 #define MBEDTLS_ERR_PEM_BAD_INPUT_DATA                    -0x1480
-/* \} name */
+/** \} name PEM Error codes */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -127,7 +127,7 @@ extern "C" {
 #endif /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
 
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 /*
  * The function pointers for calloc and free.

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -77,4 +77,5 @@ int mbedtls_platform_set_time( mbedtls_time_t (*time_func)( mbedtls_time_t* time
 }
 #endif
 
+/** \} name SECTION: Module settings */
 #endif /* platform_time.h */

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -32,14 +32,6 @@
 extern "C" {
 #endif
 
-/**
- * \name SECTION: Module settings
- *
- * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
- * \{
- */
-
 /*
  * The time_t datatype
  */
@@ -77,5 +69,4 @@ int mbedtls_platform_set_time( mbedtls_time_t (*time_func)( mbedtls_time_t* time
 }
 #endif
 
-/** \} name SECTION: Module settings */
 #endif /* platform_time.h */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -349,7 +349,7 @@
 #define MBEDTLS_SSL_TLS1_3_PADDING_GRANULARITY 1
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 /*
  * Length of the verify data for secure renegotiation

--- a/include/mbedtls/ssl_cache.h
+++ b/include/mbedtls/ssl_cache.h
@@ -50,7 +50,7 @@
 #define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50   /*!< Maximum entries in cache */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -45,7 +45,7 @@
 #define MBEDTLS_SSL_COOKIE_TIMEOUT     60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
 #endif
 
-/* \} name SECTION: Module settings */
+/** \} name SECTION: Module settings */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -255,7 +255,6 @@ typedef struct mbedtls_x509_time
 mbedtls_x509_time;
 
 /** \} name Structures for parsing X.509 certificates, CRLs and CSRs */
-/** \} addtogroup x509_module */
 
 /**
  * \brief          Store the certificate DN in printable form into buf;
@@ -310,6 +309,8 @@ int mbedtls_x509_time_is_past( const mbedtls_x509_time *to );
  *                 0 otherwise.
  */
 int mbedtls_x509_time_is_future( const mbedtls_x509_time *from );
+
+/** \} addtogroup x509_module */
 
 #if defined(MBEDTLS_SELF_TEST)
 

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -96,7 +96,7 @@
 #define MBEDTLS_ERR_X509_BUFFER_TOO_SMALL                 -0x2980
 /** A fatal error occurred, eg the chain is too long or the vrfy callback failed. */
 #define MBEDTLS_ERR_X509_FATAL_ERROR                      -0x3000
-/* \} name */
+/** \} name X509 Error codes */
 
 /**
  * \name X509 Verify codes
@@ -124,8 +124,8 @@
 #define MBEDTLS_X509_BADCRL_BAD_PK           0x040000  /**< The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA). */
 #define MBEDTLS_X509_BADCRL_BAD_KEY          0x080000  /**< The CRL is signed with an unacceptable key (eg bad curve, RSA too short). */
 
-/* \} name */
-/* \} addtogroup x509_module */
+/** \} name X509 Verify codes */
+/** \} addtogroup x509_module */
 
 /*
  * X.509 v3 Subject Alternative Name types.

--- a/include/mbedtls/x509_crl.h
+++ b/include/mbedtls/x509_crl.h
@@ -162,8 +162,8 @@ void mbedtls_x509_crl_init( mbedtls_x509_crl *crl );
  */
 void mbedtls_x509_crl_free( mbedtls_x509_crl *crl );
 
-/* \} name */
-/* \} addtogroup x509_module */
+/** \} name Structures and functions for parsing CRLs */
+/** \} addtogroup x509_module */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -851,7 +851,6 @@ void mbedtls_x509_crt_restart_free( mbedtls_x509_crt_restart_ctx *ctx );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 /** \} name Structures and functions for parsing and writing X.509 certificates */
-/** \} addtogroup x509_module */
 
 #if defined(MBEDTLS_X509_CRT_WRITE_C)
 /**
@@ -1086,6 +1085,8 @@ int mbedtls_x509write_crt_pem( mbedtls_x509write_cert *ctx, unsigned char *buf, 
                        void *p_rng );
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_X509_CRT_WRITE_C */
+
+/** \} addtogroup x509_module */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -850,8 +850,8 @@ void mbedtls_x509_crt_restart_free( mbedtls_x509_crt_restart_ctx *ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-/* \} name */
-/* \} addtogroup x509_module */
+/** \} name Structures and functions for parsing and writing X.509 certificates */
+/** \} addtogroup x509_module */
 
 #if defined(MBEDTLS_X509_CRT_WRITE_C)
 /**

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -152,7 +152,6 @@ void mbedtls_x509_csr_free( mbedtls_x509_csr *csr );
 #endif /* MBEDTLS_X509_CSR_PARSE_C */
 
 /** \} name Structures and functions for X.509 Certificate Signing Requests (CSR) */
-/** \} addtogroup x509_module */
 
 #if defined(MBEDTLS_X509_CSR_WRITE_C)
 /**
@@ -297,6 +296,8 @@ int mbedtls_x509write_csr_pem( mbedtls_x509write_csr *ctx, unsigned char *buf, s
                        void *p_rng );
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_X509_CSR_WRITE_C */
+
+/** \} addtogroup x509_module */
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/x509_csr.h
+++ b/include/mbedtls/x509_csr.h
@@ -151,8 +151,8 @@ void mbedtls_x509_csr_init( mbedtls_x509_csr *csr );
 void mbedtls_x509_csr_free( mbedtls_x509_csr *csr );
 #endif /* MBEDTLS_X509_CSR_PARSE_C */
 
-/* \} name */
-/* \} addtogroup x509_module */
+/** \} name Structures and functions for X.509 Certificate Signing Requests (CSR) */
+/** \} addtogroup x509_module */
 
 #if defined(MBEDTLS_X509_CSR_WRITE_C)
 /**


### PR DESCRIPTION
Clarify section names next to closing braces.

Backport of https://github.com/ARMmbed/mbedtls/pull/5367
Partially fixing Issue #3497
Related PRs: #5371, #5372