### PR TITLE
[3.6] Turn Wunterminated-string-initialization back into an error

### DIFF
--- a/tests/scripts/components-compiler.sh
+++ b/tests/scripts/components-compiler.sh
@@ -94,9 +94,6 @@ component_test_gcc15_drivers_opt () {
     loc_cflags="$ASAN_CFLAGS -DPSA_CRYPTO_DRIVER_TEST_ALL"
     loc_cflags="${loc_cflags} '-DMBEDTLS_USER_CONFIG_FILE=\"../tests/configs/user-config-for-test.h\"'"
     loc_cflags="${loc_cflags} -I../framework/tests/include -O2"
-    # Allow a warning that we don't yet comply to.
-    # https://github.com/Mbed-TLS/mbedtls/issues/9944
-    loc_cflags="${loc_cflags} -Wno-error=unterminated-string-initialization"
 
     make CC=$GCC_15 CFLAGS="${loc_cflags}" LDFLAGS="$ASAN_CFLAGS"
 


### PR DESCRIPTION
Now that the fixes for the GCC-15 warning `unterminated-string-initialization` are merged, we can remove the exception that stops this being an error due to `Werror`, so that it will become an error again.

Resolves https://github.com/Mbed-TLS/mbedtls/issues/9944, from comment https://github.com/Mbed-TLS/mbedtls/issues/9944#issuecomment-2995252780

## PR checklist

- [x] **changelog** not required because: CI change
- [x] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10245
- [x] **TF-PSA-Crypto PR** not required because: applicable test lives in `mbedtls`
- [x] **framework PR** not required
- [x] **3.6 PR** provided: HERE
- **tests**  not required because: change to tests