### PR TITLE
Create Python project knowledge directory

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-mypy_path = framework/scripts:scripts
+mypy_path = framework/scripts:scripts:tf-psa-crypto/scripts/project_knowledge
 namespace_packages = True
 warn_unused_configs = True

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-init-hook='import sys; sys.path.append("scripts"); sys.path.append("framework/scripts")'
+init-hook='import sys; sys.path += ["scripts", "framework/scripts", "tf-psa-crypto/scripts/project_knowledge"]'
 min-similarity-lines=10
 
 [BASIC]

--- a/scripts/framework_scripts_path.py
+++ b/scripts/framework_scripts_path.py
@@ -15,3 +15,6 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__),
                              os.path.pardir,
                              'framework', 'scripts'))
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                             os.path.pardir,
+                             'tf-psa-crypto', 'scripts', 'project_knowledge'))

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -14,23 +14,21 @@ import importlib.machinery
 import importlib.util
 import os
 import re
+import sys
+import types
 import typing
 
 import scripts_path # pylint: disable=unused-import
 from mbedtls_framework import outcome_analysis
-from mbedtls_framework import typing_util
 
-
-class CryptoAnalyzeOutcomesType(typing_util.Protocol):
-    """Our expectations on tf-psa-crypto/tests/scripts/tf_psa_crypto_test_case_info.py.
-
-    See CoverageTask._load_crypto_module().
-    """
-    #pylint: disable=too-few-public-methods
-
-    # Test cases that are about internal aspects of TF-PSA-Crypto,
-    # which Mbed TLS is therefore not required to cover.
-    INTERNAL_TEST_CASES: outcome_analysis.TestCaseSetDescription
+# Until all TF-PSA-Crypto branches we care about have
+# scripts/project_knowledge/tf_psa_crypto_test_case_info.py,
+# fall back to its previous location where we load it manually
+# (see the _load_crypto_module method below).
+try:
+    import tf_psa_crypto_test_case_info #type: ignore #pylint: disable=unused-import
+except ImportError:
+    pass
 
 
 class CoverageTask(outcome_analysis.CoverageTask):
@@ -224,33 +222,35 @@ class CoverageTask(outcome_analysis.CoverageTask):
         ],
     }
 
-    def _load_crypto_module(self) -> None:
+    @staticmethod
+    def _load_crypto_module() -> typing.Optional[types.ModuleType]:
         """Try to load the information about test cases from the tf-psa-crypto submodule.."""
         # All this complexity is because we don't want to add the directory
         # to the import path.
-        if self.crypto_module is not None:
-            return
+        if 'tf_psa_crypto_test_case_info' in sys.modules:
+            return sys.modules['tf_psa_crypto_test_case_info']
         crypto_script_path = 'tf-psa-crypto/tests/scripts/tf_psa_crypto_test_case_info.py'
         if not os.path.exists(crypto_script_path):
             # During a transition period, while the crypto script is not
             # yet present in all branches we care about, allow it not to
             # exist.
-            return
+            return None
         crypto_spec = importlib.util.spec_from_file_location(
             'tf_psa_crypto_test_case_info',
             crypto_script_path)
         # Assertions and type annotation to help mypy.
         assert crypto_spec is not None
         assert crypto_spec.loader is not None
-        self.crypto_module: typing.Optional[CryptoAnalyzeOutcomesType] = \
-            importlib.util.module_from_spec(crypto_spec)
-        crypto_spec.loader.exec_module(self.crypto_module)
+        crypto_module = importlib.util.module_from_spec(crypto_spec)
+        crypto_spec.loader.exec_module(crypto_module)
+        sys.modules['tf_psa_crypto_test_case_info'] = crypto_module
+        return crypto_module
 
     def _load_crypto_instructions(self) -> None:
         """Try to load instructions from the tf-psa-crypto submodule's outcome analysis."""
-        self._load_crypto_module()
-        if self.crypto_module is not None:
-            crypto_internal_test_cases = self.crypto_module.INTERNAL_TEST_CASES
+        crypto_module = self._load_crypto_module()
+        if crypto_module is not None:
+            crypto_internal_test_cases = crypto_module.INTERNAL_TEST_CASES
         else:
             # Legacy set of tests covered by TF-PSA-Crypto only,
             # from before Mbed TLS's outcome analysis read that information

--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -225,8 +225,12 @@ class CoverageTask(outcome_analysis.CoverageTask):
     @staticmethod
     def _load_crypto_module() -> typing.Optional[types.ModuleType]:
         """Try to load the information about test cases from the tf-psa-crypto submodule.."""
-        # All this complexity is because we don't want to add the directory
-        # to the import path.
+        # All this complexity is because we didn't want to add
+        # `tf-psa-crypto/tests/scripts/` to the import path.
+        # The new location `tf-psa-crypto/scripts/project_knowledge` is
+        # on the import path. So once we can assume that all crypto
+        # branches have the new location, this whole function can go away.
+        # https://github.com/Mbed-TLS/mbedtls/issues/10699.
         if 'tf_psa_crypto_test_case_info' in sys.modules:
             return sys.modules['tf_psa_crypto_test_case_info']
         crypto_script_path = 'tf-psa-crypto/tests/scripts/tf_psa_crypto_test_case_info.py'

--- a/tests/scripts/scripts_path.py
+++ b/tests/scripts/scripts_path.py
@@ -18,3 +18,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__),
 sys.path.append(os.path.join(os.path.dirname(__file__),
                              os.path.pardir, os.path.pardir,
                              'framework', 'scripts'))
+sys.path.append(os.path.join(os.path.dirname(__file__),
+                             os.path.pardir, os.path.pardir,
+                             'tf-psa-crypto', 'scripts', 'project_knowledge'))


### PR DESCRIPTION
Add `tf-psa-crypto/scripts/project_knowledge` (created by ) to the Python load path. In `analyze_outcomes.py`, prefer to load `tf_psa_crypto_test_case_info.py` from there if present, but keep looking in the old location during a transition period.

Resolves https://github.com/Mbed-TLS/mbedtls/issues/10698

## PR checklist

- [x] **changelog** provided | not required because: test only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto PR** not required because: backward compatibility kept
- [x] **TF-PSA-Crypto 1.1 PR** provided # | not required because: backward compatibility kept
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10700
- [x] **mbedtls 4.1 PR** https://github.com/Mbed-TLS/mbedtls/pull/10751
- [x] **mbedtls 3.6 PR** not required because: only relevant after the repo split
- **tests**  provided, plus check compatibility with https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/766
