### PR TITLE
Make mypy unconditional

### DIFF
--- a/tests/scripts/check-python-files.sh
+++ b/tests/scripts/check-python-files.sh
@@ -17,7 +17,7 @@
 
 # Purpose: check Python files for potential programming errors or maintenance
 # hurdles. Run pylint to detect some potential mistakes and enforce PEP8
-# coding standards. If available, run mypy to perform static type checking.
+# coding standards. Run mypy to perform static type checking.
 
 # We'll keep going on errors and report the status at the end.
 ret=0
@@ -72,12 +72,9 @@ $PYTHON -m pylint -j 2 scripts/mbedtls_dev/*.py scripts/*.py tests/scripts/*.py 
     ret=1
 }
 
-# Check types if mypy is available
-if can_mypy; then
-    echo
-    echo 'Running mypy ...'
-    $PYTHON -m mypy scripts/*.py tests/scripts/*.py ||
-      ret=1
-fi
+echo
+echo 'Running mypy ...'
+$PYTHON -m mypy scripts/*.py tests/scripts/*.py ||
+  ret=1
 
 exit $ret


### PR DESCRIPTION
Running mypy was optional for a transition period when it wasn't installed on the CI. Now that it is, make it mandatory, to avoid silently skipping an expected check if mypy doesn't work for some reason.

This resolves a bug that for a while, mypy has been running on Travis but not on Jenkins, because `can_mypy` was returning false on Jenkins because the `packaging` package was not installed:
```
$ ./tests/scripts/check-python-files.sh 
Running pylint ...

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named 'packaging'
```

Backport: https://github.com/ARMmbed/mbedtls/pull/5589
