### PR TITLE
Adds support for the Bazel build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ massif-*
 /TAGS
 /cscope*.out
 /tags
+
+# Bazel outputs
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,44 @@
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "mbedtls",
+    srcs = glob(["library/*.c"]),
+    hdrs = glob(
+        [
+            "include/**/*.h",
+            "library/*.h",
+        ],
+        exclude = ["include/mbedtls/mbedtls_config.h"],
+    ),
+    includes = [
+        "include",
+        "library",
+    ],
+    deps = [":mbedtls_config"],
+)
+
+cc_library(
+    name = "mbedtls_default_config",
+    hdrs = ["include/mbedtls/mbedtls_config.h"],
+    includes = [
+        "include",
+    ],
+)
+
+label_flag(
+    name = "mbedtls_config",
+    build_setting_default = ":mbedtls_default_config",
+)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There are currently three active build systems used within Mbed TLS releases:
 
 -   GNU Make
 -   CMake
+-   Bazel
 -   Microsoft Visual Studio
 
 The main systems used for development are CMake and GNU Make. Those systems are always complete and up-to-date. The others should reflect all changes present in the CMake and Make build system, although features may not be ported there automatically.
@@ -215,6 +216,51 @@ its include directories to your target (transitively, in the case of `PUBLIC` or
 Mbed TLS supports being built as a CMake subproject. One can
 use `add_subdirectory()` from a parent CMake project to include Mbed TLS as a
 subproject.
+
+### Bazel
+Currently Bazel support is minimal and limited to the library itself i.e. none
+of the tests are captured by the Bazel build configs.
+
+To start off add the following to your WORKSPACE;
+```py
+# //:WORKSPACE
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "mbedtls",
+    remote = "https://github.com/ARMmbed/mbedtls.git",
+    commit = "<TODO>",
+)
+```
+
+Now you can make use of mbedtls from a `cc_library` e.g.
+
+```py
+# //:BUILD.bazel
+cc_library(
+    name = "my_lib",
+    deps = ["@mbedtls//:mbedtls"],
+    # ...
+)
+
+# Optionally create your own mbedtls config target.
+cc_library(
+    name = "my_mbedtls_config",
+    includes = ["my_mbedtls_config.h"],
+    defines = ["MBEDTLS_CONFIG_FILE=$(location my_mbedtls_config.h)"],
+)
+```
+To build your library with the default config, you can use the command;
+
+`bazel build //:my_lib`
+
+To use your custom config as defined in the target `//:my_mbedtls_config` you
+can use the command line;
+
+`bazel build //:my_lib --@mbedtls//:mbedtls_config=@//:my_mbedtls_config`.
+
+You can of course add this to your `.bazelrc` and create a selectable dependency
+to switch the config based on your platform.
 
 ### Microsoft Visual Studio
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,18 @@
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(
+    name = "mbedtls",
+)


### PR DESCRIPTION
Signed-off-by: Nathaniel Brough <nathaniel.brough@gmail.com>

## Description
This adds support for the [Bazel build system](https://bazel.build/), including fetching, configuring and consuming mbedtls.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
This PR works as is, though I am not sure how to add this into your CI. The command you'd need to run in the CI would be;

`bazel build //....`

## Todos
- [x] Documentation
- [ ] Changelog updated

