### PR TITLE
Fix missing type conversion in the TLS-Exporter

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -8938,7 +8938,7 @@ static int mbedtls_ssl_tls13_export_keying_material(mbedtls_ssl_context *ssl,
                                                     const size_t context_len)
 {
     const psa_algorithm_t psa_hash_alg = mbedtls_md_psa_alg_from_type(hash_alg);
-    const size_t hash_len = PSA_HASH_LENGTH(hash_alg);
+    const size_t hash_len = PSA_HASH_LENGTH(psa_hash_alg);
     const unsigned char *secret = ssl->session->app_secrets.exporter_master_secret;
 
     /* The length of the label must be at most 249 bytes to fit into the HkdfLabel


### PR DESCRIPTION
In the TLS-Exporter for TLS 1.3 we mistakenly call PSA_HASH_LENGTH() on an mbedtls_md_type_t when it should be called on a psa_algorithm_t.

Fortunately, these two types have almost the same values, since we have previously aligned them to make conversion more efficient. As a result, PSA_HASH_LENGTH() produces exactly the same value when called on an mbedtls_md_type_t as with the equivalent psa_algorithm_t.

Thanks to this happy coincidence, fix a largely cosmetic issue (rather than a major functional bug).

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: No user-facing change
- [x] **development PR** here
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** not required
- [x] **3.6 PR** provided #10602 
- **tests** not required because: Existing tests suffice