### PR TITLE
Fix documentation link to submodule that doesn't work on GitHub

### DIFF
--- a/docs/4.0-migration-guide.md
+++ b/docs/4.0-migration-guide.md
@@ -11,7 +11,7 @@ The changes are detailed below. Here is a summary of the main points:
 - The cryptography API is now mostly the PSA API: most legacy cryptography APIs have been removed. This has led to adaptations in some X.509 and TLS APIs, notably because the library always uses the PSA random generator.
 - Various deprecated or minor functionality has been removed.
 
-Please consult the [TF-PSA-Crypto migration guide](../tf-psa-crypto/docs/1.0-migration-guide.md) for all information related to the crytography part of the library.
+Please consult the [TF-PSA-Crypto migration guide](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/docs/1.0-migration-guide.md) for all information related to the crytography part of the library.
 
 ## CMake as the only build system
 Mbed TLS now uses CMake exclusively to configure and drive its build process.


### PR DESCRIPTION
Fixes #10458.

I didn't find any other similar cross-submodule relative link in documentation in Mbed TLS or in TF-PSA-Crypto.

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: no similar problem in crypto
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: introduced in 4.0
- **tests**  not required because: doc only
