### PR TITLE
Reject high-tag-number ASN.1 tags in mbedtls_asn1_get_tag()

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -66,6 +66,10 @@ int mbedtls_asn1_get_tag(unsigned char **p,
         return MBEDTLS_ERR_ASN1_OUT_OF_DATA;
     }
 
+    if (MBEDTLS_ASN1_TAG_VALUE_MASK == (**p & MBEDTLS_ASN1_TAG_VALUE_MASK)) {
+        return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
+    }
+
     if (**p != tag) {
         return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG;
     }


### PR DESCRIPTION
## Description

This PR hardens ASN.1 tag parsing by explicitly rejecting high-tag-number tags in mbedtls_asn1_get_tag(). If the low 5 bits of the first identifier octet are 0x1F, the function now returns MBEDTLS_ERR_ASN1_UNEXPECTED_TAG immediately, rather than proceeding. This makes the function’s behavior aligned with its existing assumption of single-octet tags, avoids attempting to parse unsupported encodings, and improves robustness and clarity. There is no change to behavior for valid single-octet tags; only inputs using the long-form tag encoding are affected.

## PR checklist

- [x] **changelog** not required because: only earlier rejection of unsupported high-tag-number tags
- [x] **development PR** not required because: no change there
- [x] **TF-PSA-Crypto PR** not required because: no change there
- [x] **3.6 PR** provided HERE
- **tests**  not required because: no change for supported inputs