### PR TITLE
Fix module-import-in-extern-c compiler error (3.6)

### DIFF
--- a/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
+++ b/ChangeLog.d/fix-module-import-in-extern-c-compiler-error.txt
@@ -1,0 +1,5 @@
+Changes
+   * Fixes a compiler error when building C++ projects that use the 'modules'
+     C++ language feature, and consume Mbed TLS. The specific error is
+     module-import-in-extern-c, which occurs when an #include occurs within
+     'extern C' blocks.

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -49,10 +49,6 @@
 /** Invalid input data. */
 #define MBEDTLS_ERR_AES_BAD_INPUT_DATA                    -0x0021
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_AES_ALT)
 // Regular implementation
 //
@@ -95,6 +91,10 @@ typedef struct mbedtls_aes_xts_context {
 #else  /* MBEDTLS_AES_ALT */
 #include "aes_alt.h"
 #endif /* MBEDTLS_AES_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes the specified AES context.

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -38,10 +38,6 @@
 /** Invalid data input length. */
 #define MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH -0x005E
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_ARIA_ALT)
 // Regular implementation
 //
@@ -59,6 +55,10 @@ mbedtls_aria_context;
 #else  /* MBEDTLS_ARIA_ALT */
 #include "aria_alt.h"
 #endif /* MBEDTLS_ARIA_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes the specified ARIA context.

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -27,10 +27,6 @@
 /** Invalid data input length. */
 #define MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH -0x0026
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 // Regular implementation
 //
@@ -47,6 +43,10 @@ mbedtls_camellia_context;
 #else  /* MBEDTLS_CAMELLIA_ALT */
 #include "camellia_alt.h"
 #endif /* MBEDTLS_CAMELLIA_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          Initialize a CAMELLIA context.

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -54,10 +54,6 @@
 /** Authenticated decryption failed. */
 #define MBEDTLS_ERR_CCM_AUTH_FAILED     -0x000F
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_CCM_ALT)
 // Regular implementation
 //
@@ -97,6 +93,10 @@ mbedtls_ccm_context;
 #else  /* MBEDTLS_CCM_ALT */
 #include "ccm_alt.h"
 #endif /* MBEDTLS_CCM_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified CCM context,

--- a/include/mbedtls/chacha20.h
+++ b/include/mbedtls/chacha20.h
@@ -29,10 +29,6 @@
 /** Invalid input parameter(s). */
 #define MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA         -0x0051
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_CHACHA20_ALT)
 
 typedef struct mbedtls_chacha20_context {
@@ -45,6 +41,10 @@ mbedtls_chacha20_context;
 #else  /* MBEDTLS_CHACHA20_ALT */
 #include "chacha20_alt.h"
 #endif /* MBEDTLS_CHACHA20_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified ChaCha20 context.

--- a/include/mbedtls/chachapoly.h
+++ b/include/mbedtls/chachapoly.h
@@ -31,10 +31,6 @@
 /** Authenticated decryption failed: data was not authentic. */
 #define MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED          -0x0056
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
     MBEDTLS_CHACHAPOLY_ENCRYPT,     /**< The mode value for performing encryption. */
     MBEDTLS_CHACHAPOLY_DECRYPT      /**< The mode value for performing decryption. */
@@ -58,6 +54,10 @@ mbedtls_chachapoly_context;
 #else /* !MBEDTLS_CHACHAPOLY_ALT */
 #include "chachapoly_alt.h"
 #endif /* !MBEDTLS_CHACHAPOLY_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified ChaCha20-Poly1305 context.

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -20,10 +20,6 @@
 
 #include "mbedtls/cipher.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define MBEDTLS_AES_BLOCK_SIZE          16
 #define MBEDTLS_DES3_BLOCK_SIZE         8
 
@@ -71,6 +67,10 @@ struct mbedtls_cmac_context_t {
 #else  /* !MBEDTLS_CMAC_ALT */
 #include "cmac_alt.h"
 #endif /* !MBEDTLS_CMAC_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief               This function starts a new CMAC computation

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -30,10 +30,6 @@
 
 #define MBEDTLS_DES_KEY_SIZE    8
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_DES_ALT)
 // Regular implementation
 //
@@ -65,6 +61,10 @@ mbedtls_des3_context;
 #else  /* MBEDTLS_DES_ALT */
 #include "des_alt.h"
 #endif /* MBEDTLS_DES_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          Initialize DES context

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -89,10 +89,6 @@ typedef enum {
     MBEDTLS_DHM_PARAM_K,  /*!<  The shared secret = \c G^(XY) mod \c P. */
 } mbedtls_dhm_parameter;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_DHM_ALT)
 
 /**
@@ -115,6 +111,10 @@ mbedtls_dhm_context;
 #else /* MBEDTLS_DHM_ALT */
 #include "dhm_alt.h"
 #endif /* MBEDTLS_DHM_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes the DHM context.

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -32,10 +32,6 @@
 #include "mbedtls/ecp.h"
 #include "mbedtls/md.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * Roles in the EC J-PAKE exchange
  */
@@ -78,6 +74,10 @@ typedef struct mbedtls_ecjpake_context {
 #else  /* MBEDTLS_ECJPAKE_ALT */
 #include "ecjpake_alt.h"
 #endif /* MBEDTLS_ECJPAKE_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           Initialize an ECJPAKE context.

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -70,10 +70,6 @@
 #define MBEDTLS_ECP_MONTGOMERY_ENABLED
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * Domain-parameter identifiers: curve, subgroup, and generator.
  *
@@ -312,6 +308,10 @@ mbedtls_ecp_group;
 #else  /* MBEDTLS_ECP_ALT */
 #include "ecp_alt.h"
 #endif /* MBEDTLS_ECP_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * The maximum size of the groups, that is, of \c N and \c P.

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -40,10 +40,6 @@
 /** An output buffer is too small. */
 #define MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL                  -0x0016
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_GCM_ALT)
 
 #if defined(MBEDTLS_GCM_LARGE_TABLE)
@@ -77,6 +73,10 @@ mbedtls_gcm_context;
 #else  /* !MBEDTLS_GCM_ALT */
 #include "gcm_alt.h"
 #endif /* !MBEDTLS_GCM_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified GCM context,

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -20,10 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_MD5_ALT)
 // Regular implementation
 //
@@ -46,6 +42,10 @@ mbedtls_md5_context;
 #else  /* MBEDTLS_MD5_ALT */
 #include "md5_alt.h"
 #endif /* MBEDTLS_MD5_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          Initialize MD5 context

--- a/include/mbedtls/nist_kw.h
+++ b/include/mbedtls/nist_kw.h
@@ -28,10 +28,6 @@
 
 #include "mbedtls/cipher.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
     MBEDTLS_KW_MODE_KW = 0,
     MBEDTLS_KW_MODE_KWP = 1
@@ -55,6 +51,10 @@ typedef struct {
 #else  /* MBEDTLS_NIST_key wrapping_ALT */
 #include "nist_kw_alt.h"
 #endif /* MBEDTLS_NIST_KW_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified key wrapping context

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -33,10 +33,6 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * \name SECTION: Module settings
  *
@@ -128,6 +124,10 @@ extern "C" {
 #define MBEDTLS_PLATFORM_STD_FREE
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \} name SECTION: Module settings */
 
 /*
@@ -143,8 +143,14 @@ extern "C" {
 #define mbedtls_free       MBEDTLS_PLATFORM_FREE_MACRO
 #define mbedtls_calloc     MBEDTLS_PLATFORM_CALLOC_MACRO
 #else
+#ifdef __cplusplus
+}
+#endif
 /* For size_t */
 #include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void *mbedtls_calloc(size_t n, size_t size);
 extern void mbedtls_free(void *ptr);
 
@@ -171,8 +177,14 @@ int mbedtls_platform_set_calloc_free(void *(*calloc_func)(size_t, size_t),
  * The function pointers for fprintf
  */
 #if defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
+#ifdef __cplusplus
+}
+#endif
 /* We need FILE * */
 #include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int (*mbedtls_fprintf)(FILE *stream, const char *format, ...);
 
 /**
@@ -266,13 +278,25 @@ int mbedtls_platform_set_snprintf(int (*snprintf_func)(char *s, size_t n,
  *   the destination buffer is too short.
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
+#ifdef __cplusplus
+}
+#endif
 #include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
 int mbedtls_platform_win32_vsnprintf(char *s, size_t n, const char *fmt, va_list arg);
 #endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
+#ifdef __cplusplus
+}
+#endif
 #include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int (*mbedtls_vsnprintf)(char *s, size_t n, const char *format, va_list arg);
 
 /**
@@ -297,7 +321,13 @@ int mbedtls_platform_set_vsnprintf(int (*vsnprintf_func)(char *s, size_t n,
  * The function pointers for setbuf
  */
 #if defined(MBEDTLS_PLATFORM_SETBUF_ALT)
+#ifdef __cplusplus
+}
+#endif
 #include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * \brief                  Function pointer to call for `setbuf()` functionality
  *                         (changing the internal buffering on stdio calls).
@@ -443,7 +473,13 @@ typedef struct mbedtls_platform_context {
 mbedtls_platform_context;
 
 #else
+#ifdef __cplusplus
+}
+#endif
 #include "platform_alt.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 #endif /* !MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
 
 /**

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -12,10 +12,6 @@
 
 #include "mbedtls/build_info.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * The time_t datatype
  */
@@ -34,6 +30,10 @@ typedef MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO mbedtls_ms_time_t;
 #include <inttypes.h>
 typedef int64_t mbedtls_ms_time_t;
 #endif /* MBEDTLS_PLATFORM_MS_TIME_TYPE_MACRO */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief   Get time in milliseconds.

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -19,10 +19,6 @@
 #include <time.h>
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Internal helper macros for deprecating API constants. */
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -56,6 +52,10 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
 #else
 #define MBEDTLS_CHECK_RETURN
 #endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /** Critical-failure function

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -29,10 +29,6 @@
 /** Invalid input parameter(s). */
 #define MBEDTLS_ERR_POLY1305_BAD_INPUT_DATA         -0x0057
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_POLY1305_ALT)
 
 typedef struct mbedtls_poly1305_context {
@@ -47,6 +43,10 @@ mbedtls_poly1305_context;
 #else  /* MBEDTLS_POLY1305_ALT */
 #include "poly1305_alt.h"
 #endif /* MBEDTLS_POLY1305_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief           This function initializes the specified Poly1305 context.

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -16,10 +16,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_RIPEMD160_ALT)
 // Regular implementation
 //
@@ -37,6 +33,10 @@ mbedtls_ripemd160_context;
 #else  /* MBEDTLS_RIPEMD160_ALT */
 #include "ripemd160_alt.h"
 #endif /* MBEDTLS_RIPEMD160_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          Initialize RIPEMD-160 context

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -65,10 +65,6 @@
  * eg for alternative (PKCS#11) RSA implementations in the PK layers.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_RSA_ALT)
 // Regular implementation
 //
@@ -125,6 +121,10 @@ mbedtls_rsa_context;
 #else  /* MBEDTLS_RSA_ALT */
 #include "rsa_alt.h"
 #endif /* MBEDTLS_RSA_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes an RSA context.

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -26,10 +26,6 @@
 /** SHA-1 input data was malformed. */
 #define MBEDTLS_ERR_SHA1_BAD_INPUT_DATA                   -0x0073
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_SHA1_ALT)
 // Regular implementation
 //
@@ -52,6 +48,10 @@ mbedtls_sha1_context;
 #else  /* MBEDTLS_SHA1_ALT */
 #include "sha1_alt.h"
 #endif /* MBEDTLS_SHA1_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes a SHA-1 context.

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -22,10 +22,6 @@
 /** SHA-256 input data was malformed. */
 #define MBEDTLS_ERR_SHA256_BAD_INPUT_DATA                 -0x0074
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_SHA256_ALT)
 // Regular implementation
 //
@@ -51,6 +47,10 @@ mbedtls_sha256_context;
 #else  /* MBEDTLS_SHA256_ALT */
 #include "sha256_alt.h"
 #endif /* MBEDTLS_SHA256_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes a SHA-256 context.

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -21,10 +21,6 @@
 /** SHA-512 input data was malformed. */
 #define MBEDTLS_ERR_SHA512_BAD_INPUT_DATA                 -0x0075
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_SHA512_ALT)
 // Regular implementation
 //
@@ -50,6 +46,10 @@ mbedtls_sha512_context;
 #else  /* MBEDTLS_SHA512_ALT */
 #include "sha512_alt.h"
 #endif /* MBEDTLS_SHA512_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * \brief          This function initializes a SHA-512 context.

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -15,6 +15,15 @@
 
 #include <stdlib.h>
 
+#if defined(MBEDTLS_THREADING_PTHREAD)
+#include <pthread.h>
+#endif
+
+#if defined(MBEDTLS_THREADING_ALT)
+/* You should define the mbedtls_threading_mutex_t type in your header */
+#include "threading_alt.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +34,6 @@ extern "C" {
 #define MBEDTLS_ERR_THREADING_MUTEX_ERROR                 -0x001E
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
-#include <pthread.h>
 typedef struct mbedtls_threading_mutex_t {
     pthread_mutex_t MBEDTLS_PRIVATE(mutex);
 
@@ -40,9 +48,6 @@ typedef struct mbedtls_threading_mutex_t {
 #endif
 
 #if defined(MBEDTLS_THREADING_ALT)
-/* You should define the mbedtls_threading_mutex_t type in your header */
-#include "threading_alt.h"
-
 /**
  * \brief           Set your alternate threading implementation function
  *                  pointers and initialize global mutexes. If used, this

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -15,10 +15,6 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if !defined(MBEDTLS_TIMING_ALT)
 // Regular implementation
 //
@@ -42,6 +38,10 @@ typedef struct mbedtls_timing_delay_context {
 #else  /* MBEDTLS_TIMING_ALT */
 #include "timing_alt.h"
 #endif /* MBEDTLS_TIMING_ALT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Internal use */
 unsigned long mbedtls_timing_get_timer(struct mbedtls_timing_hr_time *val, int reset);

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -31,10 +31,6 @@
 /**@}*/
 #endif /* __DOXYGEN_ONLY__ */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* The file "crypto_types.h" declares types that encode errors,
  * algorithms, key types, policies, etc. */
 #include "crypto_types.h"
@@ -69,6 +65,10 @@ extern "C" {
 #include MBEDTLS_PSA_CRYPTO_STRUCT_FILE
 #else
 #include "crypto_struct.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /** \defgroup initialization Library initialization

--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -50,10 +50,6 @@
 #define PSA_CRYPTO_STRUCT_H
 #include "mbedtls/private_access.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * Include the build-time configuration information header. Here, we do not
  * include `"mbedtls/build_info.h"` directly but `"psa/build_info.h"`, which
@@ -66,6 +62,10 @@ extern "C" {
 /* Include the context definition for the compiled-in drivers for the primitive
  * algorithms. */
 #include "psa/crypto_driver_contexts_primitives.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_hash_operation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
@@ -124,9 +124,15 @@ static inline struct psa_cipher_operation_s psa_cipher_operation_init(void)
     return v;
 }
 
+#ifdef __cplusplus
+}
+#endif
 /* Include the context definition for the compiled-in drivers for the composite
  * algorithms. */
 #include "psa/crypto_driver_contexts_composites.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_mac_operation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)
@@ -195,9 +201,15 @@ static inline struct psa_aead_operation_s psa_aead_operation_init(void)
     return v;
 }
 
+#ifdef __cplusplus
+}
+#endif
 /* Include the context definition for the compiled-in drivers for the key
  * derivation algorithms. */
 #include "psa/crypto_driver_contexts_key_derivation.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct psa_key_derivation_s {
 #if defined(MBEDTLS_PSA_CRYPTO_CLIENT) && !defined(MBEDTLS_PSA_CRYPTO_C)

--- a/programs/test/CMakeLists.txt
+++ b/programs/test/CMakeLists.txt
@@ -30,6 +30,7 @@ if(TEST_CPP)
     )
     add_executable(cpp_dummy_build "${cpp_dummy_build_cpp}")
     target_include_directories(cpp_dummy_build PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+    target_compile_options(cpp_dummy_build PRIVATE -fmodules)
     target_link_libraries(cpp_dummy_build ${mbedcrypto_target} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 


### PR DESCRIPTION
## Description
This fixes https://github.com/Mbed-TLS/mbedtls/issues/10490.

This fixes a compiler error when building C++ projects that use the 'modules' C++ language feature consume Mbed TLS. The specific error is module-import-in-extern-c, which occurs when `#include`s occur within `extern C` blocks.

Example:
```
$ clang-17 -std=c++20 -fmodules -Iinclude sample.cpp     
In file included from sample.cpp:2:
In file included from include/mbedtls/platform_util.h:18:
include/mbedtls/platform_time.h:33:1: error: import of C++ module '_Builtin_stdint' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   33 | #include <stdint.h>
      | ^
include/mbedtls/platform_time.h:16:1: note: extern "C" language linkage specification begins here
   16 | extern "C" {
      | ^
include/mbedtls/platform_time.h:34:1: error: import of C++ module '_Builtin_inttypes' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
   34 | #include <inttypes.h>
      | ^
include/mbedtls/platform_time.h:16:1: note: extern "C" language linkage specification begins here
   16 | extern "C" {
      | ^
2 errors generated.
```

This seems to primarily be an issue with clang. See https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fmodules

## PR checklist

- [X] **changelog** entry added
- [X] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10488
- [X] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/557
- [ ] **framework PR** not required
- [X] **3.6 PR** this PR
- **tests**
  - Sample C++ file that includes all affected headers compiles