### PR TITLE
[Backport 2.28] Silence gcc 12.2.0 warning

### DIFF
--- a/library/psa_crypto_cipher.c
+++ b/library/psa_crypto_cipher.c
@@ -26,7 +26,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_psa(
     mbedtls_cipher_id_t *cipher_id)
 {
     mbedtls_cipher_mode_t mode;
-    mbedtls_cipher_id_t cipher_id_tmp;
+    mbedtls_cipher_id_t cipher_id_tmp = MBEDTLS_CIPHER_ID_NONE;
 
     if (PSA_ALG_IS_AEAD(alg)) {
         alg = PSA_ALG_AEAD_WITH_SHORTENED_TAG(alg, 0);


### PR DESCRIPTION
Backport of #9139
## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** done
- [x] **2.28 backport** not required (this is the backport)
- [ ] **tests** no
