### PR TITLE
Backport 4.1: Fix variable set but not used warning

### DIFF
--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -302,11 +302,12 @@ static int ssl_tls13_parse_certificate_verify(mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_DEBUG_BUF(3, "verify hash", verify_hash, verify_hash_len);
 
-    if ((ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) sig_alg,
-                                     &ssl->session_negotiate->peer_cert->pk,
-                                     md_alg, verify_hash, verify_hash_len,
-                                     p, signature_len)) == 0) {
-        return 0;
+    ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) sig_alg,
+                                &ssl->session_negotiate->peer_cert->pk,
+                                md_alg, verify_hash, verify_hash_len,
+                                p, signature_len);
+    if (ret == 0) {
+        return ret;
     }
     MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_ext", ret);
 


### PR DESCRIPTION
## Description

Add ret return pattern to avoid variable ret was set but never used warning. contributes https://github.com/Mbed-TLS/mbedtls/issues/10448

## PR checklist

- [ ] **changelog** not required because: No Public changes
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR**  not required because: No changes
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: No changes
- [ ] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10656
- [ ] **mbedtls 4.1 PR** provided #here
- [ ] **mbedtls 3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10657
- **tests**  not required because: No changes
