### PR TITLE
Improve python and pip instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ The source code of Mbed TLS includes some files that are automatically generated
 The following tools are required:
 
 * Perl, for some library source files and for Visual Studio build files.
-* Python 3 and some Python packages, for some library source files, sample programs and test data. To install the necessary packages, run
+* Python 3 and some Python packages, for some library source files, sample programs and test data. To install the necessary packages, run:
     ```
-    python -m pip install -r scripts/basic.requirements.txt
+    python3 -m pip install --user -r scripts/basic.requirements.txt
     ```
+    Depending on your Python installation, you may need to invoke `python` instead of `python3`. To install the packages system-wide, omit the `--user` option.
 * A C compiler for the host platform, for some test data.
 
 If you are cross-compiling, you must set the `CC` environment variable to a C compiler for the host platform when generating the configuration-independent files.


### PR DESCRIPTION
Make the python/pip instructions more informative for readers who don't know Python well. Default to the safest method in the sample command:

* For users who are unaware, it's easier to figure out that they need to replace `python3` by `python` if no `python3` command is available, than to figure out that the reason the necessary packages don't appear to be installed is that running `python` only installed Python 2 packages.
* Casual users should install Python packages in their home directory. Venv users are more likely to be familiar with pip options.

## Gatekeeper checklist

- [x] **changelog** N/A (documentation only)
- [x] **backport** no (not present in 2.28)
- [x] **tests** N/A (documentation clarity only)
