### PR TITLE
Fix comment typo in threading.c

### DIFF
--- a/library/threading.c
+++ b/library/threading.c
@@ -113,7 +113,7 @@ int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t * ) = threading_mutex_lock_
 int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_unlock_pthread;
 
 /*
- * With phtreads we can statically initialize mutexes
+ * With pthreads we can statically initialize mutexes
  */
 #define MUTEX_INIT  = { PTHREAD_MUTEX_INITIALIZER, 1 }
 


### PR DESCRIPTION
Fixes #5349
sorry about the exessive pull requests, its my first issue fix i have done.
Signed-off-by: Artur Allmann <Artur.Allmann@tptlive.ee>

Notes:
* Pull requests cannot be accepted until the PR follows the [contributing guidelines](../CONTRIBUTING.md). In particular, each commit must have at least one `Signed-off-by:` line from the committer to certify that the contribution is made under the terms of the [Developer Certificate of Origin](../dco.txt).
* This is just a template, so feel free to use/remove the unnecessary things
## Description
fixed typo in /library/threading.c


## Status
**READY**

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO  
Which branch?
development
## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
again, sorry about the exessive commits and pull requests, its my first commit and i have been struggling with the signing part.

## Todos
- [x] Backported
