### PR TITLE
Fix duplication of product version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,7 +522,7 @@ if(NOT DISABLE_PACKAGE_CONFIG_AND_INSTALL)
     write_basic_package_version_file(
         "cmake/MbedTLSConfigVersion.cmake"
             COMPATIBILITY SameMajorVersion
-            VERSION 4.0.0)
+            VERSION "${MBEDTLS_VERSION}")
 
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfig.cmake"


### PR DESCRIPTION
Fix duplication of the product version. We need to fix this before the next release, otherwise we'll have the same problem as
https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/553

## PR checklist

- [x] **changelog** not required because: not buggy yet
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/554 (similar bug, not prerequisite)
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: in 3.6, `bump_version.sh` catches all occurrences of the version (although we could backport this if we want more consistency, and we should probably backport this if we move 3.6 to the new release script)
- **tests**  not required because: it's now automatic, so I don't think it's worth testing
