### PR TITLE
Backport 2.28: Add missing key destruction calls in ssl_write_client_key_exchange

### DIFF
--- a/ChangeLog.d/raw-agreement-destroy-missing.txt
+++ b/ChangeLog.d/raw-agreement-destroy-missing.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Add missing key slot destruction calls when a raw key agreement or
+     a public key export fails in ssl_write_client_key_exchange.


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbedtls/pull/5576.