### PR TITLE
Backport 3.6: Add fix for -DENABLE_PROGRAMS=OFF build error

### DIFF
--- a/ChangeLog.d/fix-ENABLE_PROGRAMS-bug.txt
+++ b/ChangeLog.d/fix-ENABLE_PROGRAMS-bug.txt
@@ -1,2 +1,2 @@
 Bugfix
-   * Add fix for -DENABLE_PROGRAMS=OFF build error reported in issue 10587.
+   * Fix failure of cmake -DENABLE_PROGRAMS=OFF. Fixes #10587.

--- a/ChangeLog.d/fix-ENABLE_PROGRAMS-bug.txt
+++ b/ChangeLog.d/fix-ENABLE_PROGRAMS-bug.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * Add fix for -DENABLE_PROGRAMS=OFF build error reported in issue 10587.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,7 +140,9 @@ if(GEN_FILES)
     add_custom_target(handshake-generated.sh
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/opt-testcases/handshake-generated.sh)
     set_target_properties(handshake-generated.sh PROPERTIES EXCLUDE_FROM_ALL NO)
+if(ENABLE_PROGRAMS)
     add_dependencies(${ssl_opt_target} handshake-generated.sh)
+endif()
 
     add_custom_command(
         OUTPUT
@@ -195,8 +197,11 @@ if(GEN_FILES)
     )
     add_custom_target(tls13-compat.sh
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/opt-testcases/tls13-compat.sh)
+
+if(ENABLE_PROGRAMS)
     set_target_properties(tls13-compat.sh PROPERTIES EXCLUDE_FROM_ALL NO)
     add_dependencies(${ssl_opt_target} tls13-compat.sh)
+endif()
 
 else()
     foreach(file ${all_generated_data_files})


### PR DESCRIPTION
## Description

Add fix for -DENABLE_PROGRAMS=OFF build error, resolves https://github.com/Mbed-TLS/mbedtls/issues/10587

## PR checklist

- [ ] **changelog** provided
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10654
- [ ] **mbedtls 4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10799
- [x] **TF-PSA-Crypto development PR** not required because: TF-PSA-Crypto not buggy
- [x] **TF-PSA-Crypto 1.1 PR** not required because: TF-PSA-Crypto not buggy
- [x] **framework PR** not required
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10655
- **tests**  not required because: too minor to bother on the CI (test locally)