### PR TITLE
Fix build warning/error using llvm-mingw

### DIFF
--- a/ChangeLog.d/pr_10695__fix_build_llvm_mingw.txt
+++ b/ChangeLog.d/pr_10695__fix_build_llvm_mingw.txt
@@ -1,0 +1,4 @@
+Bugfix
+   * Fix a build error using the LLVM based MinGW toolchain.
+     Bug reported and fix contributed by valord577.
+     Fixes #10695.

--- a/ChangeLog.d/pr_10695__fix_build_llvm_mingw.txt
+++ b/ChangeLog.d/pr_10695__fix_build_llvm_mingw.txt
@@ -1,4 +1,3 @@
 Bugfix
    * Fix a build error using the LLVM based MinGW toolchain.
      Bug reported and fix contributed by valord577.
-     Fixes #10695.

--- a/include/mbedtls/debug.h
+++ b/include/mbedtls/debug.h
@@ -59,7 +59,7 @@
  */
 #if defined(__has_attribute)
 #if __has_attribute(format)
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(__clang__)
 #define MBEDTLS_PRINTF_ATTRIBUTE(string_index, first_to_check)    \
     __attribute__((__format__(gnu_printf, string_index, first_to_check)))
 #else /* defined(__MINGW32__) */


### PR DESCRIPTION
## Description

error logs refs: https://github.com/valord577/nativepkgs/actions/runs/24490614774/job/71574726128



## PR checklist

- [x] **changelog** provided
- [x] **mbedtls development PR** provided: `This PR`
- [x] **mbedtls 4.1 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10711
- [x] **mbedtls 3.6 PR** Not Required (affected code was different)
- **tests**  provided: https://github.com/valord577/nativepkgs/actions/runs/24495889854/job/71590610976
