### PR TITLE
Actually check committed generated files

### DIFF
--- a/tests/scripts/components-basic-checks.sh
+++ b/tests/scripts/components-basic-checks.sh
@@ -43,6 +43,7 @@ component_check_generated_files () {
 
     cd $TF_PSA_CRYPTO_ROOT_DIR
     ./framework/scripts/make_generated_files.py --root "$OUT_OF_SOURCE_DIR/tf-psa-crypto" --check
+    cd "$MBEDTLS_ROOT_DIR"
 
     # This component ends with the generated files present in the source tree.
     # This is necessary for subsequent components!


### PR DESCRIPTION
We were accidentally running the check in TF-PSA-Crypto instead of in Mbed TLS.

Necessary for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/690.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: not buggy in crypto
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: not present in 3.6
- **tests**  provided
