### PR TITLE
check_config: add missing check for TLS 1.3 key exchanges

### DIFF
--- a/library/mbedtls_check_config.h
+++ b/library/mbedtls_check_config.h
@@ -142,6 +142,15 @@
         "but no key exchange methods defined with MBEDTLS_KEY_EXCHANGE_xxxx"
 #endif
 
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3) &&                                    \
+    !(defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED) ||    \
+      defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED) ||          \
+      defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED) )
+#error "TLS 1.3 protocol is enabled but no key exchange method is defined" \
+        "with MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_xxxx"
+#endif
+
+
 #if defined(MBEDTLS_SSL_EARLY_DATA) && \
     ( !defined(MBEDTLS_SSL_SESSION_TICKETS) || \
       ( !defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED) && \

--- a/library/mbedtls_check_config.h
+++ b/library/mbedtls_check_config.h
@@ -138,8 +138,8 @@
       defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED) ||                          \
       defined(MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED) ||                    \
       defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED) )
-#error "One or more versions of the TLS protocol are enabled " \
-        "but no key exchange methods defined with MBEDTLS_KEY_EXCHANGE_xxxx"
+#error "TLS 1.2 protocol is enabled but no key exchange method is defined" \
+        "with MBEDTLS_KEY_EXCHANGE_xxxx"
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) &&                                    \


### PR DESCRIPTION
## Description

Add a check to ensure that at least 1 key exchange is selected when TLS 1.3 is also enabled.

## PR checklist

- [ ] **changelog** not required because: minor, just adding a guard to a function
- [ ] **development PR** not required because: this one
- [ ] **Mbed TLS 4.1 backport** https://github.com/Mbed-TLS/mbedtls/pull/10713
- [ ] **TF-PSA-Crypto PR** not required because: no change there
- [ ] **framework PR** not required
- [ ] **3.6 PR** not required because: not backported
- **tests**  not required because: no code change
