### PR TITLE
Replace references of mbedtls_ecp_set_max_ops

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -4591,7 +4591,7 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
  *                 mbedtls_ssl_conf_async_private_cb()) - in this case you
  *                 must call this function again when the operation is ready.
  * \return         #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS if a cryptographic
- *                 operation is in progress (see mbedtls_ecp_set_max_ops()) -
+ *                 operation is in progress (see psa_interruptible_set_max_ops()) -
  *                 in this case you must call this function again to complete
  *                 the handshake when you're done attending other tasks.
  * \return         #MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED if DTLS is in use
@@ -4762,7 +4762,7 @@ int mbedtls_ssl_renegotiate(mbedtls_ssl_context *ssl);
  *                 mbedtls_ssl_conf_async_private_cb()) - in this case you
  *                 must call this function again when the operation is ready.
  * \return         #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS if a cryptographic
- *                 operation is in progress (see mbedtls_ecp_set_max_ops()) -
+ *                 operation is in progress (see psa_interruptible_set_max_ops()) -
  *                 in this case you must call this function again to complete
  *                 the handshake when you're done attending other tasks.
  * \return         #MBEDTLS_ERR_SSL_CLIENT_RECONNECT if we're at the server
@@ -4847,7 +4847,7 @@ int mbedtls_ssl_read(mbedtls_ssl_context *ssl, unsigned char *buf, size_t len);
  *                 mbedtls_ssl_conf_async_private_cb()) - in this case you
  *                 must call this function again when the operation is ready.
  * \return         #MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS if a cryptographic
- *                 operation is in progress (see mbedtls_ecp_set_max_ops()) -
+ *                 operation is in progress (see psa_interruptible_set_max_ops()) -
  *                 in this case you must call this function again to complete
  *                 the handshake when you're done attending other tasks.
  * \return         #MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA if early data, as

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -714,7 +714,7 @@ int mbedtls_x509_crt_verify_with_profile(mbedtls_x509_crt *crt,
  *
  * \note           Performs the same job as \c mbedtls_crt_verify_with_profile()
  *                 but can return early and restart according to the limit
- *                 set with \c mbedtls_ecp_set_max_ops() to reduce blocking.
+ *                 set with \c psa_interruptible_set_max_ops() to reduce blocking.
  *
  * \param crt      The certificate chain to be verified.
  * \param trust_ca The list of trusted CAs.
@@ -733,7 +733,7 @@ int mbedtls_x509_crt_verify_with_profile(mbedtls_x509_crt *crt,
  *
  * \return         See \c mbedtls_crt_verify_with_profile(), or
  * \return         #PSA_OPERATION_INCOMPLETE if maximum number of
- *                 operations was reached: see \c mbedtls_ecp_set_max_ops().
+ *                 operations was reached: see \c psa_interruptible_set_max_ops().
  */
 int mbedtls_x509_crt_verify_restartable(mbedtls_x509_crt *crt,
                                         mbedtls_x509_crt *trust_ca,


### PR DESCRIPTION
## Description

Replace references of mbedtls_ecp_set_max_ops with psa_interruptible_set_max_ops as it is now internal contributes to https://github.com/Mbed-TLS/mbedtls/issues/10545.

## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** provided #https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/620
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No Backports
- **tests**  not required because: No increase in test matrix