### PR TITLE
Avoid dead code in some configurations

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1841,15 +1841,18 @@ static inline const void *mbedtls_ssl_get_sig_algs(
                                                 const mbedtls_ssl_context *ssl )
 {
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
     if( ssl->handshake != NULL && ssl->handshake->sig_algs != NULL )
         return( ssl->handshake->sig_algs );
 #endif
     return( ssl->conf->sig_algs );
-#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
+
+#else /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
     ((void) ssl);
     return( NULL );
+#endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 }
 
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)


### PR DESCRIPTION
## Description

Found by Coverity, but some compilers could also be unhappy about it.

## Status
**READY**

## Requires Backporting

NO  - this is new in development.


