### PR TITLE
Backport 2.28: Fix test md api violation 2.28

### DIFF
--- a/ChangeLog.d/add-mbedtls_md_starts-to-mbedtls_md_process-test.txt
+++ b/ChangeLog.d/add-mbedtls_md_starts-to-mbedtls_md_process-test.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix API violation in mbedtls_md_process() test by adding a call to
+     mbedtls_md_starts(). Fixes #2227.

--- a/tests/suites/test_suite_md.function
+++ b/tests/suites/test_suite_md.function
@@ -31,6 +31,7 @@ void mbedtls_md_process(  )
         info = mbedtls_md_info_from_type( *md_type_ptr );
         TEST_ASSERT( info != NULL );
         TEST_ASSERT( mbedtls_md_setup( &ctx, info, 0 ) == 0 );
+        TEST_ASSERT( mbedtls_md_starts( &ctx ) == 0 );
         TEST_ASSERT( mbedtls_md_process( &ctx, buf ) == 0 );
         mbedtls_md_free( &ctx );
     }


### PR DESCRIPTION
Backport of #2229