### PR TITLE
Remove FFDH-specific code from compat.sh 

### DIFF
--- a/tests/compat.sh
+++ b/tests/compat.sh
@@ -541,19 +541,6 @@ setup_arguments()
     G_SERVER_ARGS="-p $PORT --http $G_MODE"
     G_SERVER_PRIO="NORMAL:${G_PRIO_CCM}+NULL:+MD5:+PSK:+ECDHE-PSK:+SHA256:+SHA384:-VERS-TLS-ALL:$G_PRIO_MODE"
 
-    # The default prime for `openssl s_server` depends on the version:
-    # * OpenSSL <= 1.0.2a: 512-bit
-    # * OpenSSL 1.0.2b to 1.1.1b: 1024-bit
-    # * OpenSSL >= 1.1.1c: 2048-bit
-    # Mbed TLS wants >=1024, so force that for older versions. Don't force
-    # it for newer versions, which reject a 1024-bit prime. Indifferently
-    # force it or not for intermediate versions.
-    case $($OPENSSL version) in
-        "OpenSSL 1.0"*)
-            O_SERVER_ARGS="$O_SERVER_ARGS -dhparam $DATA_FILES_PATH/dhparams.pem"
-            ;;
-    esac
-
     # with OpenSSL 1.0.1h, -www, -WWW and -HTTP break DTLS handshakes
     if is_dtls "$MODE"; then
         O_SERVER_ARGS="$O_SERVER_ARGS"


### PR DESCRIPTION
## Description

Issue: #9686 | Remove FFDH-specific code from compat.sh 



## PR checklist
- [x] **changelog** not required because: No user-visible change
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto PR** not required because: Not related
- [x] **TF-PSA-Crypto 1.1 PR** not required because: Not related
- [x] **mbedtls development PR** provided: here
- [x] **mbedtls 4.1 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10709
- [x] **mbedtls 3.6 PR** not required because: No need: FFDH (TLS_DHE_RSA/PSK**) code is used in 3.6
- **tests** not required because: No changes