### PR TITLE
Resolve failure caused by empty digest algorithm

### DIFF
--- a/ChangeLog.d/empty-digest-failure.txt
+++ b/ChangeLog.d/empty-digest-failure.txt
@@ -1,4 +1,4 @@
 Bugfix
-   * Fix PKCS7 parsing so that it is able to deal with and empty
-     digestAlgorithm. The system will now alwys pass the digest algorithm,
-     though if it is not support is will fail later in verification.
+   * Fix PKCS7 so that it successfully parses also in case of empty
+     or not supported digest algorithms. Validation of the digest algorithm
+     is performed at validation step.

--- a/ChangeLog.d/empty-digest-failure.txt
+++ b/ChangeLog.d/empty-digest-failure.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix PKCS7 parsing so that it is able to deal with and empty
+     digestAlgorithm.

--- a/ChangeLog.d/empty-digest-failure.txt
+++ b/ChangeLog.d/empty-digest-failure.txt
@@ -1,3 +1,4 @@
 Bugfix
    * Fix PKCS7 parsing so that it is able to deal with and empty
-     digestAlgorithm.
+     digestAlgorithm. The system will now alwys pass the digest algorithm,
+     though if it is not support is will fail later in verification.

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -142,6 +142,10 @@ static int pkcs7_get_digest_algorithm_set(unsigned char **p,
         return MBEDTLS_ERROR_ADD(MBEDTLS_ERR_PKCS7_INVALID_ALG, ret);
     }
 
+    if (len == 0) {
+        return 0;
+    }
+
     end = *p + len;
 
     ret = mbedtls_asn1_get_alg_null(p, end, alg);
@@ -481,9 +485,11 @@ static int pkcs7_get_signed_data(unsigned char *buf, size_t buflen,
         return ret;
     }
 
-    ret = mbedtls_x509_oid_get_md_alg(&signed_data->digest_alg_identifiers, &md_alg);
-    if (ret != 0) {
-        return MBEDTLS_ERR_PKCS7_INVALID_ALG;
+    if (signed_data->digest_alg_identifiers.p != NULL) {
+        ret = mbedtls_x509_oid_get_md_alg(&signed_data->digest_alg_identifiers, &md_alg);
+        if (ret != 0) {
+           return MBEDTLS_ERR_PKCS7_INVALID_ALG;
+        }
     }
 
     mbedtls_pkcs7_buf content_type;

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -337,10 +337,15 @@ static int pkcs7_get_signer_info(unsigned char **p, unsigned char *end,
         goto out;
     }
 
-    /* Check that the digest algorithm used matches the one provided earlier */
-    if (signer->alg_identifier.tag != alg->tag ||
-        signer->alg_identifier.len != alg->len ||
-        memcmp(signer->alg_identifier.p, alg->p, alg->len) != 0) {
+    /*
+     * If digestAlgorithms is present, require the signer digest algorithm to
+     * match it. If the outer set is empty, defer the failure until
+     * verification, where the missing digest algorithm is reported.
+     */
+    if (alg->p != NULL &&
+        (signer->alg_identifier.tag != alg->tag ||
+         signer->alg_identifier.len != alg->len ||
+         memcmp(signer->alg_identifier.p, alg->p, alg->len) != 0)) {
         ret = MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO;
         goto out;
     }

--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -488,7 +488,7 @@ static int pkcs7_get_signed_data(unsigned char *buf, size_t buflen,
     if (signed_data->digest_alg_identifiers.p != NULL) {
         ret = mbedtls_x509_oid_get_md_alg(&signed_data->digest_alg_identifiers, &md_alg);
         if (ret != 0) {
-           return MBEDTLS_ERR_PKCS7_INVALID_ALG;
+            return MBEDTLS_ERR_PKCS7_INVALID_ALG;
         }
     }
 

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -93,6 +93,10 @@ PKCS7 Signed Data Verification Fail empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:MBEDTLS_ERR_X509_UNKNOWN_OID
 
+PKCS7 Signed Hash Verification Fail empty digestAlgorithms
+depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
+pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:MBEDTLS_ERR_X509_UNKNOWN_OID
+
 PKCS7 Signed Data Parse Pass SHA256 empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
@@ -100,10 +104,6 @@ pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.
 PKCS7 Signed Data Verification Pass SHA256 #9.1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:0
-
-PKCS7 Signed Hash Verification Fail empty digestAlgorithms
-depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
-pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:MBEDTLS_ERR_X509_UNKNOWN_OID
 
 PKCS7 Signed Data Verification Pass SHA1 #10
 depends_on:PSA_WANT_ALG_SHA_1:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -3,6 +3,7 @@ depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
 PKCS7 Signed Data Parse Unsupported DigestAlgorithmSet
+depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA
 
 PKCS7 Signed Data Parse Pass SHA256 #1

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -89,6 +89,10 @@ PKCS7 Signed Data Verification Pass SHA256 #9
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:0
 
+PKCS7 Signed Data Parse Fail SHA256 empty digestAlgorithms
+depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
+pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO
+
 PKCS7 Signed Data Verification Pass SHA256 #9.1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:0

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -2,6 +2,9 @@ PKCS7 PKCS11 With Empty Digest
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
+PKCS7 Signed Data Parse Unsupported DigestAlgorithmSet
+pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA
+
 PKCS7 Signed Data Parse Pass SHA256 #1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -1,8 +1,7 @@
-PKCS7 PKCS11 With Empty Digest
-depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
+PKCS7 With Empty Digest
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
-PKCS7 PKCS11 With Unsupported DigestAlgorithmnSet
+PKCS7 With Unsupported DigestAlgorithmnSet
 depends_on:!PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -2,6 +2,10 @@ PKCS7 PKCS11 With Empty Digest
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
+PKCS7 PKCS11 With Unsupported DigestAlgorithmnSet
+depends_on:!PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
+pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
+
 PKCS7 Signed Data Parse Unsupported DigestAlgorithmSet
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -1,10 +1,6 @@
 PKCS7 With Empty Digest
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
-PKCS7 With Unsupported DigestAlgorithmnSet
-depends_on:!PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
-pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
-
 PKCS7 Signed Data Parse Unsupported DigestAlgorithmSet
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -96,11 +96,11 @@ pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../fra
 
 PKCS7 Signed Data Verification Fail empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
-pkcs7_verify:"../framework/data_files/pkcs7_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:MBEDTLS_ERR_X509_UNKNOWN_OID
+pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:MBEDTLS_ERR_X509_UNKNOWN_OID
 
-PKCS7 Signed Data Parse Fail SHA256 empty digestAlgorithms
+PKCS7 Signed Data Parse Pass SHA256 empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
-pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO
+pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
 PKCS7 Signed Data Verification Pass SHA256 #9.1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
@@ -108,7 +108,7 @@ pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../fra
 
 PKCS7 Signed Hash Verification Fail empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
-pkcs7_verify:"../framework/data_files/pkcs7_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:MBEDTLS_ERR_X509_UNKNOWN_OID
+pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:MBEDTLS_ERR_X509_UNKNOWN_OID
 
 PKCS7 Signed Data Verification Pass SHA1 #10
 depends_on:PSA_WANT_ALG_SHA_1:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -1,3 +1,7 @@
+PKCS7 PKCS11 With Empty Digest
+depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
+pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
+
 PKCS7 Signed Data Parse Pass SHA256 #1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -94,6 +94,10 @@ PKCS7 Signed Data Verification Pass SHA256 #9
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:0
 
+PKCS7 Signed Data Verification Fail empty digestAlgorithms
+depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
+pkcs7_verify:"../framework/data_files/pkcs7_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":0:MBEDTLS_ERR_X509_UNKNOWN_OID
+
 PKCS7 Signed Data Parse Fail SHA256 empty digestAlgorithms
 depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.der":MBEDTLS_ERR_PKCS7_INVALID_SIGNER_INFO
@@ -101,6 +105,10 @@ pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256_empty_digest.
 PKCS7 Signed Data Verification Pass SHA256 #9.1
 depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
 pkcs7_verify:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:0
+
+PKCS7 Signed Hash Verification Fail empty digestAlgorithms
+depends_on:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY
+pkcs7_verify:"../framework/data_files/pkcs7_empty_digest.der":"../framework/data_files/pkcs7-rsa-sha256-1.der":"../framework/data_files/pkcs7_data.bin":MBEDTLS_MD_SHA256:MBEDTLS_ERR_X509_UNKNOWN_OID
 
 PKCS7 Signed Data Verification Pass SHA1 #10
 depends_on:PSA_WANT_ALG_SHA_1:PSA_WANT_ALG_SHA_256:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY

--- a/tests/suites/test_suite_pkcs7.data
+++ b/tests/suites/test_suite_pkcs7.data
@@ -2,7 +2,7 @@ PKCS7 With Empty Digest
 pkcs7_parse:"../framework/data_files/pkcs7_empty_digest.der":MBEDTLS_PKCS7_SIGNED_DATA
 
 PKCS7 Signed Data Parse Unsupported DigestAlgorithmSet
-depends_on:PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
+depends_on:!PSA_WANT_ALG_SHA_256:PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 pkcs7_parse:"../framework/data_files/pkcs7_data_cert_signed_sha256.der":MBEDTLS_PKCS7_SIGNED_DATA
 
 PKCS7 Signed Data Parse Pass SHA256 #1


### PR DESCRIPTION
## Description

Resolve failure caused by empty digest algorithm. Resolves https://github.com/Mbed-TLS/mbedtls/issues/10480

This PR is part of a two part set which must be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls-framework/pull/302
2. https://github.com/Mbed-TLS/mbedtls/pull/10746

Parameterised build https://ci.trustedfirmware.org/view/Mbed-TLS/job/mbed-tls-restricted-pr-test-parametrized/177/

## PR checklist

- [ ] **changelog** provided | not required because: TBC
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# https://github.com/Mbed-TLS/mbedtls-framework/pull/302
- [ ] **TF-PSA-Crypto development PR** not required because: No changes
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: No changes
- [ ] **mbedtls development PR** provided #HERE
- [ ] **mbedtls 4.1 PR** provided # | not required because: TBC
- [ ] **mbedtls 3.6 PR** provided # | not required because: TBC
- **tests**  provided
