### PR TITLE
Remove use of mbedtls_md_get_name() from ssl_context_info.c 

### DIFF
--- a/programs/ssl/ssl_context_info.c
+++ b/programs/ssl/ssl_context_info.c
@@ -547,14 +547,10 @@ static void print_deserialized_ssl_session(const uint8_t *ssl, uint32_t len,
     if (ciphersuite_info == NULL) {
         printf_err("Cannot find ciphersuite info\n");
     } else {
-
         printf("\tciphersuite    : %s\n", mbedtls_ssl_ciphersuite_get_name(ciphersuite_info));
         printf("\tcipher flags   : 0x%02X\n", ciphersuite_info->MBEDTLS_PRIVATE(flags));
         printf("\tcipher type     : %d\n", ciphersuite_info->MBEDTLS_PRIVATE(cipher));
-
-#if defined(MBEDTLS_MD_C)
         printf("\tMessage-Digest : %d\n", ciphersuite_info->MBEDTLS_PRIVATE(mac));
-#endif /* MBEDTLS_MD_C */
     }
 
     CHECK_SSL_END(1);

--- a/tests/context-info.sh
+++ b/tests/context-info.sh
@@ -205,7 +205,7 @@ run_test "Default configuration, server" \
          -u "MBEDTLS_SSL_ALPN$" \
          -u "ciphersuite.* TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256$" \
          -u "cipher flags.* 0x00$" \
-         -u "Message-Digest.* [0-9]\+$" \
+         -u "Message-Digest.* 9$" \
          -u "compression.* disabled$" \
          -u "DTLS datagram packing.* enabled$" \
          -n "Certificate" \
@@ -227,7 +227,7 @@ run_test "Default configuration, client" \
          -u "MBEDTLS_SSL_ALPN$" \
          -u "ciphersuite.* TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256$" \
          -u "cipher flags.* 0x00$" \
-         -u "Message-Digest.* [0-9]\+$" \
+         -u "Message-Digest.* 9$" \
          -u "compression.* disabled$" \
          -u "DTLS datagram packing.* enabled$" \
          -u "cert. version .* 3$" \
@@ -348,7 +348,7 @@ run_test "Older version (v2.19.1)" \
          -u "minor.* 19$" \
          -u "path.* 1$" \
          -u "ciphersuite.* TLS-ECDHE-ECDSA-WITH-AES-128-CCM-8$" \
-         -u "Message-Digest.* [0-9]\+$" \
+         -u "Message-Digest.* 9$" \
          -u "compression.* disabled$" \
          -u "serial number.* 01:70:AF:40:B4:E6$" \
          -u "issuer name.* CN=ca$" \


### PR DESCRIPTION
## Description

Resolves #10154 

## PR checklist
- [x] **changelog**  not required because:  This doesn't fix anything relevant
- [x] **development PR** not required because:  This is going to be refactored
- [x] **TF-PSA-Crypto PR** not required because: It doesn't apply
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: 
- [x] **tests**  not required because: 