### PR TITLE
Backport 3.6: Unsafe macros

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1090,10 +1090,10 @@ typedef uint32_t psa_pake_primitive_t;
  *         Return 0 if the requested primitive can't be encoded as
  *         ::psa_pake_primitive_t.
  */
-#define PSA_PAKE_PRIMITIVE(pake_type, pake_family, pake_bits) \
-    ((pake_bits & 0xFFFF) != pake_bits) ? 0 :                 \
-    ((psa_pake_primitive_t) (((pake_type) << 24 |             \
-                              (pake_family) << 16) | (pake_bits)))
+#define PSA_PAKE_PRIMITIVE(pake_type, pake_family, pake_bits)              \
+    ((((pake_bits) & 0xFFFF) != (pake_bits)) ? 0 :                         \
+     ((psa_pake_primitive_t) ((((pake_type) << 24) |                       \
+                               ((pake_family) << 16)) | (pake_bits))))
 
 /** The key share being sent to or received from the peer.
  *
@@ -1170,12 +1170,12 @@ typedef uint32_t psa_pake_primitive_t;
  *                      return 0.
  */
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step)               \
-    (alg == PSA_ALG_JPAKE &&                                           \
-     primitive == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,      \
+    ((alg) == PSA_ALG_JPAKE &&                                          \
+     (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
-         output_step == PSA_PAKE_STEP_KEY_SHARE ? 65 :                   \
-         output_step == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                   \
+         (output_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                \
+         (output_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                \
          32                                                              \
      ) :                                                               \
      0)
@@ -1200,12 +1200,12 @@ typedef uint32_t psa_pake_primitive_t;
  *                      the parameters are incompatible, return 0.
  */
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step)                 \
-    (alg == PSA_ALG_JPAKE &&                                           \
-     primitive == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,      \
+    ((alg) == PSA_ALG_JPAKE &&                                          \
+     (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
                                      PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
-         input_step == PSA_PAKE_STEP_KEY_SHARE ? 65 :                    \
-         input_step == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                    \
+         (input_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                 \
+         (input_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                 \
          32                                                              \
      ) :                                                               \
      0)

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -1172,7 +1172,7 @@ typedef uint32_t psa_pake_primitive_t;
 #define PSA_PAKE_OUTPUT_SIZE(alg, primitive, output_step)               \
     ((alg) == PSA_ALG_JPAKE &&                                          \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
-                                     PSA_ECC_FAMILY_SECP_R1, 256) ?    \
+                                       PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
          (output_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                \
          (output_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                \
@@ -1202,7 +1202,7 @@ typedef uint32_t psa_pake_primitive_t;
 #define PSA_PAKE_INPUT_SIZE(alg, primitive, input_step)                 \
     ((alg) == PSA_ALG_JPAKE &&                                          \
      (primitive) == PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC,     \
-                                     PSA_ECC_FAMILY_SECP_R1, 256) ?    \
+                                       PSA_ECC_FAMILY_SECP_R1, 256) ?    \
      (                                                                 \
          (input_step) == PSA_PAKE_STEP_KEY_SHARE ? 65 :                 \
          (input_step) == PSA_PAKE_STEP_ZK_PUBLIC ? 65 :                 \

--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -590,7 +590,7 @@
                          0))
 
 /** Check if the curve of given family is Weierstrass elliptic curve. */
-#define PSA_ECC_FAMILY_IS_WEIERSTRASS(family) ((family & 0xc0) == 0)
+#define PSA_ECC_FAMILY_IS_WEIERSTRASS(family) (((family) & 0xc0) == 0)
 
 /** SEC Koblitz curves over prime fields.
  *

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5019,7 +5019,7 @@ int mbedtls_ecp_mod_p192_raw(mbedtls_mpi_uint *Np, size_t Nn)
 
 #else /* 64 bit */
 
-#define MAX32   ((X_limbs) * 2)
+#define MAX32   (X_limbs * 2)
 #define A(j)                                                \
     (j) % 2 ?                                               \
     (uint32_t) (X[(j) / 2] >> 32) :                         \

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -5012,14 +5012,14 @@ int mbedtls_ecp_mod_p192_raw(mbedtls_mpi_uint *Np, size_t Nn)
 
 #if defined(MBEDTLS_HAVE_INT32)  /* 32 bit */
 
-#define MAX32       X_limbs
+#define MAX32       (X_limbs)
 #define A(j)        X[j]
 #define STORE32     X[i] = (mbedtls_mpi_uint) cur;
 #define STORE0      X[i] = 0;
 
 #else /* 64 bit */
 
-#define MAX32   X_limbs * 2
+#define MAX32   ((X_limbs) * 2)
 #define A(j)                                                \
     (j) % 2 ?                                               \
     (uint32_t) (X[(j) / 2] >> 32) :                         \

--- a/library/pk_internal.h
+++ b/library/pk_internal.h
@@ -153,7 +153,7 @@ static inline mbedtls_ecp_group_id mbedtls_pk_get_ec_group_id(const mbedtls_pk_c
 #endif /* MBEDTLS_ECP_HAVE_CURVE25519 || MBEDTLS_ECP_DP_CURVE448 */
 
 #define MBEDTLS_PK_IS_RFC8410_GROUP_ID(id)  \
-    ((id == MBEDTLS_ECP_DP_CURVE25519) || (id == MBEDTLS_ECP_DP_CURVE448))
+    (((id) == MBEDTLS_ECP_DP_CURVE25519) || ((id) == MBEDTLS_ECP_DP_CURVE448))
 
 static inline int mbedtls_pk_is_rfc8410(const mbedtls_pk_context *pk)
 {

--- a/library/sha3.c
+++ b/library/sha3.c
@@ -72,7 +72,7 @@
  * YMMV.
  */
 /* Helper macro to set the values of the higher bits in unused low positions */
-#define H(b63, b31, b15) (b63 << 6 | b31 << 5 | b15 << 4)
+#define H(b63, b31, b15) (((b63) << 6) | ((b31) << 5) | ((b15) << 4))
 static const uint8_t iota_r_packed[24] = {
     H(0, 0, 0) | 0x01, H(0, 0, 1) | 0x82, H(1, 0, 1) | 0x8a, H(1, 1, 1) | 0x00,
     H(0, 0, 1) | 0x8b, H(0, 1, 0) | 0x01, H(1, 1, 1) | 0x81, H(1, 0, 1) | 0x09,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -11173,6 +11173,7 @@ void ecjpake_size_macros()
 {
     const psa_algorithm_t alg = PSA_ALG_JPAKE;
     const size_t bits = 256;
+    const psa_pake_primitive_t invalid_primitive = 1;
     const psa_pake_primitive_t prim = PSA_PAKE_PRIMITIVE(
         PSA_PAKE_PRIMITIVE_TYPE_ECC, PSA_ECC_FAMILY_SECP_R1, bits);
     const psa_key_type_t key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(
@@ -11209,5 +11210,11 @@ void ecjpake_size_macros()
               PSA_PAKE_INPUT_MAX_SIZE);
     TEST_LE_U(PSA_PAKE_INPUT_SIZE(alg, prim, PSA_PAKE_STEP_ZK_PROOF),
               PSA_PAKE_INPUT_MAX_SIZE);
+
+    /* Invalid primitives must not match the supported J-PAKE suite. */
+    TEST_EQUAL(PSA_PAKE_OUTPUT_SIZE(alg, invalid_primitive,
+                                    PSA_PAKE_STEP_KEY_SHARE), 0);
+    TEST_EQUAL(PSA_PAKE_INPUT_SIZE(alg, invalid_primitive,
+                                   PSA_PAKE_STEP_KEY_SHARE), 0);
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_pake.function
+++ b/tests/suites/test_suite_psa_crypto_pake.function
@@ -937,6 +937,7 @@ void ecjpake_size_macros()
 {
     const psa_algorithm_t alg = PSA_ALG_JPAKE;
     const size_t bits = 256;
+    const psa_pake_primitive_t invalid_primitive = 1;
     const psa_pake_primitive_t prim = PSA_PAKE_PRIMITIVE(
         PSA_PAKE_PRIMITIVE_TYPE_ECC, PSA_ECC_FAMILY_SECP_R1, bits);
     const psa_key_type_t key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(
@@ -973,6 +974,12 @@ void ecjpake_size_macros()
               PSA_PAKE_INPUT_MAX_SIZE);
     TEST_LE_U(PSA_PAKE_INPUT_SIZE(alg, prim, PSA_PAKE_STEP_ZK_PROOF),
               PSA_PAKE_INPUT_MAX_SIZE);
+
+    /* Invalid primitives must not match the supported J-PAKE suite. */
+    TEST_EQUAL(PSA_PAKE_OUTPUT_SIZE(alg, invalid_primitive,
+                                    PSA_PAKE_STEP_KEY_SHARE), 0);
+    TEST_EQUAL(PSA_PAKE_INPUT_SIZE(alg, invalid_primitive,
+                                   PSA_PAKE_STEP_KEY_SHARE), 0);
 }
 /* END_CASE */
 


### PR DESCRIPTION
## Description

Backport 3.6: Unsafe macros contributes https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/712


## PR checklist

- [x] **changelog** not required because: No public changes
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/716
- [x] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/828
- [x] **mbedtls development PR** not required because: crypto only
- [x] **mbedtls 4.1 PR** not required because: crypto only
- [x] **mbedtls 3.6 PR** provided: #HERE
- **tests**  not required because: No changes