### PR TITLE
Restore full TLS compatibility testing

### DIFF
--- a/library/ssl_srv.c
+++ b/library/ssl_srv.c
@@ -2047,12 +2047,6 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
     const mbedtls_cipher_info_t *cipher = NULL;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-    if( ssl->session_negotiate->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED )
-    {
-        *olen = 0;
-        return;
-    }
-
     /*
      * RFC 7366: "If a server receives an encrypt-then-MAC request extension
      * from a client and then selects a stream or Authenticated Encryption
@@ -2069,6 +2063,11 @@ static void ssl_write_encrypt_then_mac_ext( mbedtls_ssl_context *ssl,
         ( cipher = mbedtls_cipher_info_from_type( suite->cipher ) ) == NULL ||
         cipher->mode != MBEDTLS_MODE_CBC )
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
+    {
+        ssl->session_negotiate->encrypt_then_mac = MBEDTLS_SSL_ETM_DISABLED;
+    }
+
+    if( ssl->session_negotiate->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED )
     {
         *olen = 0;
         return;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7450,9 +7450,9 @@ static int ssl_tls12_populate_transform( mbedtls_ssl_transform *transform,
             goto end;
         }
 
-        if( ( transform->psa_alg == MBEDTLS_SSL_NULL_CIPHER ||
-              transform->psa_alg == PSA_ALG_CBC_NO_PADDING ) &&
-            transform->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED )
+        if( ( transform->psa_alg == MBEDTLS_SSL_NULL_CIPHER ) ||
+            ( ( transform->psa_alg == PSA_ALG_CBC_NO_PADDING ) &&
+              ( transform->encrypt_then_mac == MBEDTLS_SSL_ETM_DISABLED ) ) )
             /* mbedtls_ct_hmac() requires the key to be exportable */
             psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_EXPORT |
                                                   PSA_KEY_USAGE_VERIFY_HASH );

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -213,15 +213,6 @@ filter_ciphersuites()
         G_CIPHERS=$( filter "$G_CIPHERS" )
     fi
 
-    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check what OpenSSL
-    # supports from the s_server help. (The s_client help isn't
-    # accurate as of 1.0.2g: it supports DTLS 1.2 but doesn't list it.
-    # But the s_server help seems to be accurate.)
-    if ! $OPENSSL_CMD s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
-        M_CIPHERS=""
-        O_CIPHERS=""
-    fi
-
     # For GnuTLS client -> mbed TLS server,
     # we need to force IPv4 by connecting to 127.0.0.1 but then auth fails
     if [ "X$VERIFY" = "XYES" ] && is_dtls "$MODE"; then
@@ -1077,6 +1068,15 @@ for VERIFY in $VERIFIES; do
                 [Oo]pen*)
 
                     if test "$OSSL_NO_DTLS" -gt 0 && is_dtls "$MODE"; then
+                        continue;
+                    fi
+
+                    # OpenSSL <1.0.2 doesn't support DTLS 1.2. Check if OpenSSL
+                    # supports $O_MODE from the s_server help. (The s_client
+                    # help isn't accurate as of 1.0.2g: it supports DTLS 1.2
+                    # but doesn't list it. But the s_server help seems to be
+                    # accurate.)
+                    if ! $OPENSSL_CMD s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
                         continue;
                     fi
 

--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -217,7 +217,7 @@ filter_ciphersuites()
     # supports from the s_server help. (The s_client help isn't
     # accurate as of 1.0.2g: it supports DTLS 1.2 but doesn't list it.
     # But the s_server help seems to be accurate.)
-    if ! $OPENSSL_CMD s_server -help 2>&1 | grep -q "^ *-$MODE "; then
+    if ! $OPENSSL_CMD s_server -help 2>&1 | grep -q "^ *-$O_MODE "; then
         M_CIPHERS=""
         O_CIPHERS=""
     fi
@@ -631,12 +631,15 @@ add_mbedtls_ciphersuites()
 
 setup_arguments()
 {
+    O_MODE=""
     G_MODE=""
     case "$MODE" in
         "tls12")
+            O_MODE="tls1_2"
             G_PRIO_MODE="+VERS-TLS1.2"
             ;;
         "dtls12")
+            O_MODE="dtls1_2"
             G_PRIO_MODE="+VERS-DTLS1.2"
             G_MODE="-u"
             ;;
@@ -653,7 +656,7 @@ setup_arguments()
     fi
 
     M_SERVER_ARGS="server_port=$PORT server_addr=0.0.0.0 force_version=$MODE"
-    O_SERVER_ARGS="-accept $PORT -cipher NULL,ALL -$MODE"
+    O_SERVER_ARGS="-accept $PORT -cipher NULL,ALL -$O_MODE"
     G_SERVER_ARGS="-p $PORT --http $G_MODE"
     G_SERVER_PRIO="NORMAL:${G_PRIO_CCM}+NULL:+MD5:+PSK:+DHE-PSK:+ECDHE-PSK:+SHA256:+SHA384:+RSA-PSK:-VERS-TLS-ALL:$G_PRIO_MODE"
 
@@ -678,7 +681,7 @@ setup_arguments()
     fi
 
     M_CLIENT_ARGS="server_port=$PORT server_addr=127.0.0.1 force_version=$MODE"
-    O_CLIENT_ARGS="-connect localhost:$PORT -$MODE"
+    O_CLIENT_ARGS="-connect localhost:$PORT -$O_MODE"
     G_CLIENT_ARGS="-p $PORT --debug 3 $G_MODE"
     G_CLIENT_PRIO="NONE:$G_PRIO_MODE:+COMP-NULL:+CURVE-ALL:+SIGN-ALL"
 


### PR DESCRIPTION
## Description
Restore full TLS compatibility testing that was broken in #5166 / #5262. Fixes #5629.

## Status
IN DEVELOPMENT

## Requires Backporting
Yes
Which branch: [2.28](https://github.com/ARMmbed/mbedtls/pull/5660)