### PR TITLE
Backport 4.1: Support DESTDIR for install and add build-system test

### DIFF
--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,3 +1,3 @@
 Changes
-   * CMake installs now honor `DESTDIR` for the compatibility
-     `libmbedcrypto.so` symlink during staged installs.
+   * Restore DESTDIR support for CMake installs of compatibility
+   `libmbedcrypto` symlinks.

--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * CMake installs now honor `DESTDIR` for the compatibility
+     `libmbedcrypto.so` symlink during staged installs.

--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,3 +1,3 @@
-Bugfix
+Changes
    * CMake installs now honor `DESTDIR` for the compatibility
      `libmbedcrypto.so` symlink during staged installs.

--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,3 +1,3 @@
-Feature
+Features
    * Restore DESTDIR support for CMake installs of compatibility
      libmbedcrypto symlinks. Fixes #10627.

--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,3 +1,3 @@
-Changes
+Feature
    * Restore DESTDIR support for CMake installs of compatibility
-     `libmbedcrypto` symlinks.
+     libmbedcrypto symlinks. Fixes #10627.

--- a/ChangeLog.d/cmake-destdir-instal.txt
+++ b/ChangeLog.d/cmake-destdir-instal.txt
@@ -1,3 +1,3 @@
 Changes
    * Restore DESTDIR support for CMake installs of compatibility
-   `libmbedcrypto` symlinks.
+     `libmbedcrypto` symlinks.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -361,7 +361,7 @@ foreach(target IN LISTS tf_psa_crypto_library_targets)
                     RENAME "libmbedcrypto.so.${MBEDTLS_VERSION}"
             )
             install(CODE "
-                set(_libdir \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\")
+                set(_libdir \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\")
 
                 execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E create_symlink
                                 \"libmbedcrypto.so.${MBEDTLS_VERSION}\"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -169,9 +169,37 @@ component_test_cmake_install_with_destdir () {
 
     DESTDIR="$OUT_OF_SOURCE_DIR/stage" make install
 
-    install_libdir="$(sed -n 's/^CMAKE_INSTALL_LIBDIR:PATH=//p' CMakeCache.txt)"
-    test -n "$install_libdir"
-    test -L "$OUT_OF_SOURCE_DIR/stage/usr/${install_libdir}/libmbedcrypto.so"
+    install_lib_subdir="$(sed -n 's/^CMAKE_INSTALL_LIBDIR:PATH=//p' CMakeCache.txt)"
+    if [ -z "$install_lib_subdir" ]; then
+        echo "Error: Failed to read CMAKE_INSTALL_LIBDIR from CMakeCache.txt" >&2
+        exit 1
+    fi
+
+    install_lib_path="$OUT_OF_SOURCE_DIR/stage/usr/${install_lib_subdir}"
+
+    if [ ! -L "$install_lib_path/libmbedcrypto.so" ]; then
+        echo "Error: Expected symlink missing: $install_lib_path/libmbedcrypto.so" >&2
+        ls -l "$install_lib_path" >&2 || true
+        exit 1
+    fi
+
+    # Match the install(CODE) logic in library/CMakeLists.txt:
+    # libmbedcrypto.so.${MBEDTLS_CRYPTO_SOVERSION} -> libmbedcrypto.so.${MBEDTLS_VERSION}
+    # libmbedcrypto.so -> libmbedcrypto.so.${MBEDTLS_CRYPTO_SOVERSION}
+    symlink_count="$(find "$install_lib_path" -maxdepth 1 -type l -name 'libmbedcrypto.so*' | wc -l)"
+    if [ "$symlink_count" -lt 2 ]; then
+        echo "Error: Expected at least 2 libmbedcrypto.so* symlinks, got $symlink_count" >&2
+        ls -l "$install_lib_path"/libmbedcrypto.so* >&2 || true
+        exit 1
+    fi
+
+    for symlink in "$install_lib_path"/libmbedcrypto.so*; do
+        if [ -L "$symlink" ] && [ ! -e "$symlink" ]; then
+            echo "Error: Dangling symlink found: $symlink -> $(readlink "$symlink")" >&2
+            ls -l "$install_lib_path"/libmbedcrypto.so* >&2 || true
+            exit 1
+        fi
+    done
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -155,6 +155,32 @@ support_test_cmake_as_package_install () {
     support_test_cmake_out_of_source
 }
 
+component_test_cmake_install_with_destdir () {
+    # Remove existing generated files so that we use the ones CMake
+    # generates
+    $MAKE_COMMAND neat
+
+    msg "install: cmake with DESTDIR staging"
+    MBEDTLS_ROOT_DIR="$PWD"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+    cmake -DGEN_FILES=ON -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr "$MBEDTLS_ROOT_DIR"
+    make
+
+    DESTDIR="$OUT_OF_SOURCE_DIR/stage" make install
+
+    install_libdir="$(sed -n 's/^CMAKE_INSTALL_LIBDIR:PATH=//p' CMakeCache.txt)"
+    test -n "$install_libdir"
+    test -L "$OUT_OF_SOURCE_DIR/stage/usr/${install_libdir}/libmbedcrypto.so"
+
+    cd "$MBEDTLS_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
+}
+
+support_test_cmake_install_with_destdir () {
+    support_test_cmake_out_of_source
+}
+
 component_build_cmake_custom_config_file () {
     # Make a copy of config file to use for the in-tree test
     cp "$CONFIG_H" include/mbedtls_config_in_tree_copy.h

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -174,7 +174,14 @@ component_test_cmake_install_with_destdir () {
 
     install_lib_path="$OUT_OF_SOURCE_DIR/stage/usr/${install_lib_subdir}"
 
-    if [[ "$OSTYPE" != darwin* ]]; then
+    if [[ "$OSTYPE" == darwin* ]]; then
+        # On macOS the custom install logic installs libmbedcrypto.dylib
+        # directly without a versioned symlink chain.
+        for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
+            [ -f "$install_lib_path/lib${lib}.a" ]
+            [ -e "$install_lib_path/lib${lib}.dylib" ]
+        done
+    else
         # library/CMakeLists.txt installs libmbedcrypto.so with a versioned
         # symlink chain on Linux.
         for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
@@ -188,19 +195,10 @@ component_test_cmake_install_with_destdir () {
             if [ "$QUIET" -eq 0 ]; then
                 declare -p versioned
             fi
-            [ "${#versioned[@]}" -ge 1 ]
-            # [ -L "${versioned[0]}" ]
+            # [ "${#versioned[@]}" -ge 1 ]
+            [ -L "${versioned[0]}" ]
             [ -e "${versioned[0]}" ]
         done
-    elif [[ "$OSTYPE" == darwin* ]]; then
-        # On macOS the custom install logic installs libmbedcrypto.dylib
-        # directly without a versioned symlink chain.
-        for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
-            [ -f "$install_lib_path/lib${lib}.a" ]
-            [ -e "$install_lib_path/lib${lib}.dylib" ]
-        done
-    else
-        echo "Unsupported platform for DESTDIR shared library checks"
     fi
 }
 

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -170,39 +170,31 @@ component_test_cmake_install_with_destdir () {
     DESTDIR="$OUT_OF_SOURCE_DIR/stage" make install
 
     install_lib_subdir="$(sed -n 's/^CMAKE_INSTALL_LIBDIR:PATH=//p' CMakeCache.txt)"
-    if [ -z "$install_lib_subdir" ]; then
-        echo "Error: Failed to read CMAKE_INSTALL_LIBDIR from CMakeCache.txt" >&2
-        exit 1
-    fi
+    [ -n "$install_lib_subdir" ] # Failed to read CMAKE_INSTALL_LIBDIR from CMakeCache.txt
 
     install_lib_path="$OUT_OF_SOURCE_DIR/stage/usr/${install_lib_subdir}"
 
-    if [ ! -L "$install_lib_path/libmbedcrypto.so" ]; then
-        echo "Error: Expected symlink missing: $install_lib_path/libmbedcrypto.so" >&2
-        ls -l "$install_lib_path" >&2 || true
-        exit 1
+    if [[ "$OSTYPE" == linux* ]]; then
+        # library/CMakeLists.txt installs libmbedcrypto.so with a versioned
+        # symlink chain on Linux.
+        for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
+            [ -f "$install_lib_path/lib${lib}.a" ]
+            [ -L "$install_lib_path/lib${lib}.so" ]
+            [ -e "$install_lib_path/lib${lib}.so" ]
+            versioned=( "$install_lib_path/lib${lib}.so".* )
+            [ -L "${versioned[0]}" ]
+            [ -e "${versioned[0]}" ]
+        done
+    elif [[ "$OSTYPE" == darwin* ]]; then
+        # On macOS the custom install logic installs libmbedcrypto.dylib
+        # directly without a versioned symlink chain.
+        for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
+            [ -f "$install_lib_path/lib${lib}.a" ]
+            [ -e "$install_lib_path/lib${lib}.dylib" ]
+        done
+    else
+        echo "Unsupported platform for DESTDIR shared library checks"
     fi
-
-    # Match the install(CODE) logic in library/CMakeLists.txt:
-    # libmbedcrypto.so.${MBEDTLS_CRYPTO_SOVERSION} -> libmbedcrypto.so.${MBEDTLS_VERSION}
-    # libmbedcrypto.so -> libmbedcrypto.so.${MBEDTLS_CRYPTO_SOVERSION}
-    symlink_count="$(find "$install_lib_path" -maxdepth 1 -type l -name 'libmbedcrypto.so*' | wc -l)"
-    if [ "$symlink_count" -lt 2 ]; then
-        echo "Error: Expected at least 2 libmbedcrypto.so* symlinks, got $symlink_count" >&2
-        ls -l "$install_lib_path"/libmbedcrypto.so* >&2 || true
-        exit 1
-    fi
-
-    for symlink in "$install_lib_path"/libmbedcrypto.so*; do
-        if [ -L "$symlink" ] && [ ! -e "$symlink" ]; then
-            echo "Error: Dangling symlink found: $symlink -> $(readlink "$symlink")" >&2
-            ls -l "$install_lib_path"/libmbedcrypto.so* >&2 || true
-            exit 1
-        fi
-    done
-
-    cd "$MBEDTLS_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
 }
 
 support_test_cmake_install_with_destdir () {

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -191,13 +191,21 @@ component_test_cmake_install_with_destdir () {
             [ -f "$install_lib_path/lib${lib}.a" ]
             [ -L "$install_lib_path/lib${lib}.so" ]
             [ -e "$install_lib_path/lib${lib}.so" ]
+
+            # do not assume a fixed match ordering.
             versioned=( "$install_lib_path/lib${lib}.so".* )
             if [ "$QUIET" -eq 0 ]; then
                 declare -p versioned
             fi
-            # [ "${#versioned[@]}" -ge 1 ]
-            [ -L "${versioned[0]}" ]
-            [ -e "${versioned[0]}" ]
+            versioned_symlink=
+            for candidate in "${versioned[@]}"; do
+                if [ -L "$candidate" ]; then
+                    versioned_symlink="$candidate"
+                    break
+                fi
+            done
+            [ -n "$versioned_symlink" ]
+            [ -e "$versioned_symlink" ]
         done
     fi
 }

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -192,20 +192,15 @@ component_test_cmake_install_with_destdir () {
             [ -L "$install_lib_path/lib${lib}.so" ]
             [ -e "$install_lib_path/lib${lib}.so" ]
 
-            # do not assume a fixed match ordering.
-            versioned=( "$install_lib_path/lib${lib}.so".* )
+            # Match ABI-version names such as libxxx.so.17
+            # and check that symlink.
+            versioned=( "$install_lib_path/lib${lib}.so".+([0-9]) )
             if [ "$QUIET" -eq 0 ]; then
                 declare -p versioned
             fi
-            versioned_symlink=
-            for candidate in "${versioned[@]}"; do
-                if [ -L "$candidate" ]; then
-                    versioned_symlink="$candidate"
-                    break
-                fi
-            done
-            [ -n "$versioned_symlink" ]
-            [ -e "$versioned_symlink" ]
+            [ "${#versioned[@]}" -eq 1 ]
+            [ -L "${versioned[0]}" ]
+            [ -e "${versioned[0]}" ]
         done
     fi
 }

--- a/tests/scripts/components-build-system.sh
+++ b/tests/scripts/components-build-system.sh
@@ -174,15 +174,22 @@ component_test_cmake_install_with_destdir () {
 
     install_lib_path="$OUT_OF_SOURCE_DIR/stage/usr/${install_lib_subdir}"
 
-    if [[ "$OSTYPE" == linux* ]]; then
+    if [[ "$OSTYPE" != darwin* ]]; then
         # library/CMakeLists.txt installs libmbedcrypto.so with a versioned
         # symlink chain on Linux.
         for lib in tfpsacrypto mbedcrypto mbedx509 mbedtls; do
+            if [ "$QUIET" -eq 0 ]; then
+                echo "Checking lib=$lib"
+            fi
             [ -f "$install_lib_path/lib${lib}.a" ]
             [ -L "$install_lib_path/lib${lib}.so" ]
             [ -e "$install_lib_path/lib${lib}.so" ]
             versioned=( "$install_lib_path/lib${lib}.so".* )
-            [ -L "${versioned[0]}" ]
+            if [ "$QUIET" -eq 0 ]; then
+                declare -p versioned
+            fi
+            [ "${#versioned[@]}" -ge 1 ]
+            # [ -L "${versioned[0]}" ]
             [ -e "${versioned[0]}" ]
         done
     elif [[ "$OSTYPE" == darwin* ]]; then


### PR DESCRIPTION
## Description

Add support for DESTDIR env for build install.
Tests are added

Issue: https://github.com/Mbed-TLS/mbedtls/issues/10627
Backport of: https://github.com/Mbed-TLS/mbedtls/pull/10631



## PR checklist

- [x] **changelog** provided
- [x] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10631
- [x] **mbedtls 4.1 PR** here
- [x] **TF-PSA-Crypto development PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/755
- [x] **TF-PSA-Crypto 1.1 PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/756
- [x] **framework PR** provided not required
- [x] **3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10637
- **tests**  provided