### PR TITLE
Set OpenSSL/GnuTLS variables when running release components

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -748,7 +748,7 @@ pre_check_tools () {
         # Require OpenSSL and GnuTLS if running any tests (as opposed to
         # only doing builds). Not all tests run OpenSSL and GnuTLS, but this
         # is a good enough approximation in practice.
-        *" test_"*)
+        *" test_"* | *" release_test_"*)
             # To avoid setting OpenSSL and GnuTLS for each call to compat.sh
             # and ssl-opt.sh, we just export the variables they require.
             export OPENSSL="$OPENSSL"


### PR DESCRIPTION
## Description

This PR fixes a logic interaction in `all.sh` that was missed when we introduced `release_` components in #8613 

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required: test changes only
- [x] **backport**: #8640 
- [x] **tests** not required: all.sh changes only