### PR TITLE
[3.6] [CMake] Fix `clang.exe` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,11 +78,23 @@ endif()
 
 option(DISABLE_PACKAGE_CONFIG_AND_INSTALL "Disable package configuration, target export and installation" ${MBEDTLS_AS_SUBPROJECT})
 
-if (CMAKE_C_SIMULATE_ID)
+# CMAKE_C_COMPILER_ID identifies the compiler family/ABI target, but not the
+# command-line frontend. For Clang on Windows, this stays "Clang" for both
+# clang.exe (GNU-style flags) and clang-cl.exe (MSVC-style flags).
+# Use CMAKE_C_COMPILER_FRONTEND_VARIANT to select the expected flag syntax.
+set(COMPILER_ID ${CMAKE_C_COMPILER_ID})
+
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        set(COMPILER_ID MSVC)
+    elseif (NOT CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "GNU" AND CMAKE_C_SIMULATE_ID)
+        # Fallback for old CMake versions that don't report
+        # CMAKE_C_COMPILER_FRONTEND_VARIANT.
+        set(COMPILER_ID ${CMAKE_C_SIMULATE_ID})
+    endif()
+elseif (CMAKE_C_SIMULATE_ID)
     set(COMPILER_ID ${CMAKE_C_SIMULATE_ID})
-else()
-    set(COMPILER_ID ${CMAKE_C_COMPILER_ID})
-endif(CMAKE_C_SIMULATE_ID)
+endif()
 
 string(REGEX MATCH "Clang" CMAKE_COMPILER_IS_CLANG "${COMPILER_ID}")
 string(REGEX MATCH "GNU" CMAKE_COMPILER_IS_GNU "${COMPILER_ID}")


### PR DESCRIPTION
## Description

Fix deprecation warning and bug with `COMPILER_ID` not being set correctly when using `clang.exe` on Windows (#9896)

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: not required because: CMake/build-system-only fix, no library/API/ABI behavior change
- [x] **development PR** provided #10611
- [x] **TF-PSA-Crypto PR** not required because: build system changes
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [x] **3.6 PR** provided because: I use 3.6 in my project
- **tests**  not required because: I tested manually on Windows, adding additional CI for this seems overkill

```sh
cmake -B build -G Ninja -DCMAKE_C_COMPILER=clang.exe
cmake -B build-clangcl -T ClangCL
```

I also ran with `-DGEN_FILES=ON` from a git bash shell once.


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
