### PR TITLE
Ensure ctr_drbg is initialised every time in fuzz_server

### DIFF
--- a/library/aes.c
+++ b/library/aes.c
@@ -971,6 +971,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                            unsigned char output[16] )
 {
     AES_VALIDATE_RET( ctx != NULL );
+    AES_VALIDATE_RET( ctx->rk != NULL );
     AES_VALIDATE_RET( input != NULL );
     AES_VALIDATE_RET( output != NULL );
     AES_VALIDATE_RET( mode == MBEDTLS_AES_ENCRYPT ||

--- a/programs/fuzz/fuzz_server.c
+++ b/programs/fuzz/fuzz_server.c
@@ -55,13 +55,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
     options = Data[Size - 1];
 
-    if (initialized == 0) {
-        mbedtls_ctr_drbg_init( &ctr_drbg );
-        mbedtls_entropy_init( &entropy );
+    mbedtls_ctr_drbg_init( &ctr_drbg );
+    mbedtls_entropy_init( &entropy );
 
-        if( mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy, &entropy,
-                                  (const unsigned char *) pers, strlen( pers ) ) != 0 )
-            return 1;
+    if( mbedtls_ctr_drbg_seed( &ctr_drbg, dummy_entropy, &entropy,
+                               ( const unsigned char * ) pers, strlen( pers ) ) != 0 )
+        return 1;
+
+    if (initialized == 0) {
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(MBEDTLS_PEM_PARSE_C)
         mbedtls_x509_crt_init( &srvcert );


### PR DESCRIPTION
## Description

ctr_drbg is a local variable and thus needs initialisation every time LLVMFuzzerTestOneInput() is called, the rest of the variables inside the if(initialised) block are all static, and therefore do not.

This means that the second time the fuzzer takes the session tickets path, crt_drbg will be uninitialised, which means that the AES context round key will be NULL, and this is accessed without checking.

Fix the initialisation problem, and add a safety check for a NULL round key.

## Status
**READY**

## Requires Backporting
Unsure.
Issue is not present in any other branch, but it could be worth adding the safety check.

## Migrations
NO

## Additional comments

## Todos
- [ ] Tests
- [ ] Backported

## Steps to test or reproduce
Oss Fuzz should run clean for https://oss-fuzz.com/testcase-detail/4853426134056960 - I have checked this locally and its good.
