### PR TITLE
PK: RSA signing

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -204,9 +204,7 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
     psa_status_t status;
     mbedtls_pk_context key;
     int key_len;
-    /* see RSA_PRV_DER_MAX_BYTES in pkwrite.c */
-    unsigned char buf[47 + 3 * MBEDTLS_MPI_MAX_SIZE + \
-                      5 * ( MBEDTLS_MPI_MAX_SIZE / 2 + MBEDTLS_MPI_MAX_SIZE % 2 )];
+    unsigned char buf[MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES];
     mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
     psa_algorithm_t psa_alg_md = PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -222,7 +222,7 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
     if( sig_size < *sig_len )
         return( MBEDTLS_ERR_PK_BUFFER_TOO_SMALL );
 
-    /* mbedtls_pk_write_pubkey() expects a full PK context;
+    /* mbedtls_pk_write_key_der() expects a full PK context;
      * re-construct one to make it happy */
     key.pk_info = &pk_info;
     key.pk_ctx = ctx;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -254,7 +254,10 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
     ret = 0;
 
 cleanup:
-    psa_destroy_key( key_id );
+    status = psa_destroy_key( key_id );
+    if( ret == 0 && status != PSA_SUCCESS )
+        ret = mbedtls_psa_err_translate_pk( status );
+
     return( ret );
 }
 #else

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -206,7 +206,8 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
     int key_len;
     unsigned char buf[MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES];
     mbedtls_pk_info_t pk_info = mbedtls_rsa_info;
-    psa_algorithm_t psa_alg_md = PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
+    psa_algorithm_t psa_alg_md =
+        PSA_ALG_RSA_PKCS1V15_SIGN( mbedtls_psa_translate_md( md_alg ) );
 
     ((void) f_rng);
     ((void) p_rng);

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -238,7 +238,7 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                              &key_id );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
         goto cleanup;
     }
 
@@ -246,7 +246,7 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
                             sig, sig_size, sig_len );
     if( status != PSA_SUCCESS )
     {
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa_rsa( status );
         goto cleanup;
     }
 
@@ -255,7 +255,7 @@ static int rsa_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 cleanup:
     status = psa_destroy_key( key_id );
     if( ret == 0 && status != PSA_SUCCESS )
-        ret = mbedtls_psa_err_translate_pk( status );
+        ret = mbedtls_pk_error_from_psa( status );
 
     return( ret );
 }

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -93,6 +93,8 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
 
+    USE_PSA_INIT( );
+
     mbedtls_pk_init( &key );
     TEST_ASSERT( mbedtls_pk_parse_keyfile( &key, key_file, NULL,
                         mbedtls_test_rnd_std_rand, NULL ) == 0 );
@@ -140,6 +142,7 @@ void x509_csr_check( char * key_file, char * cert_req_check_file, int md_type,
 exit:
     mbedtls_x509write_csr_free( &req );
     mbedtls_pk_free( &key );
+    USE_PSA_DONE( );
 }
 /* END_CASE */
 
@@ -219,6 +222,8 @@ void x509_crt_check( char *subject_key_file, char *subject_pwd,
 
     memset( &rnd_info, 0x2a, sizeof( mbedtls_test_rnd_pseudo_info ) );
     mbedtls_mpi_init( &serial );
+
+    USE_PSA_INIT( );
 
     mbedtls_pk_init( &subject_key );
     mbedtls_pk_init( &issuer_key  );
@@ -316,6 +321,7 @@ exit:
     mbedtls_pk_free( &subject_key );
     mbedtls_pk_free( &issuer_key );
     mbedtls_mpi_free( &serial );
+    USE_PSA_DONE( );
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description
In `library/pk_wrap.c`, provide an implementation of `rsa_sign_wrap` to use `psa_sign_hash()` instead of `mbedtls_rsa_pkcs1_sign()`.

Resolves #5162 

## Status
**READY**

## Requires Backporting
NO

## Migrations
NO

## Todos
- [x] Implementation
- [x] Tests

## Steps to test or reproduce
test_suite_pk should run clean