### PR TITLE
Remove `tf-psa-crypto/include/mbedtls/private` from Doxygen

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -8,6 +8,7 @@ EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = NO
 INPUT                  = ../include input ../tf-psa-crypto/include ../tests/include/alt-dummy
 FILE_PATTERNS          = *.h
+EXCLUDE                = ../tf-psa-crypto/include/mbedtls/private
 RECURSIVE              = YES
 EXCLUDE_SYMLINKS       = YES
 SOURCE_BROWSER         = YES


### PR DESCRIPTION
Don't render files in `tf-psa-crypto/include/mbedtls/private`

## PR checklist

- [x] **changelog** not required because: documentation change
- [x] **development PR** provided: HERE 
- [x] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/424
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: directory new in 4.0/1.0
- **tests**  not required because: documentation change