### PR TITLE
cmake: make Thread package search quiet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 # We now potentially need to link all executables against PThreads, if available
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
+find_package(Threads QUIET)
 
 # If this is the root project add longer list of available CMAKE_BUILD_TYPE values
 if(NOT MBEDTLS_AS_SUBPROJECT)


### PR DESCRIPTION
## Description

this is the exact same thing as https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/724 but for the `mbedtls` repo

## PR checklist

- [ ] **changelog** not required because: minor CMake message removal
- [ ] **development PR** not required because: this one
- [ ] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/724
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: not backported
- **tests**  not required because: no code change
