### PR TITLE
timing: replace deprecated gettimeofday() with clock()

### DIFF
--- a/library/timing.c
+++ b/library/timing.c
@@ -38,7 +38,7 @@ struct _hr_time {
 #include <time.h>
 #include <sys/time.h>
 struct _hr_time {
-    struct timeval start;
+    clock_t start;
 };
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 
@@ -88,15 +88,11 @@ unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int r
     struct _hr_time *t = (struct _hr_time *) val;
 
     if (reset) {
-        gettimeofday(&t->start, NULL);
+        t->start = clock();
         return 0;
     } else {
-        unsigned long delta;
-        struct timeval now;
-        gettimeofday(&now, NULL);
-        delta = (now.tv_sec  - t->start.tv_sec) * 1000ul
-                + (now.tv_usec - t->start.tv_usec) / 1000;
-        return delta;
+        clock_t now = clock();
+        return (now - t->start) / (CLOCKS_PER_SEC * 1000ul);
     }
 }
 


### PR DESCRIPTION
## Description

`gettimeofday()` got marked obsolete in POSIX.1-2008 and removed
in POSIX.1-2024.

Alternatives:
* `clock()` introduced in C89, part of POSIX.1-1995 (and meant for CPU time)
* `timespec_get()` introduced in C11 and part of POSIX.1-2024
* `clock_gettime()` introduced in POSIX.1-1995,
  absent in ISO C so requires POSIX feature macros

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: internal change
- [x] **development PR** this is against `development` branch
- [ ] **TF-PSA-Crypto PR** not required because: internal change
- [ ] **framework PR** not required: internal change
- [ ] **3.6 PR** provided # | not required because: (waiting for first feedback, applies cleanly)
- **tests**  not required because: not an API change


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
