### PR TITLE
Fix possible integer overflows

### DIFF
--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -753,7 +753,8 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         session_negotiate->ticket != NULL) {
         mbedtls_ms_time_t now = mbedtls_ms_time();
         mbedtls_ms_time_t age = now - session_negotiate->ticket_reception_time;
-        if (age < 0 || age > session_negotiate->ticket_lifetime * 1000) {
+        if (age < 0 ||
+            age > (mbedtls_ms_time_t) session_negotiate->ticket_lifetime * 1000) {
             /* Without valid ticket, disable session resumption.*/
             MBEDTLS_SSL_DEBUG_MSG(
                 3, ("Ticket expired, disable session resumption"));

--- a/library/ssl_ticket.c
+++ b/library/ssl_ticket.c
@@ -510,7 +510,8 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
         }
 #endif
 
-        mbedtls_ms_time_t ticket_lifetime = ctx->ticket_lifetime * 1000;
+        mbedtls_ms_time_t ticket_lifetime =
+            (mbedtls_ms_time_t) ctx->ticket_lifetime * 1000;
 
         if (ticket_age < 0 || ticket_age > ticket_lifetime) {
             ret = MBEDTLS_ERR_SSL_SESSION_TICKET_EXPIRED;


### PR DESCRIPTION
When calculating a result to go into an `mbedtls_ms_time_t`, make sure that arithmetic is performed at the final size to prevent overflow.

Reported by Coverity.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required - trivial change, non-user-facing
- [x] **backport** not required - issue not present in 2.28
- [x] **tests** not required - cast only added