### PR TITLE
Added shallow clone for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "framework"]
 	path = framework
 	url = https://github.com/Mbed-TLS/mbedtls-framework
+	shallow = true
 [submodule "tf-psa-crypto"]
 	path = tf-psa-crypto
 	url = https://github.com/Mbed-TLS/TF-PSA-Crypto.git
+	shallow = true


### PR DESCRIPTION
-will result in kb checkout instead of 180mb
-if necessary to pull entire repo, can run `git pull --unshallow`

## Description
Resolves #10218 


## PR checklist

- [ ] **changelog** provided | Pulling project by default will shallow clone resulting in a faster checkout
- [ ] **development PR** | not required because: not touched
- [ ] **TF-PSA-Crypto PR**  | not required because:  not touched
- [ ] **framework PR** | not required: not touched
- [ ] **3.6 PR**  | not required because: 
- **tests**  | not required because: nothing to test
