### PR TITLE
TLS Cipher 2a: tickets: use PSA for protection

### DIFF
--- a/include/mbedtls/ssl_ticket.h
+++ b/include/mbedtls/ssl_ticket.h
@@ -34,6 +34,10 @@
 #include "mbedtls/ssl.h"
 #include "mbedtls/cipher.h"
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#include "psa/crypto.h"
+#endif
+
 #if defined(MBEDTLS_THREADING_C)
 #include "mbedtls/threading.h"
 #endif
@@ -53,7 +57,14 @@ typedef struct mbedtls_ssl_ticket_key
     unsigned char MBEDTLS_PRIVATE(name)[MBEDTLS_SSL_TICKET_KEY_NAME_BYTES];
                                                      /*!< random key identifier              */
     uint32_t MBEDTLS_PRIVATE(generation_time);       /*!< key generation timestamp (seconds) */
+#if !defined(MBEDTLS_USE_PSA_CRYPTO)
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(ctx);   /*!< context for auth enc/decryption    */
+#else
+    mbedtls_svc_key_id_t MBEDTLS_PRIVATE(key);       /*!< key used for auth enc/decryption   */
+    psa_algorithm_t MBEDTLS_PRIVATE(alg);            /*!< algorithm of auth enc/decryption   */
+    psa_key_type_t MBEDTLS_PRIVATE(key_type);        /*!< key type                           */
+    size_t MBEDTLS_PRIVATE(key_bits);                /*!< key length in bits                 */
+#endif
 }
 mbedtls_ssl_ticket_key;
 

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -162,7 +162,7 @@ int mbedtls_ssl_ticket_rotate( mbedtls_ssl_ticket_context *ctx,
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    const int bitlen = key->key_bits;
+    const size_t bitlen = key->key_bits;
 #else
     const int bitlen = mbedtls_cipher_get_key_bitlen( &key->ctx );
 #endif

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -166,7 +166,7 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
 
     ctx->ticket_lifetime = lifetime;
 
-    cipher_info = mbedtls_cipher_info_from_type( cipher);
+    cipher_info = mbedtls_cipher_info_from_type( cipher );
 
     if( mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_GCM &&
         mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_CCM )

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -236,7 +236,8 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     cipher_info = mbedtls_cipher_info_from_type( cipher );
 
     if( mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_GCM &&
-        mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_CCM )
+        mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_CCM &&
+        mbedtls_cipher_info_get_mode( cipher_info ) != MBEDTLS_MODE_CHACHAPOLY )
     {
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
     }

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -88,7 +88,6 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
         return( ret );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
     psa_set_key_usage_flags( &attributes,
                              PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT );
     psa_set_key_algorithm( &attributes, key->alg );
@@ -99,14 +98,11 @@ static int ssl_ticket_gen_key( mbedtls_ssl_ticket_context *ctx,
             psa_import_key( &attributes, buf,
                             PSA_BITS_TO_BYTES( key->key_bits ),
                             &key->key ) );
-
 #else
-
     /* With GCM and CCM, same context can encrypt & decrypt */
     ret = mbedtls_cipher_setkey( &key->ctx, buf,
                                  mbedtls_cipher_get_key_bitlen( &key->ctx ),
                                  MBEDTLS_ENCRYPT );
-
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     mbedtls_platform_zeroize( buf, sizeof( buf ) );
@@ -140,11 +136,9 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
         ctx->active = 1 - ctx->active;
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
         if( ( ret = psa_ssl_status_to_mbedtls(
                         psa_destroy_key( ctx->keys[ctx->active].key ) ) ) != 0 )
             return( ret );
-
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
         return( ssl_ticket_gen_key( ctx, ctx->active ) );
@@ -177,7 +171,6 @@ int mbedtls_ssl_ticket_rotate( mbedtls_ssl_ticket_context *ctx,
         return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
     if( ( ret = psa_ssl_status_to_mbedtls(
                     psa_destroy_key( key->key ) ) ) != 0 )
         return( ret );
@@ -193,13 +186,10 @@ int mbedtls_ssl_ticket_rotate( mbedtls_ssl_ticket_context *ctx,
                                     PSA_BITS_TO_BYTES( key->key_bits ),
                                     &key->key ) ) ) != 0 )
         return( ret );
-
 #else
-
     ret = mbedtls_cipher_setkey( &key->ctx, k, bitlen, MBEDTLS_ENCRYPT );
     if( ret != 0 )
         return( ret );
-
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     ctx->active = idx;
@@ -246,7 +236,6 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
     if( mbedtls_ssl_cipher_to_psa( cipher_info->type, TICKET_AUTH_TAG_BYTES,
                                    &alg, &key_type, &key_bits ) != PSA_SUCCESS )
         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
@@ -258,15 +247,12 @@ int mbedtls_ssl_ticket_setup( mbedtls_ssl_ticket_context *ctx,
     ctx->keys[1].alg = alg;
     ctx->keys[1].key_type = key_type;
     ctx->keys[1].key_bits = key_bits;
-
 #else
-
     if( ( ret = mbedtls_cipher_setup( &ctx->keys[0].ctx, cipher_info ) ) != 0 )
         return( ret );
 
     if( ( ret = mbedtls_cipher_setup( &ctx->keys[1].ctx, cipher_info ) ) != 0 )
         return( ret );
-
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if( ( ret = ssl_ticket_gen_key( ctx, 0 ) ) != 0 ||
@@ -506,15 +492,11 @@ cleanup:
 void mbedtls_ssl_ticket_free( mbedtls_ssl_ticket_context *ctx )
 {
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
     psa_destroy_key( ctx->keys[0].key );
     psa_destroy_key( ctx->keys[1].key );
-
 #else
-
     mbedtls_cipher_free( &ctx->keys[0].ctx );
     mbedtls_cipher_free( &ctx->keys[1].ctx );
-
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_THREADING_C)

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -138,7 +138,7 @@ static int ssl_ticket_update_keys( mbedtls_ssl_ticket_context *ctx )
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if( ( status = psa_destroy_key( ctx->keys[ctx->active].key ) ) != PSA_SUCCESS )
         {
-            return psa_ssl_status_to_mbedtls( ret );
+            return psa_ssl_status_to_mbedtls( status );
         }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
@@ -185,9 +185,9 @@ int mbedtls_ssl_ticket_rotate( mbedtls_ssl_ticket_context *ctx,
     psa_set_key_type( &attributes, key->key_type );
     psa_set_key_bits( &attributes, key->key_bits );
 
-    if( ( ret = psa_import_key( &attributes, k,
-                                PSA_BITS_TO_BYTES( key->key_bits ),
-                                &key->key ) ) != PSA_SUCCESS )
+    if( ( status = psa_import_key( &attributes, k,
+                                   PSA_BITS_TO_BYTES( key->key_bits ),
+                                   &key->key ) ) != PSA_SUCCESS )
     {
         ret = psa_ssl_status_to_mbedtls( status );
         return( ret );

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -2816,7 +2816,6 @@ run_test    "Session resume using tickets: basic" \
             -c "a session has been resumed"
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
-requires_config_disabled MBEDTLS_USE_PSA_CRYPTO
 run_test    "Session resume using tickets: manual rotation" \
             "$P_SRV debug_level=3 tickets=1 ticket_rotate=1" \
             "$P_CLI debug_level=3 tickets=1 reconnect=1" \

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -3108,6 +3108,21 @@ run_test    "Session resume using tickets: ARIA-256-CCM" \
             -s "a session has been resumed" \
             -c "a session has been resumed"
 
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "Session resume using tickets: CHACHA20-POLY1305" \
+            "$P_SRV debug_level=3 tickets=1 ticket_aead=CHACHA20-POLY1305" \
+            "$P_CLI debug_level=3 tickets=1 reconnect=1" \
+            0 \
+            -c "client hello, adding session ticket extension" \
+            -s "found session ticket extension" \
+            -s "server hello, adding session ticket extension" \
+            -c "found session_ticket extension" \
+            -c "parse new session ticket" \
+            -S "session successfully restored from cache" \
+            -s "session successfully restored from ticket" \
+            -s "a session has been resumed" \
+            -c "a session has been resumed"
+
 # Tests for Session Tickets with DTLS
 
 requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2


### PR DESCRIPTION
## Description
In `ssl_ticket.c`, use `psa_aead` instead of `mbedtls_cipher` in order to protect tickets when `MBEDTLS_USE_PSA_CRYPTO` is enabled.

Resolve #5203 