### PR TITLE
Remove unnecessary casting for return value of mbedtls_calloc

### DIFF
--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -382,8 +382,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
     if ((cur = asn1_find_named_data(*head, oid, oid_len)) == NULL) {
         // Add new entry if not present yet based on OID
         //
-        cur = (mbedtls_asn1_named_data *) mbedtls_calloc(1,
-                                                         sizeof(mbedtls_asn1_named_data));
+        cur = mbedtls_calloc(1, sizeof(mbedtls_asn1_named_data));
         if (cur == NULL) {
             return NULL;
         }

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -382,7 +382,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_store_named_data(
     if ((cur = asn1_find_named_data(*head, oid, oid_len)) == NULL) {
         // Add new entry if not present yet based on OID
         //
-        cur = mbedtls_calloc(1, sizeof(mbedtls_asn1_named_data));
+        cur = mbedtls_calloc(1, sizeof(*cur));
         if (cur == NULL) {
             return NULL;
         }

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -214,7 +214,7 @@ int mbedtls_mpi_grow(mbedtls_mpi *X, size_t nblimbs)
     }
 
     if (X->n < nblimbs) {
-        if ((p = (mbedtls_mpi_uint *) mbedtls_calloc(nblimbs, ciL)) == NULL) {
+        if ((p = mbedtls_calloc(nblimbs, ciL)) == NULL) {
             return MBEDTLS_ERR_MPI_ALLOC_FAILED;
         }
 
@@ -262,7 +262,7 @@ int mbedtls_mpi_shrink(mbedtls_mpi *X, size_t nblimbs)
         i = nblimbs;
     }
 
-    if ((p = (mbedtls_mpi_uint *) mbedtls_calloc(i, ciL)) == NULL) {
+    if ((p = mbedtls_calloc(i, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
@@ -1641,7 +1641,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
      * Allocate working memory for mbedtls_mpi_core_exp_mod()
      */
     size_t T_limbs = mbedtls_mpi_core_exp_mod_working_limbs(N->n, E->n);
-    mbedtls_mpi_uint *T = (mbedtls_mpi_uint *) mbedtls_calloc(T_limbs, sizeof(mbedtls_mpi_uint));
+    mbedtls_mpi_uint *T = mbedtls_calloc(T_limbs, sizeof(mbedtls_mpi_uint));
     if (T == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1641,7 +1641,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
      * Allocate working memory for mbedtls_mpi_core_exp_mod()
      */
     size_t T_limbs = mbedtls_mpi_core_exp_mod_working_limbs(N->n, E->n);
-    mbedtls_mpi_uint *T = mbedtls_calloc(T_limbs, sizeof(mbedtls_mpi_uint));
+    mbedtls_mpi_uint *T = mbedtls_calloc(T_limbs, sizeof(*T));
     if (T == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }

--- a/library/bignum_mod.c
+++ b/library/bignum_mod.c
@@ -263,7 +263,7 @@ int mbedtls_mpi_mod_inv(mbedtls_mpi_mod_residue *X,
         mbedtls_mpi_mod_raw_inv_prime_working_limbs(N->limbs);
 
     mbedtls_mpi_uint *working_memory = mbedtls_calloc(working_limbs,
-                                                      sizeof(mbedtls_mpi_uint));
+                                                      sizeof(*working_memory));
     if (working_memory == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
@@ -363,7 +363,7 @@ int mbedtls_mpi_mod_write(const mbedtls_mpi_mod_residue *r,
 
     if (N->int_rep == MBEDTLS_MPI_MOD_REP_MONTGOMERY) {
 
-        working_memory = mbedtls_calloc(r->limbs, sizeof(mbedtls_mpi_uint));
+        working_memory = mbedtls_calloc(r->limbs, sizeof(*working_memory));
 
         if (working_memory == NULL) {
             ret = MBEDTLS_ERR_MPI_ALLOC_FAILED;

--- a/library/bignum_mod_raw.c
+++ b/library/bignum_mod_raw.c
@@ -234,7 +234,7 @@ int mbedtls_mpi_mod_raw_to_mont_rep(mbedtls_mpi_uint *X,
     mbedtls_mpi_uint *T;
     const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(N->limbs);
 
-    if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
+    if ((T = mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
@@ -251,7 +251,7 @@ int mbedtls_mpi_mod_raw_from_mont_rep(mbedtls_mpi_uint *X,
     const size_t t_limbs = mbedtls_mpi_core_montmul_working_limbs(N->limbs);
     mbedtls_mpi_uint *T;
 
-    if ((T = (mbedtls_mpi_uint *) mbedtls_calloc(t_limbs, ciL)) == NULL) {
+    if ((T = mbedtls_calloc(t_limbs, ciL)) == NULL) {
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -285,9 +285,9 @@ int mbedtls_cipher_setup_psa(mbedtls_cipher_context_t *ctx,
         return MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE;
     }
 
-    memset(ctx, 0, sizeof(mbedtls_cipher_context_t));
+    memset(ctx, 0, sizeof(*ctx));
 
-    cipher_psa = mbedtls_calloc(1, sizeof(mbedtls_cipher_context_psa));
+    cipher_psa = mbedtls_calloc(1, sizeof(*cipher_psa));
     if (cipher_psa == NULL) {
         return MBEDTLS_ERR_CIPHER_ALLOC_FAILED;
     }

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -120,10 +120,10 @@ enum mbedtls_cipher_base_index {
 /* shared by all GCM ciphers */
 static void *gcm_ctx_alloc(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_gcm_context));
+    mbedtls_gcm_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
-        mbedtls_gcm_init((mbedtls_gcm_context *) ctx);
+        mbedtls_gcm_init(ctx);
     }
 
     return ctx;
@@ -142,10 +142,10 @@ static void gcm_ctx_free(void *ctx)
 /* shared by all CCM ciphers */
 static void *ccm_ctx_alloc(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_ccm_context));
+    mbedtls_ccm_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
-        mbedtls_ccm_init((mbedtls_ccm_context *) ctx);
+        mbedtls_ccm_init(ctx);
     }
 
     return ctx;
@@ -246,7 +246,7 @@ static int aes_setkey_enc_wrap(void *ctx, const unsigned char *key,
 
 static void *aes_ctx_alloc(void)
 {
-    mbedtls_aes_context *aes = mbedtls_calloc(1, sizeof(mbedtls_aes_context));
+    mbedtls_aes_context *aes = mbedtls_calloc(1, sizeof(*aes));
 
     if (aes == NULL) {
         return NULL;
@@ -259,7 +259,7 @@ static void *aes_ctx_alloc(void)
 
 static void aes_ctx_free(void *ctx)
 {
-    mbedtls_aes_free((mbedtls_aes_context *) ctx);
+    mbedtls_aes_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -503,14 +503,10 @@ static void *xts_aes_ctx_alloc(void)
 
 static void xts_aes_ctx_free(void *ctx)
 {
-    mbedtls_aes_xts_context *xts_ctx = ctx;
-
-    if (xts_ctx == NULL) {
-        return;
+    if (ctx != NULL) {
+        mbedtls_aes_xts_free(ctx);
+        mbedtls_free(ctx);
     }
-
-    mbedtls_aes_xts_free(xts_ctx);
-    mbedtls_free(xts_ctx);
 }
 
 static const mbedtls_cipher_base_t xts_aes_info = {
@@ -827,21 +823,18 @@ static int camellia_setkey_enc_wrap(void *ctx, const unsigned char *key,
 
 static void *camellia_ctx_alloc(void)
 {
-    mbedtls_camellia_context *ctx;
-    ctx = mbedtls_calloc(1, sizeof(mbedtls_camellia_context));
+    mbedtls_camellia_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
-    if (ctx == NULL) {
-        return NULL;
+    if (ctx != NULL) {
+        mbedtls_camellia_init(ctx);
     }
-
-    mbedtls_camellia_init(ctx);
 
     return ctx;
 }
 
 static void camellia_ctx_free(void *ctx)
 {
-    mbedtls_camellia_free((mbedtls_camellia_context *) ctx);
+    mbedtls_camellia_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -1016,7 +1009,7 @@ static const mbedtls_cipher_info_t camellia_256_ctr_info = {
 static int gcm_camellia_setkey_wrap(void *ctx, const unsigned char *key,
                                     unsigned int key_bitlen)
 {
-    return mbedtls_gcm_setkey((mbedtls_gcm_context *) ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
+    return mbedtls_gcm_setkey(ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
                               key, key_bitlen);
 }
 
@@ -1087,7 +1080,7 @@ static const mbedtls_cipher_info_t camellia_256_gcm_info = {
 static int ccm_camellia_setkey_wrap(void *ctx, const unsigned char *key,
                                     unsigned int key_bitlen)
 {
-    return mbedtls_ccm_setkey((mbedtls_ccm_context *) ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
+    return mbedtls_ccm_setkey(ctx, MBEDTLS_CIPHER_ID_CAMELLIA,
                               key, key_bitlen);
 }
 
@@ -1195,7 +1188,7 @@ static int aria_crypt_ecb_wrap(void *ctx, mbedtls_operation_t operation,
                                const unsigned char *input, unsigned char *output)
 {
     (void) operation;
-    return mbedtls_aria_crypt_ecb((mbedtls_aria_context *) ctx, input,
+    return mbedtls_aria_crypt_ecb(ctx, input,
                                   output);
 }
 
@@ -1204,7 +1197,7 @@ static int aria_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation,
                                size_t length, unsigned char *iv,
                                const unsigned char *input, unsigned char *output)
 {
-    return mbedtls_aria_crypt_cbc((mbedtls_aria_context *) ctx, operation, length, iv,
+    return mbedtls_aria_crypt_cbc(ctx, operation, length, iv,
                                   input, output);
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
@@ -1214,7 +1207,7 @@ static int aria_crypt_cfb128_wrap(void *ctx, mbedtls_operation_t operation,
                                   size_t length, size_t *iv_off, unsigned char *iv,
                                   const unsigned char *input, unsigned char *output)
 {
-    return mbedtls_aria_crypt_cfb128((mbedtls_aria_context *) ctx, operation, length,
+    return mbedtls_aria_crypt_cfb128(ctx, operation, length,
                                      iv_off, iv, input, output);
 }
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
@@ -1224,7 +1217,7 @@ static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
                                unsigned char *nonce_counter, unsigned char *stream_block,
                                const unsigned char *input, unsigned char *output)
 {
-    return mbedtls_aria_crypt_ctr((mbedtls_aria_context *) ctx, length, nc_off,
+    return mbedtls_aria_crypt_ctr(ctx, length, nc_off,
                                   nonce_counter, stream_block, input, output);
 }
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
@@ -1233,33 +1226,30 @@ static int aria_crypt_ctr_wrap(void *ctx, size_t length, size_t *nc_off,
 static int aria_setkey_dec_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
 {
-    return mbedtls_aria_setkey_dec((mbedtls_aria_context *) ctx, key, key_bitlen);
+    return mbedtls_aria_setkey_dec(ctx, key, key_bitlen);
 }
 #endif
 
 static int aria_setkey_enc_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
 {
-    return mbedtls_aria_setkey_enc((mbedtls_aria_context *) ctx, key, key_bitlen);
+    return mbedtls_aria_setkey_enc(ctx, key, key_bitlen);
 }
 
 static void *aria_ctx_alloc(void)
 {
-    mbedtls_aria_context *ctx;
-    ctx = mbedtls_calloc(1, sizeof(mbedtls_aria_context));
+    mbedtls_aria_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
-    if (ctx == NULL) {
-        return NULL;
+    if (ctx != NULL) {
+        mbedtls_aria_init(ctx);
     }
-
-    mbedtls_aria_init(ctx);
 
     return ctx;
 }
 
 static void aria_ctx_free(void *ctx)
 {
-    mbedtls_aria_free((mbedtls_aria_context *) ctx);
+    mbedtls_aria_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -1434,7 +1424,7 @@ static const mbedtls_cipher_info_t aria_256_ctr_info = {
 static int gcm_aria_setkey_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
 {
-    return mbedtls_gcm_setkey((mbedtls_gcm_context *) ctx, MBEDTLS_CIPHER_ID_ARIA,
+    return mbedtls_gcm_setkey(ctx, MBEDTLS_CIPHER_ID_ARIA,
                               key, key_bitlen);
 }
 
@@ -1505,7 +1495,7 @@ static const mbedtls_cipher_info_t aria_256_gcm_info = {
 static int ccm_aria_setkey_wrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
 {
-    return mbedtls_ccm_setkey((mbedtls_ccm_context *) ctx, MBEDTLS_CIPHER_ID_ARIA,
+    return mbedtls_ccm_setkey(ctx, MBEDTLS_CIPHER_ID_ARIA,
                               key, key_bitlen);
 }
 
@@ -1613,21 +1603,21 @@ static int des_crypt_ecb_wrap(void *ctx, mbedtls_operation_t operation,
                               const unsigned char *input, unsigned char *output)
 {
     ((void) operation);
-    return mbedtls_des_crypt_ecb((mbedtls_des_context *) ctx, input, output);
+    return mbedtls_des_crypt_ecb(ctx, input, output);
 }
 
 static int des3_crypt_ecb_wrap(void *ctx, mbedtls_operation_t operation,
                                const unsigned char *input, unsigned char *output)
 {
     ((void) operation);
-    return mbedtls_des3_crypt_ecb((mbedtls_des3_context *) ctx, input, output);
+    return mbedtls_des3_crypt_ecb(ctx, input, output);
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 static int des_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation, size_t length,
                               unsigned char *iv, const unsigned char *input, unsigned char *output)
 {
-    return mbedtls_des_crypt_cbc((mbedtls_des_context *) ctx, operation, length, iv, input,
+    return mbedtls_des_crypt_cbc(ctx, operation, length, iv, input,
                                  output);
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
@@ -1636,7 +1626,7 @@ static int des_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation, size_t l
 static int des3_crypt_cbc_wrap(void *ctx, mbedtls_operation_t operation, size_t length,
                                unsigned char *iv, const unsigned char *input, unsigned char *output)
 {
-    return mbedtls_des3_crypt_cbc((mbedtls_des3_context *) ctx, operation, length, iv, input,
+    return mbedtls_des3_crypt_cbc(ctx, operation, length, iv, input,
                                   output);
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
@@ -1646,7 +1636,7 @@ static int des_setkey_dec_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des_setkey_dec((mbedtls_des_context *) ctx, key);
+    return mbedtls_des_setkey_dec(ctx, key);
 }
 
 static int des_setkey_enc_wrap(void *ctx, const unsigned char *key,
@@ -1654,7 +1644,7 @@ static int des_setkey_enc_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des_setkey_enc((mbedtls_des_context *) ctx, key);
+    return mbedtls_des_setkey_enc(ctx, key);
 }
 
 static int des3_set2key_dec_wrap(void *ctx, const unsigned char *key,
@@ -1662,7 +1652,7 @@ static int des3_set2key_dec_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des3_set2key_dec((mbedtls_des3_context *) ctx, key);
+    return mbedtls_des3_set2key_dec(ctx, key);
 }
 
 static int des3_set2key_enc_wrap(void *ctx, const unsigned char *key,
@@ -1670,7 +1660,7 @@ static int des3_set2key_enc_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des3_set2key_enc((mbedtls_des3_context *) ctx, key);
+    return mbedtls_des3_set2key_enc(ctx, key);
 }
 
 static int des3_set3key_dec_wrap(void *ctx, const unsigned char *key,
@@ -1678,7 +1668,7 @@ static int des3_set3key_dec_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des3_set3key_dec((mbedtls_des3_context *) ctx, key);
+    return mbedtls_des3_set3key_dec(ctx, key);
 }
 
 static int des3_set3key_enc_wrap(void *ctx, const unsigned char *key,
@@ -1686,12 +1676,12 @@ static int des3_set3key_enc_wrap(void *ctx, const unsigned char *key,
 {
     ((void) key_bitlen);
 
-    return mbedtls_des3_set3key_enc((mbedtls_des3_context *) ctx, key);
+    return mbedtls_des3_set3key_enc(ctx, key);
 }
 
 static void *des_ctx_alloc(void)
 {
-    mbedtls_des_context *des = mbedtls_calloc(1, sizeof(mbedtls_des_context));
+    mbedtls_des_context *des = mbedtls_calloc(1, sizeof(*des));
 
     if (des == NULL) {
         return NULL;
@@ -1704,27 +1694,24 @@ static void *des_ctx_alloc(void)
 
 static void des_ctx_free(void *ctx)
 {
-    mbedtls_des_free((mbedtls_des_context *) ctx);
+    mbedtls_des_free(ctx);
     mbedtls_free(ctx);
 }
 
 static void *des3_ctx_alloc(void)
 {
-    mbedtls_des3_context *des3;
-    des3 = mbedtls_calloc(1, sizeof(mbedtls_des3_context));
+    mbedtls_des3_context *des3 = mbedtls_calloc(1, sizeof(*des3));
 
-    if (des3 == NULL) {
-        return NULL;
+    if (des3 != NULL) {
+        mbedtls_des3_init(des3);
     }
-
-    mbedtls_des3_init(des3);
 
     return des3;
 }
 
 static void des3_ctx_free(void *ctx)
 {
-    mbedtls_des3_free((mbedtls_des3_context *) ctx);
+    mbedtls_des3_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -1890,7 +1877,7 @@ static int chacha20_setkey_wrap(void *ctx, const unsigned char *key,
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 
-    if (0 != mbedtls_chacha20_setkey((mbedtls_chacha20_context *) ctx, key)) {
+    if (0 != mbedtls_chacha20_setkey(ctx, key)) {
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 
@@ -1913,21 +1900,18 @@ static int chacha20_stream_wrap(void *ctx,  size_t length,
 
 static void *chacha20_ctx_alloc(void)
 {
-    mbedtls_chacha20_context *ctx;
-    ctx = mbedtls_calloc(1, sizeof(mbedtls_chacha20_context));
+    mbedtls_chacha20_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
-    if (ctx == NULL) {
-        return NULL;
+    if (ctx != NULL) {
+        mbedtls_chacha20_init(ctx);
     }
-
-    mbedtls_chacha20_init(ctx);
 
     return ctx;
 }
 
 static void chacha20_ctx_free(void *ctx)
 {
-    mbedtls_chacha20_free((mbedtls_chacha20_context *) ctx);
+    mbedtls_chacha20_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -1981,7 +1965,7 @@ static int chachapoly_setkey_wrap(void *ctx,
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 
-    if (0 != mbedtls_chachapoly_setkey((mbedtls_chachapoly_context *) ctx, key)) {
+    if (0 != mbedtls_chachapoly_setkey(ctx, key)) {
         return MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA;
     }
 
@@ -1990,21 +1974,18 @@ static int chachapoly_setkey_wrap(void *ctx,
 
 static void *chachapoly_ctx_alloc(void)
 {
-    mbedtls_chachapoly_context *ctx;
-    ctx = mbedtls_calloc(1, sizeof(mbedtls_chachapoly_context));
+    mbedtls_chachapoly_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
-    if (ctx == NULL) {
-        return NULL;
+    if (ctx != NULL) {
+        mbedtls_chachapoly_init(ctx);
     }
-
-    mbedtls_chachapoly_init(ctx);
 
     return ctx;
 }
 
 static void chachapoly_ctx_free(void *ctx)
 {
-    mbedtls_chachapoly_free((mbedtls_chachapoly_context *) ctx);
+    mbedtls_chachapoly_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -2122,10 +2103,10 @@ static const mbedtls_cipher_info_t null_cipher_info = {
 #if defined(MBEDTLS_NIST_KW_C)
 static void *kw_ctx_alloc(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_nist_kw_context));
+    mbedtls_nist_kw_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
-        mbedtls_nist_kw_init((mbedtls_nist_kw_context *) ctx);
+        mbedtls_nist_kw_init(ctx);
     }
 
     return ctx;
@@ -2140,14 +2121,14 @@ static void kw_ctx_free(void *ctx)
 static int kw_aes_setkey_wrap(void *ctx, const unsigned char *key,
                               unsigned int key_bitlen)
 {
-    return mbedtls_nist_kw_setkey((mbedtls_nist_kw_context *) ctx,
+    return mbedtls_nist_kw_setkey(ctx,
                                   MBEDTLS_CIPHER_ID_AES, key, key_bitlen, 1);
 }
 
 static int kw_aes_setkey_unwrap(void *ctx, const unsigned char *key,
                                 unsigned int key_bitlen)
 {
-    return mbedtls_nist_kw_setkey((mbedtls_nist_kw_context *) ctx,
+    return mbedtls_nist_kw_setkey(ctx,
                                   MBEDTLS_CIPHER_ID_AES, key, key_bitlen, 0);
 }
 

--- a/library/cmac.c
+++ b/library/cmac.c
@@ -183,7 +183,7 @@ int mbedtls_cipher_cmac_starts(mbedtls_cipher_context_t *ctx,
 
     /* Allocated and initialise in the cipher context memory for the CMAC
      * context */
-    cmac_ctx = mbedtls_calloc(1, sizeof(mbedtls_cmac_context_t));
+    cmac_ctx = mbedtls_calloc(1, sizeof(*cmac_ctx));
     if (cmac_ctx == NULL) {
         return MBEDTLS_ERR_CIPHER_ALLOC_FAILED;
     }

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -1377,7 +1377,7 @@ static int ecp_normalize_jac_many(const mbedtls_ecp_group *grp,
     size_t i;
     mbedtls_mpi *c, t;
 
-    if ((c = mbedtls_calloc(T_size, sizeof(mbedtls_mpi))) == NULL) {
+    if ((c = mbedtls_calloc(T_size, sizeof(*c))) == NULL) {
         return MBEDTLS_ERR_ECP_ALLOC_FAILED;
     }
 
@@ -2333,7 +2333,7 @@ static int ecp_mul_comb(mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 #endif
     /* Allocate table if we didn't have any */
     {
-        T = mbedtls_calloc(T_size, sizeof(mbedtls_ecp_point));
+        T = mbedtls_calloc(T_size, sizeof(*T));
         if (T == NULL) {
             ret = MBEDTLS_ERR_ECP_ALLOC_FAILED;
             goto cleanup;

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -447,16 +447,16 @@ static int rsa_check_pair_wrap(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
 {
     (void) f_rng;
     (void) p_rng;
-    return mbedtls_rsa_check_pub_priv((const mbedtls_rsa_context *) pub->pk_ctx,
-                                      (const mbedtls_rsa_context *) prv->pk_ctx);
+    return mbedtls_rsa_check_pub_priv((const void *) pub->pk_ctx,
+                                      (const void *) prv->pk_ctx);
 }
 
 static void *rsa_alloc_wrap(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_rsa_context));
+    mbedtls_rsa_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
-        mbedtls_rsa_init((mbedtls_rsa_context *) ctx);
+        mbedtls_rsa_init(ctx);
     }
 
     return ctx;
@@ -464,7 +464,7 @@ static void *rsa_alloc_wrap(void)
 
 static void rsa_free_wrap(void *ctx)
 {
-    mbedtls_rsa_free((mbedtls_rsa_context *) ctx);
+    mbedtls_rsa_free(ctx);
     mbedtls_free(ctx);
 }
 
@@ -475,7 +475,7 @@ static void rsa_debug(mbedtls_pk_context *pk, mbedtls_pk_debug_item *items)
     (void) pk;
     (void) items;
 #else
-    mbedtls_rsa_context *rsa = (mbedtls_rsa_context *) pk->pk_ctx;
+    mbedtls_rsa_context *rsa = pk->pk_ctx;
 
     items->type = MBEDTLS_PK_DEBUG_MPI;
     items->name = "rsa.N";
@@ -845,32 +845,26 @@ typedef struct {
 
 static void *eckey_rs_alloc(void)
 {
-    eckey_restart_ctx *rs_ctx;
+    eckey_restart_ctx *rs_ctx = mbedtls_calloc(1, sizeof(*rs_ctx));
 
-    void *ctx = mbedtls_calloc(1, sizeof(eckey_restart_ctx));
-
-    if (ctx != NULL) {
-        rs_ctx = ctx;
+    if (rs_ctx != NULL) {
         mbedtls_ecdsa_restart_init(&rs_ctx->ecdsa_rs);
         mbedtls_ecdsa_init(&rs_ctx->ecdsa_ctx);
     }
 
-    return ctx;
+    return rs_ctx;
 }
 
 static void eckey_rs_free(void *ctx)
 {
-    eckey_restart_ctx *rs_ctx;
+    eckey_restart_ctx *rs_ctx = ctx;
 
-    if (ctx == NULL) {
-        return;
+    if (ctx != NULL) {
+        mbedtls_ecdsa_restart_free(&rs_ctx->ecdsa_rs);
+        mbedtls_ecdsa_free(&rs_ctx->ecdsa_ctx);
+
+        mbedtls_free(ctx);
     }
-
-    rs_ctx = ctx;
-    mbedtls_ecdsa_restart_free(&rs_ctx->ecdsa_rs);
-    mbedtls_ecdsa_free(&rs_ctx->ecdsa_ctx);
-
-    mbedtls_free(ctx);
 }
 
 static int eckey_verify_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
@@ -1080,7 +1074,7 @@ static int ecdsa_opaque_check_pair_wrap(mbedtls_pk_context *pub,
 #if !defined(MBEDTLS_PK_USE_PSA_EC_DATA)
 static void *eckey_alloc_wrap(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_ecp_keypair));
+    mbedtls_ecp_keypair *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
         mbedtls_ecp_keypair_init(ctx);
@@ -1219,7 +1213,7 @@ static int ecdsa_sign_rs_wrap(mbedtls_pk_context *pk, mbedtls_md_type_t md_alg,
 
 static void *ecdsa_rs_alloc(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_ecdsa_restart_ctx));
+    mbedtls_ecdsa_restart_ctx *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
         mbedtls_ecdsa_restart_init(ctx);
@@ -1365,10 +1359,10 @@ static int rsa_alt_check_pair(mbedtls_pk_context *pub, mbedtls_pk_context *prv,
 
 static void *rsa_alt_alloc_wrap(void)
 {
-    void *ctx = mbedtls_calloc(1, sizeof(mbedtls_rsa_alt_context));
+    mbedtls_rsa_alt_context *ctx = mbedtls_calloc(1, sizeof(*ctx));
 
     if (ctx != NULL) {
-        memset(ctx, 0, sizeof(mbedtls_rsa_alt_context));
+        memset(ctx, 0, sizeof(*ctx));
     }
 
     return ctx;

--- a/library/sha256.c
+++ b/library/sha256.c
@@ -888,7 +888,7 @@ static int mbedtls_sha256_common_self_test(int verbose, int is224)
     sha_test_sum_t *sha_test_sum = sha224_test_sum;
 #endif
 
-    buf = mbedtls_calloc(1024, sizeof(unsigned char));
+    buf = mbedtls_calloc(1024, sizeof(*buf));
     if (NULL == buf) {
         if (verbose != 0) {
             mbedtls_printf("Buffer allocation failed\n");

--- a/library/sha512.c
+++ b/library/sha512.c
@@ -1022,7 +1022,7 @@ static int mbedtls_sha512_common_self_test(int verbose, int is384)
     sha_test_sum_t *sha_test_sum = sha384_test_sum;
 #endif
 
-    buf = mbedtls_calloc(1024, sizeof(unsigned char));
+    buf = mbedtls_calloc(1024, sizeof(*buf));
     if (NULL == buf) {
         if (verbose != 0) {
             mbedtls_printf("Buffer allocation failed\n");

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -183,7 +183,7 @@ static int ssl_cache_pick_writing_slot(mbedtls_ssl_cache_context *cache,
 
     if (count < cache->max_entries) {
         /* Create new entry */
-        cur = mbedtls_calloc(1, sizeof(mbedtls_ssl_cache_entry));
+        cur = mbedtls_calloc(1, sizeof(*cur));
         if (cur == NULL) {
             return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -2419,7 +2419,7 @@ static int ssl_flight_append(mbedtls_ssl_context *ssl)
                           ssl->out_msg, ssl->out_msglen);
 
     /* Allocate space for current message */
-    if ((msg = mbedtls_calloc(1, sizeof(mbedtls_ssl_flight_item))) == NULL) {
+    if ((msg = mbedtls_calloc(1, sizeof(*msg))) == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("alloc %" MBEDTLS_PRINTF_SIZET " bytes failed",
                                   sizeof(mbedtls_ssl_flight_item)));
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1069,16 +1069,16 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
      * Now allocate missing structures.
      */
     if (ssl->transform_negotiate == NULL) {
-        ssl->transform_negotiate = mbedtls_calloc(1, sizeof(mbedtls_ssl_transform));
+        ssl->transform_negotiate = mbedtls_calloc(1, sizeof(*ssl->transform_negotiate));
     }
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
     if (ssl->session_negotiate == NULL) {
-        ssl->session_negotiate = mbedtls_calloc(1, sizeof(mbedtls_ssl_session));
+        ssl->session_negotiate = mbedtls_calloc(1, sizeof(*ssl->session_negotiate));
     }
 
     if (ssl->handshake == NULL) {
-        ssl->handshake = mbedtls_calloc(1, sizeof(mbedtls_ssl_handshake_params));
+        ssl->handshake = mbedtls_calloc(1, sizeof(*ssl->handshake));
     }
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
     /* If the buffers are too small - reallocate */
@@ -1171,7 +1171,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
         }
 
         /* Leave room for zero termination */
-        uint16_t *group_list = mbedtls_calloc(length + 1, sizeof(uint16_t));
+        uint16_t *group_list = mbedtls_calloc(length + 1, sizeof(*group_list));
         if (group_list == NULL) {
             return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }
@@ -1234,7 +1234,7 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
         }
 
         ssl->handshake->sig_algs = mbedtls_calloc(1, sig_algs_len +
-                                                  sizeof(uint16_t));
+                                                  sizeof(*ssl->handshake->sig_algs));
         if (ssl->handshake->sig_algs == NULL) {
             return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }
@@ -1857,7 +1857,7 @@ static int ssl_append_key_cert(mbedtls_ssl_key_cert **head,
         return 0;
     }
 
-    new_cert = mbedtls_calloc(1, sizeof(mbedtls_ssl_key_cert));
+    new_cert = mbedtls_calloc(1, sizeof(*new_cert));
     if (new_cert == NULL) {
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
@@ -3628,7 +3628,7 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
-        session->peer_cert = mbedtls_calloc(1, sizeof(mbedtls_x509_crt));
+        session->peer_cert = mbedtls_calloc(1, sizeof(*session->peer_cert));
 
         if (session->peer_cert == NULL) {
             return MBEDTLS_ERR_SSL_ALLOC_FAILED;
@@ -8232,7 +8232,7 @@ int mbedtls_ssl_parse_certificate(mbedtls_ssl_context *ssl)
      * reuse a session but it failed, and allocate a new one. */
     ssl_clear_peer_cert(ssl->session_negotiate);
 
-    chain = mbedtls_calloc(1, sizeof(mbedtls_x509_crt));
+    chain = mbedtls_calloc(1, sizeof(*chain));
     if (chain == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("alloc(%" MBEDTLS_PRINTF_SIZET " bytes) failed",
                                   sizeof(mbedtls_x509_crt)));

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -479,9 +479,9 @@ int mbedtls_ssl_tls13_parse_certificate(mbedtls_ssl_context *ssl,
     }
 
     if ((ssl->session_negotiate->peer_cert =
-             mbedtls_calloc(1, sizeof(mbedtls_x509_crt))) == NULL) {
+             mbedtls_calloc(1, sizeof(*ssl->session_negotiate->peer_cert))) == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("alloc( %" MBEDTLS_PRINTF_SIZET " bytes ) failed",
-                                  sizeof(mbedtls_x509_crt)));
+                                  sizeof(*ssl->session_negotiate->peer_cert)));
         MBEDTLS_SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR,
                                      MBEDTLS_ERR_SSL_ALLOC_FAILED);
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1245,7 +1245,7 @@ int mbedtls_ssl_tls13_compute_early_transform(mbedtls_ssl_context *ssl)
         goto cleanup;
     }
 
-    transform_earlydata = mbedtls_calloc(1, sizeof(mbedtls_ssl_transform));
+    transform_earlydata = mbedtls_calloc(1, sizeof(*transform_earlydata));
     if (transform_earlydata == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto cleanup;
@@ -1717,7 +1717,7 @@ int mbedtls_ssl_tls13_compute_handshake_transform(mbedtls_ssl_context *ssl)
         goto cleanup;
     }
 
-    transform_handshake = mbedtls_calloc(1, sizeof(mbedtls_ssl_transform));
+    transform_handshake = mbedtls_calloc(1, sizeof(*transform_handshake));
     if (transform_handshake == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto cleanup;
@@ -1808,7 +1808,7 @@ int mbedtls_ssl_tls13_compute_application_transform(mbedtls_ssl_context *ssl)
     }
 
     transform_application =
-        mbedtls_calloc(1, sizeof(mbedtls_ssl_transform));
+        mbedtls_calloc(1, sizeof(*transform_application));
     if (transform_application == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto cleanup;

--- a/library/x509.c
+++ b/library/x509.c
@@ -528,7 +528,7 @@ int mbedtls_x509_get_name(unsigned char **p, const unsigned char *end,
             /* Mark this item as being no the only one in a set */
             cur->next_merged = 1;
 
-            cur->next = mbedtls_calloc(1, sizeof(mbedtls_x509_name));
+            cur->next = mbedtls_calloc(1, sizeof(*cur->next));
 
             if (cur->next == NULL) {
                 ret = MBEDTLS_ERR_X509_ALLOC_FAILED;
@@ -545,7 +545,7 @@ int mbedtls_x509_get_name(unsigned char **p, const unsigned char *end,
             return 0;
         }
 
-        cur->next = mbedtls_calloc(1, sizeof(mbedtls_x509_name));
+        cur->next = mbedtls_calloc(1, sizeof(*cur->next));
 
         if (cur->next == NULL) {
             ret = MBEDTLS_ERR_X509_ALLOC_FAILED;
@@ -733,7 +733,7 @@ int mbedtls_x509_get_sig_alg(const mbedtls_x509_buf *sig_oid, const mbedtls_x509
     if (*pk_alg == MBEDTLS_PK_RSASSA_PSS) {
         mbedtls_pk_rsassa_pss_options *pss_opts;
 
-        pss_opts = mbedtls_calloc(1, sizeof(mbedtls_pk_rsassa_pss_options));
+        pss_opts = mbedtls_calloc(1, sizeof(*pss_opts));
         if (pss_opts == NULL) {
             return MBEDTLS_ERR_X509_ALLOC_FAILED;
         }
@@ -1261,7 +1261,7 @@ int mbedtls_x509_get_subject_alt_name_ext(unsigned char **p,
                 return MBEDTLS_ERR_X509_INVALID_EXTENSIONS;
             }
 
-            cur->next = mbedtls_calloc(1, sizeof(mbedtls_asn1_sequence));
+            cur->next = mbedtls_calloc(1, sizeof(*cur->next));
 
             if (cur->next == NULL) {
                 return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_X509_INVALID_EXTENSIONS,

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -264,7 +264,7 @@ static int x509_get_entries(unsigned char **p,
         }
 
         if (*p < end) {
-            cur_entry->next = mbedtls_calloc(1, sizeof(mbedtls_x509_crl_entry));
+            cur_entry->next = mbedtls_calloc(1, sizeof(*cur_entry->next));
 
             if (cur_entry->next == NULL) {
                 return MBEDTLS_ERR_X509_ALLOC_FAILED;
@@ -296,9 +296,9 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
         return MBEDTLS_ERR_X509_BAD_INPUT_DATA;
     }
 
-    memset(&sig_params1, 0, sizeof(mbedtls_x509_buf));
-    memset(&sig_params2, 0, sizeof(mbedtls_x509_buf));
-    memset(&sig_oid2, 0, sizeof(mbedtls_x509_buf));
+    memset(&sig_params1, 0, sizeof(sig_params1));
+    memset(&sig_params2, 0, sizeof(sig_params2));
+    memset(&sig_oid2, 0, sizeof(sig_oid2));
 
     /*
      * Add new CRL on the end of the chain if needed.
@@ -308,7 +308,7 @@ int mbedtls_x509_crl_parse_der(mbedtls_x509_crl *chain,
     }
 
     if (crl->version != 0 && crl->next == NULL) {
-        crl->next = mbedtls_calloc(1, sizeof(mbedtls_x509_crl));
+        crl->next = mbedtls_calloc(1, sizeof(*crl->next));
 
         if (crl->next == NULL) {
             mbedtls_x509_crl_free(crl);

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -803,7 +803,7 @@ static int x509_get_certificate_policies(unsigned char **p,
                 return MBEDTLS_ERR_X509_INVALID_EXTENSIONS;
             }
 
-            cur->next = mbedtls_calloc(1, sizeof(mbedtls_asn1_sequence));
+            cur->next = mbedtls_calloc(1, sizeof(*cur->next));
 
             if (cur->next == NULL) {
                 return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_X509_INVALID_EXTENSIONS,
@@ -1334,7 +1334,7 @@ static int mbedtls_x509_crt_parse_der_internal(mbedtls_x509_crt *chain,
      * Add new certificate on the end of the chain if needed.
      */
     if (crt->version != 0 && crt->next == NULL) {
-        crt->next = mbedtls_calloc(1, sizeof(mbedtls_x509_crt));
+        crt->next = mbedtls_calloc(1, sizeof(*crt->next));
 
         if (crt->next == NULL) {
             return MBEDTLS_ERR_X509_ALLOC_FAILED;

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -802,7 +802,7 @@ sni_entry *sni_parse(char *sni_string)
     *end = ',';
 
     while (p <= end) {
-        if ((new = mbedtls_calloc(1, sizeof(sni_entry))) == NULL) {
+        if ((new = mbedtls_calloc(1, sizeof(*new))) == NULL) {
             sni_free(cur);
             return NULL;
         }
@@ -816,8 +816,8 @@ sni_entry *sni_parse(char *sni_string)
 #endif
         GET_ITEM(auth_str);
 
-        if ((new->cert = mbedtls_calloc(1, sizeof(mbedtls_x509_crt))) == NULL ||
-            (new->key = mbedtls_calloc(1, sizeof(mbedtls_pk_context))) == NULL) {
+        if ((new->cert = mbedtls_calloc(1, sizeof(*new->cert))) == NULL ||
+            (new->key = mbedtls_calloc(1, sizeof(*new->key))) == NULL) {
             goto error;
         }
 
@@ -830,7 +830,7 @@ sni_entry *sni_parse(char *sni_string)
         }
 
         if (strcmp(ca_file, "-") != 0) {
-            if ((new->ca = mbedtls_calloc(1, sizeof(mbedtls_x509_crt))) == NULL) {
+            if ((new->ca = mbedtls_calloc(1, sizeof(*new->ca))) == NULL) {
                 goto error;
             }
 
@@ -843,7 +843,7 @@ sni_entry *sni_parse(char *sni_string)
 
 #if defined(MBEDTLS_X509_CRL_PARSE_C)
         if (strcmp(crl_file, "-") != 0) {
-            if ((new->crl = mbedtls_calloc(1, sizeof(mbedtls_x509_crl))) == NULL) {
+            if ((new->crl = mbedtls_calloc(1, sizeof(*new->crl))) == NULL) {
                 goto error;
             }
 
@@ -881,7 +881,7 @@ error:
 int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
                  const unsigned char *name, size_t name_len)
 {
-    const sni_entry *cur = (const sni_entry *) p_info;
+    const sni_entry *cur = (const void*)p_info;
 
     /* preserve behavior which checks for SNI match in sni_callback() for
      * the benefits of tests using sni_callback(), even though the actual
@@ -911,7 +911,7 @@ int sni_callback(void *p_info, mbedtls_ssl_context *ssl,
  */
 int cert_callback(mbedtls_ssl_context *ssl)
 {
-    const sni_entry *cur = (sni_entry *) mbedtls_ssl_get_user_data_p(ssl);
+    const sni_entry *cur = (const void *) mbedtls_ssl_get_user_data_p(ssl);
     if (cur != NULL) {
         /*(exercise mbedtls_ssl_get_hs_sni(); not otherwise used here)*/
         size_t name_len;
@@ -998,11 +998,11 @@ psk_entry *psk_parse(char *psk_string)
     *end = ',';
 
     while (p <= end) {
-        if ((new = mbedtls_calloc(1, sizeof(psk_entry))) == NULL) {
+        if ((new = mbedtls_calloc(1, sizeof(*new))) == NULL) {
             goto error;
         }
 
-        memset(new, 0, sizeof(psk_entry));
+        memset(new, 0, sizeof(*new));
 
         GET_ITEM(new->name);
         GET_ITEM(key_hex);

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -240,7 +240,7 @@ usage:
                     r = NULL;
                 }
 
-                cur = mbedtls_calloc(1, sizeof(mbedtls_x509_san_list));
+                cur = mbedtls_calloc(1, sizeof(*cur));
                 if (cur == NULL) {
                     mbedtls_printf("Not enough memory for subjectAltName list\n");
                     goto usage;

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -504,7 +504,7 @@ usage:
                     *r++ = '\0';
                 }
 
-                ext_key_usage = mbedtls_calloc(1, sizeof(mbedtls_asn1_sequence));
+                ext_key_usage = mbedtls_calloc(1, sizeof(*ext_key_usage));
                 ext_key_usage->buf.tag = MBEDTLS_ASN1_OID;
                 if (strcmp(q, "serverAuth") == 0) {
                     SET_OID(ext_key_usage->buf, MBEDTLS_OID_SERVER_AUTH);
@@ -561,7 +561,7 @@ usage:
                     r = NULL;
                 }
 
-                cur = mbedtls_calloc(1, sizeof(mbedtls_x509_san_list));
+                cur = mbedtls_calloc(1, sizeof(*cur));
                 if (cur == NULL) {
                     mbedtls_printf("Not enough memory for subjectAltName list\n");
                     goto usage;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -115,8 +115,7 @@ void mbedtls_test_ssl_buffer_init(mbedtls_test_ssl_buffer *buf)
 int mbedtls_test_ssl_buffer_setup(mbedtls_test_ssl_buffer *buf,
                                   size_t capacity)
 {
-    buf->buffer = (unsigned char *) mbedtls_calloc(capacity,
-                                                   sizeof(unsigned char));
+    buf->buffer = mbedtls_calloc(capacity, sizeof(unsigned char));
     if (NULL == buf->buffer) {
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
@@ -215,7 +214,7 @@ int mbedtls_test_ssl_buffer_get(mbedtls_test_ssl_buffer *buf,
 int mbedtls_test_ssl_message_queue_setup(
     mbedtls_test_ssl_message_queue *queue, size_t capacity)
 {
-    queue->messages = (size_t *) mbedtls_calloc(capacity, sizeof(size_t));
+    queue->messages = mbedtls_calloc(capacity, sizeof(size_t));
     if (NULL == queue->messages) {
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
@@ -344,9 +343,7 @@ int mbedtls_test_mock_socket_connect(mbedtls_test_mock_socket *peer1,
 {
     int ret = -1;
 
-    peer1->output =
-        (mbedtls_test_ssl_buffer *) mbedtls_calloc(
-            1, sizeof(mbedtls_test_ssl_buffer));
+    peer1->output = mbedtls_calloc(1, sizeof(mbedtls_test_ssl_buffer));
     if (peer1->output == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto exit;
@@ -356,9 +353,7 @@ int mbedtls_test_mock_socket_connect(mbedtls_test_mock_socket *peer1,
         goto exit;
     }
 
-    peer2->output =
-        (mbedtls_test_ssl_buffer *) mbedtls_calloc(
-            1, sizeof(mbedtls_test_ssl_buffer));
+    peer2->output = mbedtls_calloc(1, sizeof(mbedtls_test_ssl_buffer));
     if (peer2->output == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto exit;

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -214,7 +214,7 @@ int mbedtls_test_ssl_buffer_get(mbedtls_test_ssl_buffer *buf,
 int mbedtls_test_ssl_message_queue_setup(
     mbedtls_test_ssl_message_queue *queue, size_t capacity)
 {
-    queue->messages = mbedtls_calloc(capacity, sizeof(size_t));
+    queue->messages = mbedtls_calloc(capacity, sizeof(*queue->messages));
     if (NULL == queue->messages) {
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
@@ -343,7 +343,7 @@ int mbedtls_test_mock_socket_connect(mbedtls_test_mock_socket *peer1,
 {
     int ret = -1;
 
-    peer1->output = mbedtls_calloc(1, sizeof(mbedtls_test_ssl_buffer));
+    peer1->output = mbedtls_calloc(1, sizeof(*peer1->output));
     if (peer1->output == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto exit;
@@ -353,7 +353,7 @@ int mbedtls_test_mock_socket_connect(mbedtls_test_mock_socket *peer1,
         goto exit;
     }
 
-    peer2->output = mbedtls_calloc(1, sizeof(mbedtls_test_ssl_buffer));
+    peer2->output = mbedtls_calloc(1, sizeof(*peer2->output));
     if (peer2->output == NULL) {
         ret = MBEDTLS_ERR_SSL_ALLOC_FAILED;
         goto exit;

--- a/tests/suites/test_suite_pem.function
+++ b/tests/suites/test_suite_pem.function
@@ -17,7 +17,7 @@ void mbedtls_pem_write_buffer(char *start, char *end, data_t *buf,
     ret = mbedtls_pem_write_buffer(start, end, buf->x, buf->len, NULL, 0, &olen);
     TEST_ASSERT(ret == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL);
 
-    check_buf = (unsigned char *) mbedtls_calloc(1, olen);
+    check_buf = mbedtls_calloc(1, olen);
     TEST_ASSERT(check_buf != NULL);
 
     ret = mbedtls_pem_write_buffer(start, end, buf->x, buf->len, check_buf, olen, &olen2);


### PR DESCRIPTION
## Description

mbedTLS library has inconsistent syntax of the `mbedtls_calloc` function, with some functions casting the return value of the function, that is not necessary, since as per C standard `void*` is well promoted to the type of the variable pointer we are assigning the value.

Resolves #9184

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [x] **3.6 backport** done, or not required
- [x] **2.28 backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
