### PR TITLE
Clarify CRL validity flags for multiple CRLs

### DIFF
--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -629,6 +629,11 @@ int mbedtls_x509_crt_verify_info(char *buf, size_t size, const char *prefix,
  *                 all trusted CAs. If no CRL is provided for the CA that was
  *                 used to sign the certificate, CRL verification is skipped
  *                 silently, that is *without* setting any flag.
+ *                 If multiple CRLs are provided for the same CA, all CRLs
+ *                 matching the CA are checked. Flags from matching CRLs are
+ *                 cumulative, so an expired or not-yet-valid CRL can set
+ *                 #MBEDTLS_X509_BADCRL_EXPIRED or #MBEDTLS_X509_BADCRL_FUTURE
+ *                 even if another matching CRL is currently valid.
  *
  * \note           The \c trust_ca list can contain two types of certificates:
  *                 (1) those of trusted root CAs, so that certificates

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -627,6 +627,22 @@ X509 CRT verification #5''' (Revoked Cert, differing upper and lower case)
 depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY:MBEDTLS_HAVE_TIME_DATE
 x509_verify:"../framework/data_files/server1.crt":"../framework/data_files/test-ca_uppercase.crt":"../framework/data_files/crl.pem":"NULL":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_REVOKED:"compat":"NULL"
 
+X509 CRT verification #5a (Valid Cert, Expired and Valid CRLs)
+depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY:MBEDTLS_HAVE_TIME_DATE
+x509_verify_two_crls:"../framework/data_files/server2.crt":"../framework/data_files/test-ca.crt":"../framework/data_files/crl_expired.pem":"../framework/data_files/crl.pem":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCRL_EXPIRED:"compat"
+
+X509 CRT verification #5b (Valid Cert, Valid and Expired CRLs)
+depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY:MBEDTLS_HAVE_TIME_DATE
+x509_verify_two_crls:"../framework/data_files/server2.crt":"../framework/data_files/test-ca.crt":"../framework/data_files/crl.pem":"../framework/data_files/crl_expired.pem":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCRL_EXPIRED:"compat"
+
+X509 CRT verification #5c (Valid Cert, Future and Valid CRLs)
+depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_ECDSA_VERIFY:PSA_WANT_ECC_SECP_R1_256:PSA_WANT_ECC_SECP_R1_384:MBEDTLS_HAVE_TIME_DATE
+x509_verify_two_crls:"../framework/data_files/server5.crt":"../framework/data_files/test-ca2.crt":"../framework/data_files/crl-future.pem":"../framework/data_files/crl-ec-sha1.pem":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCRL_FUTURE:"compat"
+
+X509 CRT verification #5d (Valid Cert, Valid and Future CRLs)
+depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_ECDSA_VERIFY:PSA_WANT_ECC_SECP_R1_256:PSA_WANT_ECC_SECP_R1_384:MBEDTLS_HAVE_TIME_DATE
+x509_verify_two_crls:"../framework/data_files/server5.crt":"../framework/data_files/test-ca2.crt":"../framework/data_files/crl-ec-sha1.pem":"../framework/data_files/crl-future.pem":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCRL_FUTURE:"compat"
+
 X509 CRT verification #6 (Revoked Cert)
 depends_on:MBEDTLS_PEM_PARSE_C:PSA_WANT_ALG_SHA_1:PSA_HAVE_ALG_RSA_PKCS1V15_VERIFY:MBEDTLS_HAVE_TIME_DATE
 x509_verify:"../framework/data_files/server1.crt":"../framework/data_files/test-ca.crt":"../framework/data_files/crl.pem":"PolarSSL Server 1":MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:MBEDTLS_X509_BADCERT_REVOKED:"compat":"NULL"

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -723,6 +723,63 @@ exit:
 /* END_CASE */
 
 /* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_X509_CRL_PARSE_C */
+void x509_verify_two_crls(char *crt_file, char *ca_file,
+                          char *crl_file1, char *crl_file2,
+                          int result, int flags_result,
+                          char *profile_str)
+{
+    mbedtls_x509_crt   crt;
+    mbedtls_x509_crt   ca;
+    mbedtls_x509_crl   crl;
+    uint32_t           flags = 0;
+    int                res;
+    const mbedtls_x509_crt_profile *profile;
+
+    mbedtls_x509_crt_init(&crt);
+    mbedtls_x509_crt_init(&ca);
+    mbedtls_x509_crl_init(&crl);
+    MD_OR_USE_PSA_INIT();
+
+    if (strcmp(profile_str, "") == 0) {
+        profile = &mbedtls_x509_crt_profile_default;
+    } else if (strcmp(profile_str, "next") == 0) {
+        profile = &mbedtls_x509_crt_profile_next;
+    } else if (strcmp(profile_str, "suite_b") == 0) {
+        profile = &mbedtls_x509_crt_profile_suiteb;
+    } else if (strcmp(profile_str, "compat") == 0) {
+        profile = &compat_profile;
+    } else if (strcmp(profile_str, "all") == 0) {
+        profile = &profile_all;
+    } else {
+        TEST_FAIL("Unknown algorithm profile");
+    }
+
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&crt, crt_file), 0);
+    TEST_EQUAL(mbedtls_x509_crt_parse_file(&ca, ca_file), 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file1), 0);
+    TEST_EQUAL(mbedtls_x509_crl_parse_file(&crl, crl_file2), 0);
+
+    res = mbedtls_x509_crt_verify_with_profile(&crt,
+                                               &ca,
+                                               &crl,
+                                               profile,
+                                               NULL,
+                                               &flags,
+                                               NULL,
+                                               NULL);
+
+    TEST_EQUAL(res, result);
+    TEST_EQUAL(flags, (uint32_t) flags_result);
+
+exit:
+    mbedtls_x509_crt_free(&crt);
+    mbedtls_x509_crt_free(&ca);
+    mbedtls_x509_crl_free(&crl);
+    MD_OR_USE_PSA_DONE();
+}
+/* END_CASE */
+
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_X509_CRL_PARSE_C */
 void x509_verify(char *crt_file, char *ca_file, char *crl_file,
                  char *cn_name_str, int result, int flags_result,
                  char *profile_str,


### PR DESCRIPTION
## Description

Clarify the documented behavior of certificate verification when the CRL list contains multiple matching CRLs for the same CA. The verifier checks all matching CRLs and accumulates flags, so an expired or not-yet-valid CRL can set `MBEDTLS_X509_BADCRL_EXPIRED` or `MBEDTLS_X509_BADCRL_FUTURE` even when another matching CRL is currently valid.

Add x509 verification test cases covering valid certificates with mixed valid/expired CRLs and mixed valid/future CRLs in both list orders.

Fixes #10797.

## PR checklist

- [x] **changelog** not required because: documentation/test clarification only, no user-visible behavior change.
- [x] **framework PR** not required.
- [x] **TF-PSA-Crypto development PR** not required because: no TF-PSA-Crypto changes.
- [x] **TF-PSA-Crypto 1.1 PR** not required because: no TF-PSA-Crypto changes.
- [x] **mbedtls development PR** provided: this PR.
- [x] **mbedtls 4.1 PR** not required because: targeting development first.
- [x] **mbedtls 3.6 PR** not required because: targeting development first.
- **tests** provided: added x509 verification cases for mixed CRL validity.

## Notes

Local validation:

- `git diff --check` passes.
- `framework/scripts/generate_test_code.py` was exercised through `make -C tests test_suite_x509parse`; the new x509 cases generated into `tests/test_suite_x509parse.c`/`.datax` successfully.
- The local test executable build did not complete in this checkout because the Make build fails earlier while generating/building TF-PSA-Crypto config-check headers, before reaching the x509 suite.
