### PR TITLE
Accessor for mbedtls_timing_delay_context final delay

### DIFF
--- a/ChangeLog.d/add_final_delay_accessor
+++ b/ChangeLog.d/add_final_delay_accessor
@@ -1,0 +1,4 @@
+Features
+   * Add the function mbedtls_timing_get_final_delay() to access the private
+     final delay field in an mbedtls_timing_delay_context, as requested in
+     #5183

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -90,6 +90,17 @@ void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms );
  */
 int mbedtls_timing_get_delay( void *data );
 
+/**
+ * \brief          Get the final timing delay
+ *
+ * \param data     Pointer to timing data
+ *                 Must point to a valid \c mbedtls_timing_delay_context struct.
+ *
+ * \return         Final timing delay in milliseconds.
+ */
+uint32_t mbedtls_timing_get_final_delay(
+                                     const mbedtls_timing_delay_context *data );
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/timing.c
+++ b/library/timing.c
@@ -158,13 +158,28 @@ int mbedtls_timing_get_delay( void *data )
 
     return( 0 );
 }
-#else
-int mbedtls_timing_get_delay( void *data )
+
+/*
+ * Get the final delay.
+ */
+uint32_t mbedtls_timing_get_final_delay(
+                                      const mbedtls_timing_delay_context *data )
+{
+    return( data->fin_ms );
+}
+#else /* MBEDTLS_HAVE_TIME */
+uint32_t mbedtls_timing_get_final_delay(
+                                      const mbedtls_timing_delay_context *data )
 {
     (void) data;
     return( 0 );
 }
 
+int mbedtls_timing_get_delay( void *data )
+{
+    (void) data;
+    return( 0 );
+}
 void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms )
 {
     (void) data;
@@ -178,6 +193,7 @@ unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int 
     (void) reset;
     return( 0 );
 }
+
 #endif /* MBEDTLS_HAVE_TIME */
 #endif /* !MBEDTLS_TIMING_ALT */
 #endif /* MBEDTLS_TIMING_C */

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -4779,3 +4779,6 @@ conf_curve:
 
 Test configuration of groups for DHE through mbedtls_ssl_conf_groups()
 conf_group:
+
+Test accessor into timing_delay_context
+timing_accessor

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -4781,4 +4781,4 @@ Test configuration of groups for DHE through mbedtls_ssl_conf_groups()
 conf_group:
 
 Test accessor into timing_delay_context
-timing_accessor
+timing_final_delay_accessor

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5279,7 +5279,7 @@ void conf_group()
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_TIMING_C:MBEDTLS_HAVE_TIME */
-void timing_accessor( )
+void timing_final_delay_accessor( )
 {
     mbedtls_timing_delay_context    delay_context;
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -5277,3 +5277,14 @@ void conf_group()
     mbedtls_ssl_config_free( &conf );
 }
 /* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_TIMING_C:MBEDTLS_HAVE_TIME */
+void timing_accessor( )
+{
+    mbedtls_timing_delay_context    delay_context;
+
+    mbedtls_timing_set_delay( &delay_context, 50, 100 );
+
+    TEST_ASSERT( mbedtls_timing_get_final_delay( &delay_context ) == 100 );
+}
+/* END_CASE */


### PR DESCRIPTION
## Description
Add an accessor for mbedtls_timing_delay_context final delay (fin_ms) as requested in #5183 

Add a simple test for this in test_suite_ssl

This closes #5183 

## Status
**READY**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [ ] Tests
- [x] Changelog updated

## Steps to test or reproduce
test_suite_ssl should run clean.
