### PR TITLE
Fix AEAD multipart incorrect offset in test_suite_psa_crypto.function

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -506,7 +506,7 @@ static int aead_multipart_internal_func( int key_type_arg, data_t *key_data,
 
             if( output_data && output_part_length )
             {
-                memcpy( ( output_data + part_offset ), part_data,
+                memcpy( ( output_data + output_length ), part_data,
                         output_part_length );
             }
 


### PR DESCRIPTION
When working with block cipher modes like GCM(PSA_ALG_IS_AEAD_ON_BLOCK_CIPHER),
aead_multipart_internal_func() should calculate the offset in the output buffer based on output_length, not using the offset of the input buffer(part_offset).

Backport: no (multipart AEAD didn't exist in 2.28)