### PR TITLE
mbedtls/ssl.h: ssl_user_data_* accepts const pointers.

### DIFF
--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -2725,7 +2725,7 @@ static inline void mbedtls_ssl_conf_set_user_data_n(
  * \return               The current value of the user data.
  */
 static inline void *mbedtls_ssl_conf_get_user_data_p(
-    mbedtls_ssl_config *conf)
+    const mbedtls_ssl_config *conf)
 {
     return conf->MBEDTLS_PRIVATE(user_data).p;
 }
@@ -2741,7 +2741,7 @@ static inline void *mbedtls_ssl_conf_get_user_data_p(
  * \return               The current value of the user data.
  */
 static inline uintptr_t mbedtls_ssl_conf_get_user_data_n(
-    mbedtls_ssl_config *conf)
+    const mbedtls_ssl_config *conf)
 {
     return conf->MBEDTLS_PRIVATE(user_data).n;
 }
@@ -2788,7 +2788,7 @@ static inline void mbedtls_ssl_set_user_data_n(
  * \return               The current value of the user data.
  */
 static inline void *mbedtls_ssl_get_user_data_p(
-    mbedtls_ssl_context *ssl)
+    const mbedtls_ssl_context *ssl)
 {
     return ssl->MBEDTLS_PRIVATE(user_data).p;
 }
@@ -2804,7 +2804,7 @@ static inline void *mbedtls_ssl_get_user_data_p(
  * \return               The current value of the user data.
  */
 static inline uintptr_t mbedtls_ssl_get_user_data_n(
-    mbedtls_ssl_context *ssl)
+   const mbedtls_ssl_context *ssl)
 {
     return ssl->MBEDTLS_PRIVATE(user_data).n;
 }


### PR DESCRIPTION
## Description

modified the function argument in ssl_user_data_* to accept `const mbedtls_ssl_*` arguments.

Fixes #10760

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because:
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **mbedtls development PR** provided # | not required because:
- [ ] **mbedtls 4.1 PR** provided # | not required because:
- [ ] **mbedtls 3.6 PR** provided # | not required because:
- **tests**  provided | not required because:


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
