### PR TITLE
Update .gitattributes to add exlusion lists.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
 # Classify all '.function' files as C for syntax highlighting purposes
 *.function linguist-language=C
+
+# Ignore listed files when creating an archive
+.github/**         export-ignore
+.git*              export-ignore
+.pylintrc          export-ignore
+.mypy.ini.         export-ignore
+.globalrc	       export-ignore
+.travis.yml        export-ignore
+.readthedocs.yaml  export-ignore


### PR DESCRIPTION
## Description

We are using [git-archive](https://git-scm.com/docs/git-archive) as the standard way to generate tarballs. As part of the tarball creation, the tool, is parsing .gitattributes for context. 

This pr is using the `export-ignore` directive as defined by git-scm [manual](https://git-scm.com/docs/gitattributes#_export_ignore) to remove certain files that do not belong to a flattened product release of a code-base.

The hidden files that I am aiming for are
~~~~~
ls .*
.gitattributes		.gitmodules		.mypy.ini		.readthedocs.yaml	.uncrustify.cfg
.gitignore		.globalrc		.pylintrc		.travis.yml
~~~~~

I have kept the .uncrustify.cfg because there is value in codifying our code-style.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Does not affect the library, this PR focuses tooling.
- [x] **development PR** provided here.
- [x] **TF-PSA-Crypto PR** provided  Mbed-TLS/TF-PSA-Crypto#354
- [x] **framework PR** not required  because framework is not distributed as an independant release.
- [x] **3.6 PR** provided #10268
- **tests**  provided | not required because: Does not affect the library, this PR focuses tooling.