### PR TITLE
Fix non-determinism when generating mbedtls_config_check_user.h

### DIFF
--- a/scripts/generate_config_checks.py
+++ b/scripts/generate_config_checks.py
@@ -37,8 +37,8 @@ def checkers_for_removed_options() -> Iterator[Checker]:
             yield CryptoInternal(option)
         else:
             yield Removed(option, 'Mbed TLS 4.0')
-    for option in (current.internal() - new_public - old_public -
-                   crypto.options() - crypto.internal()):
+    for option in sorted(current.internal() - new_public - old_public -
+                         crypto.options() - crypto.internal()):
         yield Internal(option)
 
 def all_checkers() -> Iterator[Checker]:


### PR DESCRIPTION
Not caught in the CI because of https://github.com/Mbed-TLS/mbedtls-framework/issues/244

## PR checklist

- [x] **changelog** provided | not required because: only maintainers care
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/646
- [x] **mbedtls development PR** here
- [x] **mbedtls 3.6 PR** not required because: added in 1.0/4.0
- **tests**  no message about an out-of-date file in `tests/scripts/all.sh -k check_generated_files`; will be enforced on the CI once https://github.com/Mbed-TLS/mbedtls-framework/pull/245 is merged
