### PR TITLE
feat: MD: X.509 hashing

### DIFF
--- a/ChangeLog.d/MD-X.509-hashing.txt
+++ b/ChangeLog.d/MD-X.509-hashing.txt
@@ -1,0 +1,2 @@
+Features
+   * The X.509 module now uses PSA hash acceleration if present.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -47,7 +47,8 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#endif
+#include "psa/crypto_values.h"
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
@@ -2336,8 +2337,14 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                                const mbedtls_x509_crt_profile *profile )
 {
     int flags = 0;
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    unsigned char hash[PSA_HASH_MAX_SIZE];
+    psa_algorithm_t psa_algorithm;
+#else
     unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     const mbedtls_md_info_t *md_info;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+    size_t hash_length;
 
     if( ca == NULL )
         return( flags );
@@ -2370,8 +2377,21 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
         if( x509_profile_check_pk_alg( profile, crl_list->sig_pk ) != 0 )
             flags |= MBEDTLS_X509_BADCRL_BAD_PK;
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+        psa_algorithm = mbedtls_psa_translate_md( crl_list->sig_md );
+        if(psa_hash_compute( psa_algorithm,
+                             crl_list->tbs.p,
+                             crl_list->tbs.len,
+                             hash,PSA_HASH_MAX_SIZE,
+                             &hash_length ) != PSA_SUCCESS )
+#else
         md_info = mbedtls_md_info_from_type( crl_list->sig_md );
-        if( mbedtls_md( md_info, crl_list->tbs.p, crl_list->tbs.len, hash ) != 0 )
+        hash_length = mbedtls_md_get_size( md_info );
+        if( mbedtls_md( md_info,
+                        crl_list->tbs.p,
+                        crl_list->tbs.len,
+                        hash ) != 0 )
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
         {
             /* Note: this can't happen except after an internal error */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
@@ -2382,7 +2402,7 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
             flags |= MBEDTLS_X509_BADCERT_BAD_KEY;
 
         if( mbedtls_pk_verify_ext( crl_list->sig_pk, crl_list->sig_opts, &ca->pk,
-                           crl_list->sig_md, hash, mbedtls_md_get_size( md_info ),
+                           crl_list->sig_md, hash, hash_length,
                            crl_list->sig.p, crl_list->sig.len ) != 0 )
         {
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
@@ -2421,9 +2441,9 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
                                      mbedtls_x509_crt *parent,
                                      mbedtls_x509_crt_restart_ctx *rs_ctx )
 {
-    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     size_t hash_len;
 #if !defined(MBEDTLS_USE_PSA_CRYPTO)
+    unsigned char hash[MBEDTLS_MD_MAX_SIZE];
     const mbedtls_md_info_t *md_info;
     md_info = mbedtls_md_info_from_type( child->sig_md );
     hash_len = mbedtls_md_get_size( md_info );
@@ -2432,23 +2452,21 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
     if( mbedtls_md( md_info, child->tbs.p, child->tbs.len, hash ) != 0 )
         return( -1 );
 #else
-    psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
+    unsigned char hash[PSA_HASH_MAX_SIZE];
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( child->sig_md );
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-    if( psa_hash_setup( &hash_operation, hash_alg ) != PSA_SUCCESS )
-        return( -1 );
-
-    if( psa_hash_update( &hash_operation, child->tbs.p, child->tbs.len )
-        != PSA_SUCCESS )
+    status = psa_hash_compute( hash_alg,
+                               child->tbs.p,
+                               child->tbs.len,
+                               hash,
+                               PSA_HASH_MAX_SIZE,
+                               &hash_len );
+    if( status != PSA_SUCCESS )
     {
-        return( -1 );
+        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
     }
 
-    if( psa_hash_finish( &hash_operation, hash, sizeof( hash ), &hash_len )
-        != PSA_SUCCESS )
-    {
-        return( -1 );
-    }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
     /* Skip expensive computation on obvious mismatch */
     if( ! mbedtls_pk_can_do( &parent->pk, child->sig_pk ) )

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -47,7 +47,6 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#include "psa/crypto_values.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PLATFORM_C)
@@ -2382,7 +2381,8 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
         if(psa_hash_compute( psa_algorithm,
                              crl_list->tbs.p,
                              crl_list->tbs.len,
-                             hash,PSA_HASH_MAX_SIZE,
+                             hash,
+                             sizeof( hash ),
                              &hash_length ) != PSA_SUCCESS )
 #else
         md_info = mbedtls_md_info_from_type( crl_list->sig_md );
@@ -2460,7 +2460,7 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
                                child->tbs.p,
                                child->tbs.len,
                                hash,
-                               PSA_HASH_MAX_SIZE,
+                               sizeof( hash ),
                                &hash_len );
     if( status != PSA_SUCCESS )
     {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2384,6 +2384,11 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                              hash,
                              sizeof( hash ),
                              &hash_length ) != PSA_SUCCESS )
+        {
+            /* Note: this can't happen except after an internal error */
+            flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
+            break;
+        }
 #else
         md_info = mbedtls_md_info_from_type( crl_list->sig_md );
         hash_length = mbedtls_md_get_size( md_info );
@@ -2391,12 +2396,13 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
                         crl_list->tbs.p,
                         crl_list->tbs.len,
                         hash ) != 0 )
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
         {
             /* Note: this can't happen except after an internal error */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
             break;
         }
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
+
 
         if( x509_profile_check_key( profile, &ca->pk ) != 0 )
             flags |= MBEDTLS_X509_BADCERT_BAD_KEY;

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2464,7 +2464,7 @@ static int x509_crt_check_signature( const mbedtls_x509_crt *child,
                                &hash_len );
     if( status != PSA_SUCCESS )
     {
-        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+        return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2378,12 +2378,12 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         psa_algorithm = mbedtls_psa_translate_md( crl_list->sig_md );
-        if(psa_hash_compute( psa_algorithm,
-                             crl_list->tbs.p,
-                             crl_list->tbs.len,
-                             hash,
-                             sizeof( hash ),
-                             &hash_length ) != PSA_SUCCESS )
+        if( psa_hash_compute( psa_algorithm,
+                              crl_list->tbs.p,
+                              crl_list->tbs.len,
+                              hash,
+                              sizeof( hash ),
+                              &hash_length ) != PSA_SUCCESS )
         {
             /* Note: this can't happen except after an internal error */
             flags |= MBEDTLS_X509_BADCRL_NOT_TRUSTED;
@@ -2402,7 +2402,6 @@ static int x509_crt_verifycrl( mbedtls_x509_crt *crt, mbedtls_x509_crt *ca,
             break;
         }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
-
 
         if( x509_profile_check_key( profile, &ca->pk ) != 0 )
             flags |= MBEDTLS_X509_BADCERT_BAD_KEY;

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -236,9 +236,9 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
                           mbedtls_pk_write_pubkey( &c, buf, ctx->issuer_key ) );
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_hash_compute( PSA_ALG_SHA_1,
-                               buf + sizeof( buf ) - len,
+                               buf + sizeof(buf) - len,
                                len,
-                               buf + sizeof( buf ) - 20 ,
+                               buf + sizeof(buf) - 20,
                                PSA_HASH_LENGTH(PSA_ALG_SHA_1),
                                &hash_length );
     if( status != PSA_SUCCESS )
@@ -523,7 +523,7 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx,
                                c,
                                len,
                                hash,
-                               PSA_HASH_MAX_SIZE,
+                               sizeof( hash ),
                                &hash_length );
     if( status != PSA_SUCCESS )
     {

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -172,68 +172,36 @@ int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
 }
 
 #if defined(MBEDTLS_SHA1_C)
-int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx )
+static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
+*ctx,
+                                              int is_ca,
+                                              unsigned char tag )
 {
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-    size_t hash_length;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char buf[MBEDTLS_MPI_MAX_SIZE * 2 + 20]; /* tag, length + 2xMPI */
     unsigned char *c = buf + sizeof(buf);
     size_t len = 0;
-
-    memset( buf, 0, sizeof(buf) );
-    MBEDTLS_ASN1_CHK_ADD( len,
-                mbedtls_pk_write_pubkey( &c, buf, ctx->subject_key ) );
-
-#if defined(MBEDTLS_USE_PSA_CRYPTO)
-    status = psa_hash_compute( PSA_ALG_SHA_1,
-                               buf + sizeof( buf ) - len,
-                               len,
-                               buf + sizeof( buf ) - 20 ,
-                               PSA_HASH_LENGTH(PSA_ALG_SHA_1),
-                               &hash_length );
-    if( status != PSA_SUCCESS )
-    {
-        return( MBEDTLS_ERR_ERROR_GENERIC_ERROR );
-    }
-#else
-    ret = mbedtls_sha1( buf + sizeof( buf ) - len, len,
-                        buf + sizeof( buf ) - 20 );
-    if( ret != 0 )
-        return( ret );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
-
-    c = buf + sizeof( buf ) - 20;
-    len = 20;
-
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
-    MBEDTLS_ASN1_CHK_ADD( len,
-            mbedtls_asn1_write_tag( &c, buf, MBEDTLS_ASN1_OCTET_STRING ) );
-
-    return mbedtls_x509write_crt_set_extension( ctx,
-                 MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
-                 MBEDTLS_OID_SIZE( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
-                 0, buf + sizeof(buf) - len, len );
-}
-
-int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *ctx )
-{
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     size_t hash_length;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
-    unsigned char buf[MBEDTLS_MPI_MAX_SIZE * 2 + 20]; /* tag, length + 2xMPI */
-    unsigned char *c = buf + sizeof( buf );
-    size_t len = 0;
-
     memset( buf, 0, sizeof(buf) );
-    MBEDTLS_ASN1_CHK_ADD( len,
-                          mbedtls_pk_write_pubkey( &c, buf, ctx->issuer_key ) );
+    if( is_ca )
+    {
+        MBEDTLS_ASN1_CHK_ADD( len,
+                              mbedtls_pk_write_pubkey( &c,
+                                                       buf,
+                                                       ctx->issuer_key ) );
+    }
+    else
+    {
+        MBEDTLS_ASN1_CHK_ADD( len,
+                              mbedtls_pk_write_pubkey( &c,
+                                                       buf,
+                                                       ctx->subject_key ) );
+    }
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     status = psa_hash_compute( PSA_ALG_SHA_1,
                                buf + sizeof(buf) - len,
@@ -257,18 +225,48 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
     MBEDTLS_ASN1_CHK_ADD( len,
-        mbedtls_asn1_write_tag( &c, buf, MBEDTLS_ASN1_CONTEXT_SPECIFIC | 0 ) );
+                          mbedtls_asn1_write_tag( &c, buf, tag ) );
 
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
-    MBEDTLS_ASN1_CHK_ADD( len,
-                          mbedtls_asn1_write_tag( &c, buf,
-                                                  MBEDTLS_ASN1_CONSTRUCTED |
-                                                  MBEDTLS_ASN1_SEQUENCE ) );
+    if( is_ca ) // writes AuthorityKeyIdentifier sequence
+    {
+        MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ));
+        MBEDTLS_ASN1_CHK_ADD( len,
+                              mbedtls_asn1_write_tag( &c,
+                                                      buf,
+                                                      MBEDTLS_ASN1_CONSTRUCTED |
+                                                      MBEDTLS_ASN1_SEQUENCE ) );
+        return mbedtls_x509write_crt_set_extension(
+                   ctx,
+                   MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER,
+                   MBEDTLS_OID_SIZE( MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ),
+                   0,
+                   buf + sizeof( buf ) - len,
+                   len );
+    }
+    else
+    {
+        return mbedtls_x509write_crt_set_extension(
+                   ctx,
+                   MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
+                   MBEDTLS_OID_SIZE( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
+                   0,
+                   buf + sizeof( buf ) - len,
+                   len );
+    }
+}
 
-    return mbedtls_x509write_crt_set_extension(
-        ctx, MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER,
-        MBEDTLS_OID_SIZE( MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ),
-        0, buf + sizeof( buf ) - len, len );
+int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx )
+{
+    return mbedtls_x509write_crt_set_key_identifier( ctx,
+                                                     0,
+                                                     MBEDTLS_ASN1_OCTET_STRING );
+}
+
+int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *ctx )
+{
+    return mbedtls_x509write_crt_set_key_identifier( ctx,
+                                                     1,
+                                                     (MBEDTLS_ASN1_CONTEXT_SPECIFIC | 0) );
 }
 #endif /* MBEDTLS_SHA1_C */
 

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -172,8 +172,7 @@ int mbedtls_x509write_crt_set_basic_constraints( mbedtls_x509write_cert *ctx,
 }
 
 #if defined(MBEDTLS_SHA1_C)
-static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
-*ctx,
+static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert *ctx,
                                               int is_ca,
                                               unsigned char tag )
 {
@@ -230,15 +229,15 @@ static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
     }
 
     if( is_ca )
-        return mbedtls_x509write_crt_set_extension( ctx,
+        return( mbedtls_x509write_crt_set_extension( ctx,
                 MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER,
                 MBEDTLS_OID_SIZE( MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ),
-                0, buf + sizeof(buf) - len, len );
-
-    return mbedtls_x509write_crt_set_extension( ctx,
-            MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
-            MBEDTLS_OID_SIZE( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
-            0, buf + sizeof(buf) - len, len );
+                0, buf + sizeof(buf) - len, len ) );
+    else
+        return( mbedtls_x509write_crt_set_extension( ctx,
+                MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
+                MBEDTLS_OID_SIZE( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
+                0, buf + sizeof(buf) - len, len ) );
 }
 
 int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx )

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -187,11 +187,12 @@ static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     memset( buf, 0, sizeof(buf) );
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_pk_write_pubkey( &c,
-                                                        buf,
-                                                        is_ca ?
-                                                          ctx->issuer_key :
-                                                          ctx->subject_key ) );
+    MBEDTLS_ASN1_CHK_ADD( len,
+                          mbedtls_pk_write_pubkey( &c,
+                                                   buf,
+                                                   is_ca ?
+                                                   ctx->issuer_key :
+                                                   ctx->subject_key ) );
 
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -216,8 +217,7 @@ static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
     len = 20;
 
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );
-    MBEDTLS_ASN1_CHK_ADD( len,
-                          mbedtls_asn1_write_tag( &c, buf, tag ) );
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( &c, buf, tag ) );
 
     if( is_ca ) // writes AuthorityKeyIdentifier sequence
     {
@@ -228,17 +228,17 @@ static int mbedtls_x509write_crt_set_key_identifier( mbedtls_x509write_cert
                                                       MBEDTLS_ASN1_CONSTRUCTED |
                                                       MBEDTLS_ASN1_SEQUENCE ) );
     }
-    return mbedtls_x509write_crt_set_extension(
-                   ctx,
-                   is_ca ? MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER :
-                               MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
-                   is_ca ? MBEDTLS_OID_SIZE(
-                               MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ) :
-                           MBEDTLS_OID_SIZE(
-                               MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
-                   0,
-                   buf + sizeof( buf ) - len,
-                   len );
+
+    if( is_ca )
+        return mbedtls_x509write_crt_set_extension( ctx,
+                MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER,
+                MBEDTLS_OID_SIZE( MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER ),
+                0, buf + sizeof(buf) - len, len );
+
+    return mbedtls_x509write_crt_set_extension( ctx,
+            MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER,
+            MBEDTLS_OID_SIZE( MBEDTLS_OID_SUBJECT_KEY_IDENTIFIER ),
+            0, buf + sizeof(buf) - len, len );
 }
 
 int mbedtls_x509write_crt_set_subject_key_identifier( mbedtls_x509write_cert *ctx )

--- a/library/x509write_crt.c
+++ b/library/x509write_crt.c
@@ -243,7 +243,7 @@ int mbedtls_x509write_crt_set_authority_key_identifier( mbedtls_x509write_cert *
                                &hash_length );
     if( status != PSA_SUCCESS )
     {
-        return( MBEDTLS_ERR_ERROR_GENERIC_ERROR );
+        return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 #else
     ret = mbedtls_sha1( buf + sizeof( buf ) - len, len,
@@ -527,7 +527,7 @@ int mbedtls_x509write_crt_der( mbedtls_x509write_cert *ctx,
                                &hash_length );
     if( status != PSA_SUCCESS )
     {
-        return MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+        return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 #else
     if( ( ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c,

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -225,7 +225,7 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
                           sizeof( hash ),
                           &hash_len ) != PSA_SUCCESS )
     {
-        return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
+        return( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -222,7 +222,7 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
                           c,
                           len,
                           hash,
-                          PSA_HASH_MAX_SIZE,
+                          sizeof( hash ),
                           &hash_len ) != PSA_SUCCESS )
     {
         return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -35,7 +35,7 @@
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "psa/crypto.h"
 #include "mbedtls/psa_util.h"
-#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #include <string.h>
 #include <stdlib.h>
@@ -149,7 +149,6 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
     size_t len = 0;
     mbedtls_pk_type_t pk_alg;
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_hash_operation_t hash_operation = PSA_HASH_OPERATION_INIT;
     size_t hash_len;
     psa_algorithm_t hash_alg = mbedtls_psa_translate_md( ctx->md_alg );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -219,16 +218,14 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
      * Note: hash errors can happen only after an internal error
      */
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    if( psa_hash_setup( &hash_operation, hash_alg ) != PSA_SUCCESS )
-        return( MBEDTLS_ERR_X509_FATAL_ERROR );
-
-    if( psa_hash_update( &hash_operation, c, len ) != PSA_SUCCESS )
-        return( MBEDTLS_ERR_X509_FATAL_ERROR );
-
-    if( psa_hash_finish( &hash_operation, hash, sizeof( hash ), &hash_len )
-        != PSA_SUCCESS )
+    if( psa_hash_compute( hash_alg,
+                          c,
+                          len,
+                          hash,
+                          PSA_HASH_MAX_SIZE,
+                          &hash_len ) != PSA_SUCCESS )
     {
-        return( MBEDTLS_ERR_X509_FATAL_ERROR );
+        return ( MBEDTLS_ERR_X509_FATAL_ERROR );
     }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -225,7 +225,7 @@ static int x509write_csr_der_internal( mbedtls_x509write_csr *ctx,
                           PSA_HASH_MAX_SIZE,
                           &hash_len ) != PSA_SUCCESS )
     {
-        return ( MBEDTLS_ERR_X509_FATAL_ERROR );
+        return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
     }
 #else /* MBEDTLS_USE_PSA_CRYPTO */
     ret = mbedtls_md( mbedtls_md_info_from_type( ctx->md_alg ), c, len, hash );


### PR DESCRIPTION
## Description
Make x.509 use PSA for hashing (conditionally on MBEDTLS_USE_PSA_CRYPTO). This resolves #5157.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
using psa_hash_compute() instead of mbedtls_md() in:
-x509_crt_verifycrl() in x509_crt.c
-mbedtls_x509write_crt_der() in x509write_crt.c
-mbedtls_x509write_crt_set_subject_key_identifier() in x509write_crt.c
-mbedtls_x509write_crt_set_authority_key_identifier() in x509write_crt.c

Changed psa_hash_operation_t to psa_hash_compute() in:
-x509_crt_check_signature()
-mbedtls_x509write_csr_der_internal()

## Steps to test or reproduce
run test_suite_x509parse and test_suite_x509write with MBEDTLS_USE_PSA_CRYPTO
