### PR TITLE
Build the docs in realfull config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.9"
   jobs:
     pre_build:
-    - make apidoc
+    - ./scripts/apidoc_full.sh
     - breathe-apidoc -o docs/api apidoc/xml
     post_build:
     - |


### PR DESCRIPTION
Fixes #7742.

Ensure that all possible config options are documented by building the docs in the `realfull` config on Read The Docs.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - internal non-API change
- [x] **backport** #7751 
- [x] **tests** not required - docs changes only
