### PR TITLE
Add 1.1 line to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,15 +9,14 @@ Please write a few sentences describing the overall goals of the pull request's 
 Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
 If the provided content is part of the present PR remove the # symbol.
 
-- [ ] **changelog** provided | not required because: 
-- [ ] **development PR** provided # | not required because: 
-- [ ] **prerequisite TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because: 
-- [ ] **prerequisite framework PR** provided Mbed-TLS/mbedtls-framework# | not required
-- [ ] **backport 4.1 PR** provided # | not required because: 
-- [ ] **prerequisite backport 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because: 
-- [ ] **backport 3.6 PR** provided # | not required because: 
-- **tests**  provided | not required because: 
-
+- [ ] **changelog** provided | not required because:
+- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
+- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
+- [ ] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
+- [ ] **mbedtls development PR** provided # | not required because:
+- [ ] **mbedtls 4.1 PR** provided # | not required because:
+- [ ] **mbedtls 3.6 PR** provided # | not required because:
+- **tests**  provided | not required because:
 
 
 ## Notes for the submitter


### PR DESCRIPTION
Starting now, pull requests may need backports to the upcoming LTS branches (TF-PSA-Crypto 1.1 and Mbed TLS 4.1).

## PR checklist

- [x] **changelog** provided | not required because: github only
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/290
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/719
- [x] **TF-PSA-Crypto 1.1 PR** not required because: only for default branch
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10647
- [x] **mbedtls 4.1 PR** not required because: only for default branch
- [x] **mbedtls 3.6 PR** not required because: only for default branch
- **tests**  not required because: no code
