### PR TITLE
Refactor ssl_context_info time printing

### DIFF
--- a/ChangeLog.d/timeless.txt
+++ b/ChangeLog.d/timeless.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix compile errors when MBEDTLS_HAVE_TIME is not defined. Add tests
+     to catch bad uses of time.h.

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -62,7 +62,9 @@ extern "C" {
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS)
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #if !defined(MBEDTLS_PLATFORM_STD_SNPRINTF)
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
 #define MBEDTLS_PLATFORM_STD_SNPRINTF   mbedtls_platform_win32_snprintf /**< The default \c snprintf function to use.  */

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -52,10 +52,12 @@
 #define mbedtls_snprintf   snprintf
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO) || defined(EFIX64) || defined(EFI32)

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -63,10 +63,12 @@
 #include "mbedtls/threading.h"
 #endif
 
+#if defined(MBEDTLS_HAVE_TIME)
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
 #include <windows.h>
 #else
 #include <time.h>
+#endif
 #endif
 
 #if defined(MBEDTLS_FS_IO)

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -4,15 +4,17 @@
 #include <stdlib.h>
 #include "mbedtls/ctr_drbg.h"
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 void dummy_init()
 {
-#if defined(MBEDTLS_PLATFORM_TIME_ALT)
+#if (defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_PLATFORM_TIME_ALT))
     mbedtls_platform_set_time( dummy_constant_time );
 #else
     fprintf(stderr, "Warning: fuzzing without constant time\n");

--- a/programs/fuzz/common.c
+++ b/programs/fuzz/common.c
@@ -14,7 +14,7 @@ mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 
 void dummy_init()
 {
-#if (defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_PLATFORM_TIME_ALT))
+#if defined(MBEDTLS_PLATFORM_TIME_ALT)
     mbedtls_platform_set_time( dummy_constant_time );
 #else
     fprintf(stderr, "Warning: fuzzing without constant time\n");

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -1,4 +1,13 @@
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/mbedtls_config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct fuzzBufferOffset
@@ -8,7 +17,9 @@ typedef struct fuzzBufferOffset
     size_t Offset;
 } fuzzBufferOffset_t;
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time );
+#endif
 void dummy_init();
 
 int dummy_send( void *ctx, const unsigned char *buf, size_t len );

--- a/programs/fuzz/common.h
+++ b/programs/fuzz/common.h
@@ -1,8 +1,4 @@
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/mbedtls_config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/build_info.h"
 
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -41,7 +41,9 @@ int main( void )
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
+#endif
 #include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/base64.h"
@@ -299,6 +301,7 @@ void print_hex( const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
+#if defined(MBEDTLS_HAVE_TIME)
 void print_time( const time_t *time )
 {
     char buf[20];
@@ -314,6 +317,7 @@ void print_time( const time_t *time )
         printf( "unknown\n" );
     }
 }
+#endif
 
 /*
  * Print the input string if the bit is set in the value
@@ -599,7 +603,12 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
                 ( (uint64_t) ssl[7] );
         ssl += 8;
         printf( "\tstart time     : " );
+#if defined(MBEDTLS_HAVE_TIME)
         print_time( (time_t*) &start );
+#else
+        (void) start;
+        printf( "not supported\n" );
+#endif
     }
 
     CHECK_SSL_END( 2 );

--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -301,11 +301,11 @@ void print_hex( const uint8_t *b, size_t len,
 /*
  *  Print the value of time_t in format e.g. 2020-01-23 13:05:59
  */
-#if defined(MBEDTLS_HAVE_TIME)
-void print_time( const time_t *time )
+void print_time( const uint64_t *time )
 {
+#if defined(MBEDTLS_HAVE_TIME)
     char buf[20];
-    struct tm *t = gmtime( time );
+    struct tm *t = gmtime( (time_t*)time );
     static const char format[] = "%Y-%m-%d %H:%M:%S";
     if( NULL != t )
     {
@@ -316,8 +316,11 @@ void print_time( const time_t *time )
     {
         printf( "unknown\n" );
     }
-}
+#else
+    (void) time;
+    printf( "not supported\n" );
 #endif
+}
 
 /*
  * Print the input string if the bit is set in the value
@@ -603,12 +606,7 @@ void print_deserialized_ssl_session( const uint8_t *ssl, uint32_t len,
                 ( (uint64_t) ssl[7] );
         ssl += 8;
         printf( "\tstart time     : " );
-#if defined(MBEDTLS_HAVE_TIME)
-        print_time( (time_t*) &start );
-#else
-        (void) start;
-        printf( "not supported\n" );
-#endif
+        print_time( &start );
     }
 
     CHECK_SSL_END( 2 );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2657,8 +2657,10 @@ int main( int argc, char *argv[] )
     if( opt.cache_max != -1 )
         mbedtls_ssl_cache_set_max_entries( &cache, opt.cache_max );
 
+#if defined(MBEDTLS_HAVE_TIME)
     if( opt.cache_timeout != -1 )
         mbedtls_ssl_cache_set_timeout( &cache, opt.cache_timeout );
+#endif
 
     mbedtls_ssl_conf_session_cache( &conf, &cache,
                                    mbedtls_ssl_cache_get,

--- a/programs/ssl/ssl_test_lib.c
+++ b/programs/ssl/ssl_test_lib.c
@@ -46,11 +46,13 @@ void my_debug( void *ctx, int level,
     fflush( (FILE *) ctx  );
 }
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time )
 {
     (void) time;
     return 0x5af2a056;
 }
+#endif
 
 #if !defined(MBEDTLS_TEST_USE_PSA_CRYPTO_RNG)
 static int dummy_entropy( void *data, unsigned char *output, size_t len )

--- a/programs/ssl/ssl_test_lib.h
+++ b/programs/ssl/ssl_test_lib.h
@@ -134,7 +134,9 @@ void my_debug( void *ctx, int level,
                const char *file, int line,
                const char *str );
 
+#if defined(MBEDTLS_HAVE_TIME)
 mbedtls_time_t dummy_constant_time( mbedtls_time_t* time );
+#endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /* If MBEDTLS_TEST_USE_PSA_CRYPTO_RNG is defined, the SSL test programs will use

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -32,9 +32,11 @@
 #else
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
 #define mbedtls_time            time
 #define mbedtls_time_t          time_t
+#endif
 #define mbedtls_printf          printf
 #define mbedtls_calloc          calloc
 #define mbedtls_free            free
@@ -821,6 +823,7 @@ int main( int argc, char *argv[] )
 
     get_options( argc, argv );
 
+#if defined(MBEDTLS_HAVE_TIME)
     /*
      * Decisions to drop/delay/duplicate packets are pseudo-random: dropping
      * exactly 1 in N packets would lead to problems when a flight has exactly
@@ -831,11 +834,12 @@ int main( int argc, char *argv[] )
      */
     if( opt.seed == 0 )
     {
-        opt.seed = (unsigned int) time( NULL );
+        opt.seed = (unsigned int) mbedtls_time( NULL );
         mbedtls_printf( "  . Pseudo-random seed: %u\n", opt.seed );
     }
 
     srand( opt.seed );
+#endif /* MBEDTLS_HAVE_TIME */
 
     /*
      * 0. "Connect" to the server

--- a/scripts/data_files/query_config.fmt
+++ b/scripts/data_files/query_config.fmt
@@ -67,7 +67,9 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/pkcs12.h"
 #include "mbedtls/pkcs5.h"
+#if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
+#endif
 #include "mbedtls/platform_util.h"
 #include "mbedtls/poly1305.h"
 #include "mbedtls/ripemd160.h"

--- a/tests/configs/config-wrapper-malloc-0-null.h
+++ b/tests/configs/config-wrapper-malloc-0-null.h
@@ -21,6 +21,8 @@
 #include "mbedtls/mbedtls_config.h"
 
 #include <stdlib.h>
+
+#ifndef MBEDTLS_PLATFORM_STD_CALLOC
 static inline void *custom_calloc( size_t nmemb, size_t size )
 {
     if( nmemb == 0 || size == 0 )
@@ -30,3 +32,4 @@ static inline void *custom_calloc( size_t nmemb, size_t size )
 
 #define MBEDTLS_PLATFORM_MEMORY
 #define MBEDTLS_PLATFORM_STD_CALLOC custom_calloc
+#endif

--- a/tests/include/baremetal-override/time.h
+++ b/tests/include/baremetal-override/time.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#error "time.h included in a configuration without MBEDTLS_HAVE_TIME"

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1419,7 +1419,7 @@ component_build_crypto_full () {
 component_build_crypto_baremetal () {
   msg "build: make, crypto only, baremetal config"
   scripts/config.py crypto_baremetal
-  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+  make CFLAGS="-O1 -Werror -I$PWD/tests/include/baremetal-override/"
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 support_build_crypto_baremetal () {
@@ -1429,7 +1429,7 @@ support_build_crypto_baremetal () {
 component_build_baremetal () {
   msg "build: make, baremetal config"
   scripts/config.py baremetal
-  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+  make CFLAGS="-O1 -Werror -I$PWD/tests/include/baremetal-override/"
 }
 support_build_baremetal () {
     # Older Glibc versions include time.h from other headers such as stdlib.h,

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1419,8 +1419,14 @@ component_build_crypto_full () {
 component_build_crypto_baremetal () {
   msg "build: make, crypto only, baremetal config"
   scripts/config.py crypto_baremetal
-  make CFLAGS='-O1 -Werror'
+  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
+}
+support_build_crypto_baremetal () {
+    # Older Glibc versions include time.h from other headers such as stdlib.h,
+    # which makes the no-time.h-in-baremetal check fail. Ubuntu 16.04 has this
+    # problem, Ubuntu 18.04 is ok.
+    ! grep -q -F time.h /usr/include/x86_64-linux-gnu/sys/types.h
 }
 
 component_test_depends_curves () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1423,6 +1423,15 @@ component_build_crypto_baremetal () {
   are_empty_libraries library/libmbedx509.* library/libmbedtls.*
 }
 support_build_crypto_baremetal () {
+    support_build_baremetal "$@"
+}
+
+component_build_baremetal () {
+  msg "build: make, baremetal config"
+  scripts/config.py baremetal
+  make CFLAGS="-O1 -Werror -I$(pwd)/tests/include/baremetal-override/"
+}
+support_build_baremetal () {
     # Older Glibc versions include time.h from other headers such as stdlib.h,
     # which makes the no-time.h-in-baremetal check fail. Ubuntu 16.04 has this
     # problem, Ubuntu 18.04 is ok.


### PR DESCRIPTION
Follow-up for #3624 - refactoring time printing. 
Please only review the last commit. To be merged after #3624.