### PR TITLE
library: check_config: fix required hash algorithms for TLS 1.2

### DIFF
--- a/library/mbedtls_check_config.h
+++ b/library/mbedtls_check_config.h
@@ -142,11 +142,6 @@
         "but no key exchange methods defined with MBEDTLS_KEY_EXCHANGE_xxxx"
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
-    !(defined(PSA_WANT_ALG_SHA_1) || defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_512))
-#error "MBEDTLS_SSL_PROTO_TLS1_2 defined, but not all prerequisites"
-#endif
-
 #if defined(MBEDTLS_SSL_EARLY_DATA) && \
     ( !defined(MBEDTLS_SSL_SESSION_TICKETS) || \
       ( !defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED) && \


### PR DESCRIPTION
## Description

TLS-PRF uses either SHA-256 and SHA-384 so these are the guards that should be used.

## PR checklist

- [x] **changelog** [not required](https://github.com/Mbed-TLS/mbedtls/pull/10595#issuecomment-3890033420)
- [x] **development PR** not required because: it's this one
- [x] **TF-PSA-Crypto PR** not required because: no change there
- [x] **framework PR** not required
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10597
