### PR TITLE
PK: ECDSA signing

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -870,7 +870,6 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     size_t curve_bits;
     psa_ecc_family_t curve =
         mbedtls_ecc_group_to_psa( ctx->grp.id, &curve_bits );
-    ((void) md_alg);
 
     /* PSA has its own RNG */
     ((void) f_rng);

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -718,7 +718,7 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
 cleanup:
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
 
     return( ret );
 }
@@ -902,15 +902,15 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
                              &key_id );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
         goto cleanup;
     }
 
-    if( psa_sign_hash( key_id, psa_sig_md, hash, hash_len,
-                       sig, sig_size, sig_len)
-         != PSA_SUCCESS )
+    status = psa_sign_hash( key_id, psa_sig_md, hash, hash_len,
+                            sig, sig_size, sig_len );
+    if( status != PSA_SUCCESS )
     {
-         ret = MBEDTLS_ERR_ECP_VERIFY_FAILED;
+         ret = mbedtls_pk_error_from_psa_ecdca( status );
          goto cleanup;
     }
 
@@ -919,7 +919,7 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
 cleanup:
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
 
     return( ret );
 }

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -823,11 +823,28 @@ static int pk_ecdsa_sig_asn1_from_psa( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
+/* Locate an ECDSA privateKey in a RFC 5915, or SEC1 Appendix C.4 ASN.1 buffer
+ *
+ * [in/out] buf: ASN.1 buffer start as input - ECDSA privateKey start as output
+ * [in] end: ASN.1 buffer end
+ * [out] key_len: the ECDSA privateKey length in bytes
+ */
 static int find_ecdsa_private_key( unsigned char **buf, unsigned char *end,
                                    size_t *key_len )
 {
     size_t len;
     int ret;
+
+    /*
+     * RFC 5915, or SEC1 Appendix C.4
+     *
+     * ECPrivateKey ::= SEQUENCE {
+     *      version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+     *      privateKey     OCTET STRING,
+     *      parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
+     *      publicKey  [1] BIT STRING OPTIONAL
+     *    }
+     */
 
     if( ( ret = mbedtls_asn1_get_tag( buf, end, &len,
                                       MBEDTLS_ASN1_CONSTRUCTED |

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -744,7 +744,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
 static int pk_ecdsa_sig_asn1_from_psa( unsigned char *sig, size_t *sig_len,
                                        size_t buf_len );
 
-static int find_ecdsa_private_key( unsigned char **buf, unsigned char *end, size_t *key_len)
+static int find_ecdsa_private_key( unsigned char **buf, unsigned char *end, size_t *key_len )
 {
     size_t len;
     int ret;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -917,7 +917,10 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     ret = pk_ecdsa_sig_asn1_from_psa( sig, sig_len, sig_size );
 
 cleanup:
-    psa_destroy_key( key_id );
+    status = psa_destroy_key( key_id );
+    if( ret == 0 && status != PSA_SUCCESS )
+        ret = mbedtls_psa_err_translate_pk( status );
+
     return( ret );
 }
 #else

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -861,8 +861,7 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     psa_status_t status;
     mbedtls_pk_context key;
     size_t key_len;
-    /* see ECP_PRV_DER_MAX_BYTES in pkwrite.c */
-    unsigned char buf[29 + 3 * MBEDTLS_ECP_MAX_BYTES];
+    unsigned char buf[MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES];
     unsigned char *p;
     mbedtls_pk_info_t pk_info = mbedtls_eckey_info;
     psa_algorithm_t psa_sig_md = PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -823,13 +823,15 @@ static int pk_ecdsa_sig_asn1_from_psa( unsigned char *sig, size_t *sig_len,
     return( 0 );
 }
 
-static int find_ecdsa_private_key( unsigned char **buf, unsigned char *end, size_t *key_len )
+static int find_ecdsa_private_key( unsigned char **buf, unsigned char *end,
+                                   size_t *key_len )
 {
     size_t len;
     int ret;
 
     if( ( ret = mbedtls_asn1_get_tag( buf, end, &len,
-                                      MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) ) != 0 )
+                                      MBEDTLS_ASN1_CONSTRUCTED |
+                                      MBEDTLS_ASN1_SEQUENCE ) ) != 0 )
         return( ret );
 
     /* version */
@@ -864,7 +866,8 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     unsigned char buf[MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES];
     unsigned char *p;
     mbedtls_pk_info_t pk_info = mbedtls_eckey_info;
-    psa_algorithm_t psa_sig_md = PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
+    psa_algorithm_t psa_sig_md =
+        PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
     size_t curve_bits;
     psa_ecc_family_t curve =
         mbedtls_ecc_group_to_psa( ctx->grp.id, &curve_bits );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -917,6 +917,7 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     ret = pk_ecdsa_sig_asn1_from_psa( sig, sig_len, sig_size );
 
 cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( buf ) );
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
         ret = mbedtls_pk_error_from_psa( status );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -716,7 +716,10 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     ret = 0;
 
 cleanup:
-    psa_destroy_key( key_id );
+    status = psa_destroy_key( key_id );
+    if( ret == 0 && status != PSA_SUCCESS )
+        ret = mbedtls_psa_err_translate_pk( status );
+
     return( ret );
 }
 #else /* MBEDTLS_USE_PSA_CRYPTO */

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -865,7 +865,6 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     size_t key_len;
     unsigned char buf[MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES];
     unsigned char *p;
-    mbedtls_pk_info_t pk_info = mbedtls_eckey_info;
     psa_algorithm_t psa_sig_md =
         PSA_ALG_ECDSA( mbedtls_psa_translate_md( md_alg ) );
     size_t curve_bits;
@@ -882,7 +881,7 @@ static int ecdsa_sign_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
 
     /* mbedtls_pk_write_key_der() expects a full PK context;
      * re-construct one to make it happy */
-    key.pk_info = &pk_info;
+    key.pk_info = &mbedtls_eckey_info;
     key.pk_ctx = ctx;
     key_len = mbedtls_pk_write_key_der( &key, buf, sizeof( buf ) );
     if( key_len <= 0 )

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -83,11 +83,14 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     mbedtls_pk_context key;
     mbedtls_x509write_csr req;
     unsigned char buf[4096];
-    unsigned char check_buf[4000];
     int ret;
-    size_t olen = 0, pem_len = 0, buf_index;
-    int der_len = -1;
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
+    unsigned char check_buf[4000];
     FILE *f;
+    size_t olen = 0;
+#endif /* !MBEDTLS_USE_PSA_CRYPTO */
+    size_t pem_len = 0, buf_index;
+    int der_len = -1;
     const char *subject_name = "C=NL,O=PolarSSL,CN=PolarSSL Server 1";
     mbedtls_test_rnd_pseudo_info rnd_info;
 
@@ -121,9 +124,6 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     // When using PSA crypto, RNG isn't controllable, so cert_req_check_file can't be used
-    (void)f;
-    (void)olen;
-    (void)check_buf;
     (void)cert_req_check_file;
     buf[pem_len] = '\0';
     TEST_ASSERT( x509_crt_verifycsr( buf, pem_len + 1 ) == 0 );
@@ -135,7 +135,7 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     TEST_ASSERT( olen >= pem_len - 1 );
     TEST_ASSERT( memcmp( buf, check_buf, pem_len - 1 ) == 0 );
-#endif
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     der_len = mbedtls_x509write_csr_der( &req, buf, sizeof( buf ),
                                          mbedtls_test_rnd_pseudo_rand,

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -93,6 +93,8 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
+    USE_PSA_INIT( );
+
     mbedtls_pk_init( &key );
     TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL,
                         mbedtls_test_rnd_std_rand, NULL ) == 0 );
@@ -117,6 +119,15 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
         TEST_ASSERT( buf[buf_index] == 0 );
     }
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    // When using PSA crypto, RNG isn't controllable, so cert_req_check_file can't be used
+    (void)f;
+    (void)olen;
+    (void)check_buf;
+    (void)cert_req_check_file;
+    buf[pem_len] = '\0';
+    TEST_ASSERT( x509_crt_verifycsr( buf, pem_len + 1 ) == 0 );
+#else
     f = fopen( cert_req_check_file, "r" );
     TEST_ASSERT( f != NULL );
     olen = fread( check_buf, 1, sizeof( check_buf ), f );
@@ -124,6 +135,7 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     TEST_ASSERT( olen >= pem_len - 1 );
     TEST_ASSERT( memcmp( buf, check_buf, pem_len - 1 ) == 0 );
+#endif
 
     der_len = mbedtls_x509write_csr_der( &req, buf, sizeof( buf ),
                                          mbedtls_test_rnd_pseudo_rand,
@@ -133,13 +145,22 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
     if( der_len == 0 )
         goto exit;
 
-    ret = mbedtls_x509write_csr_der( &req, buf, (size_t)( der_len - 1 ),
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    // When using PSA crypto, RNG isn't controllable, result length isn't
+    // deterministic over multiple runs, removing a single byte isn't enough to
+    // go into the MBEDTLS_ERR_ASN1_BUF_TOO_SMALL error case
+    der_len /= 2;
+#else
+    der_len -= 1;
+#endif
+    ret = mbedtls_x509write_csr_der( &req, buf, (size_t)( der_len ),
                                      mbedtls_test_rnd_pseudo_rand, &rnd_info );
     TEST_ASSERT( ret == MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
 
 exit:
     mbedtls_x509write_csr_free( &req );
     mbedtls_pk_free( &key );
+    USE_PSA_DONE( );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
In `library/pk_wrap.c`, provide an implementation of `ecdsa_sign_wrap` to use `psa_sign_hash()` instead of `mbedtls_ecdsa_write_signature()`.

Resolves #5274

## Status
**READY**

## Requires Backporting
NO 

## Migrations
NO

## Additional comments
X509write suite failed:
```
Certificate Request check Server5 ECDSA, key_usage ................ FAILED
  memcmp( buf, check_buf, pem_len - 1 ) == 0
  at line 135, /home/narmstrong/projects/nordic/mbedtls/tests/suites/test_suite_x509write.function
```
because reference vector is calculated with `mbedtls_test_rnd_pseudo_rand`.

Using PSA DETERMINISTIC ECDSA in `pk_wrap` makes the test PASS, the only viable solution
is to disable the reference check and verify the signature instead.

## Todos
- [X] Implementation
- [x] Tests


## Steps to test or reproduce
test_suite_x509write and test_suite_pk should run clean