### PR TITLE
Backport 3.6: Create a directory for maintainer-only Python scripts

### DIFF
--- a/scripts/maintainer/maintainer_scripts_path.py
+++ b/scripts/maintainer/maintainer_scripts_path.py
@@ -1,0 +1,20 @@
+"""Add our Python library directories for maintainer scripts to the module search path.
+
+Usage:
+
+    import maintainer_scripts_path # pylint: disable=unused-import
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+#
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                             os.path.pardir, os.path.pardir,
+                             'framework', 'scripts'))
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                             os.path.pardir, os.path.pardir,
+                             'framework', 'util'))


### PR DESCRIPTION
This directory is currently excluded from `check-python-files.sh`, because we run it on the CI in an old Python version that doesn't support some of our new maintainer scripts (specifically, to start with, the MLDSA test generator).

## PR checklist

- [x] **changelog** provided | not required because: no user-visible feature yet
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/282
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/700
- [x] **TF-PSA-Crypto 1.1 PR** provided (partial) https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/750
- [x] **mbedtls development PR** (only creating `scripts/maintainer`) https://github.com/Mbed-TLS/mbedtls/pull/10684
- [x] **mbedtls 4.1 PR** (only creating `scripts/maintainer`) https://github.com/Mbed-TLS/mbedtls/pull/10685
- [x] **mbedtls 3.6 PR** (only creating `scripts/maintainer`) https://github.com/Mbed-TLS/mbedtls/pull/10686
- **tests**  provided
