### PR TITLE
Fix null context when using dummy_rand with mbedtls_pk_parse_key()

### DIFF
--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -60,8 +60,11 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
     size_t i;
 
 #if defined(MBEDTLS_CTR_DRBG_C)
-    //use mbedtls_ctr_drbg_random to find bugs in it
-    ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
+    //mbedtls_ctr_drbg_random requires a valid mbedtls_ctr_drbg_context in p_rng
+    if( p_rng != NULL ) {
+        //use mbedtls_ctr_drbg_random to find bugs in it
+        ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
+    }
 #else
     (void) p_rng;
     ret = 0;

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -64,6 +64,9 @@ int dummy_random( void *p_rng, unsigned char *output, size_t output_len )
     if( p_rng != NULL ) {
         //use mbedtls_ctr_drbg_random to find bugs in it
         ret = mbedtls_ctr_drbg_random(p_rng, output, output_len);
+    } else {
+        //fall through to pseudo-random
+        ret = 0;
     }
 #else
     (void) p_rng;


### PR DESCRIPTION
## Description

In fuzz_privkey, we switched over to using the dedicated dummy_rand() function, which uses ctr_drbg internally, and thus requires an initialised ctr_drbg_context to be passed in via p_rng when calling mbedtls_pk_parse_key(). Leaving the context as null will cause a null pointer dereference.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests

## Steps to test or reproduce

Test case from https://oss-fuzz.com/testcase?key=5126567532036096 should run clean. I have managed this locally using docker.