### PR TITLE
Clarify key types message from ssl_client2 and ssl_server2

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1703,7 +1703,8 @@ int main( int argc, char *argv[] )
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    mbedtls_printf( " ok (key type: %s)\n", mbedtls_pk_get_name( &pkey ) );
+    mbedtls_printf( " ok (key type: %s)\n",
+                    strlen( opt.key_file ) ? mbedtls_pk_get_name( &pkey ) : "none" );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
     /*

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2516,7 +2516,7 @@ int main( int argc, char *argv[] )
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_printf( " ok (key types: %s, %s)\n",
-                    key_cert_init2 ? mbedtls_pk_get_name( &pkey ) : "none",
+                    key_cert_init ? mbedtls_pk_get_name( &pkey ) : "none",
                     key_cert_init2 ? mbedtls_pk_get_name( &pkey2 ) : "none" );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2515,7 +2515,9 @@ int main( int argc, char *argv[] )
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    mbedtls_printf( " ok (key types: %s - %s)\n", mbedtls_pk_get_name( &pkey ), mbedtls_pk_get_name( &pkey2 ) );
+    mbedtls_printf( " ok (key types: %s, %s)\n",
+                    key_cert_init2 ? mbedtls_pk_get_name( &pkey ) : "none",
+                    key_cert_init2 ? mbedtls_pk_get_name( &pkey2 ) : "none" );
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_DHM_C) && defined(MBEDTLS_FS_IO)

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1556,7 +1556,7 @@ run_test    "Opaque key for server authentication" \
             0 \
             -c "Verifying peer X.509 certificate... ok" \
             -c "Ciphersuite is TLS-ECDHE-ECDSA" \
-            -s "key types: Opaque - invalid PK" \
+            -s "key types: Opaque, none" \
             -s "Ciphersuite is TLS-ECDHE-ECDSA" \
             -S "error" \
             -C "error"
@@ -1575,7 +1575,7 @@ run_test    "Opaque key for client/server authentication" \
             -c "key type: Opaque" \
             -c "Verifying peer X.509 certificate... ok" \
             -c "Ciphersuite is TLS-ECDHE-ECDSA" \
-            -s "key types: Opaque - invalid PK" \
+            -s "key types: Opaque, none" \
             -s "Verifying peer X.509 certificate... ok" \
             -s "Ciphersuite is TLS-ECDHE-ECDSA" \
             -S "error" \


### PR DESCRIPTION
Small tweak to a message in test programs that I found misleading.

The message is only misleading when there's no second key (“none” vs “unknown”), so this is mostly about the server. The server doesn't print this message in 2.28, so no backport needed.