### PR TITLE
Make generate_errors.pl scan through private directories too

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -89,7 +89,7 @@ foreach my $file (@files) {
         $description =~ s/^\s+//;
         $description =~ s/\n( *\*)? */ /g;
         $description =~ s/\.?\s+$//;
-        push @matches, [$name, $value, $description, grep(/^.*private\/[^\/]+$/, $file)];
+        push @matches, [$name, $value, $description, scalar($file =~ /^.*private\/[^\/]+$/)];
         ++$found;
     }
     if ($found) {


### PR DESCRIPTION
## Description

Part of the moving headers to private directories PR series:

This PR changes generate_errors.pl so that it goes through headers in private directories too, and correctly includes them in the final output.

## PR checklist

- [x] **changelog** not required (internal only)
- [X] **development PR** provided #10281
- [X] **TF-PSA-Crypto PR** not required because: not related
- [X] **framework PR** not required
- [x] **3.6 PR** not required because: 4.0 only
- **tests**  not required because: this change is tested by the CI 

