### PR TITLE
Re-instate failure when disabling non-existing option

### DIFF
--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -109,12 +109,6 @@ def set_config_option_value(conf, option, colors, value: Union[bool, str]):
 value can be either True/False (set/unset config option), or a string,
 which will make a symbol defined with a certain value."""
     if not option_exists(conf, option):
-        if value is False:
-            log_line(
-                f'Warning, disabling {option} that does not exist in {conf.filename}',
-                color=colors.cyan
-            )
-            return True
         log_line('Symbol {} was not found in {}'.format(option, conf.filename), color=colors.red)
         return False
 


### PR DESCRIPTION
## Description

Re-instate failure when disabling non-existing option resolves https://github.com/Mbed-TLS/mbedtls/issues/10411

## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **development PR** provided #HERE
- [x] **TF-PSA-Crypto PR** not required because: No changes
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: No backports required
- **tests**  not required because: No change to the test matrix
