### PR TITLE
ChangeLog 3.6: Fixed  references to TF-PSA-Crypto

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -91,7 +91,7 @@ Bugfix
      correctly encrypted but could not be authenticated. The bug was only
      observed with GCC 10.0 to 14.2 inclusive, when compiling with -O3, and
      running without AESNI or AESCE.
-     Fixes #665.
+     Fixes Mbed-TLS/TF-PSA-Crypto#665.
    * Fix a build failure with dietlibc.
    * Support re-assembly of fragmented DTLS 1.2 ClientHello in Mbed TLS server.
    * Support re-assembly of fragmented TLS 1.2 ClientHello in Mbed TLS server
@@ -102,7 +102,7 @@ Bugfix
      small stack. Those buffers are now allocated on the heap, except in
      configurations where ECC is the only supported key type in PK, making PK
      still independent of the heap in such configurations (if the ECC driver
-     itself is not using the heap). Fixes #476.
+     itself is not using the heap). Fixes Mbed-TLS/TF-PSA-Crypto#476.
 
 Changes
    * Add casts to some Enums to remove compiler errors thrown by IAR 6.5.


### PR DESCRIPTION
## Description

Fix incorrect cross-repo issue references in ChangeLog

Update ChangeLog issue references so cross-repository links use the correct
owner/repo#number format and resolve properly.

Discussed in #10665


## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: This is a changelog fix
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: Those issues are not present in TF-PSA-Crypto
- [x] **TF-PSA-Crypto 1.1 PR** not required because: Those issues are not present in TF-PSA-Crypto
- [x] **mbedtls development PR** provided #10701
- [x] **mbedtls 4.1 PR** provided #10703 
- [x] **mbedtls 3.6 PR** provided This is it
- **tests**  provided | not required because:

