### PR TITLE
Add link to TF-PSA-Crypto `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,9 +21,13 @@ Users are urged to always use the latest version of a maintained branch.
 
 ## Use of TF-PSA-Crypto
 
-Note that Mbed TLS uses the cryptography API provided by TF-PSA-Crypto. Its
-security policy can be found
-[here](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/SECURITY.md).
+Note that Mbed TLS uses the cryptography API provided by TF-PSA-Crypto.
+Its
+[threat model](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/SECURITY.md#threat-model)
+applies to all cryptographic operations performed by Mbed TLS. In particular,
+users of Mbed TLS should note the considerations around
+[block ciphers](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/SECURITY.md#block-ciphers)
+since they apply to the block ciphers used in TLS.
 
 ## Threat model
 


### PR DESCRIPTION
To avoid confusion about the threat model of cryptographic code, add a link to the `SECURITY.md` of TF-PSA-Crypto. This should help users who are unaware that the cryptography has been split into a separate repository.

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: Docs only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: We're linking to TF-PSA-Crypto's threat model because we use it. The reverse is not true.
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: Cryptography is not separate in 3.6
- **tests**  not required because: Docs only