### PR TITLE
Backport 2.28: Fix builds with MBEDTLS_HAVE_TIME disabled and test

### DIFF
--- a/ChangeLog.d/timeless.txt
+++ b/ChangeLog.d/timeless.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compile errors when MBEDTLS_HAVE_TIME is not defined. Add tests
+     to catch bad uses of time.h.

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -70,7 +70,9 @@ extern "C" {
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
 #define MBEDTLS_PLATFORM_STD_SNPRINTF   mbedtls_platform_win32_snprintf /**< The default \c snprintf function to use.  */

--- a/library/net_sockets.c
+++ b/library/net_sockets.c
@@ -107,7 +107,9 @@ static int wsa_init_done = 0;
 
 #include <stdio.h>
 
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 
 #include <stdint.h>
 

--- a/library/timing.c
+++ b/library/timing.c
@@ -56,17 +56,18 @@ struct _hr_time
 
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/time.h>
 #include <signal.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
-
+#include <sys/time.h>
 struct _hr_time
 {
     struct timeval start;
 };
-
+#endif
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
     ( defined(_MSC_VER) && defined(_M_IX86) ) || defined(__WATCOMC__)
 
@@ -364,7 +365,6 @@ int mbedtls_timing_get_delay( void *data )
     return( 0 );
 }
 
-#endif /* !MBEDTLS_TIMING_ALT */
 
 #if defined(MBEDTLS_SELF_TEST)
 
@@ -527,4 +527,44 @@ hard_test_done:
 
 #endif /* MBEDTLS_SELF_TEST */
 
+#else
+volatile int mbedtls_timing_alarmed = 0;
+int mbedtls_timing_get_delay( void *data )
+{
+    (void) data;
+    return( 0 );
+}
+
+void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms )
+{
+    (void) data;
+    (void) int_ms;
+    (void) fin_ms;
+}
+
+unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset )
+{
+    (void) val;
+    (void) reset;
+    return( 0 );
+}
+
+unsigned long mbedtls_timing_hardclock( void )
+{
+    return( 0 );
+}
+
+void mbedtls_set_alarm( int seconds )
+{
+    (void) seconds;
+}
+#if defined(MBEDTLS_SELF_TEST)
+int mbedtls_timing_self_test( int verbose )
+{
+    (void) verbose;
+    return( 0 );
+}
+#endif /* MBEDTLS_SELF_TEST */
+#endif /* MBEDTLS_HAVE_TIME */
+#endif /* !MBEDTLS_TIMING_ALT */
 #endif /* MBEDTLS_TIMING_C */

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -52,10 +52,12 @@
 #define mbedtls_snprintf   snprintf
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO) || defined(EFIX64) || defined(EFI32)

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -63,10 +63,12 @@
 #include "mbedtls/threading.h"
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO)

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -5,15 +5,17 @@
 #include <stdlib.h>
 #include "mbedtls/ctr_drbg.h"
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 void dummy_init()
 {
-#if defined(MBEDTLS_PLATFORM_TIME_ALT)
+#if (defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_PLATFORM_TIME_ALT))
     mbedtls_platform_set_time( dummy_constant_time );
 #else
     fprintf(stderr, "Warning: fuzzing without constant time\n");

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -15,7 +15,7 @@ mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 
 void dummy_init()
 {
-#if (defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_PLATFORM_TIME_ALT))
+#if defined(MBEDTLS_PLATFORM_TIME_ALT)
     mbedtls_platform_set_time( dummy_constant_time );
 #else
     fprintf(stderr, "Warning: fuzzing without constant time\n");

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include "mbedtls/ctr_drbg.h"
 
-#if defined(MBEDTLS_HAVE_TIME)
+#if defined(MBEDTLS_PLATFORM_TIME_ALT)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -1,4 +1,13 @@
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct fuzzBufferOffset
@@ -8,7 +17,9 @@ typedef struct fuzzBufferOffset
     size_t Offset;
 } fuzzBufferOffset_t;
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time );
+#endif
 void dummy_init();
 
 int dummy_send( void *ctx, const unsigned char *buf, size_t len );

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -44,7 +44,9 @@ int main( void )
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/base64.h"
@@ -310,6 +312,7 @@ void print_hex( const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
+#if defined(MBEDTLS_HAVE_TIME)
 void print_time( const time_t *time )
 {
     char buf[20];
@@ -325,6 +328,7 @@ void print_time( const time_t *time )
         printf( "unknown\n" );
     }
 }
+#endif
 
 /*
  * Print the input string if the bit is set in the value
@@ -609,7 +613,12 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
                 ( (uint64_t) ssl[7] );
         ssl += 8;
         printf( "\tstart time     : " );
+#if defined(MBEDTLS_HAVE_TIME)
         print_time( (time_t*) &start );
+#else
+        (void) start;
+        printf( "not supported\n" );
+#endif
     }
 
     CHECK_SSL_END( 2 );

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -312,11 +312,11 @@ void print_hex( const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
-#if defined(MBEDTLS_HAVE_TIME)
-void print_time( const time_t *time )
+void print_time( const uint64_t *time )
 {
+#if defined(MBEDTLS_HAVE_TIME)
     char buf[20];
-    struct tm *t = gmtime( time );
+    struct tm *t = gmtime( (time_t*) time );
     static const char format[] = "%Y-%m-%d %H:%M:%S";
     if( NULL != t )
     {
@@ -327,8 +327,11 @@ void print_time( const time_t *time )
     {
         printf( "unknown\n" );
     }
-}
+#else
+    (void) time;
+    printf( "not supported\n" );
 #endif
+}
 
 /*
  * Print the input string if the bit is set in the value
@@ -613,12 +616,7 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
                 ( (uint64_t) ssl[7] );
         ssl += 8;
         printf( "\tstart time     : " );
-#if defined(MBEDTLS_HAVE_TIME)
-        print_time( (time_t*) &start );
-#else
-        (void) start;
-        printf( "not supported\n" );
-#endif
+        print_time( &start );
     }
 
     CHECK_SSL_END( 2 );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -310,10 +310,16 @@ int main( void )
 
 #if defined(MBEDTLS_SSL_CACHE_C)
 #define USAGE_CACHE                                             \
-    "    cache_max=%%d        default: cache default (50)\n"    \
+    "    cache_max=%%d        default: cache default (50)\n"
+#if defined(MBEDTLS_HAVE_TIME)
+#define USAGE_CACHE_TIME \
     "    cache_timeout=%%d    default: cache default (1d)\n"
 #else
+#define USAGE_CACHE_TIME ""
+#endif
+#else
 #define USAGE_CACHE ""
+#define USAGE_CACHE_TIME ""
 #endif /* MBEDTLS_SSL_CACHE_C */
 
 #if defined(SNI_OPTION)
@@ -494,6 +500,7 @@ int main( void )
     USAGE_NSS_KEYLOG                                        \
     USAGE_NSS_KEYLOG_FILE                                   \
     USAGE_CACHE                                             \
+    USAGE_CACHE_TIME                                        \
     USAGE_MAX_FRAG_LEN                                      \
     USAGE_TRUNC_HMAC                                        \
     USAGE_ALPN                                              \
@@ -593,7 +600,9 @@ struct options
     int tickets;                /* enable / disable session tickets         */
     int ticket_timeout;         /* session ticket lifetime                  */
     int cache_max;              /* max number of session cache entries      */
-    int cache_timeout;          /* expiration delay of session cache entries */
+#if defined(MBEDTLS_HAVE_TIME)
+    int cache_timeout;          /* expiration delay of session cache entries*/
+#endif
     char *sni;                  /* string describing sni information        */
     const char *curves;         /* list of supported elliptic curves        */
     const char *alpn_string;    /* ALPN supported protocols                 */
@@ -1512,7 +1521,9 @@ int main( int argc, char *argv[] )
     opt.tickets             = DFL_TICKETS;
     opt.ticket_timeout      = DFL_TICKET_TIMEOUT;
     opt.cache_max           = DFL_CACHE_MAX;
+#if defined(MBEDTLS_HAVE_TIME)
     opt.cache_timeout       = DFL_CACHE_TIMEOUT;
+#endif
     opt.sni                 = DFL_SNI;
     opt.alpn_string         = DFL_ALPN_STRING;
     opt.curves              = DFL_CURVES;
@@ -1896,12 +1907,14 @@ int main( int argc, char *argv[] )
             if( opt.cache_max < 0 )
                 goto usage;
         }
+#if defined(MBEDTLS_HAVE_TIME)
         else if( strcmp( p, "cache_timeout" ) == 0 )
         {
             opt.cache_timeout = atoi( q );
             if( opt.cache_timeout < 0 )
                 goto usage;
         }
+#endif
         else if( strcmp( p, "cookies" ) == 0 )
         {
             opt.cookies = atoi( q );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2705,8 +2705,10 @@ int main( int argc, char *argv[] )
     if( opt.cache_max != -1 )
         mbedtls_ssl_cache_set_max_entries( &cache, opt.cache_max );
 
+#if defined(MBEDTLS_HAVE_TIME)
     if( opt.cache_timeout != -1 )
         mbedtls_ssl_cache_set_timeout( &cache, opt.cache_timeout );
+#endif
 
     mbedtls_ssl_conf_session_cache( &conf, &cache,
                                    mbedtls_ssl_cache_get,

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -44,11 +44,13 @@ void my_debug( void *ctx, int level,
     fflush( (FILE *) ctx  );
 }
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 #if !defined(MBEDTLS_TEST_USE_PSA_CRYPTO_RNG)
 static int dummy_entropy( void *data, unsigned char *output, size_t len )

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -138,7 +138,9 @@ void my_debug( void *ctx, int level,
                const char *file, int line,
                const char *str );
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time );
+#endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /* If MBEDTLS_TEST_USE_PSA_CRYPTO_RNG is defined, the SSL test programs will use

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -81,7 +81,9 @@
 #include "mbedtls/pkcs11.h"
 #include "mbedtls/pkcs12.h"
 #include "mbedtls/pkcs5.h"
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
 #include "mbedtls/ripemd160.h"

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -75,7 +75,9 @@ int main( void )
 #endif
 #endif /* _MSC_VER */
 #else /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
+#if defined(MBEDTLS_HAVE_TIME)
 #include <sys/time.h>
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 #endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -34,9 +34,11 @@
 #else
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
 #define mbedtls_time            time
 #define mbedtls_time_t          time_t
+#endif
 #define mbedtls_printf          printf
 #define mbedtls_calloc          calloc
 #define mbedtls_free            free
@@ -823,6 +825,7 @@ int main( int argc, char *argv[] )
 
     get_options( argc, argv );
 
+#if defined(MBEDTLS_HAVE_TIME)
     /*
      * Decisions to drop/delay/duplicate packets are pseudo-random: dropping
      * exactly 1 in N packets would lead to problems when a flight has exactly
@@ -833,11 +836,12 @@ int main( int argc, char *argv[] )
      */
     if( opt.seed == 0 )
     {
-        opt.seed = (unsigned int) time( NULL );
+        opt.seed = (unsigned int) mbedtls_time( NULL );
         mbedtls_printf( "  . Pseudo-random seed: %u\n", opt.seed );
     }
 
     srand( opt.seed );
+#endif /* MBEDTLS_HAVE_TIME */
 
     /*
      * 0. "Connect" to the server

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -81,7 +81,9 @@
 #include "mbedtls/pkcs11.h"
 #include "mbedtls/pkcs12.h"
 #include "mbedtls/pkcs5.h"
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
 #include "mbedtls/ripemd160.h"

--- a/tests/configs/config-wrapper-malloc-0-null.h
+++ b/tests/configs/config-wrapper-malloc-0-null.h
@@ -24,6 +24,8 @@
 #include "mbedtls/config.h"
 
 #include <stdlib.h>
+
+#ifndef MBEDTLS_PLATFORM_STD_CALLOC
 static inline void *custom_calloc( size_t nmemb, size_t size )
 {
     if( nmemb == 0 || size == 0 )
@@ -33,5 +35,6 @@ static inline void *custom_calloc( size_t nmemb, size_t size )
 
 #define MBEDTLS_PLATFORM_MEMORY
 #define MBEDTLS_PLATFORM_STD_CALLOC custom_calloc
+#endif
 
 #endif /* MBEDTLS_CONFIG_H */

--- a/tests/include/baremetal-override/time.h
+++ b/tests/include/baremetal-override/time.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#error "time.h included in a configuration without MBEDTLS_HAVE_TIME"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1507,7 +1507,7 @@ component_build_crypto_full () {
 component_build_crypto_baremetal () {
   msg "build: make, crypto only, baremetal config"
   scripts/config.py crypto_baremetal
-  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+  make CFLAGS="-O1 -Werror -I$PWD/tests/include/baremetal-override/"
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 support_build_crypto_baremetal () {
@@ -1517,7 +1517,7 @@ support_build_crypto_baremetal () {
 component_build_baremetal () {
   msg "build: make, baremetal config"
   scripts/config.py baremetal
-  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+  make CFLAGS="-O1 -Werror -I$PWD/tests/include/baremetal-override/"
 }
 support_build_baremetal () {
     # Older Glibc versions include time.h from other headers such as stdlib.h,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1507,8 +1507,14 @@ component_build_crypto_full () {
 component_build_crypto_baremetal () {
   msg "build: make, crypto only, baremetal config"
   scripts/config.py crypto_baremetal
-  make CFLAGS='-O1 -Werror'
+  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
+}
+support_build_crypto_baremetal () {
+    # Older Glibc versions include time.h from other headers such as stdlib.h,
+    # which makes the no-time.h-in-baremetal check fail. Ubuntu 16.04 has this
+    # problem, Ubuntu 18.04 is ok.
+    ! grep -q -F time.h /usr/include/x86_64-linux-gnu/sys/types.h
 }
 
 component_test_depends_curves () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1511,6 +1511,15 @@ component_build_crypto_baremetal () {
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 support_build_crypto_baremetal () {
+    support_build_baremetal "$@"
+}
+
+component_build_baremetal () {
+  msg "build: make, baremetal config"
+  scripts/config.py baremetal
+  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+}
+support_build_baremetal () {
     # Older Glibc versions include time.h from other headers such as stdlib.h,
     # which makes the no-time.h-in-baremetal check fail. Ubuntu 16.04 has this
     # problem, Ubuntu 18.04 is ok.

--- a/tests/suites/test_suite_timing.data
+++ b/tests/suites/test_suite_timing.data
@@ -1,17 +1,23 @@
 Timing: hardclock
+depends_on:MBEDTLS_HAVE_TIME
 timing_hardclock:
 
 Timing: get timer
+depends_on:MBEDTLS_HAVE_TIME
 timing_get_timer:
 
 Timing: set alarm with no delay
+depends_on:MBEDTLS_HAVE_TIME
 timing_set_alarm:0:
 
 Timing: set alarm with 1s delay
+depends_on:MBEDTLS_HAVE_TIME
 timing_set_alarm:1:
 
 Timing: delay 0ms
+depends_on:MBEDTLS_HAVE_TIME
 timing_delay:0:
 
 Timing: delay 100ms
+depends_on:MBEDTLS_HAVE_TIME
 timing_delay:100:


### PR DESCRIPTION
Backport of #3624. 
Fix builds that use `time.h` without `MBEDTLS_HAVE_TIME`. 
Changes compared to the original:
- `programs/fuzz/common.h` using `config.h` directly instead of `build_info.h`;
- `programs/test/query_config.c` uploaded.