### PR TITLE
ChangeLog 4.1 Fixed references to TF-PSA-Crypto

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -143,7 +143,7 @@ Removals
      in favour of mbedtls_ssl_conf_groups() since Mbed TLS 3.1.
    * Remove support for the DHE-PSK key exchange in TLS 1.2.
    * Remove support for the DHE-RSA key exchange in TLS 1.2.
-   * Following the removal of DHM module (#9972 and TF-PSA-Crypto#175) the
+   * Following the removal of DHM module (#9972 and Mbed-TLS/TF-PSA-Crypto#175) the
      following SSL functions are removed:
      - mbedtls_ssl_conf_dh_param_bin
      - mbedtls_ssl_conf_dh_param_ctx


### PR DESCRIPTION
## Description

Fix incorrect cross-repo issue references in ChangeLog

Update ChangeLog issue references so cross-repository links use the correct
owner/repo#number format and resolve properly.

Discussed in https://github.com/Mbed-TLS/mbedtls/issues/10665

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: This is a changelog fix
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: Those issues are not present in TF-PSA-Crypto
- [x] **TF-PSA-Crypto 1.1 PR** not required because: Those issues are not present in TF-PSA-Crypto
- [x] **mbedtls development PR** provided #10701
- [x] **mbedtls 4.1 PR** provided This is it
- [x] **mbedtls 3.6 PR** provided #10702
- **tests**  provided | not required because:

