### PR TITLE
ssl_tls13_server: suppress unused function warning

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -983,7 +983,7 @@ static int ssl_tls13_parse_key_shares_ext(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_SOME_EPHEMERAL_ENABLED */
 
 MBEDTLS_CHECK_RETURN_CRITICAL
-static int ssl_tls13_client_hello_has_exts(mbedtls_ssl_context *ssl,
+static int __attribute__((unused)) ssl_tls13_client_hello_has_exts(mbedtls_ssl_context *ssl,
                                            int exts_mask)
 {
     int masked = ssl->handshake->received_extensions & exts_mask;


### PR DESCRIPTION
## Description

`ssl_tls13_client_hello_has_exts()` is called from three wrapper functions, each guarded by different `MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_*_ENABLED` preprocessor conditions. In configurations where none of those modes are active (e.g., builds that compile the TLS 1.3 server source but only use TLS 1.2 at runtime), the function is unreferenced and triggers `-Wunused-function`.

Add `__attribute__((unused))` to suppress the warning without removing the function.

## PR checklist

- [ ] **changelog** not required because: trivial warning fix, no functional change
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** not required because: change is in mbedtls ssl layer only
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: change is in mbedtls ssl layer only
- [ ] **mbedtls development PR** this is the development PR
- [ ] **mbedtls 4.1 PR** not required because: targeting development
- [ ] **mbedtls 3.6 PR** not required because: targeting development
- **tests** not required because: no functional change, build-only fix