### PR TITLE
Fix generate_features.pl for X.509 section

### DIFF
--- a/ChangeLog.d/fix-x509-check-features.txt
+++ b/ChangeLog.d/fix-x509-check-features.txt
@@ -1,0 +1,3 @@
+Bugfix
+   * Fix a `mbedtls_version_check_features()` regression which caused all
+     features under the X.509 configuration section to be considered disabled.

--- a/scripts/generate_features.pl
+++ b/scripts/generate_features.pl
@@ -65,7 +65,7 @@ while (my $line = <CONFIG_H>)
     }
 
     if (!$in_section) {
-        my ($section_name) = $line =~ /SECTION: ([\w ]+)/;
+        my ($section_name) = $line =~ /SECTION: ([\w .]+)/;
         my $found_section = grep $_ eq $section_name, @sections;
 
         $in_section = 1 if ($found_section);


### PR DESCRIPTION
## Description

When trying to migrate my project to MbedTLS 4, I noticed a failure with `mbedtls_version_check_feature("MBEDTLS_X509_CRT_PARSE_C")`. After digging a bit, I found this regression causing some configuration entries to not be included in the feature table: commit 9d51a54ba2 added the X.509 section to the allowed section list, but the section regex did not support the dot character.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** not required because: unrelated
- [x] **TF-PSA-Crypto 1.1 PR** not required because: unrelated
- [x] **mbedtls development PR** provided
- [ ] **mbedtls 4.1 PR** provided # Waiting for development merge
- [x] **mbedtls 3.6 PR** not required because: unaffected (legacy section names)
- [x] **tests** not required because: until now, check_feature tests do not verify specific features