### PR TITLE
[Backport 3.6] Fix build warning related to deprecated DTLS connect ID

### DIFF
--- a/ChangeLog.d/fix-dtls-connection-id-compat-build.txt
+++ b/ChangeLog.d/fix-dtls-connection-id-compat-build.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a compilation warning in ssl.h when MBEDTLS_SSL_DTLS_CONNECTION_ID
+     and MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT are not defined. Fixes #10207.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -656,10 +656,16 @@
 #define MBEDTLS_TLS_EXT_SIG_ALG_CERT                50 /* RFC 8446 TLS 1.3 */
 #define MBEDTLS_TLS_EXT_KEY_SHARE                   51 /* RFC 8446 TLS 1.3 */
 
+/*
+ * MBEDTLS_TLS_EXT_CID is required only when
+ * MBEDTLS_SSL_DTLS_CONNECTION_ID is defined.
+ */
+#if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 #if MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT == 0
 #define MBEDTLS_TLS_EXT_CID                         54 /* RFC 9146 DTLS 1.2 CID */
 #else
 #define MBEDTLS_TLS_EXT_CID                        254 /* Pre-RFC 9146 DTLS 1.2 CID */
+#endif
 #endif
 
 #define MBEDTLS_TLS_EXT_ECJPAKE_KKPP               256 /* experimental */


### PR DESCRIPTION
## Description

Fix build issues related to deprecated MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT not being defined:
```
In file included from lib/libmbedtls/mbedtls/library/ssl_misc.h:18,
                 from lib/libmbedtls/mbedtls/library/ssl_debug_helpers_generated.c:14:
lib/libmbedtls/mbedtls/include/mbedtls/ssl.h:659:5: warning: "MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT" is not defined, evaluates to 0 [-Wundef]
  659 | #if MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT == 0
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

We faced this issue porting mbedTLS 3.6.3 in OP-TEE ([OP-TEE OS P-R 7337](https://github.com/OP-TEE/optee_os/pull/7337)). The issue seems relevant in both 3.6 stream and development stream.

## PR checklist

- [x] **changelog** not required because: it's a compiler warning issue
- [x] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10113
- [x] **TF-PSA-Crypto PR** not required because: not affected
- [x] **framework PR** not required
- [x] **3.6 PR** provided: this P-R (https://github.com/Mbed-TLS/mbedtls/pull/10112)
- [x] **tests** not required because: this only fixes a build warning
