### PR TITLE
Use GNUInstallDirs CMAKE_INSTALL_INCLUDEDDIR path for headers installation

### DIFF
--- a/ChangeLog.d/gnuinstalldirs_include.txt
+++ b/ChangeLog.d/gnuinstalldirs_include.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * CMake now installs headers to `CMAKE_INSTALL_INCLUDEDIR` instead of the
+     hard-coded `include` directory.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -5,13 +5,13 @@ if(INSTALL_MBEDTLS_HEADERS)
     file(GLOB headers "mbedtls/*.h")
 
     install(FILES ${headers}
-        DESTINATION include/mbedtls
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbedtls
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
     file(GLOB private_headers "mbedtls/private/*.h")
 
     install(FILES ${private_headers}
-        DESTINATION include/mbedtls/private
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mbedtls/private
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 endif(INSTALL_MBEDTLS_HEADERS)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -241,7 +241,7 @@ foreach(target IN LISTS target_libraries)
         PUBLIC $<BUILD_INTERFACE:${MBEDTLS_DIR}/include/>
                $<BUILD_INTERFACE:${MBEDTLS_DIR}/tf-psa-crypto/include/>
                $<BUILD_INTERFACE:${MBEDTLS_DIR}/tf-psa-crypto/drivers/builtin/include/>
-               $<INSTALL_INTERFACE:include/>
+               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         PRIVATE ${MBEDTLS_DIR}/library/
                 ${MBEDTLS_DIR}/tf-psa-crypto/core
                 ${MBEDTLS_DIR}/tf-psa-crypto/drivers/builtin/src


### PR DESCRIPTION
## Description

Using a hardcoded path like "include" for headers path doesn't follow GNUInstallDirs method.

## PR checklist
- [x] **changelog** provided                           
- [x] **development PR** provided here                   
- [x] **TF-PSA-Crypto PR** provided | https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/547                  
- [x] **framework PR** not required      
- [x] **3.6 PR** provided #10470                     
- **tests** not required because: The installation process is exercised by programs/test/cmake_package_install.