### PR TITLE
Outcome analysis: rename IGNORED_TESTS to UNCOVERED_TESTS

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -33,7 +33,7 @@ class CoverageTask(outcome_analysis.CoverageTask):
                           r'.*\b(?:' + r'|'.join(words) + r')\b.*',
                           re.DOTALL)
 
-    IGNORED_TESTS = {
+    UNCOVERED_TESTS = {
         'ssl-opt': [
             # We don't run ssl-opt.sh with Valgrind on the CI because
             # it's extremely slow. We don't intend to change this.


### PR DESCRIPTION
Restore the “needlessly ~ignored~ uncovered” error after https://github.com/Mbed-TLS/mbedtls-framework/pull/292.

Needs preceding PR: https://github.com/Mbed-TLS/mbedtls-framework/pull/292

## PR checklist

- [x] **changelog** not required because: test only
- [x] **development PR** provided #10676
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/729
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/292
- [ ] **4.1 PR** TODO
- [x] **3.6 PR** here
- **tests**  provided
