### PR TITLE
Build tests with -Wunused-function with cmake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,10 +140,6 @@ endfunction(add_test_suite)
 # on non-POSIX platforms.
 add_definitions("-D_POSIX_C_SOURCE=200809L")
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function")
-endif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-
 if(CMAKE_COMPILER_IS_CLANG)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdocumentation -Wno-documentation-deprecated-sync -Wunreachable-code")
 endif(CMAKE_COMPILER_IS_CLANG)

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -1205,7 +1205,8 @@ int psk_dummy_callback( void *p_info, mbedtls_ssl_context *ssl,
 #define SSL_CID_LEN_MIN MBEDTLS_SSL_CID_OUT_LEN_MAX
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
+    defined(MBEDTLS_CIPHER_MODE_CBC) && defined(MBEDTLS_AES_C)
 static int psa_cipher_encrypt_helper( mbedtls_ssl_transform *transform,
                     const unsigned char *iv, size_t iv_len,
                     const unsigned char *input, size_t ilen,
@@ -1246,7 +1247,7 @@ static int psa_cipher_encrypt_helper( mbedtls_ssl_transform *transform,
                             iv, iv_len, input, ilen, output, olen );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 }
-#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 && MBEDTLS_CIPHER_MODE_CBC && MBEDTLS_AES_C */
 
 static int build_transforms( mbedtls_ssl_transform *t_in,
                              mbedtls_ssl_transform *t_out,


### PR DESCRIPTION
This was previously done for make in #2053. To avoid builds passing with one build system and failing with the other, align cmake with make.

Backport: I think not. It could break the way users run unit tests in a custom configuration. Having fewer warnings in the LTS version is not going to make future backports harder, so there's no significant advantage to backporting.

