### PR TITLE
ssl: remove impossible signature algorithm null check

### DIFF
--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -2288,9 +2288,6 @@ static inline int mbedtls_ssl_sig_alg_is_received(const mbedtls_ssl_context *ssl
                                                   uint16_t own_sig_alg)
 {
     const uint16_t *sig_alg = ssl->handshake->received_sig_algs;
-    if (sig_alg == NULL) {
-        return 0;
-    }
 
     for (; *sig_alg != MBEDTLS_TLS_SIG_NONE; sig_alg++) {
         if (*sig_alg == own_sig_alg) {


### PR DESCRIPTION
## Description

Backport of Mbed-TLS/mbedtls#10794 to `mbedtls-4.1`.

`mbedtls_ssl_sig_alg_is_received()` assigns `sig_alg` from `ssl->handshake->received_sig_algs`. That member is an in-structure array, so its address cannot be `NULL`. This removes the unreachable NULL check while keeping the iteration and return behavior unchanged.

Cherry-picked from `501140ef18ff845ff8bbc434d6a5fa6cd8c9bc49`.

## PR checklist

- [ ] **changelog** not required because: no user-facing behavior change
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR** not required because: mbedtls-only change
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: mbedtls-only change
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10794
- [ ] **mbedtls 4.1 PR** provided # | not required because: this PR targets `mbedtls-4.1`
- [ ] **mbedtls 3.6 PR** provided # | not required because: separate 3.6 backport PR will be opened
- **tests** provided: `git diff --check origin/mbedtls-4.1...HEAD`, `git diff --stat origin/mbedtls-4.1...HEAD`, `git show --check --stat --oneline HEAD`