### PR TITLE
Update header guard use in p256m test

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -1356,7 +1356,7 @@ component_test_tfm_config_no_p256m () {
 
     # Disable P256M driver, which is on by default, so that analyze_outcomes
     # can compare this test with test_tfm_config_p256m_driver_accel_ec
-    sed -i '/MBEDTLS_PSA_P256M_DRIVER_ENABLED/d'  "$CRYPTO_CONFIG_H"
+    scripts/config.py -f "$CRYPTO_CONFIG_H" unset MBEDTLS_PSA_P256M_DRIVER_ENABLED
 
     msg "build: TF-M config without p256m"
     make CFLAGS='-Werror -Wall -Wextra -I../framework/tests/include/spe' tests


### PR DESCRIPTION
## Description

Update p256m test to use config instead of header guard. Contributes to https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/399

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10379
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/428

## PR checklist

- [x] **changelog** not required because: test-only
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/428
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No backports
- **tests**  provided
