### PR TITLE
[3.6 backport] Use submodule work trees during ABI check

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -207,7 +207,8 @@ class AbiChecker:
 
         try:
             # Try to update the submodules using local commits
-            # (Git will sometimes insist on fetching the remote without --no-fetch if the submodules are shallow clones)
+            # (Git will sometimes insist on fetching the remote without --no-fetch
+            # if the submodules are shallow clones)
             update_output = subprocess.check_output(
                 [self.git_command, "submodule", "update", "--init", '--recursive', '--no-fetch'],
                 cwd=git_worktree_path,


### PR DESCRIPTION
3.6 backport of #10416

## PR checklist
- [x] **changelog**  not required
- [x] **development PR** #10416
- [x] **TF-PSA-Crypto PR** not required 
- [x] **framework PR** not required
- [x] **3.6 PR**: #10417
- **tests** not required 