### PR TITLE
Fix: support empty PSK key hint in Client Key Exchange message

### DIFF
--- a/ChangeLog.d/fix-psk-identity-hint-empty.txt
+++ b/ChangeLog.d/fix-psk-identity-hint-empty.txt
@@ -1,0 +1,6 @@
+Bugfix
+   * Make the TLS 1.2 server to not reject a Client Key Exchange message which
+     has a zero-length PSK identity hint (as allowed by RFC 4279). TLS clients
+     usually pass an empty PSK identity hint when the server accepts only a
+     single pre-shared key. This fix only affects TLS 1.2 servers using PSK
+     based ciphersuites.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -3618,11 +3618,21 @@ int mbedtls_ssl_set_hs_psk_opaque(mbedtls_ssl_context *ssl,
 /**
  * \brief          Set the PSK callback (server-side only).
  *
- *                 If set, the PSK callback is called for each
- *                 handshake where a PSK-based ciphersuite was negotiated.
- *                 The caller provides the identity received and wants to
- *                 receive the actual PSK data and length.
+ * If set, the PSK callback is called for each
+ * handshake where a PSK-based ciphersuite was negotiated.
+ * The caller provides the identity received and wants to
+ * receive the actual PSK data and length.
  *
+ * If a valid PSK identity is found, the callback should use
+ * \c mbedtls_ssl_set_hs_psk() or
+ * \c mbedtls_ssl_set_hs_psk_opaque()
+ * on the SSL context to set the correct PSK and return \c 0.
+ * Any other return value will result in a denied PSK identity.
+ *
+ * \param conf     The SSL configuration to register the callback with.
+ *
+ * \param f_psk    The callback for selecting and setting the PSK based
+ *                 in the PSK identity chosen by the client.
  *                 The callback has the following parameters:
  *                 - \c void*: The opaque pointer \p p_psk.
  *                 - \c mbedtls_ssl_context*: The SSL context to which
@@ -3632,11 +3642,8 @@ int mbedtls_ssl_set_hs_psk_opaque(mbedtls_ssl_context *ssl,
  *                 - \c size_t: The length of the PSK identity
  *                              selected by the client.
  *
- *                 If a valid PSK identity is found, the callback should use
- *                 \c mbedtls_ssl_set_hs_psk() or
- *                 \c mbedtls_ssl_set_hs_psk_opaque()
- *                 on the SSL context to set the correct PSK and return \c 0.
- *                 Any other return value will result in a denied PSK identity.
+ * \param p_psk    A pointer to an opaque structure to be passed to
+ *                 the callback, for example a PSK store.
  *
  * \note           A dynamic PSK (i.e. set by the PSK callback) takes
  *                 precedence over a static PSK (i.e. set by
@@ -3647,11 +3654,10 @@ int mbedtls_ssl_set_hs_psk_opaque(mbedtls_ssl_context *ssl,
  *                 \c mbedtls_ssl_conf_psk() or
  *                 \c mbedtls_ssl_conf_psk_opaque()).
  *
- * \param conf     The SSL configuration to register the callback with.
- * \param f_psk    The callback for selecting and setting the PSK based
- *                 in the PSK identity chosen by the client.
- * \param p_psk    A pointer to an opaque structure to be passed to
- *                 the callback, for example a PSK store.
+ * \warning        If an empty PSK key identity is provided by the client the
+ *                 \p f_psk callback is invoked with the length parameter set
+ *                 to zero. It is up to the server to set the default PSK or to
+ *                 reject the request in this case.
  */
 void mbedtls_ssl_conf_psk_cb(mbedtls_ssl_config *conf,
                              int (*f_psk)(void *, mbedtls_ssl_context *, const unsigned char *,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -1901,14 +1901,16 @@ static int ssl_conf_set_psk_identity(mbedtls_ssl_config *conf,
                                      size_t psk_identity_len)
 {
     /* Identity len will be encoded on two bytes */
-    if (psk_identity               == NULL ||
-        psk_identity_len           == 0    ||
+    if (psk_identity             == NULL ||
         (psk_identity_len >> 16) != 0    ||
         psk_identity_len > MBEDTLS_SSL_OUT_CONTENT_LEN) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     conf->psk_identity = mbedtls_calloc(1, psk_identity_len);
+    if (conf->psk_identity == NULL && psk_identity_len == 0) {
+        conf->psk_identity = mbedtls_calloc(1, 1);
+    }
     if (conf->psk_identity == NULL) {
         return MBEDTLS_ERR_SSL_ALLOC_FAILED;
     }
@@ -1932,9 +1934,6 @@ int mbedtls_ssl_conf_psk(mbedtls_ssl_config *conf,
 
     /* Check and set raw PSK */
     if (psk == NULL) {
-        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
-    }
-    if (psk_len == 0) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     if (psk_len > MBEDTLS_PSK_MAX_LEN) {

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3037,7 +3037,7 @@ static int ssl_parse_client_psk_identity(mbedtls_ssl_context *ssl, unsigned char
     n = MBEDTLS_GET_UINT16_BE(*p, 0);
     *p += 2;
 
-    if (n == 0 || n > end - *p) {
+    if (n > end - *p) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("bad client key exchange message"));
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -8756,6 +8756,17 @@ run_test    "PSK callback: wrong key" \
             -S "SSL - Unknown identity received" \
             -s "SSL - Verification of the message MAC failed"
 
+requires_config_enabled MBEDTLS_SSL_SRV_C
+requires_config_enabled MBEDTLS_SSL_CLI_C
+requires_config_enabled MBEDTLS_DEBUG_C
+requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_2
+run_test    "PSK callback: empty identity hint" \
+            "$P_SRV debug_level=5 force_version=tls12 psk=73776f726466697368 psk_identity=''" \
+            "$P_CLI debug_level=5 force_version=tls12 psk=73776f726466697368 psk_identity=''" \
+            0 \
+            -s "Successful connection" \
+            -c "Successful connection"
+
 # Tests for EC J-PAKE
 
 requires_config_enabled MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED


### PR DESCRIPTION
According to RFC 4279 the psk_identity_hint can be of length 0. This patch enables the TLS 1.2 server to accept such empty hints during TLS 1.2 handshake. This is done when the server accepts only a single PSK key.

- [x] **changelog**  provided
- [x] **development PR** provided HERE
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10558
- **tests**  provided | not required because: minimal change
