### PR TITLE
Clarify use of `CC` and friends for file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ The following tools are required:
     Depending on your Python installation, you may need to invoke `python` instead of `python3`. To install the packages system-wide, omit the `--user` option.
 * A C compiler for the host platform, for some test data.
 
-If you are cross-compiling, you must set the `CC` environment variable to a C compiler for the host platform when generating the configuration-independent files.
+The scripts that generate the configuration-independent files will look for a host C compiler in the following places (in order of preference):
+
+1. The `HOSTCC` environment variable. This can be used if `CC` is pointing to a cross-compiler.
+2. The `CC` environment variable.
+3. An executable called `cc` in the current path.
+
+Note: If you have multiple toolchains installed, it is recommended to set `CC` or `HOSTCC` to the intended host compiler before generating the files.
 
 Any of the following methods are available to generate the configuration-independent files:
 


### PR DESCRIPTION
Add more detail around how generation of configuration-independent files chooses a C compiler. Mention that setting `HOSTCC` or `CC` is recommended where there are multiple toolchains.

Mention that the fallback location is the cc executable, which may help users troubleshooting when the file generation picks up the wrong toolchain (as in Mbed-TLS/mbedtls#10360).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Documentation only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because TF-PSA-Crypto uses CMake and detects its own compiler
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10366 
- **tests**  not required because: Documentation only
