### PR TITLE
Backport 3.6: Fix variable set but not used warning

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -322,11 +322,12 @@ static int ssl_tls13_parse_certificate_verify(mbedtls_ssl_context *ssl,
     }
 #endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT */
 
-    if ((ret = mbedtls_pk_verify_ext(sig_alg, options,
-                                     &ssl->session_negotiate->peer_cert->pk,
-                                     md_alg, verify_hash, verify_hash_len,
-                                     p, signature_len)) == 0) {
-        return 0;
+    ret = mbedtls_pk_verify_ext(sig_alg, options,
+                                &ssl->session_negotiate->peer_cert->pk,
+                                md_alg, verify_hash, verify_hash_len,
+                                p, signature_len);
+    if (ret == 0) {
+        return ret;
     }
     MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_ext", ret);
 


### PR DESCRIPTION
## Description

Add ret return pattern to avoid variable ret was set but never used warning. contributes https://github.com/Mbed-TLS/mbedtls/issues/10448 

## PR checklist

- [ ] **changelog** not required because: No public changes
- [ ] **development PR** provided #https://github.com/Mbed-TLS/mbedtls/pull/10656
- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **framework PR** not required
- [ ] **3.6 PR** provided #HERE
- **tests**  not required because: No changes