### PR TITLE
scripts: scan tf-psa-crypto/include/mbedtls for error codes

### DIFF
--- a/ChangeLog.d/pr_10782_include_pk_err_codes.txt
+++ b/ChangeLog.d/pr_10782_include_pk_err_codes.txt
@@ -1,0 +1,9 @@
+Slight Enhancement
+
+       * `pk.h` and other headers in the `tf-psa-crypto` submodule's include directory were not being scanned 
+         by `generate_errors.pl`, causing `MBEDTLS_ERR_PK_*` error codes to be missing from `error.c`.
+         This was needed becasue a bug was reported (#10768) that mentioned `MBED_ERR_PK_*" error codes go
+         unhandled.
+         The reporter ran a sample code e.g `int ret = mbedtls_x509_crt_parse_file(&srv_cert, config->server_cert_file);`
+         Returns `MBEDTLS_ERR_PK_FILE_IO_ERROR (-0x3e00)` when the file doesn't exist. Feeding that into `mbedtls_strerror()` 
+         returns an "error message" of `UNKNOWN ERROR CODE (3E00)`

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -51,6 +51,7 @@ if(GEN_FILES)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../tf-psa-crypto/drivers/builtin/include/mbedtls
                 ${CMAKE_CURRENT_SOURCE_DIR}/../include/mbedtls
                 ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/data_files
+                ${CMAKE_CURRENT_SOURCE_DIR}/../tf-psa-crypto/include/mbedtls
                 ${CMAKE_CURRENT_BINARY_DIR}/${TF_PSA_CRYPTO_DRIVERS_BUILTIN_SRC_DIR}/error.c
         DEPENDS
             ${MBEDTLS_DIR}/scripts/generate_errors.pl

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -11,22 +11,24 @@
 use strict;
 use warnings;
 
-my ($crypto_include_dir, $tls_include_dir, $data_dir, $error_file);
+my ($crypto_include_dir, $tls_include_dir, $data_dir, $psa_include_dir, $error_file);
 
 if( @ARGV ) {
-    die "Invalid number of arguments" if scalar @ARGV != 4;
-    ($crypto_include_dir, $tls_include_dir, $data_dir, $error_file) = @ARGV;
+    die "Invalid number of arguments" if scalar @ARGV != 5;
+    ($crypto_include_dir, $tls_include_dir, $data_dir, $psa_include_dir, $error_file) = @ARGV;
 
     -d $crypto_include_dir or die "No such directory: $crypto_include_dir\n";
     -d $tls_include_dir or die "No such directory: $tls_include_dir\n";
     -d $data_dir or die "No such directory: $data_dir\n";
+    -d $psa_include_dir or die "No such directory: $psa_include_dir\n";
 } else {
     $crypto_include_dir = 'tf-psa-crypto/drivers/builtin/include/mbedtls';
     $tls_include_dir = 'include/mbedtls';
     $data_dir = 'scripts/data_files';
     $error_file = 'library/error.c';
+    $psa_include_dir = 'tf-psa-crypto/include/mbedtls';
 
-    unless( -d $crypto_include_dir && -d $tls_include_dir && -d $data_dir ) {
+    unless( -d $crypto_include_dir && -d $tls_include_dir && -d $data_dir && -d $psa_include_dir ) {
         chdir '..' or die;
         -d $crypto_include_dir && -d $tls_include_dir && -d $data_dir
             or die "Without arguments, must be run from root or scripts\n"
@@ -52,9 +54,11 @@ close(FORMAT_FILE);
 
 my @files = glob qq("$crypto_include_dir/*.h");
 push(@files, glob qq("$tls_include_dir/*.h"));
+push(@files, glob qq("$psa_include_dir/*.h"));
 
 push(@files, glob qq("$crypto_include_dir/private/*.h"));
 push(@files, glob qq("$tls_include_dir/private/*.h"));
+push(@files, glob qq("$psa_include_dir/private/*.h"));
 
 my @necessary_include_files;
 my @matches;


### PR DESCRIPTION


## Description

`pk.h` and other headers in the `tf-psa-crypto` submodule's include directory were not being scanned by `generate_errors.pl`, causing `MBEDTLS_ERR_PK_*` error codes to be missing from `error.c`.

Resolves #10768

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because:
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **mbedtls development PR** provided # | not required because:
- [ ] **mbedtls 4.1 PR** provided # | not required because:
- [ ] **mbedtls 3.6 PR** provided # | not required because:
- **tests**  provided | not required because:


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
