### PR TITLE
Unset debug c in tests 3.6

### DIFF
--- a/tests/scripts/components-configuration-tls.sh
+++ b/tests/scripts/components-configuration-tls.sh
@@ -538,6 +538,7 @@ component_full_without_ecdhe_ecdsa_and_tls13 () {
 component_build_no_ssl_srv () {
     msg "build: full config except SSL server, make, gcc" # ~ 30s
     scripts/config.py full
+    scripts/config.py unset DEBUG_C
     scripts/config.py unset MBEDTLS_SSL_SRV_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1 -Wmissing-prototypes'
 }
@@ -545,6 +546,7 @@ component_build_no_ssl_srv () {
 component_build_no_ssl_cli () {
     msg "build: full config except SSL client, make, gcc" # ~ 30s
     scripts/config.py full
+    scripts/config.py unset DEBUG_C
     scripts/config.py unset MBEDTLS_SSL_CLI_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O1 -Wmissing-prototypes'
 }


### PR DESCRIPTION
## Description

Unset DEBUG_C in some tests  required by https://github.com/Mbed-TLS/mbedtls/pull/10577

## PR checklist

- [ ] **changelog** provided | not required because: TBC
- [ ] **development PR** provided #HERE
- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **framework PR** not required
- [ ] **3.6 PR** provided # | not required because: TBC
- **tests**  provided 