### PR TITLE
add cast to fix IAR compiler warnings

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -1322,14 +1322,14 @@ static inline void mbedtls_ssl_handshake_set_state(mbedtls_ssl_context *ssl,
                                                    mbedtls_ssl_states state)
 {
     MBEDTLS_SSL_DEBUG_MSG(3, ("handshake state: %d (%s) -> %d (%s)",
-                              ssl->state, mbedtls_ssl_states_str(ssl->state),
+                              ssl->state, mbedtls_ssl_states_str((mbedtls_ssl_states)ssl->state),
                               (int) state, mbedtls_ssl_states_str(state)));
     ssl->state = (int) state;
 }
 
 static inline void mbedtls_ssl_handshake_increment_state(mbedtls_ssl_context *ssl)
 {
-    mbedtls_ssl_handshake_set_state(ssl, ssl->state + 1);
+    mbedtls_ssl_handshake_set_state(ssl, (mbedtls_ssl_states)(ssl->state + 1));
 }
 
 MBEDTLS_CHECK_RETURN_CRITICAL


### PR DESCRIPTION

## Description

We use the IAR compiler to build mbedtls for our embedded project. This compiler throws a warning about these two lines:

```error
mbedtls_ssl_handshake_set_state(ssl, (ssl->state + 1));
                                           ^
"D:\proj\sinamics-m\firmware\lib\mbedtls\library\ssl_misc.h",1361  Error[Pe188]: 
          enumerated type mixed with another type
```

As we tread all warning as errors, we currently have to apply a patch. 

Adding the casts fixes the issue.

## Changelog
```md
* Fix IAR compiler warnings.
```
