### PR TITLE
[Backport 2.28] Add clangd compilation databases to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ massif-*
 /TAGS
 /cscope*.out
 /tags
+
+# Clangd compilation database
+compile_commands.json


### PR DESCRIPTION
Trivial backport of #7706.

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - Mbed TLS developer facing only
- [x] **backport** of #7706 
- [x] **tests** not required - No code changes
