### PR TITLE
Missing assignment certificate request context len

### DIFF
--- a/ChangeLog.d/tls13-certificate-request-context.txt
+++ b/ChangeLog.d/tls13-certificate-request-context.txt
@@ -1,0 +1,5 @@
+Bugfix
+   * Fix TLS 1.3 client handling of CertificateRequest messages with a
+     non-empty certificate_request_context during the initial handshake.
+     Clients now reject these malformed messages instead of continuing with
+     an inconsistent handshake state. Fixes #10468.

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -2412,19 +2412,10 @@ static int ssl_tls13_parse_certificate_request(mbedtls_ssl_context *ssl,
     p += 1;
 
     if (certificate_request_context_len > 0) {
-        MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, certificate_request_context_len);
-        MBEDTLS_SSL_DEBUG_BUF(3, "Certificate Request Context",
-                              p, certificate_request_context_len);
-
-        handshake->certificate_request_context =
-            mbedtls_calloc(1, certificate_request_context_len);
-        if (handshake->certificate_request_context == NULL) {
-            MBEDTLS_SSL_DEBUG_MSG(1, ("buffer too small"));
-            return MBEDTLS_ERR_SSL_ALLOC_FAILED;
-        }
-        memcpy(handshake->certificate_request_context, p,
-               certificate_request_context_len);
-        p += certificate_request_context_len;
+        MBEDTLS_SSL_DEBUG_MSG(1, ("non-empty certificate_request_context"));
+        MBEDTLS_SSL_PEND_FATAL_ALERT(MBEDTLS_SSL_ALERT_MSG_UNEXPECTED_MESSAGE,
+                                     MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE);
+        return MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE;
     }
 
     /* ...

--- a/tests/suites/test_suite_ssl.data
+++ b/tests/suites/test_suite_ssl.data
@@ -3347,6 +3347,9 @@ cookie_parsing:"16fefd0000000000000000002F010000de000000000000011efefd7b72727272
 TLS 1.3 srv Certificate msg - wrong vector lengths
 tls13_server_certificate_msg_invalid_vector_len
 
+TLS 1.3 CertificateRequest with non-empty context
+tls13_certificate_request_non_empty_context
+
 EC-JPAKE set password
 depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 ssl_ecjpake_set_password:0

--- a/tests/suites/test_suite_ssl.function
+++ b/tests/suites/test_suite_ssl.function
@@ -3995,6 +3995,61 @@ exit:
 }
 /* END_CASE */
 
+/* BEGIN_CASE depends_on:MBEDTLS_SSL_PROTO_TLS1_3:MBEDTLS_SSL_CLI_C:MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED:MBEDTLS_TEST_AT_LEAST_ONE_TLS1_3_CIPHERSUITE:MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED */
+void tls13_certificate_request_non_empty_context()
+{
+    const unsigned char certificate_request[] = {
+        MBEDTLS_SSL_HS_CERTIFICATE_REQUEST,
+        0x00, 0x00, 0x02,
+        0x01, 0x00,
+    };
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    mbedtls_test_mock_socket client_socket;
+    mbedtls_test_mock_socket server_socket;
+
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+    mbedtls_test_mock_socket_init(&client_socket);
+    mbedtls_test_mock_socket_init(&server_socket);
+    MD_OR_USE_PSA_INIT();
+
+    TEST_EQUAL(mbedtls_ssl_config_defaults(&conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_STREAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT), 0);
+    mbedtls_ssl_conf_min_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_3);
+    mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_3);
+
+    TEST_EQUAL(mbedtls_ssl_setup(&ssl, &conf), 0);
+    TEST_EQUAL(mbedtls_test_mock_socket_connect(&client_socket, &server_socket,
+                                                1024), 0);
+    mbedtls_ssl_set_bio(&ssl, &client_socket,
+                        mbedtls_test_mock_tcp_send_b,
+                        mbedtls_test_mock_tcp_recv_b,
+                        NULL);
+
+    ssl.tls_version = MBEDTLS_SSL_VERSION_TLS1_3;
+    mbedtls_ssl_handshake_set_state(&ssl, MBEDTLS_SSL_CERTIFICATE_REQUEST);
+
+    ssl.in_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+    ssl.in_msglen = sizeof(certificate_request);
+    ssl.in_hslen = sizeof(certificate_request);
+    memcpy(ssl.in_msg, certificate_request, sizeof(certificate_request));
+    ssl.keep_current_message = 1;
+
+    TEST_EQUAL(mbedtls_ssl_handshake_step(&ssl),
+               MBEDTLS_ERR_SSL_UNEXPECTED_MESSAGE);
+
+exit:
+    mbedtls_test_mock_socket_close(&client_socket);
+    mbedtls_test_mock_socket_close(&server_socket);
+    mbedtls_ssl_free(&ssl);
+    mbedtls_ssl_config_free(&conf);
+    MD_OR_USE_PSA_DONE();
+}
+/* END_CASE */
+
 /* BEGIN_CASE depends_on:MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED */
 void ssl_ecjpake_set_password(int use_opaque_arg)
 {


### PR DESCRIPTION
## Description

Modify ssl_tls13_parse_certificate_request to abort the handshake if certificate_request_context is not empty. Fixes https://github.com/Mbed-TLS/mbedtls/issues/10468

## PR checklist

- [ ] **changelog** provided | not required because: TBC
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** not required because: No changes
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: No changes
- [ ] **mbedtls development PR** provided #HERE
- [ ] **mbedtls 4.1 PR** provided # | not required because: TBC
- [ ] **mbedtls 3.6 PR** provided # | not required because: TBC
- **tests**  provided