### PR TITLE
HKDF 1b: Implement Expand in TLS 1.3 based on PSA HMAC

### DIFF
--- a/library/ssl_tls13_invasive.h
+++ b/library/ssl_tls13_invasive.h
@@ -1,0 +1,63 @@
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MBEDTLS_SSL_TLS13_INVASIVE_H
+#define MBEDTLS_SSL_TLS13_INVASIVE_H
+
+#include "common.h"
+
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#include "psa/crypto.h"
+#endif
+
+#if defined(MBEDTLS_TEST_HOOKS)
+
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+
+/**
+ *  \brief  Expand the supplied \p prk into several additional pseudorandom
+ *          keys, which is the output of the HKDF.
+ *
+ *  \param  alg       The HMAC algorithm to use (\c #PSA_ALG_HMAC( PSA_ALG_XXX )
+ *                    value such that PSA_ALG_XXX is a hash algorithm and
+ *                    #PSA_ALG_IS_HMAC(\p alg) is true).
+ *  \param  prk       A pseudorandom key of \p prk_len bytes. \p prk is
+ *                    usually the output from the HKDF extract step.
+ *  \param  prk_len   The length in bytes of \p prk.
+ *  \param  info      An optional context and application specific information
+ *                    string. This can be a zero-length string.
+ *  \param  info_len  The length of \p info in bytes.
+ *  \param  okm       The output keying material of \p okm_len bytes.
+ *  \param  okm_len   The length of the output keying material in bytes. This
+ *                    must be less than or equal to
+ *                    255 * #PSA_HASH_LENGTH( \p alg ) bytes.
+ *
+ *  \return 0 on success.
+ *  \return #PSA_ERROR_INVALID_ARGUMENT when the parameters are invalid.
+ *  \return An PSA_ERROR_* error for errors returned from the underlying
+ *          PSA layer.
+ */
+psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
+                                      const unsigned char *prk, size_t prk_len,
+                                      const unsigned char *info, size_t info_len,
+                                      unsigned char *okm, size_t okm_len );
+
+#endif /* MBEDTLS_PSA_CRYPTO_C */
+
+#endif /* MBEDTLS_TEST_HOOKS */
+
+#endif /* MBEDTLS_SSL_TLS13_INVASIVE_H */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -153,6 +153,7 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_status_t destroy_status = PSA_ERROR_CORRUPTION_DETECTED;
     unsigned char t[PSA_MAC_MAX_SIZE];
 
     if( okm == NULL )
@@ -250,11 +251,13 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
     }
 
 cleanup:
-    psa_destroy_key( key );
-    mbedtls_platform_zeroize( t, sizeof( t ) );
-    psa_mac_abort( &operation );
+    if( status != PSA_SUCCESS )
+        psa_mac_abort( &operation );
+    destroy_status = psa_destroy_key( key );
 
-    return( status );
+    mbedtls_platform_zeroize( t, sizeof( t ) );
+
+    return( ( status == PSA_SUCCESS ) ? destroy_status : status );
 }
 
 #endif /* MBEDTLS_TEST_HOOKS */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -136,6 +136,8 @@ static void ssl_tls13_hkdf_encode_label(
     *dst_len = total_hkdf_lbl_len;
 }
 
+#if defined( MBEDTLS_TEST_HOOKS )
+
 MBEDTLS_STATIC_TESTABLE
 psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
                                       const unsigned char *prk, size_t prk_len,
@@ -254,6 +256,8 @@ cleanup:
 
     return( ret );
 }
+
+#endif /* MBEDTLS_TEST_HOOKS */
 
 int mbedtls_ssl_tls13_hkdf_expand_label(
                      mbedtls_md_type_t hash_alg,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -30,6 +30,9 @@
 
 #include "ssl_misc.h"
 #include "ssl_tls13_keys.h"
+#include "ssl_tls13_invasive.h"
+
+#include "psa/crypto.h"
 
 #define MBEDTLS_SSL_TLS1_3_LABEL( name, string )       \
     .name = string,
@@ -131,6 +134,125 @@ static void ssl_tls13_hkdf_encode_label(
 
     /* Return total length to the caller.  */
     *dst_len = total_hkdf_lbl_len;
+}
+
+MBEDTLS_STATIC_TESTABLE
+psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
+                                      const unsigned char *prk, size_t prk_len,
+                                      const unsigned char *info, size_t info_len,
+                                      unsigned char *okm, size_t okm_len )
+{
+    size_t hash_len;
+    size_t where = 0;
+    size_t n;
+    size_t t_len = 0;
+    size_t i;
+    mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+    psa_status_t ret = PSA_ERROR_CORRUPTION_DETECTED;
+    unsigned char t[PSA_MAC_MAX_SIZE];
+
+    if( okm == NULL )
+    {
+        return( PSA_ERROR_INVALID_ARGUMENT );
+    }
+
+    hash_len = PSA_HASH_LENGTH( alg );
+
+    if( prk_len < hash_len || hash_len == 0 )
+    {
+        return( PSA_ERROR_INVALID_ARGUMENT );
+    }
+
+    if( info == NULL )
+    {
+        info = (const unsigned char *) "";
+        info_len = 0;
+    }
+
+    n = okm_len / hash_len;
+
+    if( okm_len % hash_len != 0 )
+    {
+        n++;
+    }
+
+    /*
+     * Per RFC 5869 Section 2.3, okm_len must not exceed
+     * 255 times the hash length
+     */
+    if( n > 255 )
+    {
+        return( PSA_ERROR_INVALID_ARGUMENT );
+    }
+
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_MESSAGE );
+    psa_set_key_algorithm( &attributes, alg );
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_HMAC );
+
+    ret = psa_import_key( &attributes, prk, prk_len, &key );
+    if( PSA_SUCCESS != ret )
+    {
+        goto cleanup;
+    }
+
+    memset( t, 0, hash_len );
+
+    /*
+     * Compute T = T(1) | T(2) | T(3) | ... | T(N)
+     * Where T(N) is defined in RFC 5869 Section 2.3
+     */
+    for( i = 1; i <= n; i++ )
+    {
+        size_t num_to_copy;
+        unsigned char c = i & 0xff;
+        size_t len;
+
+        ret = psa_mac_sign_setup( &operation, key, alg );
+        if( PSA_SUCCESS != ret )
+        {
+            goto cleanup;
+        }
+
+        ret = psa_mac_update( &operation, t, t_len );
+        if( PSA_SUCCESS != ret )
+        {
+            goto cleanup;
+        }
+
+        ret = psa_mac_update( &operation, info, info_len );
+        if( PSA_SUCCESS != ret )
+        {
+            goto cleanup;
+        }
+
+        /* The constant concatenated to the end of each T(n) is a single octet.
+         * */
+        ret = psa_mac_update( &operation, &c, 1 );
+        if( PSA_SUCCESS != ret )
+        {
+            goto cleanup;
+        }
+
+        ret = psa_mac_sign_finish( &operation, t, PSA_MAC_MAX_SIZE, &len );
+        if( PSA_SUCCESS != ret )
+        {
+            goto cleanup;
+        }
+
+        num_to_copy = i != n ? hash_len : okm_len - where;
+        memcpy( okm + where, t, num_to_copy );
+        where += hash_len;
+        t_len = hash_len;
+    }
+
+cleanup:
+    psa_destroy_key( key );
+    mbedtls_platform_zeroize( t, sizeof( t ) );
+    psa_mac_abort( &operation );
+
+    return( ret );
 }
 
 int mbedtls_ssl_tls13_hkdf_expand_label(

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -152,7 +152,7 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
-    psa_status_t ret = PSA_ERROR_CORRUPTION_DETECTED;
+    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     unsigned char t[PSA_MAC_MAX_SIZE];
 
     if( okm == NULL )
@@ -193,8 +193,8 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_HMAC );
 
-    ret = psa_import_key( &attributes, prk, prk_len, &key );
-    if( PSA_SUCCESS != ret )
+    status = psa_import_key( &attributes, prk, prk_len, &key );
+    if( status != PSA_SUCCESS )
     {
         goto cleanup;
     }
@@ -211,34 +211,34 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
         unsigned char c = i & 0xff;
         size_t len;
 
-        ret = psa_mac_sign_setup( &operation, key, alg );
-        if( PSA_SUCCESS != ret )
+        status = psa_mac_sign_setup( &operation, key, alg );
+        if( status != PSA_SUCCESS )
         {
             goto cleanup;
         }
 
-        ret = psa_mac_update( &operation, t, t_len );
-        if( PSA_SUCCESS != ret )
+        status = psa_mac_update( &operation, t, t_len );
+        if( status != PSA_SUCCESS )
         {
             goto cleanup;
         }
 
-        ret = psa_mac_update( &operation, info, info_len );
-        if( PSA_SUCCESS != ret )
+        status = psa_mac_update( &operation, info, info_len );
+        if( status != PSA_SUCCESS )
         {
             goto cleanup;
         }
 
         /* The constant concatenated to the end of each T(n) is a single octet.
          * */
-        ret = psa_mac_update( &operation, &c, 1 );
-        if( PSA_SUCCESS != ret )
+        status = psa_mac_update( &operation, &c, 1 );
+        if( status != PSA_SUCCESS )
         {
             goto cleanup;
         }
 
-        ret = psa_mac_sign_finish( &operation, t, PSA_MAC_MAX_SIZE, &len );
-        if( PSA_SUCCESS != ret )
+        status = psa_mac_sign_finish( &operation, t, PSA_MAC_MAX_SIZE, &len );
+        if( status != PSA_SUCCESS )
         {
             goto cleanup;
         }
@@ -254,7 +254,7 @@ cleanup:
     mbedtls_platform_zeroize( t, sizeof( t ) );
     psa_mac_abort( &operation );
 
-    return( ret );
+    return( status );
 }
 
 #endif /* MBEDTLS_TEST_HOOKS */

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -230,8 +230,7 @@ psa_status_t mbedtls_psa_hkdf_expand( psa_algorithm_t alg,
             goto cleanup;
         }
 
-        /* The constant concatenated to the end of each T(n) is a single octet.
-         * */
+        /* The constant concatenated to the end of each T(n) is a single octet. */
         status = psa_mac_update( &operation, &c, 1 );
         if( status != PSA_SUCCESS )
         {

--- a/tests/suites/test_suite_hkdf.function
+++ b/tests/suites/test_suite_hkdf.function
@@ -78,7 +78,7 @@ void test_hkdf_expand( int md_alg, char *hex_info_string,
     const mbedtls_md_info_t *md = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md != NULL );
 
-    output_okm = mbedtls_calloc( OKM_LEN, 1 );
+    ASSERT_ALLOC( output_okm, OKM_LEN );
 
     prk = mbedtls_test_unhexify_alloc( hex_prk_string, &prk_len );
     info = mbedtls_test_unhexify_alloc( hex_info_string, &info_len );
@@ -143,10 +143,10 @@ void test_hkdf_expand_ret( int hash_len, int prk_len, int okm_len, int ret )
     info_len = 0;
 
     if (prk_len > 0)
-        prk = mbedtls_calloc( prk_len, 1 );
+        ASSERT_ALLOC( prk, prk_len );
 
     if (okm_len > 0)
-        okm = mbedtls_calloc( okm_len, 1 );
+        ASSERT_ALLOC( okm, okm_len );
 
     output_ret = mbedtls_hkdf_expand( &fake_md_info, prk, prk_len,
                                       info, info_len, okm, okm_len );

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -4350,6 +4350,48 @@ SSL TLS 1.3 Key schedule: Secret evolution #3
 # Handshake secret to Master Secret
 ssl_tls13_key_evolution:MBEDTLS_MD_SHA256:"fb9fc80689b3a5d02c33243bf69a1b1b20705588a794304a6e7120155edf149a":"":"7f2882bb9b9a46265941653e9c2f19067118151e21d12e57a7b6aca1f8150c8d"
 
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #1 Expand
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_256):"f0f1f2f3f4f5f6f7f8f9":"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5":"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #2 Expand
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_256):"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff":"06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244":"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #3 Expand
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_256):"":"19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04":"8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #4 Expand
+depends_on:PSA_WANT_ALG_SHA_1
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_1):"f0f1f2f3f4f5f6f7f8f9":"9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243":"085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #5 Expand
+depends_on:PSA_WANT_ALG_SHA_1
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_1):"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff":"8adae09a2a307059478d309b26c4115a224cfaf6":"0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #6 Expand
+depends_on:PSA_WANT_ALG_SHA_1
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_1):"":"da8c8a73c7fa77288ec6f5e7c297786aa0d32d01":"0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918"
+
+SSL TLS 1.3 Key schedule: HKDF RFC5869 Test Vector #7 Expand
+depends_on:PSA_WANT_ALG_SHA_1
+psa_hkdf_expand:PSA_ALG_HMAC(PSA_ALG_SHA_1):"":"2adccada18779e7c2077ad2eb19d3f3e731385dd":"2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48"
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with NULL okm
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):32:0:PSA_ERROR_INVALID_ARGUMENT
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with wrong hash alg
+psa_hkdf_expand_ret:0:32:32:PSA_ERROR_INVALID_ARGUMENT
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with prk_len < hash_len
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):16:32:PSA_ERROR_INVALID_ARGUMENT
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with okm_len / hash_len > 255
+psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):32:8192:PSA_ERROR_INVALID_ARGUMENT
+
 SSL TLS 1.3 Key schedule: HKDF Expand Label #1
 # Vector from TLS 1.3 Byte by Byte (https://tls13.ulfheim.net/)
 # Server handshake traffic secret -> Server traffic key

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -4382,8 +4382,12 @@ SSL TLS 1.3 Key schedule: HKDF expand fails with NULL okm
 depends_on:PSA_WANT_ALG_SHA_256
 psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):32:0:PSA_ERROR_INVALID_ARGUMENT
 
-SSL TLS 1.3 Key schedule: HKDF expand fails with wrong hash alg
+SSL TLS 1.3 Key schedule: HKDF expand fails with invalid alg
 psa_hkdf_expand_ret:0:32:32:PSA_ERROR_INVALID_ARGUMENT
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with incompatible alg
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand_ret:PSA_ALG_SHA_256:32:32:PSA_ERROR_INVALID_ARGUMENT
 
 SSL TLS 1.3 Key schedule: HKDF expand fails with prk_len < hash_len
 depends_on:PSA_WANT_ALG_SHA_256
@@ -4391,6 +4395,10 @@ psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):16:32:PSA_ERROR_INVALID_ARGUME
 
 SSL TLS 1.3 Key schedule: HKDF expand fails with okm_len / hash_len > 255
 psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):32:8192:PSA_ERROR_INVALID_ARGUMENT
+
+SSL TLS 1.3 Key schedule: HKDF expand fails with key import
+depends_on:PSA_WANT_ALG_SHA_256
+psa_hkdf_expand_ret:PSA_ALG_HMAC(PSA_ALG_SHA_256):32:32:PSA_ERROR_INSUFFICIENT_MEMORY
 
 SSL TLS 1.3 Key schedule: HKDF Expand Label #1
 # Vector from TLS 1.3 Byte by Byte (https://tls13.ulfheim.net/)

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3831,10 +3831,10 @@ void psa_hkdf_expand( int alg, char *hex_info_string,
     ASSERT_COMPARE( output_okm, okm_len, okm, okm_len );
 
 exit:
-    mbedtls_free(info);
-    mbedtls_free(prk);
-    mbedtls_free(okm);
-    mbedtls_free(output_okm);
+    mbedtls_free( info );
+    mbedtls_free( prk );
+    mbedtls_free( okm );
+    mbedtls_free( output_okm );
 
     PSA_DONE( );
 }
@@ -3865,8 +3865,8 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
     TEST_ASSERT( output_ret == ret );
 
 exit:
-    mbedtls_free(prk);
-    mbedtls_free(okm);
+    mbedtls_free( prk );
+    mbedtls_free( okm );
 
     PSA_DONE( );
 }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -6,6 +6,7 @@
 #include <mbedtls/timing.h>
 #include <mbedtls/debug.h>
 #include <ssl_tls13_keys.h>
+#include <ssl_tls13_invasive.h>
 #include "test/certs.h"
 
 #include <psa/crypto.h>
@@ -3800,6 +3801,72 @@ exit:
     mbedtls_free( buf );
     mbedtls_free( buf_save );
     USE_PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_SSL_PROTO_TLS1_3 */
+void psa_hkdf_expand( int alg, char *hex_info_string,
+                      char *hex_prk_string, char *hex_okm_string )
+{
+    enum { OKM_LEN  = 1024 };
+    unsigned char *info = NULL;
+    unsigned char *prk = NULL;
+    unsigned char *okm = NULL;
+    unsigned char *output_okm = NULL;
+    size_t info_len, prk_len, okm_len;
+
+    ASSERT_ALLOC( output_okm, OKM_LEN );
+
+    prk = mbedtls_test_unhexify_alloc( hex_prk_string, &prk_len );
+    info = mbedtls_test_unhexify_alloc( hex_info_string, &info_len );
+    okm = mbedtls_test_unhexify_alloc( hex_okm_string, &okm_len );
+    TEST_ASSERT( prk_len == PSA_HASH_LENGTH( alg ) );
+    TEST_ASSERT( okm_len < OKM_LEN );
+
+    PSA_ASSERT( psa_crypto_init() );
+    PSA_ASSERT( mbedtls_psa_hkdf_expand( alg, prk, prk_len, info, info_len,
+                                         output_okm, OKM_LEN ) );
+
+    ASSERT_COMPARE( output_okm, okm_len, okm, okm_len );
+
+exit:
+    mbedtls_free(info);
+    mbedtls_free(prk);
+    mbedtls_free(okm);
+    mbedtls_free(output_okm);
+
+    PSA_DONE( );
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_SSL_PROTO_TLS1_3 */
+void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
+{
+    int output_ret;
+    unsigned char *info = NULL;
+    unsigned char *prk = NULL;
+    unsigned char *okm = NULL;
+    size_t info_len;
+
+    info_len = 0;
+
+    if (prk_len > 0)
+        ASSERT_ALLOC( prk, prk_len );
+
+    if (okm_len > 0)
+        ASSERT_ALLOC( okm, okm_len );
+
+    PSA_ASSERT( psa_crypto_init() );
+    output_ret = mbedtls_psa_hkdf_expand( alg, prk, prk_len,
+                                          info, info_len,
+                                          okm, okm_len );
+    TEST_ASSERT( output_ret == ret );
+
+exit:
+    mbedtls_free(prk);
+    mbedtls_free(okm);
+
+    PSA_DONE( );
 }
 /* END_CASE */
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3815,6 +3815,8 @@ void psa_hkdf_expand( int alg, char *hex_info_string,
     unsigned char *output_okm = NULL;
     size_t info_len, prk_len, okm_len;
 
+    PSA_INIT( );
+
     ASSERT_ALLOC( output_okm, OKM_LEN );
 
     prk = mbedtls_test_unhexify_alloc( hex_prk_string, &prk_len );
@@ -3823,7 +3825,6 @@ void psa_hkdf_expand( int alg, char *hex_info_string,
     TEST_ASSERT( prk_len == PSA_HASH_LENGTH( alg ) );
     TEST_ASSERT( okm_len < OKM_LEN );
 
-    PSA_ASSERT( psa_crypto_init() );
     PSA_ASSERT( mbedtls_psa_hkdf_expand( alg, prk, prk_len, info, info_len,
                                          output_okm, OKM_LEN ) );
 
@@ -3848,6 +3849,8 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
     unsigned char *okm = NULL;
     size_t info_len;
 
+    PSA_INIT( );
+
     info_len = 0;
 
     if (prk_len > 0)
@@ -3856,7 +3859,6 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
     if (okm_len > 0)
         ASSERT_ALLOC( okm, okm_len );
 
-    PSA_ASSERT( psa_crypto_init() );
     output_ret = mbedtls_psa_hkdf_expand( alg, prk, prk_len,
                                           info, info_len,
                                           okm, okm_len );

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3848,6 +3848,8 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
     unsigned char *prk = NULL;
     unsigned char *okm = NULL;
     size_t info_len;
+    size_t i;
+    mbedtls_svc_key_id_t *keys = NULL;
 
     PSA_INIT( );
 
@@ -3859,6 +3861,30 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
     if( okm_len > 0 )
         ASSERT_ALLOC( okm, okm_len );
 
+    if( ret == PSA_ERROR_INSUFFICIENT_MEMORY )
+    {
+        psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+        /* Reserve all key slot to make the key import fail. */
+        psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_MESSAGE );
+        psa_set_key_algorithm( &attributes, alg );
+        psa_set_key_type( &attributes, PSA_KEY_TYPE_HMAC );
+
+        ASSERT_ALLOC( keys, MBEDTLS_PSA_KEY_SLOT_COUNT );
+
+        for( i = 0; i < MBEDTLS_PSA_KEY_SLOT_COUNT; i++ )
+        {
+            /* Do not use the 0 value because it will be passed to
+               mbedtls_psa_hkdf_expand */
+            prk[0] = i + 1;
+            keys[i] = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_import_key( &attributes, prk, prk_len, &keys[i] );
+        }
+
+        /* reset prk buffer */
+        prk[0] = 0;
+    }
+
     output_ret = mbedtls_psa_hkdf_expand( alg, prk, prk_len,
                                           info, info_len,
                                           okm, okm_len );
@@ -3867,6 +3893,14 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
 exit:
     mbedtls_free( prk );
     mbedtls_free( okm );
+
+   if( ret == PSA_ERROR_INSUFFICIENT_MEMORY )
+   {
+        for( i = 0; i < MBEDTLS_PSA_KEY_SLOT_COUNT; i++ )
+            psa_destroy_key( keys[i] );
+
+        mbedtls_free( keys );
+   }
 
     PSA_DONE( );
 }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3853,10 +3853,10 @@ void psa_hkdf_expand_ret( int alg, int prk_len, int okm_len, int ret )
 
     info_len = 0;
 
-    if (prk_len > 0)
+    if( prk_len > 0 )
         ASSERT_ALLOC( prk, prk_len );
 
-    if (okm_len > 0)
+    if( okm_len > 0 )
         ASSERT_ALLOC( okm, okm_len );
 
     output_ret = mbedtls_psa_hkdf_expand( alg, prk, prk_len,


### PR DESCRIPTION
## Description
TLS 1.3 code (ssl_tls13_keys.c) currently uses HKDF from the legacy API, mbedtls_hkdf_. The PSA API currently only provides the full HKDF, which TLS 1.3 uses its components HKDF-Extract and HKDF-Expand separately. As a temporary measure, we'll be implementing those within TLS 1.3 based on the psa_mac_ API, which waiting for PSA to be extended.

Resolve #5402

## Todos
- [x] Tests