### PR TITLE
Erase secrets in allocated memory before freeing said memory

### DIFF
--- a/ChangeLog.d/zeroize_key_buffers_before_free.txt
+++ b/ChangeLog.d/zeroize_key_buffers_before_free.txt
@@ -1,0 +1,4 @@
+Security
+   * Zeroize dynamically-allocated buffers used by the PSA Crypto key storage
+     module before freeing them. These buffers contain secret key material, and
+     could thus potentially leak the key through freed heap.

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -349,6 +349,7 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
     status = psa_crypto_storage_store( attr->id,
                                        storage_data, storage_data_length );
 
+    mbedtls_platform_zeroize( storage_data, storage_data_length );
     mbedtls_free( storage_data );
 
     return( status );
@@ -394,6 +395,7 @@ psa_status_t psa_load_persistent_key( psa_core_key_attributes_t *attr,
         status = PSA_ERROR_STORAGE_FAILURE;
 
 exit:
+    mbedtls_platform_zeroize( loaded_data, storage_data_length );
     mbedtls_free( loaded_data );
     return( status );
 }


### PR DESCRIPTION
## Description
The PSA Crypto storage module uses dynamically-allocated buffers to buffer sensitive key material during the process of loading said key material from NVM, or storing it to NVM. To avoid leaking the key material through the heap, zero out the buffer before freeing it.


## Status
**READY**

## Requires Backporting
Unsure, maintainer can make a decision

## Migrations
NO

## Additional comments

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog updated
- [x] Backported


## Steps to test or reproduce
