### PR TITLE
ssl: remove impossible signature algorithm null check

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2288,9 +2288,6 @@ static inline int mbedtls_ssl_sig_alg_is_received(const mbedtls_ssl_context *ssl
                                                   uint16_t own_sig_alg)
 {
     const uint16_t *sig_alg = ssl->handshake->received_sig_algs;
-    if (sig_alg == NULL) {
-        return 0;
-    }
 
     for (; *sig_alg != MBEDTLS_TLS_SIG_NONE; sig_alg++) {
         if (*sig_alg == own_sig_alg) {


### PR DESCRIPTION
﻿## Summary

Fixes Mbed-TLS/mbedtls#10705.

`mbedtls_ssl_sig_alg_is_received()` assigns `sig_alg` from `ssl->handshake->received_sig_algs`. That member is an in-structure array, so its address cannot be `NULL`. The existing `sig_alg == NULL` branch is therefore unreachable and triggers static analysis warnings.

## Changes

- Remove the impossible NULL check from `mbedtls_ssl_sig_alg_is_received()`.
- Keep the iteration and return behavior unchanged.
- Leave the separate NULL check in `mbedtls_ssl_sig_alg_is_offered()` untouched, because that uses `mbedtls_ssl_get_sig_algs()`.

## Testing

- `git diff --check origin/development..HEAD`
- `rg -n "mbedtls_ssl_sig_alg_is_received|received_sig_algs|sig_alg == NULL" library/ssl_misc.h`
- `git diff --stat origin/development..HEAD`

Build not run locally: this Windows environment does not currently have CMake, Ninja, Make, GCC, or Clang available in PATH.
