### PR TITLE
2.28 backport - build(msvc): always assume source files are in UTF-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,8 @@ if(CMAKE_COMPILER_IS_IAR)
 endif(CMAKE_COMPILER_IS_IAR)
 
 if(CMAKE_COMPILER_IS_MSVC)
-    # Strictest warnings
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3")
+    # Strictest warnings, UTF-8 source and execution charset
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /utf-8")
 endif(CMAKE_COMPILER_IS_MSVC)
 
 if(MBEDTLS_FATAL_WARNINGS)

--- a/ChangeLog.d/cmake_msvc_utf8.txt
+++ b/ChangeLog.d/cmake_msvc_utf8.txt
@@ -1,0 +1,2 @@
+Changes
+   * Assume source files are in UTF-8 when using MSVC with CMake.


### PR DESCRIPTION
Backport of #5365