### PR TITLE
Require an older version of markupsafe for the sake of older Jinja2

### DIFF
--- a/scripts/driver.requirements.txt
+++ b/scripts/driver.requirements.txt
@@ -1,10 +1,16 @@
 # Python package requirements for driver implementers.
 
+# Jinja2 <3.0 needs an older version of markupsafe, but does not
+# declare it.
+#   https://github.com/pallets/markupsafe/issues/282
+#   https://github.com/pallets/jinja/issues/1585
+markupsafe < 2.1
+
 # Use the version of Jinja that's in Ubuntu 20.04.
 # See https://github.com/ARMmbed/mbedtls/pull/5067#discussion_r738794607 .
 # Note that Jinja 3.0 drops support for Python 3.5, so we need to support
 # Jinja 2.x as long as we're still using Python 3.5 anywhere.
 Jinja2 >= 2.10.1
-# Jinja2 >=2.10, <<3.0 needs a separate package for type annotations
+# Jinja2 >=2.10, <3.0 needs a separate package for type annotations
 types-Jinja2
 


### PR DESCRIPTION
Fix CI breakage on FreeBSD due to the release of a new version of a Python package (`markupsafe`, dependency of `Jinja2`):
```
  Gen   psa_crypto_driver_wrappers.c
Traceback (most recent call last):
  File "../scripts/generate_driver_wrappers.py", line 26, in <module>
    import jinja2
  File "/home/ec2-user/.local/lib/python3.8/site-packages/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/home/ec2-user/.local/lib/python3.8/site-packages/jinja2/environment.py", line 15, in <module>
    from jinja2 import nodes
  File "/home/ec2-user/.local/lib/python3.8/site-packages/jinja2/nodes.py", line 19, in <module>
    from jinja2.utils import Markup
  File "/home/ec2-user/.local/lib/python3.8/site-packages/jinja2/utils.py", line 647, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/ec2-user/.local/lib/python3.8/site-packages/markupsafe/__init__.py)
make[1]: *** [Makefile:326: psa_crypto_driver_wrappers.c] Error
```

No breakage on Linux because we use an older version of Python that the newer version of markupsafe doesn't support.

Jinja2 <<3.0 require markupsafe <<2.1.0, but does not declare this
requirement. (Jinja2 2.x has not been updated since markupsafe 2.1.0 came
out). So declare this requirement ourselves.

This is not ideal, since we would want to use the latest markupsafe with the
latest Jinja2. But at least it gives us a consistent set of versions to run
the CI with.

Note that Jinja2 3.0 requires Python 3.6 and we're still testing with Python 3.5, so we can't upgrade our requirement to `Jinja2 >= 3.0` yet. And we might not want to anyway, to avoid imposing the latest version on users who may be running other code in the same Python environment.