### PR TITLE
ssl: reject trailing bytes in TLS 1.3 encrypted extensions

### DIFF
--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2060,9 +2060,15 @@ cleanup:
  * } EncryptedExtensions;
  */
 MBEDTLS_CHECK_RETURN_CRITICAL
+#if defined(MBEDTLS_TEST_HOOKS)
+int mbedtls_ssl_tls13_parse_encrypted_extensions(mbedtls_ssl_context *ssl,
+                                                 const unsigned char *buf,
+                                                 const unsigned char *end)
+#else
 static int ssl_tls13_parse_encrypted_extensions(mbedtls_ssl_context *ssl,
                                                 const unsigned char *buf,
                                                 const unsigned char *end)
+#endif /* MBEDTLS_TEST_HOOKS */
 {
     int ret = 0;
     size_t extensions_len;
@@ -2155,6 +2161,14 @@ static int ssl_tls13_parse_encrypted_extensions(mbedtls_ssl_context *ssl,
         p += extension_data_len;
     }
 
+    /* RFC 8446 requires the extension vector to consume the full message. */
+    if (p != end) {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("EncryptedExtensions lengths misaligned"));
+        MBEDTLS_SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
+                                     MBEDTLS_ERR_SSL_DECODE_ERROR);
+        return MBEDTLS_ERR_SSL_DECODE_ERROR;
+    }
+
     if ((handshake->received_extensions & MBEDTLS_SSL_EXT_MASK(RECORD_SIZE_LIMIT)) &&
         (handshake->received_extensions & MBEDTLS_SSL_EXT_MASK(MAX_FRAGMENT_LENGTH))) {
         MBEDTLS_SSL_DEBUG_MSG(3,
@@ -2168,14 +2182,6 @@ static int ssl_tls13_parse_encrypted_extensions(mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_PRINT_EXTS(3, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
                            handshake->received_extensions);
-
-    /* Check that we consumed all the message. */
-    if (p != end) {
-        MBEDTLS_SSL_DEBUG_MSG(1, ("EncryptedExtension lengths misaligned"));
-        MBEDTLS_SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR,
-                                     MBEDTLS_ERR_SSL_DECODE_ERROR);
-        return MBEDTLS_ERR_SSL_DECODE_ERROR;
-    }
 
     return ret;
 }

--- a/library/ssl_tls13_invasive.h
+++ b/library/ssl_tls13_invasive.h
@@ -13,6 +13,9 @@
 #include "psa/crypto.h"
 
 #if defined(MBEDTLS_TEST_HOOKS)
+int mbedtls_ssl_tls13_parse_encrypted_extensions(mbedtls_ssl_context *ssl,
+                                                 const unsigned char *buf,
+                                                 const unsigned char *end);
 int mbedtls_ssl_tls13_parse_certificate(mbedtls_ssl_context *ssl,
                                         const unsigned char *buf,
                                         const unsigned char *end);

--- a/tests/include/test/ssl_helpers.h
+++ b/tests/include/test/ssl_helpers.h
@@ -745,6 +745,20 @@ void mbedtls_test_ssl_perform_handshake(
 
 #if defined(MBEDTLS_TEST_HOOKS)
 /*
+ * Tweak vector lengths in a TLS 1.3 EncryptedExtensions message.
+ *
+ * \param[in]       buf    Buffer containing the EncryptedExtensions message
+ *                         to tweak.
+ * \param[in,out]   end    End of the buffer to parse.
+ * \param           tweak  Tweak identifier (from 1 to the number of tweaks).
+ * \param[out]      expected_result  Error code expected from the parsing
+ *                                   function.
+ */
+int mbedtls_test_tweak_tls13_encrypted_extensions_msg(
+    unsigned char *buf, unsigned char **end, int tweak,
+    int *expected_result);
+
+/*
  * Tweak vector lengths in a TLS 1.3 Certificate message
  *
  * \param[in]       buf    Buffer containing the Certificate message to tweak

--- a/tests/src/test_helpers/ssl_helpers.c
+++ b/tests/src/test_helpers/ssl_helpers.c
@@ -2409,6 +2409,33 @@ exit:
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 #if defined(MBEDTLS_TEST_HOOKS)
+int mbedtls_test_tweak_tls13_encrypted_extensions_msg(
+    unsigned char *buf, unsigned char **end, int tweak,
+    int *expected_result)
+{
+    unsigned char *p_extensions_len = buf;
+    size_t extensions_len = MBEDTLS_GET_UINT16_BE(p_extensions_len, 0);
+
+    *expected_result = MBEDTLS_ERR_SSL_DECODE_ERROR;
+
+    switch (tweak) {
+        case 1:
+            /* Shrink the extension vector length and leave trailing bytes. */
+            if (extensions_len == 0) {
+                return -1;
+            }
+            MBEDTLS_PUT_UINT16_BE(extensions_len - 1, p_extensions_len, 0);
+            break;
+
+        default:
+            (void) end;
+            return -1;
+    }
+
+    (void) end;
+    return 0;
+}
+
 int mbedtls_test_tweak_tls13_certificate_msg_vector_len(
     unsigned char *buf, unsigned char **end, int tweak,
     int *expected_result, mbedtls_ssl_chk_buf_ptr_args *args)

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3344,6 +3344,9 @@ cookie_parsing:"16fefd0000000000000000002f010000de000000000000011efefd7b72727272
 Cookie parsing: one byte overread
 cookie_parsing:"16fefd0000000000000000002F010000de000000000000011efefd7b7272727272727272727272727272727272727272727272727272727272727d0001":MBEDTLS_ERR_SSL_DECODE_ERROR
 
+TLS 1.3 EncryptedExtensions msg - trailing bytes
+tls13_encrypted_extensions_msg_trailing_bytes
+
 TLS 1.3 srv Certificate msg - wrong vector lengths
 tls13_server_certificate_msg_invalid_vector_len
 

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3900,6 +3900,86 @@ exit:
 }
 /* END_CASE */
 /* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_SSL_PROTO_TLS1_3:!MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SRV_C:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:PSA_WANT_ECC_SECP_R1_384 */
+void tls13_encrypted_extensions_msg_trailing_bytes()
+{
+    int ret = -1;
+    mbedtls_test_ssl_endpoint client_ep, server_ep;
+    memset(&client_ep, 0, sizeof(client_ep));
+    memset(&server_ep, 0, sizeof(server_ep));
+    unsigned char *buf, *end;
+    size_t buf_len;
+    int step = 0;
+    int expected_result;
+    mbedtls_test_handshake_test_options client_options;
+    mbedtls_test_handshake_test_options server_options;
+
+    mbedtls_test_init_handshake_options(&client_options);
+    MD_OR_USE_PSA_INIT();
+
+    client_options.pk_alg = MBEDTLS_PK_ECDSA;
+    ret = mbedtls_test_ssl_endpoint_init(&client_ep, MBEDTLS_SSL_IS_CLIENT,
+                                         &client_options);
+    TEST_EQUAL(ret, 0);
+
+    mbedtls_test_init_handshake_options(&server_options);
+    server_options.pk_alg = MBEDTLS_PK_ECDSA;
+    ret = mbedtls_test_ssl_endpoint_init(&server_ep, MBEDTLS_SSL_IS_SERVER,
+                                         &server_options);
+    TEST_EQUAL(ret, 0);
+
+    ret = mbedtls_test_mock_socket_connect(&(client_ep.socket),
+                                           &(server_ep.socket), 1024);
+    TEST_EQUAL(ret, 0);
+
+    while (1) {
+        mbedtls_test_set_step(++step);
+
+        ret = mbedtls_test_move_handshake_to_state(
+            &(server_ep.ssl), &(client_ep.ssl),
+            MBEDTLS_SSL_CERTIFICATE_VERIFY);
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_ssl_flush_output(&(server_ep.ssl));
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_test_move_handshake_to_state(
+            &(client_ep.ssl), &(server_ep.ssl),
+            MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_ssl_tls13_fetch_handshake_msg(&(client_ep.ssl),
+                                                    MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
+                                                    &buf, &buf_len);
+        TEST_EQUAL(ret, 0);
+
+        end = buf + buf_len;
+
+        ret = mbedtls_test_tweak_tls13_encrypted_extensions_msg(
+            buf, &end, step, &expected_result);
+        if (ret != 0) {
+            break;
+        }
+
+        ret = mbedtls_ssl_tls13_parse_encrypted_extensions(&(client_ep.ssl),
+                                                           buf, end);
+        TEST_EQUAL(ret, expected_result);
+
+        ret = mbedtls_ssl_session_reset(&(client_ep.ssl));
+        TEST_EQUAL(ret, 0);
+
+        ret = mbedtls_ssl_session_reset(&(server_ep.ssl));
+        TEST_EQUAL(ret, 0);
+    }
+
+exit:
+    mbedtls_test_ssl_endpoint_free(&client_ep);
+    mbedtls_test_ssl_endpoint_free(&server_ep);
+    mbedtls_test_free_handshake_options(&client_options);
+    mbedtls_test_free_handshake_options(&server_options);
+    MD_OR_USE_PSA_DONE();
+}
+/* END_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_TEST_HOOKS:MBEDTLS_SSL_PROTO_TLS1_3:!MBEDTLS_SSL_PROTO_TLS1_2:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_SRV_C:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:PSA_WANT_ECC_SECP_R1_384 */
 void tls13_server_certificate_msg_invalid_vector_len()
 {
     int ret = -1;


### PR DESCRIPTION
## Description
The PR hardens TLS 1.3 EncryptedExtensions parsing on the client side. The parser now verifies that it consumes the full `buf..end` range after processing the internal extensions vector, and rejects messages with trailing bytes by sending `decode_error` and returning `MBEDTLS_ERR_SSL_DECODE_ERROR`.

## PR checklist
- [ ] **changelog** not required because: this is a small bug fix with no API change
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** not required because: no TF-PSA-Crypto code was changed
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: no TF-PSA-Crypto code was changed
- [ ] **mbedtls development PR** not required because: this PR is itself the development PR
- [ ] **mbedtls 4.1 PR** not required because: backport not prepared yet
- [ ] **mbedtls 3.6 PR** not required because: backport not prepared yet
- **tests**  provided