### PR TITLE
CMake: Declare pqcp driver to mbedtls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
         PRIVATE tf-psa-crypto/include
         PRIVATE tf-psa-crypto/drivers/builtin/include
         PRIVATE tf-psa-crypto/drivers/everest/include
+        PRIVATE tf-psa-crypto/drivers/pqcp/include
         PRIVATE library
         PRIVATE tf-psa-crypto/core
         PRIVATE tf-psa-crypto/drivers/builtin/src)
@@ -460,7 +461,9 @@ if(ENABLE_TESTING OR ENABLE_PROGRAMS)
         PRIVATE library
         PRIVATE tf-psa-crypto/core
         PRIVATE tf-psa-crypto/drivers/builtin/src
-        PRIVATE tf-psa-crypto/drivers/everest/include)
+        PRIVATE tf-psa-crypto/drivers/everest/include
+        PRIVATE tf-psa-crypto/drivers/pqcp/include
+    )
 
     set_config_files_compile_definitions(mbedtls_test_helpers)
 endif()


### PR DESCRIPTION
Needed for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/652.

## PR checklist

- [x] **changelog** not required because: just for crypto, not user-visible
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/652 (comes after)
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: new feature
- **tests**  provided | not required because: 
