### PR TITLE
x509_crt: Zero-initialize mbedtls_x509_time at declaration

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2494,7 +2494,7 @@ static int x509_crt_verify_chain(
     int signature_is_good;
     unsigned self_cnt;
     mbedtls_x509_crt *cur_trust_ca = NULL;
-    mbedtls_x509_time now;
+    mbedtls_x509_time now = {0};
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
     if (mbedtls_x509_time_gmtime(mbedtls_time(NULL), &now) != 0) {


### PR DESCRIPTION
'mbedtls_x509_time now' is a local struct variable. passing an uninitialized local as a const *
argument is UB-risk, since the callee is not
allowed to write into it.

Clang-21 got stricter about const pointer arguments finds it and flags it.

zero-initializing ensures all fields are defined.

## Description

Fix build with clang-21


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **3.6 PR** provided # | not required because: 
- **tests**  provided | not required because: 



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
