### PR TITLE
[backport] library: check_config: fix required hash algorithms for TLS 1.2

### DIFF
--- a/library/check_crypto_config.h
+++ b/library/check_crypto_config.h
@@ -128,11 +128,6 @@
 #error "PSA_WANT_KEY_TYPE_DH_KEY_PAIR_DERIVE defined, but feature is not supported"
 #endif
 
-#if defined(MBEDTLS_SSL_PROTO_TLS1_2) && defined(MBEDTLS_USE_PSA_CRYPTO) && \
-    !(defined(PSA_WANT_ALG_SHA_1) || defined(PSA_WANT_ALG_SHA_256) || defined(PSA_WANT_ALG_SHA_512))
-#error "MBEDTLS_SSL_PROTO_TLS1_2 defined, but not all prerequisites"
-#endif
-
 #if defined(PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS) && \
     !defined(PSA_WANT_ALG_SHA_256)
 #error "PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS defined, but not all prerequisites"


### PR DESCRIPTION
## Description

Backport of #10595.
The change is identical to the one done on the `development` branch. Only the file where it has been done changes.

## PR checklist

- [x] **changelog** not required because: see #10595
- [x] **development PR** provided #10595
- [x] **TF-PSA-Crypto PR** not required because: no change there
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: it's this one
- **tests** not required because: no code change