### PR TITLE
[Backport 3.6] Upgrade readthedocs builder to Ubuntu 26.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ submodules:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
     python: "3.9"
   jobs:


### PR DESCRIPTION
## Description

Upgrade readthedocs builder to Ubuntu 26.04

The 20.04 runner is no longer supported.

## PR checklist

- [x] **changelog** not required because: no user-visible change
- [x] **framework PR** not required: no readthedocs config
- [x] **TF-PSA-Crypto development PR**  not required because: no readthedocs config
- [x] **TF-PSA-Crypto 1.1 PR** not required because: no readthedocs config
- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10788
- [ ] **mbedtls 4.1 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10790 
- [ ] **mbedtls 3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10789
- [ ] **mbedtls-docs PR** provided: https://github.com/Mbed-TLS/mbedtls-docs/pull/209
- **tests**  provided (readthedocs build passes)