### PR TITLE
Update `prepare_release.sh`

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -9,6 +9,8 @@
 #     ignoring the automatically-generated files.
 #   - Sets the CMake option `GEN_FILES` to OFF to explicitely disable
 #     recreating the automatically-generated files.
+#.  - The script will recursively update the tf-psa-crypto files too.
+
 
 set -eu
 
@@ -25,7 +27,7 @@ psed() {
 }
 
 #### .gitignore processing ####
-for GITIGNORE in $(git ls-files -- '*.gitignore'); do
+for GITIGNORE in $(git ls-files --recurse-submodules -- '*.gitignore'); do
         psed '/###START_GENERATED_FILES###/,/###END_GENERATED_FILES###/s/^/#/' "$GITIGNORE"
         psed 's/###START_GENERATED_FILES###/###START_COMMENTED_GENERATED_FILES###/' "$GITIGNORE"
         psed 's/###END_GENERATED_FILES###/###END_COMMENTED_GENERATED_FILES###/' "$GITIGNORE"


### PR DESCRIPTION
## Description

The version of prepare_release.sh we have been using was not created with consideration of the split repository release structure and the deprecation of the Make build system. This pr is doing the following:

- Add portability to MacOS
- Removed release/unrelease modes
- Simplified regex
- Added basic file documentation
- Removed modification of the Makefiles


## PR checklist
- [x] **changelog** not required because: This is helper script for release preparation
- [x] **development PR** provided here
- [x] **TF-PSA-Crypto PR** not required because: This script is not used in TF-PSA-Crypto
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10483
- **tests**  not required because: helper utility script update


