### PR TITLE
Remove uses of mbedtls_pk_verify_new

### DIFF
--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -1995,7 +1995,7 @@ start_processing:
 
 #if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
         if (pk_alg == MBEDTLS_PK_RSASSA_PSS) {
-            ret = mbedtls_pk_verify_new(pk_alg, peer_pk,
+            ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) pk_alg, peer_pk,
                                         md_alg, hash, hashlen,
                                         p, sig_len);
         } else

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -300,13 +300,13 @@ static int ssl_tls13_parse_certificate_verify(mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF(3, "verify hash", verify_hash, verify_hash_len);
 
-    if ((ret = mbedtls_pk_verify_new(sig_alg,
+    if ((ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) sig_alg,
                                      &ssl->session_negotiate->peer_cert->pk,
                                      md_alg, verify_hash, verify_hash_len,
                                      p, signature_len)) == 0) {
         return 0;
     }
-    MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_new", ret);
+    MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_ext", ret);
 
 error:
     /* RFC 8446 section 4.4.3


### PR DESCRIPTION
## Description

Remove uses of mbedtls_pk_verify_new

This PR is part of a multistage PR to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10449
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/517

## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/517
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No Backports
- **tests**  not required because: No Changes
