### PR TITLE
MD: HMAC in DTLS cookies

### DIFF
--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -27,9 +27,11 @@
 
 #include "mbedtls/ssl.h"
 
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
 #if defined(MBEDTLS_THREADING_C)
 #include "mbedtls/threading.h"
 #endif
+#endif /* !MBEDTLS_USE_PSA_CRYPTO */
 
 /**
  * \name SECTION: Module settings

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -53,6 +53,10 @@ extern "C" {
  */
 typedef struct mbedtls_ssl_cookie_ctx
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    mbedtls_svc_key_id_t    MBEDTLS_PRIVATE(psa_hmac);   /*!< key id for the HMAC portion   */
+    psa_algorithm_t         MBEDTLS_PRIVATE(psa_hmac_alg);  /*!< key algorithm for the HMAC portion   */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_md_context_t    MBEDTLS_PRIVATE(hmac_ctx);   /*!< context for the HMAC portion   */
 #if !defined(MBEDTLS_HAVE_TIME)
     unsigned long   MBEDTLS_PRIVATE(serial);     /*!< serial number for expiration   */

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -65,9 +65,11 @@ typedef struct mbedtls_ssl_cookie_ctx
     unsigned long   MBEDTLS_PRIVATE(timeout);    /*!< timeout delay, in seconds if HAVE_TIME,
                                      or in number of tickets issued */
 
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_threading_mutex_t MBEDTLS_PRIVATE(mutex);
 #endif
+#endif /* !MBEDTLS_USE_PSA_CRYPTO */
 } mbedtls_ssl_cookie_ctx;
 
 /**

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -56,7 +56,7 @@ extern "C" {
 typedef struct mbedtls_ssl_cookie_ctx
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    mbedtls_svc_key_id_t    MBEDTLS_PRIVATE(psa_hmac);   /*!< key id for the HMAC portion   */
+    mbedtls_svc_key_id_t    MBEDTLS_PRIVATE(psa_hmac_key);  /*!< key id for the HMAC portion   */
     psa_algorithm_t         MBEDTLS_PRIVATE(psa_hmac_alg);  /*!< key algorithm for the HMAC portion   */
 #else
     mbedtls_md_context_t    MBEDTLS_PRIVATE(hmac_ctx);   /*!< context for the HMAC portion   */

--- a/include/mbedtls/ssl_cookie.h
+++ b/include/mbedtls/ssl_cookie.h
@@ -56,8 +56,9 @@ typedef struct mbedtls_ssl_cookie_ctx
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_svc_key_id_t    MBEDTLS_PRIVATE(psa_hmac);   /*!< key id for the HMAC portion   */
     psa_algorithm_t         MBEDTLS_PRIVATE(psa_hmac_alg);  /*!< key algorithm for the HMAC portion   */
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#else
     mbedtls_md_context_t    MBEDTLS_PRIVATE(hmac_ctx);   /*!< context for the HMAC portion   */
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #if !defined(MBEDTLS_HAVE_TIME)
     unsigned long   MBEDTLS_PRIVATE(serial);     /*!< serial number for expiration   */
 #endif

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -121,10 +121,11 @@ int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
     if( alg == 0 )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
-    ctx->psa_hmac_alg = PSA_ALG_HMAC( alg );
+    ctx->psa_hmac_alg = PSA_ALG_TRUNCATED_MAC( PSA_ALG_HMAC( alg ),
+                                               COOKIE_HMAC_LEN );
 
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN_MESSAGE );
-    psa_set_key_algorithm( &attributes, PSA_ALG_HMAC( alg ) );
+    psa_set_key_algorithm( &attributes, ctx->psa_hmac_alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_HMAC );
     psa_set_key_bits( &attributes, PSA_BYTES_TO_BITS( COOKIE_MD_OUTLEN ) );
 

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -68,6 +68,9 @@
 
 void mbedtls_ssl_cookie_init( mbedtls_ssl_cookie_ctx *ctx )
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    ctx->psa_hmac = MBEDTLS_SVC_KEY_ID_INIT;
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_md_init( &ctx->hmac_ctx );
 #if !defined(MBEDTLS_HAVE_TIME)
     ctx->serial = 0;
@@ -86,6 +89,9 @@ void mbedtls_ssl_cookie_set_timeout( mbedtls_ssl_cookie_ctx *ctx, unsigned long 
 
 void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx )
 {
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+    psa_destroy_key( ctx->psa_hmac );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
     mbedtls_md_free( &ctx->hmac_ctx );
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -69,7 +69,7 @@
 void mbedtls_ssl_cookie_init( mbedtls_ssl_cookie_ctx *ctx )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    ctx->psa_hmac = MBEDTLS_SVC_KEY_ID_INIT;
+    ctx->psa_hmac_key = MBEDTLS_SVC_KEY_ID_INIT;
 #else
     mbedtls_md_init( &ctx->hmac_ctx );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -93,7 +93,7 @@ void mbedtls_ssl_cookie_set_timeout( mbedtls_ssl_cookie_ctx *ctx, unsigned long 
 void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    psa_destroy_key( ctx->psa_hmac );
+    psa_destroy_key( ctx->psa_hmac_key );
 #else
     mbedtls_md_free( &ctx->hmac_ctx );
 
@@ -131,7 +131,7 @@ int mbedtls_ssl_cookie_setup( mbedtls_ssl_cookie_ctx *ctx,
     psa_set_key_bits( &attributes, PSA_BYTES_TO_BITS( COOKIE_MD_OUTLEN ) );
 
     if( ( status = psa_generate_key( &attributes,
-                                     &ctx->psa_hmac ) ) != PSA_SUCCESS )
+                                     &ctx->psa_hmac_key ) ) != PSA_SUCCESS )
     {
         return psa_ssl_status_to_mbedtls( status );
     }
@@ -215,7 +215,7 @@ int mbedtls_ssl_cookie_write( void *p_ctx,
     *p += 4;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    status = psa_mac_sign_setup( &operation, ctx->psa_hmac,
+    status = psa_mac_sign_setup( &operation, ctx->psa_hmac_key,
                                  ctx->psa_hmac_alg );
     if( status != PSA_SUCCESS )
     {
@@ -298,7 +298,7 @@ int mbedtls_ssl_cookie_check( void *p_ctx,
         return( -1 );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-    status = psa_mac_verify_setup( &operation, ctx->psa_hmac,
+    status = psa_mac_verify_setup( &operation, ctx->psa_hmac_key,
                                    ctx->psa_hmac_alg );
     if( status != PSA_SUCCESS )
     {

--- a/library/ssl_cookie.c
+++ b/library/ssl_cookie.c
@@ -70,8 +70,9 @@ void mbedtls_ssl_cookie_init( mbedtls_ssl_cookie_ctx *ctx )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     ctx->psa_hmac = MBEDTLS_SVC_KEY_ID_INIT;
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#else
     mbedtls_md_init( &ctx->hmac_ctx );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 #if !defined(MBEDTLS_HAVE_TIME)
     ctx->serial = 0;
 #endif
@@ -91,8 +92,9 @@ void mbedtls_ssl_cookie_free( mbedtls_ssl_cookie_ctx *ctx )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_destroy_key( ctx->psa_hmac );
-#endif /* MBEDTLS_USE_PSA_CRYPTO */
+#else
     mbedtls_md_free( &ctx->hmac_ctx );
+#endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_THREADING_C)
     mbedtls_mutex_free( &ctx->mutex );


### PR DESCRIPTION
## Description
In `ssl_cookie.c`, when `MBEDTLS_USE_PSA_CRYPTO` is enabled, move from using the `mbedtls_md_hmac` API to the `psa_mac` API, and from using the user-provided RNG for key generation to using `psa_generate_key()`.

Resolves #5174

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Additional comments
N/A

## Todos
- [x] Implementation
- [x] Tests


## Steps to test or reproduce
`tests/ssl-opt.sh` must run clean