### PR TITLE
Increase key size to accept RSA keys of up to 4096

### DIFF
--- a/tests/scripts/components-configuration-crypto.sh
+++ b/tests/scripts/components-configuration-crypto.sh
@@ -38,10 +38,10 @@ component_test_crypto_with_static_key_slots() {
     # Intentionally set MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE to a value that
     # is enough to contain:
     # - all RSA public keys up to 4096 bits (max of PSA_VENDOR_RSA_MAX_KEY_BITS).
-    # - RSA key pairs up to 1024 bits, but not 2048 or larger.
+    # - RSA key pairs up to 1024 bits, but not 4096 or larger.
     # - all FFDH key pairs and public keys up to 8192 bits (max of PSA_VENDOR_FFDH_MAX_KEY_BITS).
     # - all EC key pairs and public keys up to 521 bits (max of PSA_VENDOR_ECC_MAX_CURVE_BITS).
-    scripts/config.py set MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE 1212
+    scripts/config.py set MBEDTLS_PSA_STATIC_KEY_SLOT_BUFFER_SIZE 2363
     # Disable the fully dynamic key store (default on) since it conflicts
     # with the static behavior that we're testing here.
     scripts/config.py unset MBEDTLS_PSA_KEY_STORE_DYNAMIC


### PR DESCRIPTION
## Description

Increase the key size in unit tests to accept RSA 4096. Contributes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/522

This PR is part of a series and must be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls/pull/10516
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/575

## PR checklist

- [ ] **changelog** not required because: No public changes
- [ ] **development PR** provided #HERE
- [ ] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/575
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: No Backports
- **tests**  provided