### PR TITLE
Remove incorrect incompatibility information about `MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER` from mbedtls_config.h

### DIFF
--- a/include/mbedtls/mbedtls_config.h
+++ b/include/mbedtls/mbedtls_config.h
@@ -1081,7 +1081,7 @@
  * which is currently hard-coded to be int32_t.
  *
  * Note that this option is meant for internal use only and may be removed
- * without notice. It is incompatible with MBEDTLS_USE_PSA_CRYPTO.
+ * without notice.
  */
 //#define MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
 


### PR DESCRIPTION
Missed during https://github.com/ARMmbed/mbedtls/pull/5380. Local `check_files.py` passed.