### PR TITLE
Move max sizes of RSA & EC DER keys into public header

### DIFF
--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -32,6 +32,10 @@
 #include "mbedtls/ecp.h"
 #endif
 
+#if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_ECP_C)
+#include "pkwrite.h"
+#endif
+
 #if defined(MBEDTLS_ECDSA_C)
 #include "mbedtls/ecdsa.h"
 #endif
@@ -564,8 +568,7 @@ static int ecdsa_verify_wrap( void *ctx_arg, mbedtls_md_type_t md_alg,
     psa_status_t status;
     mbedtls_pk_context key;
     int key_len;
-    /* see ECP_PUB_DER_MAX_BYTES in pkwrite.c */
-    unsigned char buf[30 + 2 * MBEDTLS_ECP_MAX_BYTES];
+    unsigned char buf[MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES];
     unsigned char *p;
     mbedtls_pk_info_t pk_info = mbedtls_eckey_info;
     psa_algorithm_t psa_sig_md = PSA_ALG_ECDSA_ANY;

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -37,6 +37,9 @@
 #include "mbedtls/ecp.h"
 #include "mbedtls/platform_util.h"
 #endif
+#if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_ECP_C)
+#include "pkwrite.h"
+#endif
 #if defined(MBEDTLS_ECDSA_C)
 #include "mbedtls/ecdsa.h"
 #endif
@@ -469,84 +472,6 @@ int mbedtls_pk_write_key_der( const mbedtls_pk_context *key, unsigned char *buf,
 #define PEM_END_PRIVATE_KEY_RSA     "-----END RSA PRIVATE KEY-----\n"
 #define PEM_BEGIN_PRIVATE_KEY_EC    "-----BEGIN EC PRIVATE KEY-----\n"
 #define PEM_END_PRIVATE_KEY_EC      "-----END EC PRIVATE KEY-----\n"
-
-/*
- * Max sizes of key per types. Shown as tag + len (+ content).
- */
-
-#if defined(MBEDTLS_RSA_C)
-/*
- * RSA public keys:
- *  SubjectPublicKeyInfo  ::=  SEQUENCE  {          1 + 3
- *       algorithm            AlgorithmIdentifier,  1 + 1 (sequence)
- *                                                + 1 + 1 + 9 (rsa oid)
- *                                                + 1 + 1 (params null)
- *       subjectPublicKey     BIT STRING }          1 + 3 + (1 + below)
- *  RSAPublicKey ::= SEQUENCE {                     1 + 3
- *      modulus           INTEGER,  -- n            1 + 3 + MPI_MAX + 1
- *      publicExponent    INTEGER   -- e            1 + 3 + MPI_MAX + 1
- *  }
- */
-#define RSA_PUB_DER_MAX_BYTES   ( 38 + 2 * MBEDTLS_MPI_MAX_SIZE )
-
-/*
- * RSA private keys:
- *  RSAPrivateKey ::= SEQUENCE {                    1 + 3
- *      version           Version,                  1 + 1 + 1
- *      modulus           INTEGER,                  1 + 3 + MPI_MAX + 1
- *      publicExponent    INTEGER,                  1 + 3 + MPI_MAX + 1
- *      privateExponent   INTEGER,                  1 + 3 + MPI_MAX + 1
- *      prime1            INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
- *      prime2            INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
- *      exponent1         INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
- *      exponent2         INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
- *      coefficient       INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
- *      otherPrimeInfos   OtherPrimeInfos OPTIONAL  0 (not supported)
- *  }
- */
-#define MPI_MAX_SIZE_2          ( MBEDTLS_MPI_MAX_SIZE / 2 + \
-                                  MBEDTLS_MPI_MAX_SIZE % 2 )
-#define RSA_PRV_DER_MAX_BYTES   ( 47 + 3 * MBEDTLS_MPI_MAX_SIZE \
-                                   + 5 * MPI_MAX_SIZE_2 )
-
-#else /* MBEDTLS_RSA_C */
-
-#define RSA_PUB_DER_MAX_BYTES   0
-#define RSA_PRV_DER_MAX_BYTES   0
-
-#endif /* MBEDTLS_RSA_C */
-
-#if defined(MBEDTLS_ECP_C)
-/*
- * EC public keys:
- *  SubjectPublicKeyInfo  ::=  SEQUENCE  {      1 + 2
- *    algorithm         AlgorithmIdentifier,    1 + 1 (sequence)
- *                                            + 1 + 1 + 7 (ec oid)
- *                                            + 1 + 1 + 9 (namedCurve oid)
- *    subjectPublicKey  BIT STRING              1 + 2 + 1               [1]
- *                                            + 1 (point format)        [1]
- *                                            + 2 * ECP_MAX (coords)    [1]
- *  }
- */
-#define ECP_PUB_DER_MAX_BYTES   ( 30 + 2 * MBEDTLS_ECP_MAX_BYTES )
-
-/*
- * EC private keys:
- * ECPrivateKey ::= SEQUENCE {                  1 + 2
- *      version        INTEGER ,                1 + 1 + 1
- *      privateKey     OCTET STRING,            1 + 1 + ECP_MAX
- *      parameters [0] ECParameters OPTIONAL,   1 + 1 + (1 + 1 + 9)
- *      publicKey  [1] BIT STRING OPTIONAL      1 + 2 + [1] above
- *    }
- */
-#define ECP_PRV_DER_MAX_BYTES   ( 29 + 3 * MBEDTLS_ECP_MAX_BYTES )
-
-#else /* MBEDTLS_ECP_C */
-
-#define ECP_PUB_DER_MAX_BYTES   0
-#define ECP_PRV_DER_MAX_BYTES   0
-
-#endif /* MBEDTLS_ECP_C */
 
 #define PUB_DER_MAX_BYTES   ( RSA_PUB_DER_MAX_BYTES > ECP_PUB_DER_MAX_BYTES ? \
                               RSA_PUB_DER_MAX_BYTES : ECP_PUB_DER_MAX_BYTES )

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -473,10 +473,12 @@ int mbedtls_pk_write_key_der( const mbedtls_pk_context *key, unsigned char *buf,
 #define PEM_BEGIN_PRIVATE_KEY_EC    "-----BEGIN EC PRIVATE KEY-----\n"
 #define PEM_END_PRIVATE_KEY_EC      "-----END EC PRIVATE KEY-----\n"
 
-#define PUB_DER_MAX_BYTES   ( RSA_PUB_DER_MAX_BYTES > ECP_PUB_DER_MAX_BYTES ? \
-                              RSA_PUB_DER_MAX_BYTES : ECP_PUB_DER_MAX_BYTES )
-#define PRV_DER_MAX_BYTES   ( RSA_PRV_DER_MAX_BYTES > ECP_PRV_DER_MAX_BYTES ? \
-                              RSA_PRV_DER_MAX_BYTES : ECP_PRV_DER_MAX_BYTES )
+#define PUB_DER_MAX_BYTES                                                   \
+    ( MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES > MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES ? \
+      MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES : MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES )
+#define PRV_DER_MAX_BYTES                                                   \
+    ( MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES > MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES ? \
+      MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES : MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES )
 
 int mbedtls_pk_write_pubkey_pem( const mbedtls_pk_context *key, unsigned char *buf, size_t size )
 {

--- a/library/pkwrite.h
+++ b/library/pkwrite.h
@@ -1,0 +1,108 @@
+/**
+ * \file pkwrite.h
+ *
+ * \brief Internal defines shared by the PK write module
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MBEDTLS_PK_WRITE_H
+#define MBEDTLS_PK_WRITE_H
+
+#include "mbedtls/build_info.h"
+
+#include "mbedtls/pk.h"
+
+/*
+ * Max sizes of key per types. Shown as tag + len (+ content).
+ */
+
+#if defined(MBEDTLS_RSA_C)
+/*
+ * RSA public keys:
+ *  SubjectPublicKeyInfo  ::=  SEQUENCE  {          1 + 3
+ *       algorithm            AlgorithmIdentifier,  1 + 1 (sequence)
+ *                                                + 1 + 1 + 9 (rsa oid)
+ *                                                + 1 + 1 (params null)
+ *       subjectPublicKey     BIT STRING }          1 + 3 + (1 + below)
+ *  RSAPublicKey ::= SEQUENCE {                     1 + 3
+ *      modulus           INTEGER,  -- n            1 + 3 + MPI_MAX + 1
+ *      publicExponent    INTEGER   -- e            1 + 3 + MPI_MAX + 1
+ *  }
+ */
+#define RSA_PUB_DER_MAX_BYTES   ( 38 + 2 * MBEDTLS_MPI_MAX_SIZE )
+
+/*
+ * RSA private keys:
+ *  RSAPrivateKey ::= SEQUENCE {                    1 + 3
+ *      version           Version,                  1 + 1 + 1
+ *      modulus           INTEGER,                  1 + 3 + MPI_MAX + 1
+ *      publicExponent    INTEGER,                  1 + 3 + MPI_MAX + 1
+ *      privateExponent   INTEGER,                  1 + 3 + MPI_MAX + 1
+ *      prime1            INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
+ *      prime2            INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
+ *      exponent1         INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
+ *      exponent2         INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
+ *      coefficient       INTEGER,                  1 + 3 + MPI_MAX / 2 + 1
+ *      otherPrimeInfos   OtherPrimeInfos OPTIONAL  0 (not supported)
+ *  }
+ */
+#define MPI_MAX_SIZE_2          ( MBEDTLS_MPI_MAX_SIZE / 2 + \
+                                  MBEDTLS_MPI_MAX_SIZE % 2 )
+#define RSA_PRV_DER_MAX_BYTES   ( 47 + 3 * MBEDTLS_MPI_MAX_SIZE \
+                                   + 5 * MPI_MAX_SIZE_2 )
+
+#else /* MBEDTLS_RSA_C */
+
+#define RSA_PUB_DER_MAX_BYTES   0
+#define RSA_PRV_DER_MAX_BYTES   0
+
+#endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_ECP_C)
+/*
+ * EC public keys:
+ *  SubjectPublicKeyInfo  ::=  SEQUENCE  {      1 + 2
+ *    algorithm         AlgorithmIdentifier,    1 + 1 (sequence)
+ *                                            + 1 + 1 + 7 (ec oid)
+ *                                            + 1 + 1 + 9 (namedCurve oid)
+ *    subjectPublicKey  BIT STRING              1 + 2 + 1               [1]
+ *                                            + 1 (point format)        [1]
+ *                                            + 2 * ECP_MAX (coords)    [1]
+ *  }
+ */
+#define ECP_PUB_DER_MAX_BYTES   ( 30 + 2 * MBEDTLS_ECP_MAX_BYTES )
+
+/*
+ * EC private keys:
+ * ECPrivateKey ::= SEQUENCE {                  1 + 2
+ *      version        INTEGER ,                1 + 1 + 1
+ *      privateKey     OCTET STRING,            1 + 1 + ECP_MAX
+ *      parameters [0] ECParameters OPTIONAL,   1 + 1 + (1 + 1 + 9)
+ *      publicKey  [1] BIT STRING OPTIONAL      1 + 2 + [1] above
+ *    }
+ */
+#define ECP_PRV_DER_MAX_BYTES   ( 29 + 3 * MBEDTLS_ECP_MAX_BYTES )
+
+#else /* MBEDTLS_ECP_C */
+
+#define ECP_PUB_DER_MAX_BYTES   0
+#define ECP_PRV_DER_MAX_BYTES   0
+
+#endif /* MBEDTLS_ECP_C */
+
+#endif /* MBEDTLS_PK_WRITE_H */

--- a/library/pkwrite.h
+++ b/library/pkwrite.h
@@ -44,7 +44,7 @@
  *      publicExponent    INTEGER   -- e            1 + 3 + MPI_MAX + 1
  *  }
  */
-#define RSA_PUB_DER_MAX_BYTES   ( 38 + 2 * MBEDTLS_MPI_MAX_SIZE )
+#define MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES    ( 38 + 2 * MBEDTLS_MPI_MAX_SIZE )
 
 /*
  * RSA private keys:
@@ -61,15 +61,15 @@
  *      otherPrimeInfos   OtherPrimeInfos OPTIONAL  0 (not supported)
  *  }
  */
-#define MPI_MAX_SIZE_2          ( MBEDTLS_MPI_MAX_SIZE / 2 + \
+#define MBEDTLS_MPI_MAX_SIZE_2  ( MBEDTLS_MPI_MAX_SIZE / 2 + \
                                   MBEDTLS_MPI_MAX_SIZE % 2 )
-#define RSA_PRV_DER_MAX_BYTES   ( 47 + 3 * MBEDTLS_MPI_MAX_SIZE \
-                                   + 5 * MPI_MAX_SIZE_2 )
+#define MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES    ( 47 + 3 * MBEDTLS_MPI_MAX_SIZE \
+                                              + 5 * MBEDTLS_MPI_MAX_SIZE_2 )
 
 #else /* MBEDTLS_RSA_C */
 
-#define RSA_PUB_DER_MAX_BYTES   0
-#define RSA_PRV_DER_MAX_BYTES   0
+#define MBEDTLS_PK_RSA_PUB_DER_MAX_BYTES   0
+#define MBEDTLS_PK_RSA_PRV_DER_MAX_BYTES   0
 
 #endif /* MBEDTLS_RSA_C */
 
@@ -85,7 +85,7 @@
  *                                            + 2 * ECP_MAX (coords)    [1]
  *  }
  */
-#define ECP_PUB_DER_MAX_BYTES   ( 30 + 2 * MBEDTLS_ECP_MAX_BYTES )
+#define MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES    ( 30 + 2 * MBEDTLS_ECP_MAX_BYTES )
 
 /*
  * EC private keys:
@@ -96,12 +96,12 @@
  *      publicKey  [1] BIT STRING OPTIONAL      1 + 2 + [1] above
  *    }
  */
-#define ECP_PRV_DER_MAX_BYTES   ( 29 + 3 * MBEDTLS_ECP_MAX_BYTES )
+#define MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES    ( 29 + 3 * MBEDTLS_ECP_MAX_BYTES )
 
 #else /* MBEDTLS_ECP_C */
 
-#define ECP_PUB_DER_MAX_BYTES   0
-#define ECP_PRV_DER_MAX_BYTES   0
+#define MBEDTLS_PK_ECP_PUB_DER_MAX_BYTES   0
+#define MBEDTLS_PK_ECP_PRV_DER_MAX_BYTES   0
 
 #endif /* MBEDTLS_ECP_C */
 


### PR DESCRIPTION
## Description
The max sizes of RSA & EC DER keys are used in `pk_wrap.c`, and in #5518, #5519, #5525, #5568, #5571

It's simpler to move & rename the defines separately in this PR.

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [x] Tests

## Steps to test or reproduce
`make test` must complet without fail.
