### PR TITLE
SHA3 cleanup prep: Adapt to the split of test_suite_shax

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -230,7 +230,8 @@ class DriverVSReference_hash(outcome_analysis.DriverVSReference):
     REFERENCE = 'test_psa_crypto_config_reference_hash_use_psa'
     DRIVER = 'test_psa_crypto_config_accel_hash_use_psa'
     IGNORED_SUITES = [
-        'shax', 'mdx', # the software implementations that are being excluded
+        # the software implementations that are being excluded
+        'mdx', 'sha1', 'sha256', 'sha3', 'sha512', 'shax',
         'md.psa',  # purposefully depends on whether drivers are present
         'psa_crypto_low_hash.generated', # testing the builtins
     ]
@@ -252,7 +253,7 @@ class DriverVSReference_hmac(outcome_analysis.DriverVSReference):
     IGNORED_SUITES = [
         # These suites require legacy hash support, which is disabled
         # in the accelerated component.
-        'shax', 'mdx',
+        'mdx', 'sha1', 'sha256', 'sha3', 'sha512', 'shax',
         # This suite tests builtins directly, but these are missing
         # in the accelerated case.
         'psa_crypto_low_hash.generated',


### PR DESCRIPTION
To prepare for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/618, adapt `analyze_outcome.py`'s knowledge of crypto test suites.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/618 (follow-up)
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: post-split woes
- **tests**  provided
