### PR TITLE
Backport 3.6: PAKE getters test failure with GCC 15

### DIFF
--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -781,7 +781,7 @@ void pk_can_do_ext(int opaque_key, int key_type, int key_usage, int key_alg,
 
 exit:
     psa_reset_key_attributes(&attributes);
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_pk_free(&pk);
     USE_PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2411,7 +2411,7 @@ void aead_key_policy(int policy_usage_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_aead_abort(&operation));
+    psa_aead_abort(&operation);
     psa_destroy_key(key);
     PSA_DONE();
 }
@@ -3030,7 +3030,7 @@ void hash_compute_fail(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     mbedtls_free(output);
     PSA_DONE();
 }
@@ -3069,7 +3069,7 @@ void hash_compare_fail(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -3173,7 +3173,7 @@ void hash_compute_compare(int alg_arg, data_t *input,
     }
 
 exit:
-    PSA_ASSERT(psa_hash_abort(&operation));
+    psa_hash_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -4345,7 +4345,7 @@ void cipher_alg_without_iv(int alg_arg, int key_type_arg, data_t *key_data,
                         output, output_length);
 
 exit:
-    PSA_ASSERT(psa_cipher_abort(&operation));
+    psa_cipher_abort(&operation);
     mbedtls_free(output);
     psa_cipher_abort(&operation);
     psa_destroy_key(key);
@@ -10967,8 +10967,8 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     mbedtls_free(output_buffer);
     PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto_driver_wrappers.function
+++ b/tests/suites/test_suite_psa_crypto_driver_wrappers.function
@@ -2899,7 +2899,7 @@ void aead_encrypt_setup(int key_type_arg, data_t *key_data,
 
 exit:
     /* Cleanup */
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_free(output_data);
     PSA_DONE();
     mbedtls_test_driver_aead_hooks = mbedtls_test_driver_aead_hooks_init();
@@ -3001,7 +3001,7 @@ void aead_decrypt_setup(int key_type_arg, data_t *key_data,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
+    psa_destroy_key(key);
     mbedtls_free(output_data);
     PSA_DONE();
 }

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -593,7 +593,7 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
                    int expected_error_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_pake_primitive_t primitive = primitive_arg;
     psa_key_type_t key_type_pw = key_type_pw_arg;
@@ -779,8 +779,8 @@ void ecjpake_rounds_inject(int alg_arg, int primitive_arg, int hash_arg,
                            int inject_in_second_round)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t hash_alg = hash_arg;
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
@@ -839,8 +839,8 @@ void ecjpake_rounds(int alg_arg, int primitive_arg, int hash_arg,
                     int err_stage_arg)
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t server = psa_pake_operation_init();
-    psa_pake_operation_t client = psa_pake_operation_init();
+    psa_pake_operation_t server = psa_pake_operation_init_short();
+    psa_pake_operation_t client = psa_pake_operation_init_short();
     psa_algorithm_t alg = alg_arg;
     psa_algorithm_t hash_alg = hash_arg;
     psa_algorithm_t derive_alg = derive_alg_arg;
@@ -980,7 +980,7 @@ void ecjpake_size_macros()
 void pake_input_getters_password()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     mbedtls_svc_key_id_t key = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     const char *password = "password";
@@ -1045,7 +1045,7 @@ exit:
 void pake_input_getters_cipher_suite()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     psa_pake_cipher_suite_t cipher_suite_ret = psa_pake_cipher_suite_init();
 
     psa_pake_primitive_t primitive = PSA_PAKE_PRIMITIVE(
@@ -1079,7 +1079,7 @@ exit:
 void pake_input_getters_user()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     const char *users[] = { "client", "server", "other" };
     uint8_t user_ret[20] = { 0 }; // max user length is 20 bytes
     size_t user_len_ret = 0;
@@ -1142,7 +1142,7 @@ exit:
 void pake_input_getters_peer()
 {
     psa_pake_cipher_suite_t cipher_suite = psa_pake_cipher_suite_init();
-    psa_pake_operation_t operation = psa_pake_operation_init();
+    psa_pake_operation_t operation = psa_pake_operation_init_short();
     const char *peers[] = { "client", "server", "other" };
     uint8_t peer_ret[20] = { 0 }; // max peer length is 20 bytes
     size_t peer_len_ret = 0;

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -1058,9 +1058,6 @@ void pake_input_getters_cipher_suite()
     psa_pake_cs_set_primitive(&cipher_suite, primitive);
     psa_pake_cs_set_hash(&cipher_suite, PSA_ALG_SHA_256);
 
-    TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
-               PSA_ERROR_BAD_STATE);
-
     PSA_ASSERT(psa_pake_setup(&operation, &cipher_suite));
 
     TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
@@ -1068,6 +1065,10 @@ void pake_input_getters_cipher_suite()
 
     TEST_MEMORY_COMPARE(&cipher_suite_ret, sizeof(cipher_suite_ret),
                         &cipher_suite, sizeof(cipher_suite));
+
+    PSA_ASSERT(psa_pake_abort(&operation));
+    TEST_EQUAL(psa_crypto_driver_pake_get_cipher_suite(&operation.data.inputs, &cipher_suite_ret),
+               PSA_ERROR_BAD_STATE);
 
 exit:
     PSA_ASSERT(psa_pake_abort(&operation));

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -763,8 +763,8 @@ void ecjpake_setup(int alg_arg, int key_type_pw_arg, int key_usage_pw_arg,
     }
 
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     mbedtls_free(output_buffer);
     PSA_DONE();
 }
@@ -1035,8 +1035,8 @@ void pake_input_getters_password()
 
     TEST_MEMORY_COMPARE(password_ret, buffer_len_ret, password, strlen(password));
 exit:
-    PSA_ASSERT(psa_destroy_key(key));
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_destroy_key(key);
+    psa_pake_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1071,7 +1071,7 @@ void pake_input_getters_cipher_suite()
                PSA_ERROR_BAD_STATE);
 
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_pake_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1133,8 +1133,9 @@ void pake_input_getters_user()
 
         TEST_MEMORY_COMPARE(user_ret, buffer_len_ret, user, user_len);
     }
+
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_pake_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */
@@ -1196,8 +1197,9 @@ void pake_input_getters_peer()
 
         TEST_MEMORY_COMPARE(peer_ret, buffer_len_ret, peer, peer_len);
     }
+
 exit:
-    PSA_ASSERT(psa_pake_abort(&operation));
+    psa_pake_abort(&operation);
     PSA_DONE();
 }
 /* END_CASE */


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/584, a problem in our tests that causes them to fail with GCC 15 at `-O0`.

There were conflicts in the 3.6 backport. It seems that some test functions are organized slightly differently and fewer places needed patching.

## PR checklist

- [x] **changelog** not required because: test only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/585
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/746
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10680
- **tests**  provided
