### PR TITLE
PK: RSA decryption

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -273,7 +273,7 @@ static int rsa_decrypt_wrap( void *ctx,
     }
 
     status = psa_asymmetric_decrypt( key_id, psa_sig_md, input, ilen,
-                                     NULL, 0, output, osize, olen);
+                                     NULL, 0, output, osize, olen );
     if( status != PSA_SUCCESS )
     {
         ret = mbedtls_psa_err_translate_pk( status );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -283,7 +283,10 @@ static int rsa_decrypt_wrap( void *ctx,
     ret = 0;
 
 cleanup:
-    psa_destroy_key( key_id );
+    status = psa_destroy_key( key_id );
+    if( ret == 0 && status != PSA_SUCCESS )
+        ret = mbedtls_psa_err_translate_pk( status );
+
     return( ret );
 }
 #else

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -266,7 +266,7 @@ static int rsa_decrypt_wrap( void *ctx,
                              &key_id );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
         goto cleanup;
     }
 
@@ -274,14 +274,7 @@ static int rsa_decrypt_wrap( void *ctx,
                                      NULL, 0, output, osize, olen );
     if( status != PSA_SUCCESS )
     {
-        if ( status == PSA_ERROR_INVALID_PADDING )
-        {
-            ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
-        }
-        else
-        {
-            ret = mbedtls_psa_err_translate_pk( status );
-        }
+        ret = mbedtls_pk_error_from_psa_rsa( status );
         goto cleanup;
     }
 
@@ -290,7 +283,7 @@ static int rsa_decrypt_wrap( void *ctx,
 cleanup:
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
 
     return( ret );
 }

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -226,7 +226,6 @@ static int rsa_decrypt_wrap( void *ctx,
     mbedtls_pk_context key;
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES];
-    mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
 
     ((void) f_rng);
     ((void) p_rng);
@@ -241,7 +240,7 @@ static int rsa_decrypt_wrap( void *ctx,
 
     /* mbedtls_pk_write_key_der() expects a full PK context;
      * re-construct one to make it happy */
-    key.pk_info = &pk_info;
+    key.pk_info = &mbedtls_rsa_info;
     key.pk_ctx = ctx;
     key_len = mbedtls_pk_write_key_der( &key, buf, sizeof( buf ) );
     if( key_len <= 0 )

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -276,7 +276,14 @@ static int rsa_decrypt_wrap( void *ctx,
                                      NULL, 0, output, osize, olen );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        if ( status == PSA_ERROR_INVALID_PADDING )
+        {
+            ret = MBEDTLS_ERR_RSA_INVALID_PADDING;
+        }
+        else
+        {
+            ret = mbedtls_psa_err_translate_pk( status );
+        }
         goto cleanup;
     }
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -225,9 +225,7 @@ static int rsa_decrypt_wrap( void *ctx,
     psa_status_t status;
     mbedtls_pk_context key;
     int key_len;
-    /* see RSA_PRV_DER_MAX_BYTES in pkwrite.c */
-    unsigned char buf[47 + 3 * MBEDTLS_MPI_MAX_SIZE + \
-                      5 * ( MBEDTLS_MPI_MAX_SIZE / 2 + MBEDTLS_MPI_MAX_SIZE % 2 )];
+    unsigned char buf[MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES];
     mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
     psa_algorithm_t psa_sig_md;
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -281,6 +281,7 @@ static int rsa_decrypt_wrap( void *ctx,
     ret = 0;
 
 cleanup:
+    mbedtls_platform_zeroize( buf, sizeof( buf ) );
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
         ret = mbedtls_pk_error_from_psa( status );

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -756,6 +756,8 @@ void pk_rsa_decrypt_test_vec( data_t * cipher, int mod, int radix_P,
     mbedtls_pk_context pk;
     size_t olen;
 
+    USE_PSA_INIT( );
+
     mbedtls_pk_init( &pk );
     mbedtls_mpi_init( &N ); mbedtls_mpi_init( &P );
     mbedtls_mpi_init( &Q ); mbedtls_mpi_init( &E );
@@ -794,6 +796,7 @@ exit:
     mbedtls_mpi_free( &N ); mbedtls_mpi_free( &P );
     mbedtls_mpi_free( &Q ); mbedtls_mpi_free( &E );
     mbedtls_pk_free( &pk );
+    USE_PSA_DONE( );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
In `library/pk_wrap.c`, provide an implementation of `rsa_decrypt_wrap` using `psa_asymmetric_decrypt()` instead of `mbedtls_rsa_pkcs1_decrypt()` when `MBEDTLS_USE_PSA_CRYPTO` is enabled.

Resolves #5160 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Implementation
- [X] Tests

## Steps to test or reproduce
test_suite_pk should run clean