### PR TITLE
Fix an off-by-one error in ssl-opt.sh

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1164,7 +1164,8 @@ run_test() {
 
     analyze_test_commands "$@"
 
-    TIMES_LEFT=2
+    # One regular run and two retries
+    TIMES_LEFT=3
     while [ $TIMES_LEFT -gt 0 ]; do
         TIMES_LEFT=$(( $TIMES_LEFT - 1 ))
 


### PR DESCRIPTION
Explain and fix the number of test runs in ssl-opt.sh, as was originally intended.
Probably fixes https://github.com/Mbed-TLS/mbedtls/issues/5279.