### PR TITLE
Move client_auth to handshake

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1615,8 +1615,12 @@ struct mbedtls_ssl_context
     /*
      * PKI layer
      */
-    int MBEDTLS_PRIVATE(client_auth);                    /*!<  flag for client auth.   */
-
+#if defined(MBEDTLS_SSL_CLI_C)
+    int MBEDTLS_PRIVATE(client_auth);           /*!< used to check if CertificateRequest is
+                                                     received from server side. If
+                                                     CertificateReqeust is received, Certificate
+                                                     and CertificateVerify should be sent to server */
+#endif /* MBEDTLS_SSL_CLI_C */
     /*
      * User settings
      */

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1613,10 +1613,6 @@ struct mbedtls_ssl_context
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     /*
-     * PKI layer
-     */
-
-    /*
      * User settings
      */
 #if defined(MBEDTLS_X509_CRT_PARSE_C)

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1615,12 +1615,7 @@ struct mbedtls_ssl_context
     /*
      * PKI layer
      */
-#if defined(MBEDTLS_SSL_CLI_C)
-    int MBEDTLS_PRIVATE(client_auth);           /*!< used to check if CertificateRequest is
-                                                     received from server side. If
-                                                     CertificateReqeust is received, Certificate
-                                                     and CertificateVerify should be sent to server */
-#endif /* MBEDTLS_SSL_CLI_C */
+
     /*
      * User settings
      */

--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -3137,12 +3137,13 @@ static int ssl_parse_certificate_request( mbedtls_ssl_context *ssl )
     }
 
     ssl->state++;
-    ssl->client_auth = ( ssl->in_msg[0] == MBEDTLS_SSL_HS_CERTIFICATE_REQUEST );
+    ssl->handshake->client_auth =
+                    ( ssl->in_msg[0] == MBEDTLS_SSL_HS_CERTIFICATE_REQUEST );
 
     MBEDTLS_SSL_DEBUG_MSG( 3, ( "got %s certificate request",
-                        ssl->client_auth ? "a" : "no" ) );
+                        ssl->handshake->client_auth ? "a" : "no" ) );
 
-    if( ssl->client_auth == 0 )
+    if( ssl->handshake->client_auth == 0 )
     {
         /* Current message is probably the ServerHelloDone */
         ssl->keep_current_message = 1;
@@ -3794,7 +3795,8 @@ static int ssl_write_certificate_verify( mbedtls_ssl_context *ssl )
         return( 0 );
     }
 
-    if( ssl->client_auth == 0 || mbedtls_ssl_own_cert( ssl ) == NULL )
+    if( ssl->handshake->client_auth == 0 ||
+        mbedtls_ssl_own_cert( ssl ) == NULL )
     {
         MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write certificate verify" ) );
         ssl->state++;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -770,7 +770,7 @@ struct mbedtls_ssl_handshake_params
 
 #if defined(MBEDTLS_SSL_CLI_C)
     uint8_t client_auth;       /*!< used to check if CertificateRequest has been
-                                    received from server side. If CertificateReqeust
+                                    received from server side. If CertificateRequest
                                     has been received, Certificate and CertificateVerify
                                     should be sent to server */
 #endif /* MBEDTLS_SSL_CLI_C */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -769,9 +769,9 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_SSL_CLI_C)
-    int client_auth;           /*!< used to check if CertificateRequest is received
-                                    from server side. If CertificateReqeust is
-                                    received, Certificate and CertificateVerify
+    int client_auth;           /*!< used to check if CertificateRequest has been
+                                    received from server side. If CertificateReqeust
+                                    has been received, Certificate and CertificateVerify
                                     should be sent to server */
 #endif /* MBEDTLS_SSL_CLI_C */
     /*

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -768,6 +768,12 @@ struct mbedtls_ssl_handshake_params
                                 * but can be overwritten by the HRR. */
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
+#if defined(MBEDTLS_SSL_CLI_C)
+    int client_auth;           /*!< used to check if CertificateRequest is received
+                                    from server side. If CertificateReqeust is
+                                    received, Certificate and CertificateVerify
+                                    should be sent to server */
+#endif /* MBEDTLS_SSL_CLI_C */
     /*
      * State-local variables used during the processing
      * of a specific handshake state.

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -769,7 +769,7 @@ struct mbedtls_ssl_handshake_params
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
 #if defined(MBEDTLS_SSL_CLI_C)
-    int client_auth;           /*!< used to check if CertificateRequest has been
+    uint8_t client_auth;       /*!< used to check if CertificateRequest has been
                                     received from server side. If CertificateReqeust
                                     has been received, Certificate and CertificateVerify
                                     should be sent to server */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1701,7 +1701,7 @@ int mbedtls_ssl_write_certificate( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_CLI_C)
     if( ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT )
     {
-        if( ssl->client_auth == 0 )
+        if( ssl->handshake->client_auth == 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 2, ( "<= skip write certificate" ) );
             ssl->state++;


### PR DESCRIPTION
`ssl->client_auth` is used to indicate CertificateRequest received from server. If received, CertificateVerfiy and Certificate MUST be sent by client. The variable is used only in handshake stage.

- Guard it with `MBEDTLS_SSL_PROTO_TLS1_2`
- Move it to `ssl->handshake`

## Status
**READY**

