### PR TITLE
mbedtls 2.28: Fix build and tests when building with gcc15

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -378,4 +378,20 @@ static inline const unsigned char *mbedtls_buffer_offset_const(
 #    define MBEDTLS_MAYBE_UNUSED
 #endif
 
+/* GCC >= 15 has a warning 'unterminated-string-initialization' which complains if you initialize
+ * a string into an array without space for a terminating NULL character. In some places in the
+ * codebase this behaviour is intended, so we add the macro MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING
+ * to suppress the warning in these places.
+ */
+#if defined(__has_attribute)
+#if __has_attribute(nonstring)
+#define MBEDTLS_HAS_ATTRIBUTE_NONSTRING
+#endif /* __has_attribute(nonstring) */
+#endif /* __has_attribute */
+#if defined(MBEDTLS_HAS_ATTRIBUTE_NONSTRING)
+#define MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING __attribute__((nonstring))
+#else
+#define MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING
+#endif /* MBEDTLS_HAS_ATTRIBUTE_NONSTRING */
+
 #endif /* MBEDTLS_LIBRARY_COMMON_H */

--- a/library/psa_crypto_mac.c
+++ b/library/psa_crypto_mac.c
@@ -464,6 +464,15 @@ psa_status_t mbedtls_psa_mac_compute(
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
     mbedtls_psa_mac_operation_t operation = MBEDTLS_PSA_MAC_OPERATION_INIT;
+    /* Make sure the whole operation is zeroed.
+     * PSA_MAC_OPERATION_INIT does not necessarily do it fully,
+     * since one field is a union and initializing a union does not
+     * necessarily initialize all of its members.
+     * In multipart operations, this is done in the API functions,
+     * before driver dispatch, since it needs to be done before calling
+     * the driver entry point. Here, we bypass the multipart API,
+     * so it's our job. */
+    memset(&operation, 0, sizeof(operation));
 
     status = psa_mac_setup(&operation,
                            attributes, key_buffer, key_buffer_size,

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -67,7 +67,7 @@ struct mbedtls_ssl_tls1_3_labels_struct const mbedtls_ssl_tls1_3_labels =
  *         the HkdfLabel structure on success.
  */
 
-static const char tls1_3_label_prefix[6] = "tls13 ";
+static const char tls1_3_label_prefix[6] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "tls13 ";
 
 #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
     (2                     /* expansion length           */ \

--- a/library/ssl_tls13_keys.h
+++ b/library/ssl_tls13_keys.h
@@ -7,6 +7,8 @@
 #if !defined(MBEDTLS_SSL_TLS1_3_KEYS_H)
 #define MBEDTLS_SSL_TLS1_3_KEYS_H
 
+#include "common.h"
+
 /* This requires MBEDTLS_SSL_TLS1_3_LABEL( idx, name, string ) to be defined at
  * the point of use. See e.g. the definition of mbedtls_ssl_tls1_3_labels_union
  * below. */
@@ -30,8 +32,9 @@
     MBEDTLS_SSL_TLS1_3_LABEL(res_binder, "res binder") \
     MBEDTLS_SSL_TLS1_3_LABEL(derived, "derived")
 
+/* We need to tell the compiler that we meant to leave out the null character. */
 #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
-    const unsigned char name    [sizeof(string) - 1];
+    const unsigned char name    [sizeof(string) - 1] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING;
 
 union mbedtls_ssl_tls1_3_labels_union {
     MBEDTLS_SSL_TLS1_3_LABEL_LIST

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -7,6 +7,8 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "common.h"
+
 #include <test/helpers.h>
 #include <test/macros.h>
 #include <test/psa_exercise_key.h>
@@ -150,7 +152,7 @@ static int exercise_cipher_key(mbedtls_svc_key_id_t key,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t key_type;
     const unsigned char plaintext[16] = "Hello, world...";
-    unsigned char ciphertext[32] = "(wabblewebblewibblewobblewubble)";
+    unsigned char ciphertext[32] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "(wabblewebblewibblewobblewubble)";
     size_t ciphertext_length = sizeof(ciphertext);
     unsigned char decrypted[sizeof(ciphertext)];
     size_t part_length;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1990,7 +1990,9 @@ void mac_setup(int key_type_arg,
     psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
     psa_status_t status = PSA_ERROR_GENERIC_ERROR;
 #if defined(KNOWN_SUPPORTED_MAC_ALG)
-    const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t smoke_test_key_data[16] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING =
+        "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());
@@ -2381,7 +2383,9 @@ void cipher_setup(int key_type_arg,
     psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
     psa_status_t status;
 #if defined(KNOWN_SUPPORTED_CIPHER_ALG)
-    const uint8_t smoke_test_key_data[16] = "kkkkkkkkkkkkkkkk";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t smoke_test_key_data[16] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING =
+        "kkkkkkkkkkkkkkkk";
 #endif
 
     PSA_ASSERT(psa_crypto_init());

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -1,6 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
+#include "common.h"
 #include "psa_crypto_slot_management.h"
 #include "psa_crypto_storage.h"
 
@@ -358,8 +359,9 @@ void create_existent(int lifetime_arg, int owner_id_arg, int id_arg,
     mbedtls_svc_key_id_t returned_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t type1 = PSA_KEY_TYPE_RAW_DATA;
-    const uint8_t material1[5] = "a key";
-    const uint8_t material2[5] = "b key";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    const uint8_t material1[5] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "a key";
+    const uint8_t material2[5] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "b key";
     size_t bits1 = PSA_BYTES_TO_BITS(sizeof(material1));
     uint8_t reexported[sizeof(material1)];
     size_t reexported_length;
@@ -728,7 +730,7 @@ void invalid_handle(int handle_construction,
     psa_key_id_t key_id;
     psa_status_t close_status = close_status_arg;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    uint8_t material[1] = "a";
+    uint8_t material[1] = { 'a' };
 
     PSA_ASSERT(psa_crypto_init());
 

--- a/tests/suites/test_suite_ssl_decrypt.function
+++ b/tests/suites/test_suite_ssl_decrypt.function
@@ -36,7 +36,7 @@ void ssl_decrypt_stream(int cipher_type, int hash_id, int trunc_hmac)
         .cid = { 0 },
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
     };
-    const char sample_plaintext[3] = "ABC";
+    const char sample_plaintext[3] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING = "ABC";
     mbedtls_cipher_context_t cipher;
     mbedtls_cipher_init(&cipher);
     mbedtls_ssl_context ssl;


### PR DESCRIPTION
## Description

Fixes #10168 and #10215 for 2.28.

## PR checklist

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- [ ] **tests**  provided | not required because: 