### PR TITLE
Update broken link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ send an email to the security team at
 ## Security Incident Handling Process
 
 Our security process is detailed in our
-[security
-center](https://developer.trustedfirmware.org/w/mbed-tls/security-center/).
+[online
+documentation](https://mbed-tls.readthedocs.io/en/latest/project/vulnerabilities/).
 
 Its primary goal is to ensure fixes are ready to be deployed when the issue
 goes public.


### PR DESCRIPTION
I believe the existing link was to the TF wiki which has been retired for some time now.

## PR checklist

- [x] **changelog** not required because: doc only
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/803
- [x] **TF-PSA-Crypto 1.1 PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/802
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10769
- [x] **mbedtls 4.1 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10771
- [x] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10772
- **tests**  not required because: doc only
