### PR TITLE
Fix module-import-in-extern-c compiler error

### DIFF
--- a/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
+++ b/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
@@ -1,0 +1,5 @@
+Changes
+   * Fixes a compiler error when building C++ projects that use the 'modules'
+     C++ language feature, and consume Mbed TLS. The specific error is
+     module-import-in-extern-c, which occurs when an #include occurs within
+     'extern C' blocks.

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -15,10 +15,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_TIMING_ALT)
 // Regular implementation
 //
@@ -42,6 +38,10 @@ typedef struct mbedtls_timing_delay_context {
 #else  /* MBEDTLS_TIMING_ALT */
 #include "timing_alt.h"
 #endif /* MBEDTLS_TIMING_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Internal use */
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset);

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -25,6 +25,7 @@ if(TEST_CPP)
     )
     add_executable(cpp_dummy_build "${cpp_dummy_build_cpp}")
     set_base_compile_options(cpp_dummy_build)
+    target_compile_options(cpp_dummy_build PRIVATE -fmodules)
     target_include_directories(cpp_dummy_build
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../tf-psa-crypto/include


### PR DESCRIPTION
## Description
This fixes https://github.com/Mbed-TLS/mbedtls/issues/10490.

This fixes a compiler error when building C++ projects that use the 'modules' C++ language feature consume Mbed TLS. The specific error is module-import-in-extern-c, which occurs when `#include`s occur within `extern C` blocks.

Example:
```
$ clang-17 -std=c++20 -fmodules -Itf-psa-crypto/include -Itf-psa-crypto/drivers/builtin/include -o sample sample.cpp
In file included from sample.cpp:8:
In file included from tf-psa-crypto/drivers/builtin/include/mbedtls/private/chachapoly.h:44:
tf-psa-crypto/drivers/builtin/include/mbedtls/private/chacha20.h:26:1: error: import of C++ module '_Builtin_stdint' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   26 | #include <stdint.h>
      | ^
tf-psa-crypto/drivers/builtin/include/mbedtls/private/chachapoly.h:35:1: note: extern "C" language linkage specification begins here
   35 | extern "C" {
      | ^
1 error generated.
```

This seems to primarily be an issue with clang. See https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fmodules


## PR checklist

- [X] **changelog** entry added
- [X] **development PR** this PR
- [X] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/557
- [ ] **framework PR** not required
- [X] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10489
- **tests**
  - Sample C++ file that includes all affected headers compiles
