### PR TITLE
[mbedtls-3.6] fix arm32 build errors with GCC 15.3

### DIFF
--- a/library/common.h
+++ b/library/common.h
@@ -332,7 +332,8 @@ static inline void mbedtls_xor_no_simd(unsigned char *r,
         uint32_t x = mbedtls_get_unaligned_uint32(a + i) ^ mbedtls_get_unaligned_uint32(b + i);
         mbedtls_put_unaligned_uint32(r + i, x);
     }
-#if defined(__IAR_SYSTEMS_ICC__)
+#if defined(__IAR_SYSTEMS_ICC__) || \
+    (defined(MBEDTLS_ARCH_IS_ARM32) && defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 150300)
     if (n % 4 == 0) {
         return;
     }


### PR DESCRIPTION
It seems that GCC 15.3 has added additional OOB checks for ARCH arm32:
```
In file included from /home/db/owrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/mbedtls-3.6.6/library/aes.c:14: In function 'mbedtls_xor_no_simd',
    inlined from 'mbedtls_aes_crypt_cbc' at /home/db/owrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/mbedtls-3.6.6/library/aes.c:1119:13:
/home/db/owrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/mbedtls-3.6.6/library/common.h:343:24: error: array subscript 16 is outside array bounds of 'unsigned char[16]' [-Werror=array-bounds=]
  343 |         r[i] = a[i] ^ b[i];
      |                       ~^~~
/home/db/owrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/mbedtls-3.6.6/library/aes.c: In function 'mbedtls_aes_crypt_cbc':
/home/db/owrt/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/mbedtls-3.6.6/library/aes.c:1075:41: note: at offset 16 into object 'iv' of size [0, 16]
 1075 |                           unsigned char iv[16],
      |                           ~~~~~~~~~~~~~~^~~~~~
```