### PR TITLE
[backport 4.1] mbedtls_config.c missing mbedtls_platform_requirements.h

### DIFF
--- a/ChangeLog.d/issue10740.txt
+++ b/ChangeLog.d/issue10740.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fixed a bug which prevented the inclusion of standard C library header
+     files from the user provided configuration file. Fixes #10740.

--- a/library/mbedtls_config.c
+++ b/library/mbedtls_config.c
@@ -6,6 +6,8 @@
  *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
  */
 
+#include "mbedtls_platform_requirements.h"
+
 /* We are a special snowflake: we don't include "mbedtls_common.h",
  * because that would pull <mbedtls/build_info.h> and we need to
  * tune the way it works. */


### PR DESCRIPTION
## Description

Backport #https://github.com/Mbed-TLS/mbedtls/pull/10741

## PR checklist

- [ ] **changelog** provided
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/777
- [ ] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/785
- [ ] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10741
- [ ] **mbedtls 4.1 PR** provided THIS ONE
- [ ] **mbedtls 3.6 PR** not required because: same as in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/777
- **tests**  not required because: same as in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/777