### PR TITLE
Backport 2.28: Check storage format tests for regressions

### DIFF
--- a/docs/architecture/testing/psa-storage-format-testing.md
+++ b/docs/architecture/testing/psa-storage-format-testing.md
@@ -34,7 +34,7 @@ Use a similar approach for files other than keys where possible and relevant.
 
 Test cases should normally not be removed from the code base: if something has worked before, it should keep working in future versions, so we should keep testing it.
 
-This cannot be enforced solely by looking at a single version of Mbed TLS, since there would be no indication that more test cases used to exist. It can only be enforced through review of library changes. The review may be assisted by a tool that compares the old and the new version, in the same way that `abi-check.py` compares the library's API and ABI.
+This cannot be enforced solely by looking at a single version of Mbed TLS, since there would be no indication that more test cases used to exist. It can only be enforced through review of library changes. The review is be assisted by a tool that compares the old and the new version, which is implemented in `scripts/abi_check.py`. This tool fails the CI if load-and-check test case disappears (changed test cases are raised as false positives).
 
 If the way certain keys are stored changes, and we don't deliberately decide to stop supporting old keys (which should only be done by retiring a version of the storage format), then we should keep the corresponding test cases in load-only mode: create a file with the expected content, load it and check the data that it contains.
 

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -10,9 +10,9 @@ applying them to compare the header and library files.
 
 For the storage format, this script compares the automatically generated
 storage tests and the manual read tests, and complains if there is a
-reduction in coverage. A change in test data will be signalled as a
+reduction in coverage. A change in test data will be signaled as a
 coverage reduction since the old test data is no longer present. A change in
-how test data is presented will be signalled as well; this would be a false
+how test data is presented will be signaled as well; this would be a false
 positive.
 
 The results of the API/ABI comparison are either formatted as HTML and stored
@@ -65,7 +65,7 @@ class AbiChecker:
         configuration.report_dir: directory for output files
         configuration.keep_all_reports: if false, delete old reports
         configuration.brief: if true, output shorter report to stdout
-        configuration.check_api: if true, compare ABIs
+        configuration.check_abi: if true, compare ABIs
         configuration.check_api: if true, compare APIs
         configuration.check_storage: if true, compare storage format tests
         configuration.skip_file: path to file containing symbols and types to skip

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -249,32 +249,33 @@ class AbiChecker:
         at_paragraph_start = True
         description = None
         full_path = os.path.join(directory, filename)
-        for line_number, line in enumerate(open(full_path), 1):
-            line = line.strip()
-            if not line:
-                at_paragraph_start = True
-                continue
-            if line.startswith('#'):
-                continue
-            if at_paragraph_start:
-                description = line.strip()
-                at_paragraph_start = False
-                continue
-            if line.startswith('depends_on:'):
-                continue
-            # We've reached a test case data line
-            test_case_data = self._normalize_storage_test_case_data(line)
-            if not is_generated:
-                # In manual test data, only look at read tests.
-                function_name = test_case_data.split(':', 1)[0]
-                if 'read' not in function_name.split('_'):
+        with open(full_path) as fd:
+            for line_number, line in enumerate(fd, 1):
+                line = line.strip()
+                if not line:
+                    at_paragraph_start = True
                     continue
-            metadata = SimpleNamespace(
-                filename=filename,
-                line_number=line_number,
-                description=description
-            )
-            storage_tests[test_case_data] = metadata
+                if line.startswith('#'):
+                    continue
+                if at_paragraph_start:
+                    description = line.strip()
+                    at_paragraph_start = False
+                    continue
+                if line.startswith('depends_on:'):
+                    continue
+                # We've reached a test case data line
+                test_case_data = self._normalize_storage_test_case_data(line)
+                if not is_generated:
+                    # In manual test data, only look at read tests.
+                    function_name = test_case_data.split(':', 1)[0]
+                    if 'read' not in function_name.split('_'):
+                        continue
+                metadata = SimpleNamespace(
+                    filename=filename,
+                    line_number=line_number,
+                    description=description
+                )
+                storage_tests[test_case_data] = metadata
 
     @staticmethod
     def _list_generated_test_data_files(git_worktree_path):

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -480,7 +480,8 @@ class AbiChecker:
         """Generate a report of ABI differences
         between self.old_rev and self.new_rev."""
         self.check_repo_path()
-        self.check_abi_tools_are_installed()
+        if self.check_api or self.check_abi:
+            self.check_abi_tools_are_installed()
         self._get_abi_dump_for_ref(self.old_version)
         self._get_abi_dump_for_ref(self.new_version)
         return self.get_abi_compatibility_report()

--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 """
-Purpose
-
 This script compares the interfaces of two versions of Mbed TLS, looking
 for backward incompatibilities between two different Git revisions within
 an Mbed TLS repository. It must be run from the root of a Git working tree.
@@ -21,6 +19,8 @@ The results of the API/ABI comparison are either formatted as HTML and stored
 at a configurable location, or are given as a brief list of problems.
 Returns 0 on success, 1 on non-compliance, and 2 if there is an error
 while running the script.
+
+You must run this test from an Mbed TLS root.
 """
 
 # Copyright The Mbed TLS Contributors
@@ -490,17 +490,7 @@ class AbiChecker:
 def run_main():
     try:
         parser = argparse.ArgumentParser(
-            description=(
-                """This script is a small wrapper around the
-                abi-compliance-checker and abi-dumper tools, applying them
-                to compare the ABI and API of the library files from two
-                different Git revisions within an Mbed TLS repository.
-                The results of the comparison are either formatted as HTML and
-                stored at a configurable location, or are given as a brief list
-                of problems. Returns 0 on success, 1 on ABI/API non-compliance,
-                and 2 if there is an error while running the script.
-                Note: must be run from Mbed TLS root."""
-            )
+            description=__doc__
         )
         parser.add_argument(
             "-v", "--verbose", action="store_true",

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -264,7 +264,7 @@ class ChangeLog:
     def write(self, filename):
         """Write the changelog to the specified file.
         """
-        with open(filename, 'w') as out:
+        with open(filename, 'w', encoding='utf-8') as out:
             out.write(self.header)
             out.write(self.top_version_title)
             for title, body in self.categories.items():
@@ -407,12 +407,12 @@ def check_output(generated_output_file, main_input_file, merged_files):
     is also present in an output file. This is not perfect but good enough
     for now.
     """
-    generated_output = set(open(generated_output_file, 'r'))
-    for line in open(main_input_file, 'r'):
+    generated_output = set(open(generated_output_file, 'r', encoding='utf-8'))
+    for line in open(main_input_file, 'r', encoding='utf-8'):
         if line not in generated_output:
             raise LostContent('original file', line)
     for merged_file in merged_files:
-        for line in open(merged_file, 'r'):
+        for line in open(merged_file, 'r', encoding='utf-8'):
             if line not in generated_output:
                 raise LostContent(merged_file, line)
 
@@ -455,14 +455,14 @@ def merge_entries(options):
     Write the new changelog to options.output.
     Remove the merged entries if options.keep_entries is false.
     """
-    with open(options.input, 'r') as input_file:
+    with open(options.input, 'r', encoding='utf-8') as input_file:
         changelog = ChangeLog(input_file, TextChangelogFormat)
     files_to_merge = list_files_to_merge(options)
     if not files_to_merge:
         sys.stderr.write('There are no pending changelog entries.\n')
         return
     for filename in files_to_merge:
-        with open(filename, 'r') as input_file:
+        with open(filename, 'r', encoding='utf-8') as input_file:
             changelog.add_file(input_file)
     finish_output(changelog, options.output, options.input, files_to_merge)
     if not options.keep_entries:

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -63,15 +63,15 @@ class LostContent(Exception):
 # The category names we use in the changelog.
 # If you edit this, update ChangeLog.d/README.md.
 STANDARD_CATEGORIES = (
-    b'API changes',
-    b'Default behavior changes',
-    b'Requirement changes',
-    b'New deprecations',
-    b'Removals',
-    b'Features',
-    b'Security',
-    b'Bugfix',
-    b'Changes',
+    'API changes',
+    'Default behavior changes',
+    'Requirement changes',
+    'New deprecations',
+    'Removals',
+    'Features',
+    'Security',
+    'Bugfix',
+    'Changes',
 )
 
 # The maximum line length for an entry
@@ -122,13 +122,13 @@ class ChangelogFormat:
 class TextChangelogFormat(ChangelogFormat):
     """The traditional Mbed TLS changelog format."""
 
-    _unreleased_version_text = b'= mbed TLS x.x.x branch released xxxx-xx-xx'
+    _unreleased_version_text = '= mbed TLS x.x.x branch released xxxx-xx-xx'
     @classmethod
     def is_released_version(cls, title):
         # Look for an incomplete release date
-        return not re.search(br'[0-9x]{4}-[0-9x]{2}-[0-9x]?x', title)
+        return not re.search(r'[0-9x]{4}-[0-9x]{2}-[0-9x]?x', title)
 
-    _top_version_re = re.compile(br'(?:\A|\n)(=[^\n]*\n+)(.*?\n)(?:=|$)',
+    _top_version_re = re.compile(r'(?:\A|\n)(=[^\n]*\n+)(.*?\n)(?:=|$)',
                                  re.DOTALL)
     @classmethod
     def extract_top_version(cls, changelog_file_content):
@@ -140,17 +140,17 @@ class TextChangelogFormat(ChangelogFormat):
         top_version_body = m.group(2)
         if cls.is_released_version(top_version_title):
             top_version_end = top_version_start
-            top_version_title = cls._unreleased_version_text + b'\n\n'
-            top_version_body = b''
+            top_version_title = cls._unreleased_version_text + '\n\n'
+            top_version_body = ''
         return (changelog_file_content[:top_version_start],
                 top_version_title, top_version_body,
                 changelog_file_content[top_version_end:])
 
     @classmethod
     def version_title_text(cls, version_title):
-        return re.sub(br'\n.*', version_title, re.DOTALL)
+        return re.sub(r'\n.*', version_title, re.DOTALL)
 
-    _category_title_re = re.compile(br'(^\w.*)\n+', re.MULTILINE)
+    _category_title_re = re.compile(r'(^\w.*)\n+', re.MULTILINE)
     @classmethod
     def split_categories(cls, version_body):
         """A category title is a line with the title in column 0."""
@@ -163,10 +163,10 @@ class TextChangelogFormat(ChangelogFormat):
         title_starts = [m.start(1) for m in title_matches]
         body_starts = [m.end(0) for m in title_matches]
         body_ends = title_starts[1:] + [len(version_body)]
-        bodies = [version_body[body_start:body_end].rstrip(b'\n') + b'\n'
+        bodies = [version_body[body_start:body_end].rstrip('\n') + '\n'
                   for (body_start, body_end) in zip(body_starts, body_ends)]
-        title_lines = [version_body[:pos].count(b'\n') for pos in title_starts]
-        body_lines = [version_body[:pos].count(b'\n') for pos in body_starts]
+        title_lines = [version_body[:pos].count('\n') for pos in title_starts]
+        body_lines = [version_body[:pos].count('\n') for pos in body_starts]
         return [CategoryContent(title_match.group(1), title_line,
                                 body, body_line)
                 for title_match, title_line, body, body_line
@@ -176,9 +176,9 @@ class TextChangelogFormat(ChangelogFormat):
     def format_category(cls, title, body):
         # `split_categories` ensures that each body ends with a newline.
         # Make sure that there is additionally a blank line between categories.
-        if not body.endswith(b'\n\n'):
-            body += b'\n'
-        return title + b'\n' + body
+        if not body.endswith('\n\n'):
+            body += '\n'
+        return title + '\n' + body
 
 class ChangeLog:
     """An Mbed TLS changelog.
@@ -199,10 +199,10 @@ class ChangeLog:
     # Only accept dotted version numbers (e.g. "3.1", not "3").
     # Refuse ".x" in a version number where x is a letter: this indicates
     # a version that is not yet released. Something like "3.1a" is accepted.
-    _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
-    _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
-    _only_url_re = re.compile(br'^\s*\w+://\S+\s*$')
-    _has_url_re = re.compile(br'.*://.*')
+    _version_number_re = re.compile(r'[0-9]+\.[0-9A-Za-z.]+')
+    _incomplete_version_number_re = re.compile(r'.*\.[A-Za-z]')
+    _only_url_re = re.compile(r'^\s*\w+://\S+\s*$')
+    _has_url_re = re.compile(r'.*://.*')
 
     def add_categories_from_text(self, filename, line_offset,
                                  text, allow_unknown_category):
@@ -218,7 +218,7 @@ class ChangeLog:
                 raise InputFormatError(filename,
                                        line_offset + category.title_line,
                                        'Unknown category: "{}"',
-                                       category.name.decode('utf8'))
+                                       category.name)
 
             body_split = category.body.splitlines()
 
@@ -250,8 +250,8 @@ class ChangeLog:
         # Split the top version section into categories.
         self.categories = OrderedDict()
         for category in STANDARD_CATEGORIES:
-            self.categories[category] = b''
-        offset = (self.header + self.top_version_title).count(b'\n') + 1
+            self.categories[category] = ''
+        offset = (self.header + self.top_version_title).count('\n') + 1
         self.add_categories_from_text(input_stream.name, offset,
                                       top_version_body, True)
 
@@ -264,7 +264,7 @@ class ChangeLog:
     def write(self, filename):
         """Write the changelog to the specified file.
         """
-        with open(filename, 'wb') as out:
+        with open(filename, 'w') as out:
             out.write(self.header)
             out.write(self.top_version_title)
             for title, body in self.categories.items():
@@ -303,7 +303,7 @@ class EntryFileSortKey:
         hashes = subprocess.check_output(['git', 'log', '--format=%H',
                                           '--follow',
                                           '--', filename])
-        m = re.search(b'(.+)$', hashes)
+        m = re.search('(.+)$', hashes.decode('ascii'))
         if not m:
             # The git output is empty. This means that the file was
             # never checked in.
@@ -320,8 +320,8 @@ class EntryFileSortKey:
         """
         text = subprocess.check_output(['git', 'rev-list',
                                         '--merges', *options,
-                                        b'..'.join([some_hash, target])])
-        return text.rstrip(b'\n').split(b'\n')
+                                        '..'.join([some_hash, target])])
+        return text.decode('ascii').rstrip('\n').split('\n')
 
     @classmethod
     def merge_hash(cls, some_hash):
@@ -329,7 +329,7 @@ class EntryFileSortKey:
 
         Return None if the given commit was never merged.
         """
-        target = b'HEAD'
+        target = 'HEAD'
         # List the merges from some_hash to the target in two ways.
         # The ancestry list is the ones that are both descendants of
         # some_hash and ancestors of the target.
@@ -407,12 +407,12 @@ def check_output(generated_output_file, main_input_file, merged_files):
     is also present in an output file. This is not perfect but good enough
     for now.
     """
-    generated_output = set(open(generated_output_file, 'rb'))
-    for line in open(main_input_file, 'rb'):
+    generated_output = set(open(generated_output_file, 'r'))
+    for line in open(main_input_file, 'r'):
         if line not in generated_output:
             raise LostContent('original file', line)
     for merged_file in merged_files:
-        for line in open(merged_file, 'rb'):
+        for line in open(merged_file, 'r'):
             if line not in generated_output:
                 raise LostContent(merged_file, line)
 
@@ -455,14 +455,14 @@ def merge_entries(options):
     Write the new changelog to options.output.
     Remove the merged entries if options.keep_entries is false.
     """
-    with open(options.input, 'rb') as input_file:
+    with open(options.input, 'r') as input_file:
         changelog = ChangeLog(input_file, TextChangelogFormat)
     files_to_merge = list_files_to_merge(options)
     if not files_to_merge:
         sys.stderr.write('There are no pending changelog entries.\n')
         return
     for filename in files_to_merge:
-        with open(filename, 'rb') as input_file:
+        with open(filename, 'r') as input_file:
             changelog.add_file(input_file)
     finish_output(changelog, options.output, options.input, files_to_merge)
     if not options.keep_entries:

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -407,14 +407,17 @@ def check_output(generated_output_file, main_input_file, merged_files):
     is also present in an output file. This is not perfect but good enough
     for now.
     """
-    generated_output = set(open(generated_output_file, 'r', encoding='utf-8'))
-    for line in open(main_input_file, 'r', encoding='utf-8'):
-        if line not in generated_output:
-            raise LostContent('original file', line)
-    for merged_file in merged_files:
-        for line in open(merged_file, 'r', encoding='utf-8'):
-            if line not in generated_output:
-                raise LostContent(merged_file, line)
+    with open(generated_output_file, 'r', encoding='utf-8') as out_fd:
+        generated_output = set(out_fd)
+        with open(main_input_file, 'r', encoding='utf-8') as in_fd:
+            for line in in_fd:
+                if line not in generated_output:
+                    raise LostContent('original file', line)
+        for merged_file in merged_files:
+            with open(merged_file, 'r', encoding='utf-8') as in_fd:
+                for line in in_fd:
+                    if line not in generated_output:
+                        raise LostContent(merged_file, line)
 
 def finish_output(changelog, output_file, input_file, merged_files):
     """Write the changelog to the output file.

--- a/scripts/mbedtls_dev/macro_collector.py
+++ b/scripts/mbedtls_dev/macro_collector.py
@@ -18,7 +18,7 @@
 
 import itertools
 import re
-from typing import Dict, Iterable, Iterator, List, Optional, Pattern, Set, Tuple, Union
+from typing import Dict, IO, Iterable, Iterator, List, Optional, Pattern, Set, Tuple, Union
 
 
 class ReadFileLineException(Exception):
@@ -50,12 +50,13 @@ class read_file_lines:
     """
     def __init__(self, filename: str, binary: bool = False) -> None:
         self.filename = filename
+        self.file = None #type: Optional[IO[str]]
         self.line_number = 'entry' #type: Union[int, str]
         self.generator = None #type: Optional[Iterable[Tuple[int, str]]]
         self.binary = binary
     def __enter__(self) -> 'read_file_lines':
-        self.generator = enumerate(open(self.filename,
-                                        'rb' if self.binary else 'r'))
+        self.file = open(self.filename, 'rb' if self.binary else 'r')
+        self.generator = enumerate(self.file)
         return self
     def __iter__(self) -> Iterator[str]:
         assert self.generator is not None
@@ -64,6 +65,8 @@ class read_file_lines:
             yield content
         self.line_number = 'exit'
     def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        if self.file is not None:
+            self.file.close()
         if exc_type is not None:
             raise ReadFileLineException(self.filename, self.line_number) \
                 from exc_value

--- a/scripts/min_requirements.py
+++ b/scripts/min_requirements.py
@@ -56,18 +56,19 @@ class Requirements:
         * Comments (``#`` at the beginning of the line or after whitespace).
         * ``-r FILENAME`` to include another file.
         """
-        for line in open(filename):
-            line = line.strip()
-            line = re.sub(r'(\A|\s+)#.*', r'', line)
-            if not line:
-                continue
-            m = re.match(r'-r\s+', line)
-            if m:
-                nested_file = os.path.join(os.path.dirname(filename),
-                                           line[m.end(0):])
-                self.add_file(nested_file)
-                continue
-            self.requirements.append(self.adjust_requirement(line))
+        with open(filename) as fd:
+            for line in fd:
+                line = line.strip()
+                line = re.sub(r'(\A|\s+)#.*', r'', line)
+                if not line:
+                    continue
+                m = re.match(r'-r\s+', line)
+                if m:
+                    nested_file = os.path.join(os.path.dirname(filename),
+                                               line[m.end(0):])
+                    self.add_file(nested_file)
+                    continue
+                self.requirements.append(self.adjust_requirement(line))
 
     def write(self, out: typing_util.Writable) -> None:
         """List the gathered requirements."""

--- a/tests/scripts/generate_psa_tests.py
+++ b/tests/scripts/generate_psa_tests.py
@@ -723,6 +723,8 @@ class TestGenerator:
         filename = self.filename_for(basename)
         test_case.write_data_file(filename, test_cases)
 
+    # Note that targets whose name containns 'test_format' have their content
+    # validated by `abi_check.py`.
     TARGETS = {
         'test_suite_psa_crypto_generate_key.generated':
         lambda info: KeyGenerate(info).test_cases_for_key_generation(),


### PR DESCRIPTION
Trivial backport of #4408. Before that, two commits from #4395 to re-align `assemble_changelog.py`.