### PR TITLE
Fix usage of ASSERT_ALLOC()

### DIFF
--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -779,7 +779,7 @@ void free_named_data_list( int length )
     for( i = 0; i < length; i++ )
     {
         mbedtls_asn1_named_data *new = NULL;
-        ASSERT_ALLOC( new, sizeof( mbedtls_asn1_named_data ) );
+        ASSERT_ALLOC( new, 1 );
         new->next = head;
         head = new;
     }

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -137,7 +137,7 @@ void init_handshake_options( handshake_test_options *opts )
     opts->resize_buffers = 1;
 #if defined(MBEDTLS_SSL_CACHE_C)
     opts->cache = NULL;
-    ASSERT_ALLOC( opts->cache, sizeof( mbedtls_ssl_cache_context ) );
+    ASSERT_ALLOC( opts->cache, 1 );
     mbedtls_ssl_cache_init( opts->cache );
 exit:
     return;


### PR DESCRIPTION
The second argument is the number of elements of the type the first argument is pointing to, so we shouldn't be using sizeof there.

This was resulting in overly large allocations.

* Backport: 2.28 #6420
* ChangeLog: no, only affects the test suites
