### PR TITLE
[Backport]Update prepare_release.sh

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -34,5 +34,6 @@ for GITIGNORE in $(git ls-files --recurse-submodules -- '*.gitignore'); do
 done
 
 #### Build scripts ####
-psed '/[Oo][Ff][Ff] in development/! s/^\( *GEN_FILES[ ?:]*= *\)\([A-Za-z0-9][A-Za-z0-9]*\)/\1OFF/' Makefile library/Makefile
-psed '/[Oo][Ff][Ff] in development/! s/^\( *option *( *GEN_FILES  *"[^"]*"  *\)\([A-Za-z0-9][A-Za-z0-9]*\)/\1OFF/' CMakeLists.txt tf-psa-crypto/CMakeLists.txt
+psed 's/^\(GEN_FILES[ ?:]*=\)\([^#]*\)/\1/' Makefile */Makefile
+psed '/[Oo][Ff][Ff] in development/! s/^\( *option *( *GEN_FILES  *"[^"]*"  *\)\([A-Za-z0-9][A-Za-z0-9]*\)/\1OFF/' CMakeLists.txt
+


### PR DESCRIPTION
## Description

Backport of #10462

This pr is simplifying the logic of prepare_release.sh:

- Add portability to MacOS
- Removed the release/unrelease mode
- Added some documentation for clarity


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: release script update
- [x] **development PR** provided #10462
- [x] **TF-PSA-Crypto PR** not required because: This script is not present in TF-PSA-Crypto.
- [x] **framework PR** not required
- [x] **3.6 PR** provided here
- **tests**  not required because: This is a build script.

