### PR TITLE
Move abi_check.py to the framework

### DIFF
--- a/scripts/abi_check.py
+++ b/scripts/abi_check.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Bridge script
+See framework/scripts/mbedtls_framework/interface_checks.py for detailed documentation.
+
+This is a convenient place to encode any branch-specific information we might want to add
+in the future.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+import framework_scripts_path # pylint: disable=unused-import
+from mbedtls_framework import interface_checks
+
+if __name__ == "__main__":
+    interface_checks.run_main()


### PR DESCRIPTION
## Description

Move abi_check.py to the framework so we can share it with 3.6 and TF-PSA-Crypto.

## PR checklist
- [x] **changelog** not required because: Only test changes
- [ ] **framework PR**: https://github.com/Mbed-TLS/mbedtls-framework/pull/229
- [ ] **mbedtls-test PR**: https://github.com/Mbed-TLS/mbedtls-test/pull/241
- [ ] **TF-PSA-Crypto PR**: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/541
- [ ] **development PR**: https://github.com/Mbed-TLS/mbedtls/pull/10464
- [ ] **3.6 PR**: https://github.com/Mbed-TLS/mbedtls/pull/10465
- **tests**: only test changes