### PR TITLE
Backport 3.6: Replace cases of time_t with mbedtls_time_t

### DIFF
--- a/ChangeLog.d/replace_time_t.txt
+++ b/ChangeLog.d/replace_time_t.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a build error or incorrect TLS session
+     lifetime on platforms where mbedtls_time_t
+     is not time_t. Fixes #10236.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3627,7 +3627,7 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
     start = MBEDTLS_GET_UINT64_BE(p, 0);
     p += 8;
 
-    session->start = (time_t) start;
+    session->start = (mbedtls_time_t) start;
 #endif /* MBEDTLS_HAVE_TIME */
 
     /*

--- a/programs/test/udp_proxy.c
+++ b/programs/test/udp_proxy.c
@@ -22,7 +22,6 @@
 #if defined(MBEDTLS_HAVE_TIME)
 #include <time.h>
 #define mbedtls_time            time
-#define mbedtls_time_t          time_t
 #endif
 #define mbedtls_printf          printf
 #define mbedtls_calloc          calloc


### PR DESCRIPTION
## Description

Time t backport contributes https://github.com/Mbed-TLS/mbedtls/issues/10236


## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10423
- [x] **TF-PSA-Crypto PR** not required because: No changes
- [x] **framework PR** not required
- [x] **3.6 PR** provided #HERE
- **tests**  not required because: No changes
