### PR TITLE
[3.6] psa_crypto.c: Fix ifdefs to avoid build warning

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -6939,7 +6939,9 @@ static int psa_key_derivation_allows_free_form_secret_input(
 psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
                                       psa_algorithm_t alg)
 {
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     psa_status_t status;
+#endif
 
     if (operation->alg != 0) {
         return PSA_ERROR_BAD_STATE;
@@ -6972,10 +6974,12 @@ psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t *operation,
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
+#if defined(AT_LEAST_ONE_BUILTIN_KDF)
     if (status == PSA_SUCCESS) {
         operation->alg = alg;
     }
     return status;
+#endif /* AT_LEAST_ONE_BUILTIN_KDF */
 }
 
 #if defined(BUILTIN_ALG_ANY_HKDF)


### PR DESCRIPTION
## Description

Backport of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/723

## PR checklist

- [x] **changelog** not required because: minor change
- [x] **development PR** not required because: no change there
- [x] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/723 
- [x] **framework PR** not required
- [x] **3.6 PR** not required because: it's this one
- [x] **tf-psa-crypto 1.1 PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/741
- **tests** not required because: no code change