### PR TITLE
PSA driver description spec: minor tweaks to the JSON format

### DIFF
--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -62,6 +62,8 @@ The concrete syntax for a driver description file is JSON.
 
 In addition to the properties described here, any JSON object may have a property called `"_comment"` of type string, which will be ignored.
 
+PSA Cryptography core implementations may support additional properties. Such properties must use names consisting of the implementation's name, a slash, and additional characters. For example, the Yoyodyne implementation may use property names such as `"yoyodyne/foo"` and `"yoyodyne/widgets/girth"`.
+
 #### Driver description list
 
 PSA Cryptography core implementations should support multiple drivers. The driver description files are passed to the implementation as an ordered list in an unspecified manner. This may be, for example, a list of file names passed on a command line, or a JSON list whose elements are individual driver descriptions.

--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -72,7 +72,7 @@ PSA Cryptography core implementations should support multiple drivers. The drive
 
 A driver description is a JSON object containing the following properties:
 
-* `"prefix"` (mandatory, string). This must be a valid prefix for a C identifier. All the types and functions provided by the driver have a name that starts with this prefix unless overridden with a `"name"` element in the applicable capability as described below.
+* `"prefix"` (mandatory, string). This must be a valid, non-empty prefix for a C identifier. All the types and functions provided by the driver have a name that starts with this prefix unless overridden with a `"name"` element in the applicable capability as described below.
 * `"type"` (mandatory, string). One of `"transparent"` or `"opaque"`.
 * `"headers"` (optional, array of strings). A list of header files. These header files must define the types, macros and constants referenced by the driver description. They may declare the entry point functions, but this is not required. They may include other PSA headers and standard headers of the platform. Whether they may include other headers is implementation-specific. If omitted, the list of headers is empty. The header files must be present at the specified location relative to a directory on the compiler's include path when compiling glue code between the core and the drivers.
 * `"capabilities"` (mandatory, array of [capabilities](#driver-description-capability)).

--- a/docs/proposed/psa-driver-interface.md
+++ b/docs/proposed/psa-driver-interface.md
@@ -60,6 +60,8 @@ How to provide the driver description file, the C header files and the object co
 
 The concrete syntax for a driver description file is JSON.
 
+In addition to the properties described here, any JSON object may have a property called `"_comment"` of type string, which will be ignored.
+
 #### Driver description list
 
 PSA Cryptography core implementations should support multiple drivers. The driver description files are passed to the implementation as an ordered list in an unspecified manner. This may be, for example, a list of file names passed on a command line, or a JSON list whose elements are individual driver descriptions.


### PR DESCRIPTION
A few tweaks prompted by #5396.

The implementation-specific namespace syntax and the comment syntax may change depending on the resolution of an Arm-internal discussion to standardize this across all PSA JSON formats.