### PR TITLE
Make mbedtls_ssl_(session|context)_load functions memory-safe

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4035,7 +4035,15 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
         }
 
         if (alpn_len > 0) {
-            int ret = mbedtls_ssl_session_set_ticket_alpn(session, (char *) p);
+            /* Before using the data as a null-terminated string, check that is
+             * actually the case.
+             */
+            if (p[alpn_len - 1] != 0) {
+                return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+            }
+
+            int ret = mbedtls_ssl_session_set_ticket_alpn(session,
+                                                          (const char *) p);
             if (ret != 0) {
                 return ret;
             }
@@ -4060,6 +4068,12 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (hostname_len > 0) {
+            /* Before using the data as a null-terminated string, check that it
+             * is actually the case.
+             */
+            if (p[hostname_len - 1] != 0) {
+                return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+            }
             session->hostname = mbedtls_calloc(1, hostname_len);
             if (session->hostname == NULL) {
                 return MBEDTLS_ERR_SSL_ALLOC_FAILED;

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5455,12 +5455,20 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
+    if (ssl->transform->in_cid_len > sizeof(ssl->transform->in_cid)) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
     memcpy(ssl->transform->in_cid, p, ssl->transform->in_cid_len);
     p += ssl->transform->in_cid_len;
 
     ssl->transform->out_cid_len = *p++;
 
     if ((size_t) (end - p) < ssl->transform->out_cid_len) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    if (ssl->transform->out_cid_len > sizeof(ssl->transform->out_cid)) {
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4074,11 +4074,12 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
             if (p[hostname_len - 1] != 0) {
                 return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
             }
-            session->hostname = mbedtls_calloc(1, hostname_len);
-            if (session->hostname == NULL) {
-                return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+
+            int ret = mbedtls_ssl_session_set_hostname(session,
+                                                       (const char *) p);
+            if (ret != 0) {
+                return ret;
             }
-            memcpy(session->hostname, p, hostname_len);
             p += hostname_len;
         }
 #endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -1033,6 +1033,14 @@ Test Session id & Ciphersuite accessors TLS 1.3
 depends_on:MBEDTLS_SSL_PROTO_TLS1_3
 ssl_session_id_accessors_check:MBEDTLS_SSL_VERSION_TLS1_3
 
+TLS 1.3: SRV: session load: ticket alpn, no null terminator
+depends_on:MBEDTLS_SSL_SRV_C:MBEDTLS_SSL_SESSION_TICKETS:MBEDTLS_SSL_EARLY_DATA:MBEDTLS_SSL_ALPN
+ssl_tls13_session_load_string_check:MBEDTLS_SSL_IS_SERVER:"ALPNExample"
+
+TLS 1.3: CLI: session load: hostname, no null terminator
+depends_on:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SESSION_TICKETS:MBEDTLS_SSL_SERVER_NAME_INDICATION
+ssl_tls13_session_load_string_check:MBEDTLS_SSL_IS_CLIENT:"hostname example"
+
 Record crypt, AES-128-CBC, 1.2, SHA-384
 depends_on:MBEDTLS_SSL_HAVE_AES:MBEDTLS_SSL_HAVE_CBC:MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_MD_CAN_SHA384
 ssl_crypt_record:MBEDTLS_CIPHER_AES_128_CBC:MBEDTLS_MD_SHA384:0:0:MBEDTLS_SSL_VERSION_TLS1_2:0:0

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -2835,6 +2835,55 @@ exit:
 }
 /* END_CASE */
 
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3 */
+void ssl_tls13_session_load_string_check(int endpoint_type, const char *input_string)
+{
+    unsigned char serialized_session[2048];
+    size_t serialized_session_len;
+    unsigned char *p, *end;
+    mbedtls_ssl_session session;
+    size_t input_string_len = strlen(input_string);
+
+    mbedtls_ssl_session_init(&session);
+    USE_PSA_INIT();
+
+    TEST_EQUAL(mbedtls_test_ssl_tls13_populate_session(
+                   &session, 0, endpoint_type), 0);
+
+    /* Serialize session */
+    TEST_EQUAL(mbedtls_ssl_session_save(&session,
+                                        serialized_session,
+                                        sizeof(serialized_session),
+                                        &serialized_session_len), 0);
+
+    /* Check session deserialization */
+    TEST_EQUAL(mbedtls_ssl_session_load(&session,
+                                        serialized_session,
+                                        serialized_session_len), 0);
+    TEST_ASSERT(serialized_session_len > input_string_len);
+    end = serialized_session + serialized_session_len - input_string_len;
+
+    /* Basic search of input_string */
+    for (p = serialized_session; p < end; p++) {
+        if (memcmp(p, input_string, input_string_len) == 0) {
+            break;
+        }
+    }
+    TEST_ASSERT(p < end);
+    TEST_EQUAL(p[input_string_len], 0);
+
+    p[input_string_len] = 1;
+    TEST_EQUAL(mbedtls_ssl_session_load(&session,
+                                        serialized_session,
+                                        serialized_session_len),
+               MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
+
+exit:
+    mbedtls_ssl_session_free(&session);
+    USE_PSA_DONE();
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:MBEDTLS_RSA_C:MBEDTLS_ECP_HAVE_SECP384R1:!MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_PKCS1_V15:MBEDTLS_MD_CAN_SHA256 */
 void mbedtls_endpoint_sanity(int endpoint_type)
 {


### PR DESCRIPTION
## Description
Fixes #10682

## PR checklist
- [ ] **changelog** provided | not required because: 
- [ ] **development PR** provided # TODO
- [x] **TF-PSA-Crypto PR** not required because: TLS only work 
- [x] **framework PR** not required
- [x] **3.6 PR** provided here
- [ ] **4.1 PR** provided # TODO
- **tests**  provided