### PR TITLE
Remove deprecated compilation options

### DIFF
--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -297,9 +297,6 @@ component_build_sha_armce () {
         grep -E 'sha256[a-z0-9]+.32\s+[qv]' ${BUILTIN_SRC_PATH}/sha256.s
     scripts/config.py unset MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_ONLY
 
-
-    # test the deprecated form of the config option
-
     scripts/config.py set MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT
         msg "MBEDTLS_SHA256_USE_ARMV8_A_CRYPTO_IF_PRESENT clang, aarch64"
         make -B library/../${BUILTIN_SRC_PATH}/sha256.o library/../${BUILTIN_SRC_PATH}/sha256.s CC=clang CFLAGS="--target=aarch64-linux-gnu -march=armv8-a+crypto"


### PR DESCRIPTION
## Description

Remove deprecated compilation options contributes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/375 

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10370
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/427
3. https://github.com/Mbed-TLS/mbedtls/pull/10391


## PR checklist

- [x] **changelog** not required because:  No public changes
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/427
- [x] **framework PR** not required
- [x] **3.6 PR** not required because:  No backports
- **tests**  not required because: No changes
