### PR TITLE
[Backport #5579] Erase secrets in allocated memory before freeing said memory

### DIFF
--- a/ChangeLog.d/zeroize_key_buffers_before_free.txt
+++ b/ChangeLog.d/zeroize_key_buffers_before_free.txt
@@ -1,0 +1,4 @@
+Security
+   * Zeroize dynamically-allocated buffers used by the PSA Crypto key storage
+     module before freeing them. These buffers contain secret key material, and
+     could thus potentially leak the key through freed heap.

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -347,6 +347,7 @@ psa_status_t psa_save_persistent_key( const psa_core_key_attributes_t *attr,
     status = psa_crypto_storage_store( attr->id,
                                        storage_data, storage_data_length );
 
+    mbedtls_platform_zeroize( storage_data, storage_data_length );
     mbedtls_free( storage_data );
 
     return( status );
@@ -392,6 +393,7 @@ psa_status_t psa_load_persistent_key( psa_core_key_attributes_t *attr,
         status = PSA_ERROR_STORAGE_FAILURE;
 
 exit:
+    mbedtls_platform_zeroize( loaded_data, storage_data_length );
     mbedtls_free( loaded_data );
     return( status );
 }


### PR DESCRIPTION
## Description
Backported #5579 as requested by cherry-picking the commits on top of mbedtls-2.28


## Status
**READY**
