### PR TITLE
Disambiguate `version.h` in doxygen comment

### DIFF
--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -1,5 +1,5 @@
 /**
- * \file version.h
+ * \file mbedtls/version.h
  *
  * \brief Run-time version information
  */


### PR DESCRIPTION
Needed to progress Mbed-TLS/TF-PSA-Crypto#367

Specify `mbedtls/version.h` in the doxygen `\file` comment, since we are about to add `include/tf-psa-crypto/version.h`.


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Minor docs change
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: This PR stands alone
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: Only one `version.h` in 3.6
- **tests**  not required because: docs changes only
