### PR TITLE
Backport 3.6: Minor improvements to bump_version.sh

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -51,7 +51,7 @@ do
       echo -e "  --so-x509 <version>\tSO version to bump libmbedx509 to."
       echo -e "  --so-tls <version>\tSO version to bump libmbedtls to."
       echo -e "  -v|--verbose\t\tVerbose."
-      exit 1
+      exit 0
       ;;
     *)
       # print error


### PR DESCRIPTION
Back port of minor improvements made in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/676

## PR checklist

- [x] **changelog** not required because: dev script only
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10593
- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/676
- [x] **framework PR** not required
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10594
- **tests**  manually
