### PR TITLE
ecp: Updated ecp384 depedency macro

### DIFF
--- a/tests/suites/test_suite_ecp.function
+++ b/tests/suites/test_suite_ecp.function
@@ -1430,7 +1430,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_ECP_DP_SECP384R1_ENABLED */
 void ecp_mod_p384_raw(char *input_N,
                       char *input_X,
                       char *result)


### PR DESCRIPTION

## Description

`ecp_mod_p384_raw()` test function [introduced ](https://github.com/Mbed-TLS/mbedtls/pull/7222/files#diff-319a7ecb80b6bdc20ff02e745aad4b06586f702749e3459f67a28c59b5855e6a) by PR #7222 will cause issues when PSA ACCEL is enabled as discovered in #[7103](https://github.com/Mbed-TLS/mbedtls/pull/7103)

This PR addresses resolves that.

## Gatekeeper checklist

- [x] **changelog** not required
- [x]  **backport** not required ( New Interface)
- [x] **tests** provided ( The PR is updating the existing test code )



