### PR TITLE
pkg-config: fix static linking in Windows

### DIFF
--- a/ChangeLog.d/fix-pkgconfig-static-linking-windows.txt
+++ b/ChangeLog.d/fix-pkgconfig-static-linking-windows.txt
@@ -1,0 +1,3 @@
+Bugfix:
+   * Fix pkgconfig files on Windows: the bcrypt library was missing when
+     linking statically.

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -8,6 +8,11 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
   set(PKGCONFIG_PROJECT_DESCRIPTION "Mbed TLS is a C library that implements cryptographic primitives, X.509 certificate manipulation and the SSL/TLS and DTLS protocols. Its small code footprint makes it suitable for embedded systems.")
   set(PKGCONFIG_PROJECT_HOMEPAGE_URL "https://www.trustedfirmware.org/projects/mbed-tls/")
 
+  set(MBEDTLS_PKGCONFIG_LIBS_PRIVATE "")
+  if(WIN32)
+    set(MBEDTLS_PKGCONFIG_LIBS_PRIVATE "-lbcrypt")
+  endif()
+
   configure_file(mbedcrypto.pc.in mbedcrypto.pc @ONLY)
     install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/mbedcrypto.pc

--- a/pkgconfig/mbedcrypto.pc.in
+++ b/pkgconfig/mbedcrypto.pc.in
@@ -8,3 +8,4 @@ URL: @PKGCONFIG_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I"${includedir}"
 Libs: -L"${libdir}" -lmbedcrypto
+Libs.private: @MBEDTLS_PKGCONFIG_LIBS_PRIVATE@


### PR DESCRIPTION
## Description

    Fix static linking with pkgconfig file in Windows.
    This adds bcrypt library in linker flag for mbedcrypto.
    bcrypt library is required for BCryptGenRandom function
    used in entropy_poll.c file.
    
    The pkgconfig output for static linking becomes as following.
    
    $ pkg-config -libs -static mbedcrypto
    -lmbedcrypto -lbcrypt
    
## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [ ] **backport** 2.28, 3.6
- [ ] **tests** no CI testing of pkgconfig
