### PR TITLE
mbedtls_ssl_check_pending: Add MBEDTLS_ERR_SSL_BAD_INPUT_DATA check

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -4798,6 +4798,9 @@ size_t mbedtls_ssl_get_bytes_avail( const mbedtls_ssl_context *ssl )
 
 int mbedtls_ssl_check_pending( const mbedtls_ssl_context *ssl )
 {
+    if( ssl == NULL || ssl->conf == NULL )
+        return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+
     /*
      * Case A: We're currently holding back
      * a message for further processing.


### PR DESCRIPTION

## Description
mbedtls_ssl_check_pending: Add MBEDTLS_ERR_SSL_BAD_INPUT_DATA check

To be consistent with mbedtls_ssl_read/mbedtls_ssl_write.

## Additional comments

    Background:
    My app is using this within a traditional non-blocking poll-loop.
    The same structure is used for both of mbedtls ssl context and a raw
    TCP socket. For such an app, it's convenient to be able to represent
    an equivalent of file descriptor -1 and EBADF. With mbedtls-2.x,
    I was using a zero'ed ssl context and checking it with ssl->conf == NULL
    before calling mbedtls_ssl_check_pending. However, the field is marked
    private for mbedtls-3.x. A more straightforward "solution" would be
    to introduce an accessor to detect such a context. But I feel it's
    more consistent to make mbedtls_ssl_check_pending check it by itself
    as other funtions including mbedtls_ssl_read/mbedtls_ssl_write do.
