### PR TITLE
[Backport 2.28] Fix a bug with executing ssl-client2 in ssl-opt.sh in a subshell

### DIFF
--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -1002,7 +1002,11 @@ do_run_test_once() {
     wait_server_start "$SRV_PORT" "$SRV_PID"
 
     printf '# %s\n%s\n' "$NAME" "$CLI_CMD" > $CLI_OUT
-    eval "$CLI_CMD" >> $CLI_OUT 2>&1 &
+    # The client must be a subprocess of the script in order for killing it to
+    # work properly, that's why the ampersand is placed inside the eval command,
+    # not at the end of the line: the latter approach will spawn eval as a
+    # subprocess, and the $CLI_CMD as a grandchild.
+    eval "$CLI_CMD &" >> $CLI_OUT 2>&1
     wait_client_done
 
     sleep 0.05


### PR DESCRIPTION
Backport of https://github.com/Mbed-TLS/mbedtls/pull/5892
When executing eval in the background, the next "$!" gives the eval PID, not the ssl-client2 pid. This causes problems when a client times out and the script tries to kill it. Instead, it kills the parent eval call. This caused problems with subsequent proxy tests receiving old packets from a client from a previous test. Moving the "&" to inside the eval call fixes the problem.