### PR TITLE
Add accessor to get der from mbedtls_pem_context

### DIFF
--- a/ChangeLog.d/mbedtls_pem_get_der.txt
+++ b/ChangeLog.d/mbedtls_pem_get_der.txt
@@ -1,0 +1,2 @@
+Features
+   * Add accessor to get der from mbedtls_pem_context

--- a/include/mbedtls/pem.h
+++ b/include/mbedtls/pem.h
@@ -104,6 +104,23 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
                      size_t pwdlen, size_t *use_len );
 
 /**
+ * \brief       Retrieve pointer to der data stored in \c mbedtls_pem_context.
+ *
+ * \param ctx       context to use
+ * \param derlen    destination for length of der data
+ *
+ * \return          const unsigned char * pointer to der data stored in
+ *                  \c mbedtls_pem_context.  Pointer is valid while
+ *                  \c mbedtls_pem_context is not further modified or freed.
+ */
+static inline const unsigned char *mbedtls_pem_get_der( mbedtls_pem_context *ctx, size_t *derlen )
+{
+    *derlen = ctx->MBEDTLS_PRIVATE(buflen);
+    return( ctx->MBEDTLS_PRIVATE(buf) );
+}
+
+
+/**
  * \brief       PEM context memory freeing
  *
  * \param ctx   context to be freed

--- a/tests/suites/test_suite_pem.function
+++ b/tests/suites/test_suite_pem.function
@@ -40,12 +40,21 @@ void mbedtls_pem_read_buffer( char *header, char *footer, char *data,
     int ret;
     size_t use_len = 0;
     size_t pwd_len = strlen( pwd );
+    const unsigned char *der;
 
     mbedtls_pem_init( &ctx );
 
     ret = mbedtls_pem_read_buffer( &ctx, header, footer, (unsigned char *)data,
                 (unsigned char *)pwd, pwd_len, &use_len );
     TEST_ASSERT( ret == res );
+    if( ret != 0 )
+        goto exit;
+
+    /*(code coverage to exercise mbedtls_pem_get_der())*/
+    use_len = 0;
+    der = mbedtls_pem_get_der( &ctx, &use_len );
+    TEST_ASSERT( der == ctx.buf );
+    TEST_ASSERT( use_len == ctx.buflen );
 
 exit:
     mbedtls_pem_free( &ctx );


### PR DESCRIPTION
## Description
Add accessor to get der from mbedtls_pem_context
#5414 [Allow access to result of PEM decoding](https://github.com/ARMmbed/mbedtls/issues/5414#)

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated