### PR TITLE
all.sh: adapt some "not grep" uses

### DIFF
--- a/tests/scripts/components-platform.sh
+++ b/tests/scripts/components-platform.sh
@@ -58,7 +58,7 @@ component_test_aesni () { # ~ 60s
     make clean
     make CC=gcc CFLAGS='-O2 -Werror'
     # check that there is no AESNI code present
-    ./programs/test/selftest aes | not grep -q "AESNI code"
+    ./programs/test/selftest aes | not grep -q "AESNI code" -
     not grep -q "AES note: using AESNI" ./programs/test/selftest
     grep -q "AES note: built-in implementation." ./programs/test/selftest
 
@@ -68,8 +68,8 @@ component_test_aesni () { # ~ 60s
     msg "AES tests, test AESNI only"
     make clean
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -mpclmul -msse2 -maes'
-    ./programs/test/selftest aes | grep -q "AES note: using AESNI"
-    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
+    ./programs/test/selftest aes | grep -q "AES note: using AESNI" -
+    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation." -
     grep -q "AES note: using AESNI" ./programs/test/selftest
     not grep -q "AES note: built-in implementation." ./programs/test/selftest
 }
@@ -107,7 +107,7 @@ component_test_aesni_m32 () { # ~ 60s
     make clean
     make CC=gcc CFLAGS='-m32 -Werror -Wall -Wextra -mpclmul -msse2 -maes' LDFLAGS='-m32'
     ./programs/test/selftest aes | grep -q "AES note: using AESNI"
-    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation."
+    ./programs/test/selftest aes | not grep -q "AES note: built-in implementation." -
     grep -q "AES note: using AESNI" ./programs/test/selftest
     not grep -q "AES note: built-in implementation." ./programs/test/selftest
     not grep -q "AES note: using VIA Padlock" ./programs/test/selftest


### PR DESCRIPTION
## Description

Revealed by https://github.com/Mbed-TLS/mbedtls-framework/pull/268 for which this is a prerequisite.

## PR checklist

- [x] **changelog** not required because: tests
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10562
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/654
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#268
- [x] **3.6 PR** provided HERE
- **tests**  this is about fixing existing tests - and f268 will ensure we've fixed everything.