### PR TITLE
Remove 'no_test' as dependency of the 'install' make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(VISUALC_FILES):
 	$(PERL) scripts/generate_visualc_files.pl
 
 ifndef WINDOWS
-install: no_test
+install:
 	mkdir -p $(DESTDIR)/include/mbedtls
 	cp -rp include/mbedtls $(DESTDIR)/include
 	mkdir -p $(DESTDIR)/include/psa


### PR DESCRIPTION
I do:

    make lib
    make install

and it builds and installs the libraries *and programs* because `no_test` depends on `programs`.

However, I am building for Android, and only want the libraries. (There is a problem building the programs for Android, I'll open an issue about that later.)

[The Makefile](https://github.com/Mbed-TLS/mbedtls/blob/development/Makefile#L58) already contains this logic for handling both cases when the programs are built or not:

        mkdir -p $(DESTDIR)/bin
        for p in programs/*/* ; do              \
            if [ -x $$p ] && [ ! -d $$p ] ;     \
            then                                \
                f=$(PREFIX)`basename $$p` ;     \
                cp $$p $(DESTDIR)/bin/$$f ;     \
            fi                                  \
        done

Signed-off-by: Mansour Moufid
