### PR TITLE
Add support for wildcard hostname checks

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -277,6 +277,20 @@ static int x509_check_wildcard(const char *cn, const mbedtls_x509_buf *name)
     size_t i;
     size_t cn_idx = 0, cn_len = strlen(cn);
 
+    /* Wildcard common name */
+    if (cn_len > 2 && cn[0] == '*' && cn[1] == '.') {
+        /* Wildcard CN: match domain part only */
+        const char *domain_start = strchr((const char *)name->p, '.');
+        if (domain_start != NULL) {
+            size_t domain_len = name->len - (domain_start - (const char *)name->p);
+            if (domain_len == cn_len - 1 &&
+            x509_memcasecmp(cn + 1, domain_start, domain_len) == 0) {
+            return 0;
+            }
+        }
+        return -1;
+    }
+
     /* We can't have a match if there is no wildcard to match */
     if (name->len < 3 || name->p[0] != '*' || name->p[1] != '.') {
         return -1;


### PR DESCRIPTION
Support configuration of wildcard hostname against which common name of certificates can be verified.

## Description

Validate wildcard hostname against certificate CN. Perform domain suffix matching for certificates. This allows a configured CN (eg., "[any].example.com") to match any subdomain like "sub.example.com", "api.example.com", etc. The function extracts the domain portion from the provided hostname (everything after the first dot) and compares it case-insensitively against the CN suffix present in the certificate.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: not a user facing change
- [ ] **development PR** provided here
- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: not breaking any APIs
- **tests** no. 