### PR TITLE
library: x509: fix guard in mbedtls_x509_crt_profile_next

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -118,7 +118,7 @@ const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_next =
     MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA384) |
     MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA512),
     0xFFFFFFF, /* Any PK alg    */
-#if defined(MBEDTLS_ECP_C)
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     /* Curves at or above 128-bit security level. */
     MBEDTLS_X509_ID_FLAG(MBEDTLS_ECP_DP_SECP256R1) |
     MBEDTLS_X509_ID_FLAG(MBEDTLS_ECP_DP_SECP384R1) |


### PR DESCRIPTION
## Description

Replace MBEDTLS_ECP_C with PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY which is already used in all other profiles in this file.

## PR checklist

- [x] **changelog** not required because: internal change
- [x] **development PR** not required because:  this one
- [x] **TF-PSA-Crypto PR** not required because: no change there
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: not backportable
- **tests** not required because: minor change