### PR TITLE
server certificate selection callback

### DIFF
--- a/ChangeLog.d/mbedtls_ssl_cert_cb.txt
+++ b/ChangeLog.d/mbedtls_ssl_cert_cb.txt
@@ -1,0 +1,3 @@
+Features
+   * Add server certificate selection callback near end of Client Hello.
+     Register callback with mbedtls_ssl_conf_cert_cb().

--- a/ChangeLog.d/mbedtls_ssl_cert_cb.txt
+++ b/ChangeLog.d/mbedtls_ssl_cert_cb.txt
@@ -3,3 +3,5 @@ Features
      Register callback with mbedtls_ssl_conf_cert_cb().
    * Provide mechanism to reset handshake cert list by calling
      mbedtls_ssl_set_hs_own_cert() with NULL value for own_cert param.
+   * Add accessor mbedtls_ssl_get_hs_sni() to retrieve SNI from within
+     cert callback (mbedtls_ssl_conf_cert_cb()) during handshake.

--- a/ChangeLog.d/mbedtls_ssl_cert_cb.txt
+++ b/ChangeLog.d/mbedtls_ssl_cert_cb.txt
@@ -1,3 +1,5 @@
 Features
    * Add server certificate selection callback near end of Client Hello.
      Register callback with mbedtls_ssl_conf_cert_cb().
+   * Provide mechanism to reset handshake cert list by calling
+     mbedtls_ssl_set_hs_own_cert() with NULL value for own_cert param.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3546,6 +3546,9 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
  * \note           Same as \c mbedtls_ssl_conf_own_cert() but for use within
  *                 the SNI callback.
  *
+ * \note           Passing null \c own_cert clears the certificate list for
+ *                 the current handshake.
+ *
  * \param ssl      SSL context
  * \param own_cert own public certificate chain
  * \param pk_key   own private key

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1475,6 +1475,10 @@ struct mbedtls_ssl_config
      * access it afterwards.
      */
     mbedtls_ssl_user_data_t MBEDTLS_PRIVATE(user_data);
+
+#if defined(MBEDTLS_SSL_SRV_C)
+    int (*MBEDTLS_PRIVATE(f_cert_cb))(mbedtls_ssl_context *); /*!< certificate selection callback */
+#endif /* MBEDTLS_SSL_SRV_C */
 };
 
 struct mbedtls_ssl_context
@@ -2219,6 +2223,28 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
                                void *p_timer,
                                mbedtls_ssl_set_timer_t *f_set_timer,
                                mbedtls_ssl_get_timer_t *f_get_timer );
+
+#if defined(MBEDTLS_SSL_SRV_C)
+/**
+ * \brief           Set the certificate selection callback (server-side only).
+ *
+ *                  If set, the callback is always called for each handshake,
+ *                  after `ClientHello` processing has finished.
+ *
+ *                  The callback has the following parameters:
+ *                  - \c mbedtls_ssl_context*: The SSL context to which
+ *                                             the operation applies.
+ *                  The return value of the callback is 0 if successful,
+ *                  or a specific MBEDTLS_ERR_XXX code, which will cause
+ *                  the handshake to be aborted.
+ *
+ * \param conf      The SSL configuration to register the callback with.
+ * \param f_cert_cb The callback for selecting server certificate after
+ *                  `ClientHello` processing has finished.
+ */
+void mbedtls_ssl_conf_cert_cb( mbedtls_ssl_config *conf,
+                               int (*f_cert_cb)(mbedtls_ssl_context *) );
+#endif /* MBEDTLS_SSL_SRV_C */
 
 /**
  * \brief           Callback type: generate and write session ticket

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3624,8 +3624,7 @@ void mbedtls_ssl_set_hs_authmode( mbedtls_ssl_context *ssl,
  *                 mbedtls_ssl_set_hs_ca_chain() as well as the client
  *                 authentication mode with \c mbedtls_ssl_set_hs_authmode(),
  *                 then must return 0. If no matching name is found, the
- *                 callback must either set a default cert, or
- *                 return non-zero to abort the handshake at this point.
+ *                 callback may return non-zero to abort the handshake.
  *
  * \param conf     SSL configuration
  * \param f_sni    verification function

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3541,6 +3541,27 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 /**
+ * \brief          Retrieve SNI extension value for the current handshake.
+ *                 Available in \p f_cert_cb of \c mbedtls_ssl_conf_cert_cb(),
+ *                 this is the same value passed to \p f_sni callback of
+ *                 \c mbedtls_ssl_conf_sni() and may be used instead of
+ *                 \c mbedtls_ssl_conf_sni().
+ *
+ * \param ssl      SSL context
+ * \param name_len pointer into which to store length of returned value.
+ *                 0 if SNI extension is not present or not yet processed.
+ *
+ * \return         const pointer to SNI extension value.
+ *                 - value is valid only when called in \p f_cert_cb
+ *                   registered with \c mbedtls_ssl_conf_cert_cb().
+ *                 - value is NULL if SNI extension is not present.
+ *                 - value is not '\0'-terminated.  Use \c name_len for len.
+ *                 - value must not be freed.
+ */
+const unsigned char *mbedtls_ssl_get_hs_sni( mbedtls_ssl_context *ssl,
+                                             size_t *name_len );
+
+/**
  * \brief          Set own certificate and key for the current handshake
  *
  * \note           Same as \c mbedtls_ssl_conf_own_cert() but for use within

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3565,7 +3565,7 @@ const unsigned char *mbedtls_ssl_get_hs_sni( mbedtls_ssl_context *ssl,
  * \brief          Set own certificate and key for the current handshake
  *
  * \note           Same as \c mbedtls_ssl_conf_own_cert() but for use within
- *                 the SNI callback.
+ *                 the SNI callback or the certificate selection callback.
  *
  * \note           Passing null \c own_cert clears the certificate list for
  *                 the current handshake.
@@ -3585,7 +3585,7 @@ int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
  *                 current handshake
  *
  * \note           Same as \c mbedtls_ssl_conf_ca_chain() but for use within
- *                 the SNI callback.
+ *                 the SNI callback or the certificate selection callback.
  *
  * \param ssl      SSL context
  * \param ca_chain trusted CA chain (meaning all fully trusted top-level CAs)
@@ -3599,7 +3599,7 @@ void mbedtls_ssl_set_hs_ca_chain( mbedtls_ssl_context *ssl,
  * \brief          Set authmode for the current handshake.
  *
  * \note           Same as \c mbedtls_ssl_conf_authmode() but for use within
- *                 the SNI callback.
+ *                 the SNI callback or the certificate selection callback.
  *
  * \param ssl      SSL context
  * \param authmode MBEDTLS_SSL_VERIFY_NONE, MBEDTLS_SSL_VERIFY_OPTIONAL or

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -849,6 +849,11 @@ struct mbedtls_ssl_handshake_params
      * The library does not use it internally. */
     void *user_async_ctx;
 #endif /* MBEDTLS_SSL_ASYNC_PRIVATE */
+
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+    const unsigned char *sni_name;      /*!< raw SNI                        */
+    size_t sni_name_len;                /*!< raw SNI len                    */
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
 };
 
 typedef struct mbedtls_ssl_hs_buffer mbedtls_ssl_hs_buffer;

--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -1871,9 +1871,19 @@ read_record_header:
     }
 
     /*
+     * Server certification selection (after processing TLS extensions)
+     */
+    if( ssl->conf->f_cert_cb && ( ret = ssl->conf->f_cert_cb( ssl ) ) != 0 )
+    {
+        MBEDTLS_SSL_DEBUG_RET( 1, "f_cert_cb", ret );
+        return( ret );
+    }
+
+    /*
      * Search for a matching ciphersuite
      * (At the end because we need information from the EC-based extensions
-     * and certificate from the SNI callback triggered by the SNI extension.)
+     * and certificate from the SNI callback triggered by the SNI extension
+     * or certificate from server certificate selection callback.)
      */
     got_common_suite = 0;
     ciphersuites = ssl->conf->ciphersuite_list;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1233,6 +1233,14 @@ void mbedtls_ssl_set_timer_cb( mbedtls_ssl_context *ssl,
 }
 
 #if defined(MBEDTLS_SSL_SRV_C)
+void mbedtls_ssl_conf_cert_cb( mbedtls_ssl_config *conf,
+                               int (*f_cert_cb)(mbedtls_ssl_context *) )
+{
+    conf->f_cert_cb = f_cert_cb;
+}
+#endif /* MBEDTLS_SSL_SRV_C */
+
+#if defined(MBEDTLS_SSL_SRV_C)
 void mbedtls_ssl_conf_session_cache( mbedtls_ssl_config *conf,
                                      void *p_cache,
                                      mbedtls_ssl_cache_get_t *f_get_cache,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1299,12 +1299,32 @@ void mbedtls_ssl_conf_cert_profile( mbedtls_ssl_config *conf,
     conf->cert_profile = profile;
 }
 
+static void ssl_key_cert_free( mbedtls_ssl_key_cert *key_cert )
+{
+    mbedtls_ssl_key_cert *cur = key_cert, *next;
+
+    while( cur != NULL )
+    {
+        next = cur->next;
+        mbedtls_free( cur );
+        cur = next;
+    }
+}
+
 /* Append a new keycert entry to a (possibly empty) list */
 static int ssl_append_key_cert( mbedtls_ssl_key_cert **head,
                                 mbedtls_x509_crt *cert,
                                 mbedtls_pk_context *key )
 {
     mbedtls_ssl_key_cert *new_cert;
+
+    if( cert == NULL )
+    {
+        /* Free list if cert is null */
+        ssl_key_cert_free( *head );
+        *head = NULL;
+        return( 0 );
+    }
 
     new_cert = mbedtls_calloc( 1, sizeof( mbedtls_ssl_key_cert ) );
     if( new_cert == NULL )
@@ -1314,7 +1334,7 @@ static int ssl_append_key_cert( mbedtls_ssl_key_cert **head,
     new_cert->key  = key;
     new_cert->next = NULL;
 
-    /* Update head is the list was null, else add to the end */
+    /* Update head if the list was null, else add to the end */
     if( *head == NULL )
     {
         *head = new_cert;
@@ -2949,20 +2969,6 @@ int mbedtls_ssl_renegotiate( mbedtls_ssl_context *ssl )
 }
 #endif /* MBEDTLS_SSL_RENEGOTIATION */
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
-static void ssl_key_cert_free( mbedtls_ssl_key_cert *key_cert )
-{
-    mbedtls_ssl_key_cert *cur = key_cert, *next;
-
-    while( cur != NULL )
-    {
-        next = cur->next;
-        mbedtls_free( cur );
-        cur = next;
-    }
-}
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
-
 void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
 {
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
@@ -3050,17 +3056,7 @@ void mbedtls_ssl_handshake_free( mbedtls_ssl_context *ssl )
      * Free only the linked list wrapper, not the keys themselves
      * since the belong to the SNI callback
      */
-    if( handshake->sni_key_cert != NULL )
-    {
-        mbedtls_ssl_key_cert *cur = handshake->sni_key_cert, *next;
-
-        while( cur != NULL )
-        {
-            next = cur->next;
-            mbedtls_free( cur );
-            cur = next;
-        }
-    }
+    ssl_key_cert_free( handshake->sni_key_cert );
 #endif /* MBEDTLS_X509_CRT_PARSE_C && MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1389,6 +1389,13 @@ void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+const unsigned char *mbedtls_ssl_get_hs_sni( mbedtls_ssl_context *ssl,
+                                             size_t *name_len )
+{
+    *name_len = ssl->handshake->sni_name_len;
+    return( ssl->handshake->sni_name );
+}
+
 int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
                                  mbedtls_x509_crt *own_cert,
                                  mbedtls_pk_context *pk_key )

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -5025,7 +5025,6 @@ run_test    "SNI: no SNI callback" \
              crt_file=data_files/server5.crt key_file=data_files/server5.key" \
             "$P_CLI server_name=localhost" \
             0 \
-            -S "parse ServerName extension" \
             -c "issuer name *: C=NL, O=PolarSSL, CN=Polarssl Test EC CA" \
             -c "subject name *: C=NL, O=PolarSSL, CN=localhost"
 
@@ -5175,7 +5174,6 @@ run_test    "SNI: DTLS, no SNI callback" \
              crt_file=data_files/server5.crt key_file=data_files/server5.key" \
             "$P_CLI server_name=localhost dtls=1" \
             0 \
-            -S "parse ServerName extension" \
             -c "issuer name *: C=NL, O=PolarSSL, CN=Polarssl Test EC CA" \
             -c "subject name *: C=NL, O=PolarSSL, CN=localhost"
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -854,6 +854,15 @@ int mbedtls_endpoint_certificate_init( mbedtls_endpoint *ep, int pk_alg )
     ret = mbedtls_ssl_conf_own_cert( &( ep->conf ), &( cert->cert ),
                                      &( cert->pkey ) );
     TEST_ASSERT( ret == 0 );
+    TEST_ASSERT( ep->conf.key_cert != NULL );
+
+    ret = mbedtls_ssl_conf_own_cert( &( ep->conf ), NULL, NULL );
+    TEST_ASSERT( ret == 0 );
+    TEST_ASSERT( ep->conf.key_cert == NULL );
+
+    ret = mbedtls_ssl_conf_own_cert( &( ep->conf ), &( cert->cert ),
+                                     &( cert->pkey ) );
+    TEST_ASSERT( ret == 0 );
 
 exit:
     if( ret != 0 )


### PR DESCRIPTION
## Description
This PR sketches out a server certificate selection callback which is run unconditionally near the end of ClientHello (and right before mbedtls internals choose and use server certificate)

## Status
**READY**

Depends on: #5426

## Requires Backporting
NO  

## Migrations
> If there is any API change, what's the incentive and logic for it.

#5430: "Add an unconditonnal (sic) end-of-ClientHello callback"

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated

## Additional comments
This PR sketches out a server certificate selection callback which is run unconditionally near the end of ClientHello (and right before mbedtls internals choose and use server certificate)

This leverages #5426: Add accessors to mbedtls_ssl_context: user data, version and is currently rebased onto that (not-yet-committed) branch.

Optional and included in this PR for interface discussion:
* reset/clear certificate list already set in ssl->handshake->sni_key_cert
  (potentially by other callbacks) by extending mbedtls_ssl_set_hs_own_cert()
* accessor to retrieve SNI during handshake (add mbedtls_ssl_get_hs_sni())

Discussion

Simple TLS extension callbacks work well when TLS extensions are assumed independent.  However, that is no longer the case in common usage, even if it once was.  SNI is required in TLSv1.3, and certificate selection may be influenced by:
* SNI
* supported_groups TLS extension ("elliptic_curves")
* some ALPN values (e.g. "acme-tls/1")
* (...)

mbedtls currently provides interfaces to allow support for simple callbacks to handle TLS extensions as if they were independent, and this works for many applications.  This can be extended with additional callbacks, but that does not appear to be the most efficient or maintainable solution since it would add more code as new extensions are standardized.

A callback near the end of ClientHello processing -- which is called unconditionally after all TLS extensions are parsed, will scale better -- and will allow an application to react to a missing TLS extension, if one is required by the application.

Should this cert_cb callback take a (void *)p_arg?  Or should new callbacks, including the cert_cb, rely on the user_data argument in #5426.  This PR prefers using user_data.

The cert_cb needs access to the SNI.  Should mbedtls save and provide access to the SNI value, or should consumers be required to use `mbedtls_ssl_conf_sni()` and save the value themselves?  Having mbedtls provide an accessor means that a separate allocation just for saving SNI values can be avoided, and configuring a separate callback for SNI can be skipped.  At the same time, this is a convenience, since there will already be a mechanism for the application to allocate its own structure to store SNI values and other data in ssl user_data in the SNI callback.  I am leaning towards removing the accessor added in this PR since if the application does not need it, then setting the certificate in the SNI callback is sufficient, and if the application does need SNI elsewhere, then the application can use user_data.

One more change in this PR is extending `mbedtls_ssl_set_hs_own_cert()` to clear ssl->handshake->sni_key_cert if NULL is passed as certificate pointer.  This may be useful if a certificate is configured in one of the callbacks, but then a later callback wishes to replace, rather than append to, the certificate list.