### PR TITLE
cmake: install libmbedcrypto compat library as a program

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -356,7 +356,7 @@ foreach(target IN LISTS tf_psa_crypto_library_targets)
                       libmbedcrypto.so.${MBEDTLS_CRYPTO_SOVERSION}
                       libmbedcrypto.so
             )
-            install(FILES $<TARGET_FILE:${target}>
+            install(PROGRAMS $<TARGET_FILE:${target}>
                     DESTINATION ${CMAKE_INSTALL_LIBDIR}
                     RENAME "libmbedcrypto.so.${MBEDTLS_VERSION}"
             )


### PR DESCRIPTION
## Description

The `libmbedcrypto` backward-compatibility library is installed with `install(FILES ...)`, which uses `0644` permissions, so the resulting shared object is not executable. Packaging tools (e.g. rpm via its shared-library checks) then fail to recognise it as a shared library: no dependency information is generated and debug symbols are not stripped from it.

Install it with `install(PROGRAMS ...)` instead, so it gets `0755` like the other shared libraries (`libmbedtls`, `libmbedx509`, `libtfpsacrypto`).

Found while packaging Mbed TLS 4.1.0 for openSUSE, where rpmlint reported `shared-library-not-executable /usr/lib64/libmbedcrypto.so.4.1.0`.

## PR checklist

- [x] **changelog** not required (build-system only, no user-visible library change)
- [x] **backport** candidate for the 3.6 LTS branch if the same pattern exists there
- [x] **tests** not applicable (install layout / file permissions)