### PR TITLE
library/alignment.h: Fix 'MBEDTLS_GCC_VERSION' is not defined error

### DIFF
--- a/ChangeLog.d/mbedtls_gcc_version.txt
+++ b/ChangeLog.d/mbedtls_gcc_version.txt
@@ -1,0 +1,2 @@
+Bugfix
+   * library/alignment.h: Fix 'MBEDTLS_GCC_VERSION' is not defined error

--- a/library/alignment.h
+++ b/library/alignment.h
@@ -280,7 +280,7 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 /*
  * Detect GCC built-in byteswap routines
  */
-#if defined(__GNUC__)
+#if defined(MBEDTLS_COMPILER_IS_GCC)
 #if MBEDTLS_GCC_VERSION >= 40800
 #define MBEDTLS_BSWAP16 __builtin_bswap16
 #endif
@@ -288,7 +288,7 @@ static inline void mbedtls_put_unaligned_uint64(void *p, uint64_t x)
 #define MBEDTLS_BSWAP32 __builtin_bswap32
 #define MBEDTLS_BSWAP64 __builtin_bswap64
 #endif
-#endif /* defined(__GNUC__) */
+#endif /* defined(MBEDTLS_COMPILER_IS_GCC) */
 
 /*
  * Detect Clang built-in byteswap routines


### PR DESCRIPTION
## Description

Only check 'MBEDTLS_GCC_VERSION' when 'MBEDTLS_COMPILER_IS_GCC' is defined


## PR checklist

- [x] **changelog** provided | not required because:
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto#800
- [x] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto#801
- [x] **mbedtls development PR** not required because: TF-PSA-Crypto code
- [x] **mbedtls 4.1 PR** not required because: TF-PSA-Crypto code
- [x] **mbedtls 3.6 PR** provided here
- **tests**  provided | not required because:
