### PR TITLE
Reduce the size of psa_crypto_rsa when there are no RSA crypt algorithms

### DIFF
--- a/library/psa_crypto_rsa.c
+++ b/library/psa_crypto_rsa.c
@@ -546,8 +546,11 @@ psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attribut
                                             size_t *output_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+    (void) attributes;
     (void) key_buffer;
     (void) key_buffer_size;
+    (void) alg;
     (void) input;
     (void) input_length;
     (void) salt;
@@ -556,9 +559,15 @@ psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attribut
     (void) output_size;
     (void) output_length;
 
+#if !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) && \
+    !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+
+    status = PSA_ERROR_INVALID_ARGUMENT;
+
+#else /* !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) &&
+       * !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
+
     if (PSA_KEY_TYPE_IS_RSA(attributes->core.type)) {
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) || \
-        defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
         mbedtls_rsa_context *rsa = NULL;
         status = mbedtls_psa_rsa_load_representation(attributes->core.type,
                                                      key_buffer,
@@ -572,10 +581,9 @@ psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attribut
             status = PSA_ERROR_BUFFER_TOO_SMALL;
             goto rsa_exit;
         }
-#endif /* defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) ||
-        * defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
-        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
+
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT)
+        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
             status = mbedtls_to_psa_error(
                 mbedtls_rsa_pkcs1_encrypt(rsa,
                                           mbedtls_psa_get_random,
@@ -583,12 +591,11 @@ psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attribut
                                           input_length,
                                           input,
                                           output));
-#else
-            status = PSA_ERROR_NOT_SUPPORTED;
-#endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT */
         } else
-        if (PSA_ALG_IS_RSA_OAEP(alg)) {
+#endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT */
+
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+        if (PSA_ALG_IS_RSA_OAEP(alg)) {
             status = mbedtls_to_psa_error(
                 psa_rsa_oaep_set_padding_mode(alg, rsa));
             if (status != PSA_SUCCESS) {
@@ -603,14 +610,12 @@ psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attribut
                                                input_length,
                                                input,
                                                output));
-#else
-            status = PSA_ERROR_NOT_SUPPORTED;
+        } else
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP */
-        } else {
+
+            /* Both #ifs above have trailing else; this is for last else */
             status = PSA_ERROR_INVALID_ARGUMENT;
-        }
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) || \
-        defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+
 rsa_exit:
         if (status == PSA_SUCCESS) {
             *output_length = mbedtls_rsa_get_len(rsa);
@@ -618,11 +623,12 @@ rsa_exit:
 
         mbedtls_rsa_free(rsa);
         mbedtls_free(rsa);
-#endif /* defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) ||
-        * defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
+
     } else {
-        status = PSA_ERROR_NOT_SUPPORTED;
+        status = PSA_ERROR_INVALID_ARGUMENT;
     }
+#endif /* !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) &&
+        * !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
 
     return status;
 }
@@ -640,8 +646,10 @@ psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attribut
                                             size_t *output_length)
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+    (void) attributes;
     (void) key_buffer;
     (void) key_buffer_size;
+    (void) alg;
     (void) input;
     (void) input_length;
     (void) salt;
@@ -652,9 +660,15 @@ psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attribut
 
     *output_length = 0;
 
+#if !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) && \
+    !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+
+    status = PSA_ERROR_INVALID_ARGUMENT;
+
+#else /* !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) &&
+       * !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
+
     if (attributes->core.type == PSA_KEY_TYPE_RSA_KEY_PAIR) {
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) || \
-        defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
         mbedtls_rsa_context *rsa = NULL;
         status = mbedtls_psa_rsa_load_representation(attributes->core.type,
                                                      key_buffer,
@@ -668,11 +682,9 @@ psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attribut
             status = PSA_ERROR_INVALID_ARGUMENT;
             goto rsa_exit;
         }
-#endif /* defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) ||
-        * defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
 
-        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT)
+        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
             status = mbedtls_to_psa_error(
                 mbedtls_rsa_pkcs1_decrypt(rsa,
                                           mbedtls_psa_get_random,
@@ -681,12 +693,11 @@ psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attribut
                                           input,
                                           output,
                                           output_size));
-#else
-            status = PSA_ERROR_NOT_SUPPORTED;
-#endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT */
         } else
-        if (PSA_ALG_IS_RSA_OAEP(alg)) {
+#endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT */
+
 #if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+        if (PSA_ALG_IS_RSA_OAEP(alg)) {
             status = mbedtls_to_psa_error(
                 psa_rsa_oaep_set_padding_mode(alg, rsa));
             if (status != PSA_SUCCESS) {
@@ -702,23 +713,20 @@ psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attribut
                                                input,
                                                output,
                                                output_size));
-#else
-            status = PSA_ERROR_NOT_SUPPORTED;
+        } else
 #endif /* MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP */
-        } else {
-            status = PSA_ERROR_INVALID_ARGUMENT;
-        }
 
-#if defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) || \
-        defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP)
+            /* Both #ifs above have trailing else; this is for last else */
+            status = PSA_ERROR_INVALID_ARGUMENT;
+
 rsa_exit:
         mbedtls_rsa_free(rsa);
         mbedtls_free(rsa);
-#endif /* defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) ||
-        * defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
     } else {
-        status = PSA_ERROR_NOT_SUPPORTED;
+        status = PSA_ERROR_INVALID_ARGUMENT;
     }
+#endif /* !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT) &&
+        * !defined(MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP) */
 
     return status;
 }


### PR DESCRIPTION
When neither `MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT` nor `MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP` are defined, `mbedtls_psa_asymmetric_encrypt()` and `mbedtls_psa_asymmetric_decrypt()` will currently return either  `PSA_ERROR_NOT_SUPPORTED` or `PSA_ERROR_INVALID_ARGUMENT` depending on whether they recognise the algorithm or not.

This changes them so that, with no supported algorithms, they return `NOT_SUPPORTED` whatever algorithm value is given.

Before this change, when built for Thumb2 without `MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT`  and `MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP`, `psa_crypto_rsa.o` would be

`    124       0       0     124      7c psa_crypto_rsa.o`

with this change it is

`     34       0       0      34      22 psa_crypto_rsa.o`

Before this, without either `MBEDTLS_PSA_BUILTIN_ALG_RSA_PKCS1V15_CRYPT`  or,  `MBEDTLS_PSA_BUILTIN_ALG_RSA_OAEP`, `mbedtls_psa_asymmetric_encrypt()` and `mbedtls_psa_asymmetric_decrypt()` would be compiled as follows.

```
psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attributes,
                                            const uint8_t *key_buffer,
                                            size_t key_buffer_size,
                                            psa_algorithm_t alg,
                                            const uint8_t *input,
                                            size_t input_length,
                                            const uint8_t *salt,
                                            size_t salt_length,
                                            uint8_t *output,
                                            size_t output_size,
                                            size_t *output_length)
{
    (void) key_buffer;
    (void) key_buffer_size;
    (void) input;
    (void) input_length;
    (void) salt;
    (void) salt_length;
    (void) output;
    (void) output_size;
    (void) output_length;

    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;

    if (PSA_KEY_TYPE_IS_RSA(attributes->core.type)) {
        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
            status = PSA_ERROR_NOT_SUPPORTED;
        } else
        if (PSA_ALG_IS_RSA_OAEP(alg)) {
            status = PSA_ERROR_NOT_SUPPORTED;
        } else {
            status = PSA_ERROR_INVALID_ARGUMENT;
        }
    } else {
        status = PSA_ERROR_NOT_SUPPORTED;
    }

    return status;
}

psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attributes,
                                            const uint8_t *key_buffer,
                                            size_t key_buffer_size,
                                            psa_algorithm_t alg,
                                            const uint8_t *input,
                                            size_t input_length,
                                            const uint8_t *salt,
                                            size_t salt_length,
                                            uint8_t *output,
                                            size_t output_size,
                                            size_t *output_length)
{
    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
    (void) key_buffer;
    (void) key_buffer_size;
    (void) input;
    (void) input_length;
    (void) salt;
    (void) salt_length;
    (void) output;
    (void) output_size;
    (void) output_length;

    *output_length = 0;

    if (attributes->core.type == PSA_KEY_TYPE_RSA_KEY_PAIR) {

        if (alg == PSA_ALG_RSA_PKCS1V15_CRYPT) {
            status = PSA_ERROR_NOT_SUPPORTED;
        } else
        if (PSA_ALG_IS_RSA_OAEP(alg)) {
            status = PSA_ERROR_NOT_SUPPORTED;
        } else {
            status = PSA_ERROR_INVALID_ARGUMENT;
        }

    } else {
        status = PSA_ERROR_NOT_SUPPORTED;
    }

    return status;
}
```

With this change we get

```
psa_status_t mbedtls_psa_asymmetric_encrypt(const psa_key_attributes_t *attributes,
                                            const uint8_t *key_buffer,
                                            size_t key_buffer_size,
                                            psa_algorithm_t alg,
                                            const uint8_t *input,
                                            size_t input_length,
                                            const uint8_t *salt,
                                            size_t salt_length,
                                            uint8_t *output,
                                            size_t output_size,
                                            size_t *output_length)
{
    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;

    (void) key_buffer;
    (void) key_buffer_size;
    (void) input;
    (void) input_length;
    (void) salt;
    (void) salt_length;
    (void) output;
    (void) output_size;
    (void) output_length;


    status = PSA_ERROR_NOT_SUPPORTED;


    return status;
}

psa_status_t mbedtls_psa_asymmetric_decrypt(const psa_key_attributes_t *attributes,
                                            const uint8_t *key_buffer,
                                            size_t key_buffer_size,
                                            psa_algorithm_t alg,
                                            const uint8_t *input,
                                            size_t input_length,
                                            const uint8_t *salt,
                                            size_t salt_length,
                                            uint8_t *output,
                                            size_t output_size,
                                            size_t *output_length)
{
    psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
    (void) key_buffer;
    (void) key_buffer_size;
    (void) input;
    (void) input_length;
    (void) salt;
    (void) salt_length;
    (void) output;
    (void) output_size;
    (void) output_length;

    *output_length = 0;


    status = PSA_ERROR_NOT_SUPPORTED;


    return status;
}
```

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** I don't think this needs one, it's a change in behaviour when calling a function on a configured-out alg
- [ ] **backport** not required: neither `mbedtls_psa_asymmetric_encrypt()` nor `mbedtls_psa_asymmetric_decrypt()` re in the LTS branch 
- [ ] **tests** not required
