### PR TITLE
[Backport 3.6] Update note about the first 4.x LTS

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -26,8 +26,9 @@ ABI compatibility within LTS branches; see the next section for details.
 
 We will make regular LTS releases on an 18-month cycle, each of which will have
 a 3 year support lifetime. On this basis, 3.6 LTS (released March 2024) will be
-supported until March 2027. The next LTS release will be a 4.x release, which is
-planned for September 2025.
+supported until March 2027. The next LTS release will be a 4.x release. Due to
+the size and scope of the 4.0 release, the release date of the first 4.x LTS is
+yet to be determined.
 
 ## Backwards Compatibility for application code
 


### PR DESCRIPTION
Trivial backport of #10286 

The release date is yet to be determined, to allow time for 4.x to stabilise.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Small docs change only
- [x] **development PR** provided: #10286 
- [x] **TF-PSA-Crypto PR** not required because: Only affects Mbed TLS
- [x] **framework PR** not required
- [x] **3.6 PR** here
- **tests**  not required because: Docs change only