### PR TITLE
Backport 2.28: Don't inline mbedtls_mpi_safe_cond_assign on MSVC/ARM64 to avoid a compiler bug

### DIFF
--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -533,6 +533,13 @@ cleanup:
  * about whether the assignment was made or not.
  * (Leaking information about the respective sizes of X and Y is ok however.)
  */
+#if defined(_MSC_VER) && defined(_M_ARM64)
+/*
+ * MSVC miscompiles this function if it's inlined. See:
+ * https://developercommunity.visualstudio.com/t/c-compiler-miscompiles-part-of-mbedtls-library-on/1646989
+ */
+__declspec(noinline)
+#endif
 int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X,
                                   const mbedtls_mpi *Y,
                                   unsigned char assign )

--- a/library/constant_time.c
+++ b/library/constant_time.c
@@ -533,9 +533,9 @@ cleanup:
  * about whether the assignment was made or not.
  * (Leaking information about the respective sizes of X and Y is ok however.)
  */
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && defined(_M_ARM64) && (_MSC_FULL_VER < 193131103)
 /*
- * MSVC miscompiles this function if it's inlined. See:
+ * MSVC miscompiles this function if it's inlined prior to Visual Studio 2022 version 17.1. See:
  * https://developercommunity.visualstudio.com/t/c-compiler-miscompiles-part-of-mbedtls-library-on/1646989
  */
 __declspec(noinline)


### PR DESCRIPTION
## Description
Don't inline mbedtls_mpi_safe_cond_assign on MSVC/ARM64 to avoid a compiler bug. This addresses https://github.com/ARMmbed/mbedtls/issues/5467. Backport of #5469 


## Status
READY

## Requires Backporting
NO  

This was introduced in 2.27 and I don't think that's maintained anymore? So 2.28 is the furthest the backport is needed.