### PR TITLE
Async hardware cryptographic function support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Mbed-TLS/mbedtls-framework
 [submodule "tf-psa-crypto"]
 	path = tf-psa-crypto
-	url = https://github.com/Mbed-TLS/TF-PSA-Crypto.git
+	url = https://github.com/crabel99/TF-PSA-Crypto.git

--- a/ChangeLog.d/async-hardware-hooks.txt
+++ b/ChangeLog.d/async-hardware-hooks.txt
@@ -1,0 +1,5 @@
+Features
+   * Add generic async hardware hook points for selected TLS handshake and
+     record-protection operations. This lets platform providers route supported
+     ECDHE, ECDSA, RSA, and TLS AEAD operations to interrupt-driven hardware
+     without blocking TLS progress.

--- a/include/mbedtls/psa_crypto_async_tls.h
+++ b/include/mbedtls/psa_crypto_async_tls.h
@@ -1,0 +1,120 @@
+#ifndef MBEDTLS_PSA_CRYPTO_ASYNC_TLS_H
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_H
+
+#include "mbedtls/psa_crypto_async_provider.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*mbedtls_psa_async_tls_callback_t)(int success, void* context);
+
+int mbedtls_psa_async_tls_bind(mbedtls_psa_async_crypto_provider_t* provider);
+int mbedtls_psa_async_tls_unbind(mbedtls_psa_async_crypto_provider_t* provider);
+int mbedtls_psa_async_tls_begin_call(void* owner);
+void mbedtls_psa_async_tls_end_call(void* owner);
+void mbedtls_psa_async_tls_service(void);
+void mbedtls_psa_async_tls_abort(void);
+void mbedtls_psa_async_tls_abort_owner(void* owner);
+int mbedtls_psa_async_tls_busy(void);
+
+void mbedtls_psa_async_tls_set_trusted_time(uint64_t unix_time);
+void mbedtls_psa_async_tls_clear_trusted_time(void);
+uint64_t mbedtls_psa_async_tls_get_trusted_time(void);
+
+time_t mbedtls_platform_time(time_t* current_time);
+
+int mbedtls_psa_async_tls_random_start(uint8_t* output, size_t length,
+                                        mbedtls_psa_async_tls_callback_t callback, void* context);
+
+int mbedtls_psa_async_tls_ecdh_p256_public_key_start(
+    const uint8_t private_key[32], uint8_t public_key[65],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdh_p384_public_key_start(
+    const uint8_t private_key[48], uint8_t public_key[97],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdh_p521_public_key_start(
+    const uint8_t private_key[66], uint8_t public_key[133],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+
+int mbedtls_psa_async_tls_ecdh_p256_start(const uint8_t private_key[32],
+                                           const uint8_t peer_public_key[65],
+                                           uint8_t shared_secret[32],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context);
+int mbedtls_psa_async_tls_ecdh_p384_start(const uint8_t private_key[48],
+                                           const uint8_t peer_public_key[97],
+                                           uint8_t shared_secret[48],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context);
+int mbedtls_psa_async_tls_ecdh_p521_start(const uint8_t private_key[66],
+                                           const uint8_t peer_public_key[133],
+                                           uint8_t shared_secret[66],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context);
+
+int mbedtls_psa_async_tls_ecdsa_p256_sign_start(
+    const uint8_t private_key[32], const uint8_t hash[32], uint8_t signature[64],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdsa_p256_verify_start(
+    const uint8_t public_key[65], const uint8_t hash[32], const uint8_t signature[64],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdsa_p384_sign_start(
+    const uint8_t private_key[48], const uint8_t hash[48], uint8_t signature[96],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdsa_p384_verify_start(
+    const uint8_t public_key[97], const uint8_t hash[48], const uint8_t signature[96],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdsa_p521_sign_start(
+    const uint8_t private_key[66], const uint8_t hash[64], uint8_t signature[132],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_ecdsa_p521_verify_start(
+    const uint8_t public_key[133], const uint8_t hash[64], const uint8_t signature[132],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+
+int mbedtls_psa_async_tls_aead_encrypt_start(
+    int algorithm, const uint8_t* key, size_t key_length, const uint8_t* nonce,
+    size_t nonce_length, const uint8_t* aad, size_t aad_length, const uint8_t* plaintext,
+    uint8_t* ciphertext, size_t length, uint8_t* tag, size_t tag_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_aead_decrypt_start(
+    int algorithm, const uint8_t* key, size_t key_length, const uint8_t* nonce,
+    size_t nonce_length, const uint8_t* aad, size_t aad_length, const uint8_t* ciphertext,
+    uint8_t* plaintext, size_t length, const uint8_t* tag, size_t tag_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+
+int mbedtls_psa_async_tls_aes_gcm128_encrypt_start(
+    const uint8_t key[16], const uint8_t nonce[12], const uint8_t* aad, size_t aad_length,
+    const uint8_t* plaintext, uint8_t* ciphertext, size_t length, uint8_t tag[16],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_aes_gcm128_decrypt_start(
+    const uint8_t key[16], const uint8_t nonce[12], const uint8_t* aad, size_t aad_length,
+    const uint8_t* ciphertext, uint8_t* plaintext, size_t length, const uint8_t tag[16],
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+
+int mbedtls_psa_async_tls_rsa_pss_verify_start(
+    int hash_bits, const uint8_t* public_key, size_t public_key_length, const uint8_t* hash,
+    size_t hash_length, const uint8_t* signature, size_t signature_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_rsa_pkcs1_verify_start(
+    int hash_bits, const uint8_t* public_key, size_t public_key_length, const uint8_t* hash,
+    size_t hash_length, const uint8_t* signature, size_t signature_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_rsa_pss_sign_start(
+    int hash_bits, const uint8_t* private_key, size_t private_key_length, const uint8_t* hash,
+    size_t hash_length, uint8_t* signature, size_t signature_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+int mbedtls_psa_async_tls_rsa_pkcs1_sign_start(
+    int hash_bits, const uint8_t* private_key, size_t private_key_length, const uint8_t* hash,
+    size_t hash_length, uint8_t* signature, size_t signature_length,
+    mbedtls_psa_async_tls_callback_t callback, void* context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_PSA_CRYPTO_ASYNC_TLS_H */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -24,6 +24,7 @@ set(src_tls
     ssl_cookie.c
     ssl_debug_helpers_generated.c
     ssl_msg.c
+    psa_crypto_async_tls.c
     ssl_ticket.c
     ssl_tls.c
     ssl_tls12_client.c

--- a/library/psa_crypto_async_tls.c
+++ b/library/psa_crypto_async_tls.c
@@ -1,0 +1,821 @@
+#define MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
+#include "mbedtls/psa_crypto_async_tls.h"
+
+#include "mbedtls/psa_crypto_async_curves.h"
+
+#include <mbedtls/platform_time.h>
+#include <mbedtls/platform_util.h>
+#include <mbedtls/private/bignum.h>
+#include <mbedtls/private/rsa.h>
+#include <stdbool.h>
+#include <string.h>
+
+int mbedtls_rsa_parse_pubkey(mbedtls_rsa_context* rsa, const unsigned char* key, size_t key_length);
+int mbedtls_rsa_parse_key(mbedtls_rsa_context* rsa, const unsigned char* key, size_t key_length);
+
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES 512u
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY 8u
+
+typedef enum mbedtls_psa_async_tls_generic_stage_e {
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE = 0,
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT = 1,
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_SIGNATURE_RANDOM = 2,
+} mbedtls_psa_async_tls_generic_stage_t;
+
+typedef struct mbedtls_psa_async_tls_generic_operation_s {
+  mbedtls_psa_async_crypto_operation_t provider_operation;
+  mbedtls_psa_async_crypto_request_t request;
+  mbedtls_psa_async_tls_callback_t callback;
+  void* callback_context;
+  void* owner;
+  mbedtls_psa_async_crypto_prime_curve_t curve;
+  const uint8_t* private_key;
+  const uint8_t* hash;
+  uint8_t* signature;
+  size_t coordinate_length;
+  size_t key_bits;
+  size_t hash_length;
+  mbedtls_psa_async_tls_generic_stage_t stage;
+  uint8_t nonce[66];
+} mbedtls_psa_async_tls_generic_operation_t;
+
+typedef enum mbedtls_psa_async_tls_rsa_stage_e {
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE = 0,
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_RANDOM = 1,
+  MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_EXPONENTIATION = 2,
+} mbedtls_psa_async_tls_rsa_stage_t;
+
+typedef struct mbedtls_psa_async_tls_rsa_operation_s {
+  mbedtls_psa_async_crypto_operation_t provider_operation;
+  mbedtls_psa_async_crypto_request_t request;
+  mbedtls_rsa_context rsa;
+  mbedtls_psa_async_tls_callback_t callback;
+  void* callback_context;
+  void* owner;
+  const uint8_t* hash;
+  uint8_t* signature_output;
+  size_t hash_length;
+  size_t modulus_length;
+  mbedtls_md_type_t hash_algorithm;
+  bool signing;
+  bool pss;
+  bool rsa_initialized;
+  mbedtls_psa_async_tls_rsa_stage_t stage;
+  uint8_t modulus[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES];
+  uint8_t exponent[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES];
+  uint8_t encoded[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES];
+  uint8_t signature[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES];
+  uint8_t salt[64];
+} mbedtls_psa_async_tls_rsa_operation_t;
+
+static mbedtls_psa_async_crypto_provider_t* provider = NULL;
+static size_t provider_bindings = 0u;
+static uint64_t current_trusted_time = 0u;
+static void* active_call_owner = NULL;
+static mbedtls_psa_async_tls_rsa_operation_t rsa_operation = {0};
+static mbedtls_psa_async_tls_generic_operation_t
+    generic_operations[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY] = {0};
+
+static void zeroize(void* data, size_t size) {
+  volatile uint8_t* bytes = (volatile uint8_t*)data;
+  while (size-- != 0u) {
+    *bytes++ = 0u;
+  }
+}
+
+static void reset_rsa(void) {
+  if (rsa_operation.rsa_initialized) {
+    mbedtls_rsa_free(&rsa_operation.rsa);
+  }
+  zeroize(&rsa_operation, sizeof(rsa_operation));
+}
+
+static void finish_rsa(bool success) {
+  mbedtls_psa_async_tls_callback_t callback = rsa_operation.callback;
+  void* context = rsa_operation.callback_context;
+  reset_rsa();
+  if (callback != NULL) {
+    callback(success ? 1 : 0, context);
+  }
+}
+
+static mbedtls_psa_async_tls_generic_operation_t*
+allocate_generic(mbedtls_psa_async_tls_callback_t callback, void* context) {
+  if (provider == NULL || callback == NULL) {
+    return NULL;
+  }
+  for (size_t index = 0u; index < MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY; ++index) {
+    if (generic_operations[index].stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE) {
+      memset(&generic_operations[index], 0, sizeof(generic_operations[index]));
+      generic_operations[index].callback = callback;
+      generic_operations[index].callback_context = context;
+      generic_operations[index].owner = active_call_owner;
+      return &generic_operations[index];
+    }
+  }
+  return NULL;
+}
+
+static void finish_generic(mbedtls_psa_async_tls_generic_operation_t* operation, bool success) {
+  mbedtls_psa_async_tls_callback_t callback = operation->callback;
+  void* context = operation->callback_context;
+  zeroize(operation, sizeof(*operation));
+  if (callback != NULL) {
+    callback(success ? 1 : 0, context);
+  }
+}
+
+static bool start_generic(mbedtls_psa_async_tls_generic_operation_t* operation,
+                          const mbedtls_psa_async_crypto_request_t* request,
+                          mbedtls_psa_async_tls_generic_stage_t stage) {
+  operation->request = *request;
+  if (mbedtls_psa_async_crypto_start(provider, &operation->provider_operation,
+                                     &operation->request) != PSA_SUCCESS) {
+    zeroize(operation, sizeof(*operation));
+    return false;
+  }
+  operation->stage = stage;
+  return true;
+}
+
+static const mbedtls_psa_async_crypto_prime_curve_t* curve_for_bits(size_t bits) {
+  return mbedtls_psa_async_crypto_resolve_prime_curve(
+      PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1), bits);
+}
+
+static bool prepare_random(uint8_t* output, size_t length,
+                           mbedtls_psa_async_tls_callback_t callback, void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  if (operation == NULL || output == NULL || length == 0u) {
+    return false;
+  }
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM;
+  request.output = (mbedtls_psa_async_crypto_buffer_t){output, length};
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT);
+}
+
+static bool prepare_ecdh_public(size_t bits, const uint8_t* private_key, uint8_t* public_key,
+                                mbedtls_psa_async_tls_callback_t callback, void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  const mbedtls_psa_async_crypto_prime_curve_t* curve = curve_for_bits(bits);
+  const size_t coordinate_length = (bits + 7u) / 8u;
+  if (operation == NULL || curve == NULL || private_key == NULL || public_key == NULL) {
+    return false;
+  }
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_EXPORT_PUBLIC_KEY;
+  request.key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+  request.key_bits = bits;
+  request.alg = PSA_ALG_ECDH;
+  request.private_key = (mbedtls_psa_async_crypto_const_buffer_t){private_key, coordinate_length};
+  request.public_key_output =
+      (mbedtls_psa_async_crypto_buffer_t){public_key, coordinate_length * 2u + 1u};
+  operation->curve = *curve;
+  request.prime_curve = &operation->curve;
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT);
+}
+
+static bool prepare_ecdh(size_t bits, const uint8_t* private_key, const uint8_t* peer_public_key,
+                         uint8_t* shared_secret, mbedtls_psa_async_tls_callback_t callback,
+                         void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  const mbedtls_psa_async_crypto_prime_curve_t* curve = curve_for_bits(bits);
+  const size_t coordinate_length = (bits + 7u) / 8u;
+  if (operation == NULL || curve == NULL || private_key == NULL || peer_public_key == NULL ||
+      shared_secret == NULL) {
+    return false;
+  }
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_KEY_AGREEMENT;
+  request.key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+  request.key_bits = bits;
+  request.alg = PSA_ALG_ECDH;
+  request.private_key = (mbedtls_psa_async_crypto_const_buffer_t){private_key, coordinate_length};
+  request.peer_key =
+      (mbedtls_psa_async_crypto_const_buffer_t){peer_public_key, coordinate_length * 2u + 1u};
+  request.shared_secret = (mbedtls_psa_async_crypto_buffer_t){shared_secret, coordinate_length};
+  operation->curve = *curve;
+  request.prime_curve = &operation->curve;
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT);
+}
+
+static bool prepare_ecdsa_verify(size_t bits, const uint8_t* public_key, const uint8_t* hash,
+                                 const uint8_t* signature,
+                                 mbedtls_psa_async_tls_callback_t callback, void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  const mbedtls_psa_async_crypto_prime_curve_t* curve = curve_for_bits(bits);
+  const size_t coordinate_length = (bits + 7u) / 8u;
+  if (operation == NULL || curve == NULL || public_key == NULL || hash == NULL ||
+      signature == NULL) {
+    return false;
+  }
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_VERIFY_HASH;
+  request.key_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_FAMILY_SECP_R1);
+  request.key_bits = bits;
+  request.alg = PSA_ALG_ECDSA(bits == 256u   ? PSA_ALG_SHA_256
+                              : bits == 384u ? PSA_ALG_SHA_384
+                                             : PSA_ALG_SHA_512);
+  request.public_key =
+      (mbedtls_psa_async_crypto_const_buffer_t){public_key, coordinate_length * 2u + 1u};
+  request.hash =
+      (mbedtls_psa_async_crypto_const_buffer_t){hash, bits == 521u ? 64u : coordinate_length};
+  request.signature =
+      (mbedtls_psa_async_crypto_buffer_t){(uint8_t*)(signature), coordinate_length * 2u};
+  operation->curve = *curve;
+  request.prime_curve = &operation->curve;
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT);
+}
+
+static bool prepare_ecdsa_sign(size_t bits, const uint8_t* private_key, const uint8_t* hash,
+                               uint8_t* signature, mbedtls_psa_async_tls_callback_t callback,
+                               void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  const mbedtls_psa_async_crypto_prime_curve_t* curve = curve_for_bits(bits);
+  const size_t coordinate_length = (bits + 7u) / 8u;
+  if (operation == NULL || curve == NULL || private_key == NULL || hash == NULL ||
+      signature == NULL) {
+    return false;
+  }
+  operation->curve = *curve;
+  operation->private_key = private_key;
+  operation->hash = hash;
+  operation->signature = signature;
+  operation->coordinate_length = coordinate_length;
+  operation->key_bits = bits;
+  operation->hash_length = bits == 521u ? 64u : coordinate_length;
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM;
+  request.output = (mbedtls_psa_async_crypto_buffer_t){operation->nonce, coordinate_length};
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_SIGNATURE_RANDOM);
+}
+
+static psa_algorithm_t tls_aead_algorithm(int algorithm) {
+  return algorithm >= 1 && algorithm <= 2   ? PSA_ALG_GCM
+         : algorithm >= 3 && algorithm <= 6 ? PSA_ALG_CCM
+                                            : (psa_algorithm_t)0u;
+}
+
+static bool prepare_aead(bool encrypting, int algorithm, const uint8_t* key, size_t key_length,
+                         const uint8_t* nonce, size_t nonce_length, const uint8_t* aad,
+                         size_t aad_length, const uint8_t* input, uint8_t* output, size_t length,
+                         const uint8_t* input_tag, uint8_t* output_tag, size_t tag_length,
+                         mbedtls_psa_async_tls_callback_t callback, void* context) {
+  mbedtls_psa_async_tls_generic_operation_t* operation = allocate_generic(callback, context);
+  const psa_algorithm_t psa_algorithm = tls_aead_algorithm(algorithm);
+  if (operation == NULL || psa_algorithm == 0u || key == NULL ||
+      (key_length != 16u && key_length != 32u) || nonce == NULL || input == NULL ||
+      output == NULL || (encrypting ? output_tag == NULL : input_tag == NULL)) {
+    return false;
+  }
+  mbedtls_psa_async_crypto_request_t request = {0};
+  request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_AEAD;
+  request.key_type = PSA_KEY_TYPE_AES;
+  request.key_bits = key_length * 8u;
+  request.alg = psa_algorithm;
+  request.direction =
+      encrypting ? MBEDTLS_PSA_ASYNC_CRYPTO_ENCRYPT : MBEDTLS_PSA_ASYNC_CRYPTO_DECRYPT;
+  request.key = (mbedtls_psa_async_crypto_const_buffer_t){key, key_length};
+  request.nonce = (mbedtls_psa_async_crypto_const_buffer_t){nonce, nonce_length};
+  request.additional_data = (mbedtls_psa_async_crypto_const_buffer_t){aad, aad_length};
+  request.input = (mbedtls_psa_async_crypto_const_buffer_t){input, length};
+  request.output = (mbedtls_psa_async_crypto_buffer_t){output, length};
+  request.input_tag =
+      (mbedtls_psa_async_crypto_const_buffer_t){input_tag, encrypting ? 0u : tag_length};
+  request.output_tag =
+      (mbedtls_psa_async_crypto_buffer_t){output_tag, encrypting ? tag_length : 0u};
+  return start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT);
+}
+
+static void service_generic(mbedtls_psa_async_tls_generic_operation_t* operation) {
+  if (operation->stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE) {
+    return;
+  }
+  const psa_status_t status =
+      mbedtls_psa_async_crypto_complete(provider, &operation->provider_operation);
+  if (status == PSA_OPERATION_INCOMPLETE) {
+    return;
+  }
+  if (status != PSA_SUCCESS) {
+    finish_generic(operation, false);
+    return;
+  }
+  if (operation->stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_SIGNATURE_RANDOM) {
+    memset(&operation->provider_operation, 0, sizeof(operation->provider_operation));
+    mbedtls_psa_async_crypto_request_t request = {0};
+    request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_SIGN_HASH;
+    request.key_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1);
+    request.key_bits = operation->key_bits;
+    request.alg = PSA_ALG_ECDSA(operation->hash_length == 32u   ? PSA_ALG_SHA_256
+                                : operation->hash_length == 48u ? PSA_ALG_SHA_384
+                                                                : PSA_ALG_SHA_512);
+    request.private_key = (mbedtls_psa_async_crypto_const_buffer_t){operation->private_key,
+                                                                    operation->coordinate_length};
+    request.nonce_scalar =
+        (mbedtls_psa_async_crypto_const_buffer_t){operation->nonce, operation->coordinate_length};
+    request.hash =
+        (mbedtls_psa_async_crypto_const_buffer_t){operation->hash, operation->hash_length};
+    request.signature = (mbedtls_psa_async_crypto_buffer_t){operation->signature,
+                                                            operation->coordinate_length * 2u};
+    request.prime_curve = &operation->curve;
+    mbedtls_psa_async_tls_callback_t callback = operation->callback;
+    void* context = operation->callback_context;
+    if (!start_generic(operation, &request, MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_DIRECT) &&
+        callback != NULL) {
+      callback(0, context);
+    }
+    return;
+  }
+  finish_generic(operation, true);
+}
+
+static mbedtls_md_type_t hash_algorithm(int hash_bits) {
+  switch (hash_bits) {
+  case 256:
+    return MBEDTLS_MD_SHA256;
+  case 384:
+    return MBEDTLS_MD_SHA384;
+  case 512:
+    return MBEDTLS_MD_SHA512;
+  default:
+    return MBEDTLS_MD_NONE;
+  }
+}
+
+static size_t hash_length(int hash_bits) {
+  return hash_bits == 256 ? 32u : hash_bits == 384 ? 48u : hash_bits == 512 ? 64u : 0u;
+}
+
+static bool export_integer(const mbedtls_mpi* value, uint8_t* output, size_t output_size,
+                           size_t* value_size, bool pad_to_output) {
+  *value_size = mbedtls_mpi_size(value);
+  if (*value_size == 0u || *value_size > output_size) {
+    return false;
+  }
+  const size_t write_size = pad_to_output ? output_size : *value_size;
+  return mbedtls_mpi_write_binary(value, output, write_size) == 0;
+}
+
+static bool prepare_rsa(bool signing, bool pss, int hash_bits, const uint8_t* key,
+                        size_t key_length, const uint8_t* hash, size_t digest_length,
+                        const uint8_t* signature, uint8_t* signature_output,
+                        size_t signature_length, mbedtls_psa_async_tls_callback_t callback,
+                        void* context) {
+  if (provider == NULL || rsa_operation.stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE || key == NULL ||
+      key_length == 0u || hash == NULL || callback == NULL ||
+      digest_length != hash_length(hash_bits) || signature_length == 0u ||
+      signature_length > MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES || (!signing && signature == NULL) ||
+      (signing && signature_output == NULL)) {
+    return false;
+  }
+
+  mbedtls_rsa_init(&rsa_operation.rsa);
+  rsa_operation.rsa_initialized = true;
+  rsa_operation.signing = signing;
+  rsa_operation.pss = pss;
+  rsa_operation.hash_algorithm = hash_algorithm(hash_bits);
+  rsa_operation.hash = hash;
+  rsa_operation.hash_length = digest_length;
+  rsa_operation.signature_output = signature_output;
+  rsa_operation.callback = callback;
+  rsa_operation.callback_context = context;
+  rsa_operation.owner = active_call_owner;
+  if (rsa_operation.hash_algorithm == MBEDTLS_MD_NONE ||
+      (signing ? mbedtls_rsa_parse_key(&rsa_operation.rsa, key, key_length)
+               : mbedtls_rsa_parse_pubkey(&rsa_operation.rsa, key, key_length)) != 0 ||
+      mbedtls_rsa_set_padding(&rsa_operation.rsa, pss ? MBEDTLS_RSA_PKCS_V21 : MBEDTLS_RSA_PKCS_V15,
+                              rsa_operation.hash_algorithm) != 0) {
+    reset_rsa();
+    return false;
+  }
+
+  rsa_operation.modulus_length = mbedtls_rsa_get_len(&rsa_operation.rsa);
+  if (rsa_operation.modulus_length != signature_length ||
+      rsa_operation.modulus_length > MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES ||
+      (rsa_operation.modulus_length & 0x03u) != 0u) {
+    reset_rsa();
+    return false;
+  }
+
+  size_t modulus_size = 0u;
+  size_t exponent_size = 0u;
+  if (!export_integer(&rsa_operation.rsa.MBEDTLS_PRIVATE(N), rsa_operation.modulus,
+                      rsa_operation.modulus_length, &modulus_size, true) ||
+      !export_integer(
+          signing ? &rsa_operation.rsa.MBEDTLS_PRIVATE(D) : &rsa_operation.rsa.MBEDTLS_PRIVATE(E),
+          rsa_operation.exponent, rsa_operation.modulus_length, &exponent_size, signing)) {
+    reset_rsa();
+    return false;
+  }
+
+  if (!signing) {
+    memcpy(rsa_operation.signature, signature, signature_length);
+    memset(&rsa_operation.request, 0, sizeof(rsa_operation.request));
+    rsa_operation.request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA;
+    rsa_operation.request.modulus = (mbedtls_psa_async_crypto_const_buffer_t){
+        rsa_operation.modulus, rsa_operation.modulus_length};
+    rsa_operation.request.exponent =
+        (mbedtls_psa_async_crypto_const_buffer_t){rsa_operation.exponent, exponent_size};
+    rsa_operation.request.input =
+        (mbedtls_psa_async_crypto_const_buffer_t){rsa_operation.signature, signature_length};
+    rsa_operation.request.output =
+        (mbedtls_psa_async_crypto_buffer_t){rsa_operation.encoded, rsa_operation.modulus_length};
+    rsa_operation.request.rsa_mode = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_MODE_REGULAR;
+    rsa_operation.request.rsa_window = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_WINDOW_1;
+    if (mbedtls_psa_async_crypto_start(provider, &rsa_operation.provider_operation,
+                                       &rsa_operation.request) != PSA_SUCCESS) {
+      reset_rsa();
+      return false;
+    }
+    rsa_operation.stage = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_EXPONENTIATION;
+    return true;
+  }
+
+  if (pss) {
+    memset(&rsa_operation.request, 0, sizeof(rsa_operation.request));
+    rsa_operation.request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM;
+    rsa_operation.request.output =
+        (mbedtls_psa_async_crypto_buffer_t){rsa_operation.salt, digest_length};
+    if (mbedtls_psa_async_crypto_start(provider, &rsa_operation.provider_operation,
+                                       &rsa_operation.request) != PSA_SUCCESS) {
+      reset_rsa();
+      return false;
+    }
+    rsa_operation.stage = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_RANDOM;
+    return true;
+  }
+
+  if (mbedtls_rsa_rsassa_pkcs1_v15_encode(&rsa_operation.rsa, rsa_operation.hash_algorithm,
+                                          (unsigned int)(digest_length), hash,
+                                          rsa_operation.encoded) != 0) {
+    reset_rsa();
+    return false;
+  }
+  memset(&rsa_operation.request, 0, sizeof(rsa_operation.request));
+  rsa_operation.request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA;
+  rsa_operation.request.modulus = (mbedtls_psa_async_crypto_const_buffer_t){
+      rsa_operation.modulus, rsa_operation.modulus_length};
+  rsa_operation.request.exponent = (mbedtls_psa_async_crypto_const_buffer_t){
+      rsa_operation.exponent, rsa_operation.modulus_length};
+  rsa_operation.request.input = (mbedtls_psa_async_crypto_const_buffer_t){
+      rsa_operation.encoded, rsa_operation.modulus_length};
+  rsa_operation.request.output =
+      (mbedtls_psa_async_crypto_buffer_t){signature_output, rsa_operation.modulus_length};
+  rsa_operation.request.rsa_mode = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_MODE_REGULAR;
+  rsa_operation.request.rsa_window = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_WINDOW_1;
+  if (mbedtls_psa_async_crypto_start(provider, &rsa_operation.provider_operation,
+                                     &rsa_operation.request) != PSA_SUCCESS) {
+    reset_rsa();
+    return false;
+  }
+  rsa_operation.stage = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_EXPONENTIATION;
+  return true;
+}
+
+static bool verify_encoded(void) {
+  if (rsa_operation.pss) {
+    return mbedtls_rsa_rsassa_pss_verify_ext_from_encoded(
+               &rsa_operation.rsa, rsa_operation.hash_algorithm,
+               (unsigned int)(rsa_operation.hash_length), rsa_operation.hash,
+               rsa_operation.hash_algorithm, MBEDTLS_RSA_SALT_LEN_ANY, rsa_operation.encoded) == 0;
+  }
+
+  uint8_t expected[MBEDTLS_PSA_CRYPTO_ASYNC_TLS_MAX_RSA_BYTES] = {0};
+  const bool valid =
+      mbedtls_rsa_rsassa_pkcs1_v15_encode(&rsa_operation.rsa, rsa_operation.hash_algorithm,
+                                          (unsigned int)(rsa_operation.hash_length),
+                                          rsa_operation.hash, expected) == 0 &&
+      memcmp(expected, rsa_operation.encoded, rsa_operation.modulus_length) == 0;
+  zeroize(expected, sizeof(expected));
+  return valid;
+}
+
+int mbedtls_psa_async_tls_bind(mbedtls_psa_async_crypto_provider_t* selected_provider) {
+  if (selected_provider == NULL || (provider != NULL && provider != selected_provider)) {
+    return 0;
+  }
+  if (provider == NULL &&
+      mbedtls_psa_async_crypto_bind_provider(selected_provider) != PSA_SUCCESS) {
+    return 0;
+  }
+  provider = selected_provider;
+  ++provider_bindings;
+  return 1;
+}
+
+int mbedtls_psa_async_tls_unbind(mbedtls_psa_async_crypto_provider_t* selected_provider) {
+  if (provider != selected_provider || provider_bindings == 0u) {
+    return 0;
+  }
+  if (provider_bindings > 1u) {
+    --provider_bindings;
+    return 1;
+  }
+  if (mbedtls_psa_async_tls_busy()) {
+    return 0;
+  }
+  if (mbedtls_psa_async_crypto_unbind_provider(selected_provider) != PSA_SUCCESS) {
+    return 0;
+  }
+  provider_bindings = 0u;
+  provider = NULL;
+  return 1;
+}
+
+int mbedtls_psa_async_tls_begin_call(void* owner) {
+  if (owner == NULL || active_call_owner != NULL) {
+    return 0;
+  }
+  active_call_owner = owner;
+  return 1;
+}
+
+void mbedtls_psa_async_tls_end_call(void* owner) {
+  if (active_call_owner == owner) {
+    active_call_owner = NULL;
+  }
+}
+
+void mbedtls_psa_async_tls_service(void) {
+  if (provider == NULL) {
+    return;
+  }
+  for (size_t index = 0u; index < MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY; ++index) {
+    service_generic(&generic_operations[index]);
+  }
+  if (rsa_operation.stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE) {
+    return;
+  }
+  const psa_status_t status =
+      mbedtls_psa_async_crypto_complete(provider, &rsa_operation.provider_operation);
+  if (status == PSA_OPERATION_INCOMPLETE) {
+    return;
+  }
+  if (status != PSA_SUCCESS) {
+    finish_rsa(false);
+    return;
+  }
+
+  if (rsa_operation.stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_RANDOM) {
+    if (mbedtls_rsa_rsassa_pss_encode_ext_with_salt(
+            &rsa_operation.rsa, rsa_operation.hash_algorithm,
+            (unsigned int)(rsa_operation.hash_length), rsa_operation.hash, MBEDTLS_RSA_SALT_LEN_ANY,
+            rsa_operation.salt, rsa_operation.hash_length, rsa_operation.encoded) != 0) {
+      finish_rsa(false);
+      return;
+    }
+    memset(&rsa_operation.provider_operation, 0, sizeof(rsa_operation.provider_operation));
+    memset(&rsa_operation.request, 0, sizeof(rsa_operation.request));
+    rsa_operation.request.operation = MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA;
+    rsa_operation.request.modulus = (mbedtls_psa_async_crypto_const_buffer_t){
+        rsa_operation.modulus, rsa_operation.modulus_length};
+    rsa_operation.request.exponent = (mbedtls_psa_async_crypto_const_buffer_t){
+        rsa_operation.exponent, rsa_operation.modulus_length};
+    rsa_operation.request.input = (mbedtls_psa_async_crypto_const_buffer_t){
+        rsa_operation.encoded, rsa_operation.modulus_length};
+    rsa_operation.request.output = (mbedtls_psa_async_crypto_buffer_t){
+        rsa_operation.signature_output, rsa_operation.modulus_length};
+    rsa_operation.request.rsa_mode = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_MODE_REGULAR;
+    rsa_operation.request.rsa_window = MBEDTLS_PSA_ASYNC_CRYPTO_RSA_WINDOW_1;
+    if (mbedtls_psa_async_crypto_start(provider, &rsa_operation.provider_operation,
+                                       &rsa_operation.request) != PSA_SUCCESS) {
+      finish_rsa(false);
+      return;
+    }
+    rsa_operation.stage = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_EXPONENTIATION;
+    return;
+  }
+
+  finish_rsa(rsa_operation.signing || verify_encoded());
+}
+
+void mbedtls_psa_async_tls_abort(void) {
+  for (size_t index = 0u; index < MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY; ++index) {
+    if (provider != NULL && generic_operations[index].stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE) {
+      (void)mbedtls_psa_async_crypto_abort(provider, &generic_operations[index].provider_operation);
+    }
+    zeroize(&generic_operations[index], sizeof(generic_operations[index]));
+  }
+  if (provider != NULL && rsa_operation.stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE) {
+    (void)mbedtls_psa_async_crypto_abort(provider, &rsa_operation.provider_operation);
+  }
+  reset_rsa();
+}
+
+void mbedtls_psa_async_tls_abort_owner(void* owner) {
+  if (owner == NULL) {
+    return;
+  }
+  for (size_t index = 0u; index < MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY; ++index) {
+    mbedtls_psa_async_tls_generic_operation_t* operation = &generic_operations[index];
+    if (operation->stage == MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE || operation->owner != owner) {
+      continue;
+    }
+    if (provider != NULL) {
+      (void)mbedtls_psa_async_crypto_abort(provider, &operation->provider_operation);
+    }
+    zeroize(operation, sizeof(*operation));
+  }
+  if (rsa_operation.stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE && rsa_operation.owner == owner) {
+    if (provider != NULL) {
+      (void)mbedtls_psa_async_crypto_abort(provider, &rsa_operation.provider_operation);
+    }
+    reset_rsa();
+  }
+}
+
+int mbedtls_psa_async_tls_busy(void) {
+  for (size_t index = 0u; index < MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_OPERATION_CAPACITY; ++index) {
+    if (generic_operations[index].stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_GENERIC_IDLE) {
+      return 1;
+    }
+  }
+  return rsa_operation.stage != MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA_IDLE ? 1 : 0;
+}
+
+void mbedtls_psa_async_tls_set_trusted_time(uint64_t unix_time) {
+  current_trusted_time = unix_time;
+}
+
+void mbedtls_psa_async_tls_clear_trusted_time(void) {
+  current_trusted_time = 0u;
+}
+
+uint64_t mbedtls_psa_async_tls_get_trusted_time(void) {
+  return current_trusted_time;
+}
+
+time_t mbedtls_platform_time(time_t* current_time) {
+  const time_t now = (time_t)(mbedtls_psa_async_tls_get_trusted_time());
+  if (current_time != NULL) {
+    *current_time = now;
+  }
+  return now;
+}
+
+int mbedtls_psa_async_tls_random_start(uint8_t* output, size_t length,
+                                        mbedtls_psa_async_tls_callback_t callback, void* context) {
+  return prepare_random(output, length, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p256_public_key_start(const uint8_t private_key[32],
+                                                      uint8_t public_key[65],
+                                                      mbedtls_psa_async_tls_callback_t callback,
+                                                      void* context) {
+  return prepare_ecdh_public(256u, private_key, public_key, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p384_public_key_start(const uint8_t private_key[48],
+                                                      uint8_t public_key[97],
+                                                      mbedtls_psa_async_tls_callback_t callback,
+                                                      void* context) {
+  return prepare_ecdh_public(384u, private_key, public_key, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p521_public_key_start(const uint8_t private_key[66],
+                                                      uint8_t public_key[133],
+                                                      mbedtls_psa_async_tls_callback_t callback,
+                                                      void* context) {
+  return prepare_ecdh_public(521u, private_key, public_key, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p256_start(const uint8_t private_key[32],
+                                           const uint8_t peer_public_key[65],
+                                           uint8_t shared_secret[32],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context) {
+  return prepare_ecdh(256u, private_key, peer_public_key, shared_secret, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p384_start(const uint8_t private_key[48],
+                                           const uint8_t peer_public_key[97],
+                                           uint8_t shared_secret[48],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context) {
+  return prepare_ecdh(384u, private_key, peer_public_key, shared_secret, callback, context) ? 1 : 0;
+}
+
+int mbedtls_psa_async_tls_ecdh_p521_start(const uint8_t private_key[66],
+                                           const uint8_t peer_public_key[133],
+                                           uint8_t shared_secret[66],
+                                           mbedtls_psa_async_tls_callback_t callback,
+                                           void* context) {
+  return prepare_ecdh(521u, private_key, peer_public_key, shared_secret, callback, context) ? 1 : 0;
+}
+
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA_HOOKS(bits, key_bytes, hash_bytes, signature_bytes)            \
+  int mbedtls_psa_async_tls_ecdsa_p##bits##_sign_start(                                            \
+      const uint8_t private_key[key_bytes], const uint8_t hash[hash_bytes],                        \
+      uint8_t signature[signature_bytes], mbedtls_psa_async_tls_callback_t callback,               \
+      void* context) {                                                                             \
+    return prepare_ecdsa_sign(bits##u, private_key, hash, signature, callback, context) ? 1 : 0;   \
+  }                                                                                                \
+  int mbedtls_psa_async_tls_ecdsa_p##bits##_verify_start(                                          \
+      const uint8_t public_key[(key_bytes * 2u) + 1u], const uint8_t hash[hash_bytes],             \
+      const uint8_t signature[signature_bytes], mbedtls_psa_async_tls_callback_t callback,         \
+      void* context) {                                                                             \
+    return prepare_ecdsa_verify(bits##u, public_key, hash, signature, callback, context) ? 1 : 0;  \
+  }
+
+MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA_HOOKS(256, 32, 32, 64)
+MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA_HOOKS(384, 48, 48, 96)
+MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA_HOOKS(521, 66, 64, 132)
+
+#undef MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA_HOOKS
+
+int mbedtls_psa_async_tls_aead_encrypt_start(int algorithm, const uint8_t* key, size_t key_length,
+                                              const uint8_t* nonce, size_t nonce_length,
+                                              const uint8_t* aad, size_t aad_length,
+                                              const uint8_t* plaintext, uint8_t* ciphertext,
+                                              size_t length, uint8_t* tag, size_t tag_length,
+                                              mbedtls_psa_async_tls_callback_t callback,
+                                              void* context) {
+  return prepare_aead(true, algorithm, key, key_length, nonce, nonce_length, aad, aad_length,
+                      plaintext, ciphertext, length, NULL, tag, tag_length, callback, context)
+             ? 1
+             : 0;
+}
+
+int mbedtls_psa_async_tls_aead_decrypt_start(int algorithm, const uint8_t* key, size_t key_length,
+                                              const uint8_t* nonce, size_t nonce_length,
+                                              const uint8_t* aad, size_t aad_length,
+                                              const uint8_t* ciphertext, uint8_t* plaintext,
+                                              size_t length, const uint8_t* tag, size_t tag_length,
+                                              mbedtls_psa_async_tls_callback_t callback,
+                                              void* context) {
+  return prepare_aead(false, algorithm, key, key_length, nonce, nonce_length, aad, aad_length,
+                      ciphertext, plaintext, length, tag, NULL, tag_length, callback, context)
+             ? 1
+             : 0;
+}
+
+int mbedtls_psa_async_tls_aes_gcm128_encrypt_start(const uint8_t key[16], const uint8_t nonce[12],
+                                                    const uint8_t* aad, size_t aad_length,
+                                                    const uint8_t* plaintext, uint8_t* ciphertext,
+                                                    size_t length, uint8_t tag[16],
+                                                    mbedtls_psa_async_tls_callback_t callback,
+                                                    void* context) {
+  return mbedtls_psa_async_tls_aead_encrypt_start(1, key, 16u, nonce, 12u, aad, aad_length,
+                                                   plaintext, ciphertext, length, tag, 16u,
+                                                   callback, context);
+}
+
+int mbedtls_psa_async_tls_aes_gcm128_decrypt_start(const uint8_t key[16], const uint8_t nonce[12],
+                                                    const uint8_t* aad, size_t aad_length,
+                                                    const uint8_t* ciphertext, uint8_t* plaintext,
+                                                    size_t length, const uint8_t tag[16],
+                                                    mbedtls_psa_async_tls_callback_t callback,
+                                                    void* context) {
+  return mbedtls_psa_async_tls_aead_decrypt_start(1, key, 16u, nonce, 12u, aad, aad_length,
+                                                   ciphertext, plaintext, length, tag, 16u,
+                                                   callback, context);
+}
+
+int mbedtls_psa_async_tls_rsa_pss_verify_start(int hash_bits, const uint8_t* public_key,
+                                                size_t public_key_length, const uint8_t* hash,
+                                                size_t hash_length, const uint8_t* signature,
+                                                size_t signature_length,
+                                                mbedtls_psa_async_tls_callback_t callback,
+                                                void* context) {
+  return prepare_rsa(false, true, hash_bits, public_key, public_key_length, hash, hash_length,
+                     signature, NULL, signature_length, callback, context)
+             ? 1
+             : 0;
+}
+
+int mbedtls_psa_async_tls_rsa_pkcs1_verify_start(int hash_bits, const uint8_t* public_key,
+                                                  size_t public_key_length, const uint8_t* hash,
+                                                  size_t hash_length, const uint8_t* signature,
+                                                  size_t signature_length,
+                                                  mbedtls_psa_async_tls_callback_t callback,
+                                                  void* context) {
+  return prepare_rsa(false, false, hash_bits, public_key, public_key_length, hash, hash_length,
+                     signature, NULL, signature_length, callback, context)
+             ? 1
+             : 0;
+}
+
+int mbedtls_psa_async_tls_rsa_pss_sign_start(int hash_bits, const uint8_t* private_key,
+                                              size_t private_key_length, const uint8_t* hash,
+                                              size_t hash_length, uint8_t* signature,
+                                              size_t signature_length,
+                                              mbedtls_psa_async_tls_callback_t callback,
+                                              void* context) {
+  return prepare_rsa(true, true, hash_bits, private_key, private_key_length, hash, hash_length,
+                     NULL, signature, signature_length, callback, context)
+             ? 1
+             : 0;
+}
+
+int mbedtls_psa_async_tls_rsa_pkcs1_sign_start(int hash_bits, const uint8_t* private_key,
+                                                size_t private_key_length, const uint8_t* hash,
+                                                size_t hash_length, uint8_t* signature,
+                                                size_t signature_length,
+                                                mbedtls_psa_async_tls_callback_t callback,
+                                                void* context) {
+  return prepare_rsa(true, false, hash_bits, private_key, private_key_length, hash, hash_length,
+                     NULL, signature, signature_length, callback, context)
+             ? 1
+             : 0;
+}

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -20,6 +20,69 @@
 #include "ssl_tls13_keys.h"
 #include "ssl_debug_helpers.h"
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+
+int samd_mbedtls_random_start(uint8_t *buffer, size_t length,
+                               samd_mbedtls_async_callback_t callback,
+                               void *context);
+
+static void samd_mbedtls_ssl_random_callback(int success, void *context)
+{
+    mbedtls_ssl_handshake_params *handshake =
+        (mbedtls_ssl_handshake_params *) context;
+    if (handshake == NULL) {
+        return;
+    }
+
+    handshake->samd_random_success = success ? 1 : 0;
+    handshake->samd_random_done = 1;
+}
+
+static int samd_mbedtls_ssl_random_fill(
+    mbedtls_ssl_context *ssl,
+    unsigned char *buffer,
+    size_t length)
+{
+    mbedtls_ssl_handshake_params *handshake;
+
+    if (ssl == NULL || ssl->handshake == NULL ||
+        buffer == NULL || length == 0) {
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    handshake = ssl->handshake;
+
+    if (handshake->samd_random_pending != 0) {
+        if (handshake->samd_random_done == 0) {
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        handshake->samd_random_pending = 0;
+        handshake->samd_random_done = 0;
+        if (handshake->samd_random_success == 0) {
+            handshake->samd_random_success = 0;
+            return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        }
+        handshake->samd_random_success = 0;
+        return 0;
+    }
+
+    handshake->samd_random_pending = 1;
+    handshake->samd_random_done = 0;
+    handshake->samd_random_success = 0;
+
+    if (samd_mbedtls_random_start(
+            buffer, length, samd_mbedtls_ssl_random_callback,
+            handshake) == 0) {
+        handshake->samd_random_pending = 0;
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+    }
+
+    return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+}
+#endif
+
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_write_hostname_ext(mbedtls_ssl_context *ssl,
@@ -725,8 +788,14 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_HAVE_TIME */
     }
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    ret = samd_mbedtls_ssl_random_fill(
+        ssl, randbytes + gmt_unix_time_len,
+        MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
+#else
     ret = psa_generate_random(randbytes + gmt_unix_time_len,
                               MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
+#endif
     return ret;
 }
 
@@ -867,8 +936,13 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         session_negotiate->id_len = session_id_len;
         if (session_id_len > 0) {
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+            ret = samd_mbedtls_ssl_random_fill(
+                ssl, session_negotiate->id, session_id_len);
+#else
             ret = psa_generate_random(session_negotiate->id,
                                       session_id_len);
+#endif
             if (ret != 0) {
                 MBEDTLS_SSL_DEBUG_RET(1, "creating session id failed", ret);
                 return ret;

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -20,14 +20,10 @@
 #include "ssl_tls13_keys.h"
 #include "ssl_debug_helpers.h"
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+#include "mbedtls/psa_crypto_async_tls.h"
 
-int mbedtls_async_hardware_random_start(uint8_t *buffer, size_t length,
-                               mbedtls_async_hardware_callback_t callback,
-                               void *context);
-
-static void mbedtls_async_hardware_ssl_random_callback(int success, void *context)
+static void mbedtls_psa_async_tls_ssl_random_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -35,11 +31,11 @@ static void mbedtls_async_hardware_ssl_random_callback(int success, void *contex
         return;
     }
 
-    handshake->async_hardware_random_success = success ? 1 : 0;
-    handshake->async_hardware_random_done = 1;
+    handshake->async_psa_random_success = success ? 1 : 0;
+    handshake->async_psa_random_done = 1;
 }
 
-static int mbedtls_async_hardware_ssl_random_fill(
+static int mbedtls_psa_async_tls_ssl_random_fill(
     mbedtls_ssl_context *ssl,
     unsigned char *buffer,
     size_t length)
@@ -53,29 +49,29 @@ static int mbedtls_async_hardware_ssl_random_fill(
 
     handshake = ssl->handshake;
 
-    if (handshake->async_hardware_random_pending != 0) {
-        if (handshake->async_hardware_random_done == 0) {
+    if (handshake->async_psa_random_pending != 0) {
+        if (handshake->async_psa_random_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->async_hardware_random_pending = 0;
-        handshake->async_hardware_random_done = 0;
-        if (handshake->async_hardware_random_success == 0) {
-            handshake->async_hardware_random_success = 0;
+        handshake->async_psa_random_pending = 0;
+        handshake->async_psa_random_done = 0;
+        if (handshake->async_psa_random_success == 0) {
+            handshake->async_psa_random_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->async_hardware_random_success = 0;
+        handshake->async_psa_random_success = 0;
         return 0;
     }
 
-    handshake->async_hardware_random_pending = 1;
-    handshake->async_hardware_random_done = 0;
-    handshake->async_hardware_random_success = 0;
+    handshake->async_psa_random_pending = 1;
+    handshake->async_psa_random_done = 0;
+    handshake->async_psa_random_success = 0;
 
-    if (mbedtls_async_hardware_random_start(
-            buffer, length, mbedtls_async_hardware_ssl_random_callback,
+    if (mbedtls_psa_async_tls_random_start(
+            buffer, length, mbedtls_psa_async_tls_ssl_random_callback,
             handshake) == 0) {
-        handshake->async_hardware_random_pending = 0;
+        handshake->async_psa_random_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
@@ -764,8 +760,8 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     unsigned char *randbytes = ssl->handshake->randbytes;
     size_t gmt_unix_time_len = 0;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    if (ssl->handshake->async_hardware_client_random_ready != 0) {
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+    if (ssl->handshake->async_psa_client_random_ready != 0) {
         return 0;
     }
 #endif
@@ -794,12 +790,12 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_HAVE_TIME */
     }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    ret = mbedtls_async_hardware_ssl_random_fill(
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+    ret = mbedtls_psa_async_tls_ssl_random_fill(
         ssl, randbytes + gmt_unix_time_len,
         MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
     if (ret == 0) {
-        ssl->handshake->async_hardware_client_random_ready = 1;
+        ssl->handshake->async_psa_client_random_ready = 1;
     }
 #else
     ret = psa_generate_random(randbytes + gmt_unix_time_len,
@@ -945,8 +941,8 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         session_negotiate->id_len = session_id_len;
         if (session_id_len > 0) {
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-            ret = mbedtls_async_hardware_ssl_random_fill(
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+            ret = mbedtls_psa_async_tls_ssl_random_fill(
                 ssl, session_negotiate->id, session_id_len);
 #else
             ret = psa_generate_random(session_negotiate->id,

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -21,13 +21,13 @@
 #include "ssl_debug_helpers.h"
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
 
-int samd_mbedtls_random_start(uint8_t *buffer, size_t length,
-                               samd_mbedtls_async_callback_t callback,
+int mbedtls_async_hardware_random_start(uint8_t *buffer, size_t length,
+                               mbedtls_async_hardware_callback_t callback,
                                void *context);
 
-static void samd_mbedtls_ssl_random_callback(int success, void *context)
+static void mbedtls_async_hardware_ssl_random_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -35,11 +35,11 @@ static void samd_mbedtls_ssl_random_callback(int success, void *context)
         return;
     }
 
-    handshake->samd_random_success = success ? 1 : 0;
-    handshake->samd_random_done = 1;
+    handshake->async_hardware_random_success = success ? 1 : 0;
+    handshake->async_hardware_random_done = 1;
 }
 
-static int samd_mbedtls_ssl_random_fill(
+static int mbedtls_async_hardware_ssl_random_fill(
     mbedtls_ssl_context *ssl,
     unsigned char *buffer,
     size_t length)
@@ -53,29 +53,29 @@ static int samd_mbedtls_ssl_random_fill(
 
     handshake = ssl->handshake;
 
-    if (handshake->samd_random_pending != 0) {
-        if (handshake->samd_random_done == 0) {
+    if (handshake->async_hardware_random_pending != 0) {
+        if (handshake->async_hardware_random_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->samd_random_pending = 0;
-        handshake->samd_random_done = 0;
-        if (handshake->samd_random_success == 0) {
-            handshake->samd_random_success = 0;
+        handshake->async_hardware_random_pending = 0;
+        handshake->async_hardware_random_done = 0;
+        if (handshake->async_hardware_random_success == 0) {
+            handshake->async_hardware_random_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->samd_random_success = 0;
+        handshake->async_hardware_random_success = 0;
         return 0;
     }
 
-    handshake->samd_random_pending = 1;
-    handshake->samd_random_done = 0;
-    handshake->samd_random_success = 0;
+    handshake->async_hardware_random_pending = 1;
+    handshake->async_hardware_random_done = 0;
+    handshake->async_hardware_random_success = 0;
 
-    if (samd_mbedtls_random_start(
-            buffer, length, samd_mbedtls_ssl_random_callback,
+    if (mbedtls_async_hardware_random_start(
+            buffer, length, mbedtls_async_hardware_ssl_random_callback,
             handshake) == 0) {
-        handshake->samd_random_pending = 0;
+        handshake->async_hardware_random_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
@@ -765,7 +765,7 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     size_t gmt_unix_time_len = 0;
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    if (ssl->handshake->samd_client_random_ready != 0) {
+    if (ssl->handshake->async_hardware_client_random_ready != 0) {
         return 0;
     }
 #endif
@@ -795,11 +795,11 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     }
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    ret = samd_mbedtls_ssl_random_fill(
+    ret = mbedtls_async_hardware_ssl_random_fill(
         ssl, randbytes + gmt_unix_time_len,
         MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
     if (ret == 0) {
-        ssl->handshake->samd_client_random_ready = 1;
+        ssl->handshake->async_hardware_client_random_ready = 1;
     }
 #else
     ret = psa_generate_random(randbytes + gmt_unix_time_len,
@@ -946,7 +946,7 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         if (session_id_len > 0) {
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-            ret = samd_mbedtls_ssl_random_fill(
+            ret = mbedtls_async_hardware_ssl_random_fill(
                 ssl, session_negotiate->id, session_id_len);
 #else
             ret = psa_generate_random(session_negotiate->id,

--- a/library/ssl_client.c
+++ b/library/ssl_client.c
@@ -764,6 +764,12 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     unsigned char *randbytes = ssl->handshake->randbytes;
     size_t gmt_unix_time_len = 0;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    if (ssl->handshake->samd_client_random_ready != 0) {
+        return 0;
+    }
+#endif
+
     /*
      * Generate the random bytes
      *
@@ -792,6 +798,9 @@ static int ssl_generate_random(mbedtls_ssl_context *ssl)
     ret = samd_mbedtls_ssl_random_fill(
         ssl, randbytes + gmt_unix_time_len,
         MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);
+    if (ret == 0) {
+        ssl->handshake->samd_client_random_ready = 1;
+    }
 #else
     ret = psa_generate_random(randbytes + gmt_unix_time_len,
                               MBEDTLS_CLIENT_HELLO_RANDOM_LEN - gmt_unix_time_len);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -713,8 +713,8 @@ struct mbedtls_ssl_handshake_params {
     uint8_t samd_ecdh_secret_done;
     uint8_t samd_ecdh_secret_success;
     uint8_t samd_ecdh_secret_ready;
-    unsigned char samd_ecdh_private_scalar[32];
-    unsigned char samd_ecdh_public_key[65];
+    unsigned char samd_ecdh_private_scalar[48];
+    unsigned char samd_ecdh_public_key[97];
 #endif
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -714,8 +714,8 @@ struct mbedtls_ssl_handshake_params {
     uint8_t samd_ecdh_secret_done;
     uint8_t samd_ecdh_secret_success;
     uint8_t samd_ecdh_secret_ready;
-    unsigned char samd_ecdh_private_scalar[48];
-    unsigned char samd_ecdh_public_key[97];
+    unsigned char samd_ecdh_private_scalar[66];
+    unsigned char samd_ecdh_public_key[133];
 #endif
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
@@ -924,6 +924,9 @@ struct mbedtls_ssl_handshake_params {
 #endif
 #if defined(PSA_WANT_ALG_SHA_384)
     psa_hash_operation_t fin_sha384_psa;
+#endif
+#if defined(PSA_WANT_ALG_SHA_512)
+    psa_hash_operation_t fin_sha512_psa;
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
@@ -2336,7 +2339,6 @@ static inline const void *mbedtls_ssl_get_sig_algs(
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 }
 
-#if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
 static inline int mbedtls_ssl_sig_alg_is_received(const mbedtls_ssl_context *ssl,
                                                   uint16_t own_sig_alg)
 {
@@ -2353,6 +2355,7 @@ static inline int mbedtls_ssl_sig_alg_is_received(const mbedtls_ssl_context *ssl
     return 0;
 }
 
+#if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
 static inline int mbedtls_ssl_tls13_sig_alg_for_cert_verify_is_supported(
     const uint16_t sig_alg)
 {
@@ -2481,6 +2484,25 @@ static inline int mbedtls_ssl_get_pk_sigalg_and_md_alg_from_sig_alg(
 static inline int mbedtls_ssl_tls12_sig_alg_is_supported(
     const uint16_t sig_alg)
 {
+    switch (sig_alg) {
+#if defined(PSA_WANT_ALG_RSA_PSS)
+#if defined(PSA_WANT_ALG_SHA_256)
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA256:
+            return 1;
+#endif
+#if defined(PSA_WANT_ALG_SHA_384)
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384:
+            return 1;
+#endif
+#if defined(PSA_WANT_ALG_SHA_512)
+        case MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA512:
+            return 1;
+#endif
+#endif /* PSA_WANT_ALG_RSA_PSS */
+        default:
+            break;
+    }
+
     /* High byte is hash */
     unsigned char hash = MBEDTLS_BYTE_1(sig_alg);
     unsigned char sig = MBEDTLS_BYTE_0(sig_alg);

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -704,6 +704,7 @@ struct mbedtls_ssl_handshake_params {
     uint8_t samd_random_pending;
     uint8_t samd_random_done;
     uint8_t samd_random_success;
+    uint8_t samd_client_random_ready;
     uint8_t samd_ecdh_public_pending;
     uint8_t samd_ecdh_public_done;
     uint8_t samd_ecdh_public_success;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -701,21 +701,21 @@ struct mbedtls_ssl_handshake_params {
 #endif
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    uint8_t samd_random_pending;
-    uint8_t samd_random_done;
-    uint8_t samd_random_success;
-    uint8_t samd_client_random_ready;
-    uint8_t samd_ecdh_public_pending;
-    uint8_t samd_ecdh_public_done;
-    uint8_t samd_ecdh_public_success;
-    uint8_t samd_ecdh_public_ready;
-    uint8_t samd_ecdh_private_ready;
-    uint8_t samd_ecdh_secret_pending;
-    uint8_t samd_ecdh_secret_done;
-    uint8_t samd_ecdh_secret_success;
-    uint8_t samd_ecdh_secret_ready;
-    unsigned char samd_ecdh_private_scalar[66];
-    unsigned char samd_ecdh_public_key[133];
+    uint8_t async_hardware_random_pending;
+    uint8_t async_hardware_random_done;
+    uint8_t async_hardware_random_success;
+    uint8_t async_hardware_client_random_ready;
+    uint8_t async_hardware_ecdh_public_pending;
+    uint8_t async_hardware_ecdh_public_done;
+    uint8_t async_hardware_ecdh_public_success;
+    uint8_t async_hardware_ecdh_public_ready;
+    uint8_t async_hardware_ecdh_private_ready;
+    uint8_t async_hardware_ecdh_secret_pending;
+    uint8_t async_hardware_ecdh_secret_done;
+    uint8_t async_hardware_ecdh_secret_success;
+    uint8_t async_hardware_ecdh_secret_ready;
+    unsigned char async_hardware_ecdh_private_scalar[66];
+    unsigned char async_hardware_ecdh_public_key[133];
 #endif
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
@@ -1137,14 +1137,14 @@ struct mbedtls_ssl_transform {
     psa_algorithm_t psa_alg;                    /*!<  psa algorithm           */
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    unsigned char samd_aead_key_enc[32];
-    unsigned char samd_aead_key_dec[32];
-    size_t samd_aead_key_len;
-    unsigned char samd_aead_algorithm;
-    unsigned char samd_aead_keys_configured;
-    unsigned char samd_aead_pending;
-    unsigned char samd_aead_done;
-    unsigned char samd_aead_success;
+    unsigned char async_hardware_aead_key_enc[32];
+    unsigned char async_hardware_aead_key_dec[32];
+    size_t async_hardware_aead_key_len;
+    unsigned char async_hardware_aead_algorithm;
+    unsigned char async_hardware_aead_keys_configured;
+    unsigned char async_hardware_aead_pending;
+    unsigned char async_hardware_aead_done;
+    unsigned char async_hardware_aead_success;
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -27,6 +27,16 @@ extern const mbedtls_error_pair_t psa_to_ssl_errors[7];
 #include "ssl_ciphersuites_internal.h"
 #include "x509_internal.h"
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM 1
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM 2
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM 3
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM 4
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM_8 5
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM_8 6
+#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305 7
+#endif
+
 /* Shorthand for restartable ECC */
 #if defined(MBEDTLS_ECP_RESTARTABLE) && \
     defined(MBEDTLS_SSL_CLI_C) && \
@@ -690,6 +700,23 @@ struct mbedtls_ssl_handshake_params {
     unsigned char retransmit_state;     /*!<  Retransmission state           */
 #endif
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    uint8_t samd_random_pending;
+    uint8_t samd_random_done;
+    uint8_t samd_random_success;
+    uint8_t samd_ecdh_public_pending;
+    uint8_t samd_ecdh_public_done;
+    uint8_t samd_ecdh_public_success;
+    uint8_t samd_ecdh_public_ready;
+    uint8_t samd_ecdh_private_ready;
+    uint8_t samd_ecdh_secret_pending;
+    uint8_t samd_ecdh_secret_done;
+    uint8_t samd_ecdh_secret_success;
+    uint8_t samd_ecdh_secret_ready;
+    unsigned char samd_ecdh_private_scalar[32];
+    unsigned char samd_ecdh_public_key[65];
+#endif
+
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
     uint8_t ecrs_enabled;               /*!< Handshake supports EC restart? */
     enum { /* this complements ssl->state with info on intra-state operations */
@@ -760,6 +787,9 @@ struct mbedtls_ssl_handshake_params {
     uint8_t xxdh_psa_privkey_is_external;
     unsigned char xxdh_psa_peerkey[PSA_EXPORT_PUBLIC_KEY_MAX_SIZE];
     size_t xxdh_psa_peerkey_len;
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    psa_key_agreement_iop_t xxdh_psa_iop;
+#endif
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_XXDH_PSA_ANY_ENABLED */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
@@ -1100,6 +1130,17 @@ struct mbedtls_ssl_transform {
     mbedtls_svc_key_id_t psa_key_enc;           /*!<  psa encryption key      */
     mbedtls_svc_key_id_t psa_key_dec;           /*!<  psa decryption key      */
     psa_algorithm_t psa_alg;                    /*!<  psa algorithm           */
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    unsigned char samd_aead_key_enc[32];
+    unsigned char samd_aead_key_dec[32];
+    size_t samd_aead_key_len;
+    unsigned char samd_aead_algorithm;
+    unsigned char samd_aead_keys_configured;
+    unsigned char samd_aead_pending;
+    unsigned char samd_aead_done;
+    unsigned char samd_aead_success;
+#endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     uint8_t in_cid_len;

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -789,6 +789,7 @@ struct mbedtls_ssl_handshake_params {
     size_t xxdh_psa_peerkey_len;
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
     psa_key_agreement_iop_t xxdh_psa_iop;
+    uint8_t xxdh_psa_iop_active;
 #endif
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_XXDH_PSA_ANY_ENABLED */
 
@@ -1763,6 +1764,16 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2(mbedtls_ssl_context *ssl,
 #endif
 
 void mbedtls_ssl_transform_init(mbedtls_ssl_transform *transform);
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+MBEDTLS_CHECK_RETURN_CRITICAL
+int mbedtls_ssl_configure_async_aead_transform(
+    mbedtls_ssl_transform *transform,
+    psa_key_type_t key_type,
+    psa_algorithm_t alg,
+    const unsigned char *key_enc,
+    const unsigned char *key_dec,
+    size_t key_len);
+#endif
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                             mbedtls_ssl_transform *transform,

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -27,14 +27,14 @@ extern const mbedtls_error_pair_t psa_to_ssl_errors[7];
 #include "ssl_ciphersuites_internal.h"
 #include "x509_internal.h"
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM 1
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM 2
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM 3
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM 4
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM_8 5
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM_8 6
-#define MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305 7
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_GCM 1
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_GCM 2
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_CCM 3
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_CCM 4
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_CCM_8 5
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_CCM_8 6
+#define MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_CHACHA20_POLY1305 7
 #endif
 
 /* Shorthand for restartable ECC */
@@ -699,22 +699,22 @@ struct mbedtls_ssl_handshake_params {
     unsigned char retransmit_state;     /*!<  Retransmission state           */
 #endif
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-    uint8_t async_hardware_random_pending;
-    uint8_t async_hardware_random_done;
-    uint8_t async_hardware_random_success;
-    uint8_t async_hardware_client_random_ready;
-    uint8_t async_hardware_ecdh_public_pending;
-    uint8_t async_hardware_ecdh_public_done;
-    uint8_t async_hardware_ecdh_public_success;
-    uint8_t async_hardware_ecdh_public_ready;
-    uint8_t async_hardware_ecdh_private_ready;
-    uint8_t async_hardware_ecdh_secret_pending;
-    uint8_t async_hardware_ecdh_secret_done;
-    uint8_t async_hardware_ecdh_secret_success;
-    uint8_t async_hardware_ecdh_secret_ready;
-    unsigned char async_hardware_ecdh_private_scalar[66];
-    unsigned char async_hardware_ecdh_public_key[133];
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+    uint8_t async_psa_random_pending;
+    uint8_t async_psa_random_done;
+    uint8_t async_psa_random_success;
+    uint8_t async_psa_client_random_ready;
+    uint8_t async_psa_ecdh_public_pending;
+    uint8_t async_psa_ecdh_public_done;
+    uint8_t async_psa_ecdh_public_success;
+    uint8_t async_psa_ecdh_public_ready;
+    uint8_t async_psa_ecdh_private_ready;
+    uint8_t async_psa_ecdh_secret_pending;
+    uint8_t async_psa_ecdh_secret_done;
+    uint8_t async_psa_ecdh_secret_success;
+    uint8_t async_psa_ecdh_secret_ready;
+    unsigned char async_psa_ecdh_private_scalar[66];
+    unsigned char async_psa_ecdh_public_key[133];
 #endif
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
@@ -1138,15 +1138,15 @@ struct mbedtls_ssl_transform {
     mbedtls_svc_key_id_t psa_key_dec;           /*!<  psa decryption key      */
     psa_algorithm_t psa_alg;                    /*!<  psa algorithm           */
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    unsigned char async_hardware_aead_key_enc[32];
-    unsigned char async_hardware_aead_key_dec[32];
-    size_t async_hardware_aead_key_len;
-    unsigned char async_hardware_aead_algorithm;
-    unsigned char async_hardware_aead_keys_configured;
-    unsigned char async_hardware_aead_pending;
-    unsigned char async_hardware_aead_done;
-    unsigned char async_hardware_aead_success;
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+    unsigned char async_psa_aead_key_enc[32];
+    unsigned char async_psa_aead_key_dec[32];
+    size_t async_psa_aead_key_len;
+    unsigned char async_psa_aead_algorithm;
+    unsigned char async_psa_aead_keys_configured;
+    unsigned char async_psa_aead_pending;
+    unsigned char async_psa_aead_done;
+    unsigned char async_psa_aead_success;
 #endif
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
@@ -1770,7 +1770,7 @@ int mbedtls_ssl_get_key_exchange_md_tls1_2(mbedtls_ssl_context *ssl,
 #endif
 
 void mbedtls_ssl_transform_init(mbedtls_ssl_transform *transform);
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_ssl_configure_async_aead_transform(
     mbedtls_ssl_transform *transform,

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -724,6 +724,8 @@ struct mbedtls_ssl_handshake_params {
         ssl_ecrs_crt_verify,            /*!< Certificate: crt_verify()      */
         ssl_ecrs_ske_start_processing,  /*!< ServerKeyExchange: pk_verify() */
         ssl_ecrs_ske_sign,              /*!< ServerKeyExchange: pk_sign()   */
+        ssl_ecrs_tls13_server_hello_finalize, /*!< ServerHello: key schedule */
+        ssl_ecrs_tls13_server_hello_postprocess, /*!< ServerHello: peer key schedule */
         ssl_ecrs_cke_ecdh_calc_secret,  /*!< ClientKeyExchange: ECDH step 2 */
         ssl_ecrs_crt_vrfy_sign,         /*!< CertificateVerify: pk_sign()   */
     } ecrs_state;                       /*!< current (or last) operation    */

--- a/library/ssl_misc.h
+++ b/library/ssl_misc.h
@@ -39,9 +39,8 @@ extern const mbedtls_error_pair_t psa_to_ssl_errors[7];
 
 /* Shorthand for restartable ECC */
 #if defined(MBEDTLS_ECP_RESTARTABLE) && \
-    defined(MBEDTLS_SSL_CLI_C) && \
-    defined(MBEDTLS_SSL_PROTO_TLS1_2) && \
-    defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
+    defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED) && \
+    (defined(MBEDTLS_SSL_CLI_C) || defined(MBEDTLS_SSL_SRV_C))
 #define MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED
 #endif
 
@@ -724,6 +723,7 @@ struct mbedtls_ssl_handshake_params {
         ssl_ecrs_none = 0,              /*!< nothing going on (yet)         */
         ssl_ecrs_crt_verify,            /*!< Certificate: crt_verify()      */
         ssl_ecrs_ske_start_processing,  /*!< ServerKeyExchange: pk_verify() */
+        ssl_ecrs_ske_sign,              /*!< ServerKeyExchange: pk_sign()   */
         ssl_ecrs_cke_ecdh_calc_secret,  /*!< ClientKeyExchange: ECDH step 2 */
         ssl_ecrs_crt_vrfy_sign,         /*!< CertificateVerify: pk_sign()   */
     } ecrs_state;                       /*!< current (or last) operation    */

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -44,58 +44,58 @@ static int local_err_translation(psa_status_t status)
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
 
-int samd_mbedtls_aes_gcm128_encrypt_start(
+int mbedtls_async_hardware_aes_gcm128_encrypt_start(
     const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
     size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
-    size_t length, uint8_t tag[16], samd_mbedtls_async_callback_t callback,
+    size_t length, uint8_t tag[16], mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_aes_gcm128_decrypt_start(
+int mbedtls_async_hardware_aes_gcm128_decrypt_start(
     const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
     size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
     size_t length, const uint8_t tag[16],
-    samd_mbedtls_async_callback_t callback, void *context);
-int samd_mbedtls_aead_encrypt_start(
+    mbedtls_async_hardware_callback_t callback, void *context);
+int mbedtls_async_hardware_aead_encrypt_start(
     int algorithm, const uint8_t *key, size_t keyLength,
     const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
     size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
     size_t length, uint8_t *tag, size_t tagLength,
-    samd_mbedtls_async_callback_t callback, void *context);
-int samd_mbedtls_aead_decrypt_start(
+    mbedtls_async_hardware_callback_t callback, void *context);
+int mbedtls_async_hardware_aead_decrypt_start(
     int algorithm, const uint8_t *key, size_t keyLength,
     const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
     size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
     size_t length, const uint8_t *tag, size_t tagLength,
-    samd_mbedtls_async_callback_t callback, void *context);
+    mbedtls_async_hardware_callback_t callback, void *context);
 
-static void samd_mbedtls_ssl_aead_callback(int success, void *context)
+static void mbedtls_async_hardware_ssl_aead_callback(int success, void *context)
 {
     mbedtls_ssl_transform *transform = (mbedtls_ssl_transform *) context;
     if (transform == NULL) {
         return;
     }
 
-    transform->samd_aead_success = success ? 1 : 0;
-    transform->samd_aead_done = 1;
+    transform->async_hardware_aead_success = success ? 1 : 0;
+    transform->async_hardware_aead_done = 1;
 }
 
 /**
- * @brief Return whether the transform has explicit SAMD AEAD metadata.
+ * @brief Return whether the transform has explicit async hardware AEAD metadata.
  *
  * @todo Extend the provider dispatch behind this metadata for AES-256-GCM,
  * AES-CCM, AES-CCM-8, and ChaCha20-Poly1305. Until then those algorithms are
  * intentional fail-closed stubs instead of PSA/software fallbacks.
  */
-static int samd_mbedtls_ssl_transform_has_aead(
+static int mbedtls_async_hardware_ssl_transform_has_aead(
     const mbedtls_ssl_transform *transform)
 {
     return transform != NULL &&
-           transform->samd_aead_keys_configured != 0 &&
-           transform->samd_aead_algorithm != 0 &&
-           transform->samd_aead_key_len != 0 &&
-           transform->samd_aead_key_len <=
-               sizeof(transform->samd_aead_key_enc) &&
+           transform->async_hardware_aead_keys_configured != 0 &&
+           transform->async_hardware_aead_algorithm != 0 &&
+           transform->async_hardware_aead_key_len != 0 &&
+           transform->async_hardware_aead_key_len <=
+               sizeof(transform->async_hardware_aead_key_enc) &&
            transform->ivlen == 12;
 }
 
@@ -110,7 +110,7 @@ int mbedtls_ssl_configure_async_aead_transform(
     unsigned char async_algorithm = 0;
 
     if (transform == NULL || key_enc == NULL || key_dec == NULL ||
-        key_len == 0 || key_len > sizeof(transform->samd_aead_key_enc) ||
+        key_len == 0 || key_len > sizeof(transform->async_hardware_aead_key_enc) ||
         transform->ivlen != 12 || transform->taglen != 16) {
         return 0;
     }
@@ -146,11 +146,11 @@ int mbedtls_ssl_configure_async_aead_transform(
         }
     }
 
-    memcpy(transform->samd_aead_key_enc, key_enc, key_len);
-    memcpy(transform->samd_aead_key_dec, key_dec, key_len);
-    transform->samd_aead_key_len = key_len;
-    transform->samd_aead_algorithm = async_algorithm;
-    transform->samd_aead_keys_configured = 1;
+    memcpy(transform->async_hardware_aead_key_enc, key_enc, key_len);
+    memcpy(transform->async_hardware_aead_key_dec, key_dec, key_len);
+    transform->async_hardware_aead_key_len = key_len;
+    transform->async_hardware_aead_algorithm = async_algorithm;
+    transform->async_hardware_aead_keys_configured = 1;
     return 1;
 }
 #endif
@@ -1101,8 +1101,8 @@ hmac_failed_etm_disabled:
         int dynamic_iv_is_explicit =
             ssl_transform_aead_dynamic_iv_is_explicit(transform);
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        int use_samd_aead =
-            samd_mbedtls_ssl_transform_has_aead(transform);
+        int use_async_hardware_aead =
+            mbedtls_async_hardware_ssl_transform_has_aead(transform);
 #endif
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -1129,17 +1129,17 @@ hmac_failed_etm_disabled:
         dynamic_iv_len = sizeof(rec->ctr);
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_samd_aead && transform->samd_aead_pending != 0) {
-            if (transform->samd_aead_done == 0) {
+        if (use_async_hardware_aead && transform->async_hardware_aead_pending != 0) {
+            if (transform->async_hardware_aead_done == 0) {
                 return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
-            transform->samd_aead_pending = 0;
-            transform->samd_aead_done = 0;
-            if (transform->samd_aead_success == 0) {
-                transform->samd_aead_success = 0;
+            transform->async_hardware_aead_pending = 0;
+            transform->async_hardware_aead_done = 0;
+            if (transform->async_hardware_aead_success == 0) {
+                transform->async_hardware_aead_success = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
-            transform->samd_aead_success = 0;
+            transform->async_hardware_aead_success = 0;
 
             MBEDTLS_SSL_DEBUG_BUF(4, "after encrypt: tag",
                                   data + rec->data_len,
@@ -1161,7 +1161,7 @@ hmac_failed_etm_disabled:
             }
 
             auth_done++;
-            goto samd_aead_encrypt_done;
+            goto async_hardware_aead_encrypt_done;
         }
 #endif
 
@@ -1194,20 +1194,20 @@ hmac_failed_etm_disabled:
          * Encrypt and authenticate
          */
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_samd_aead) {
-            transform->samd_aead_pending = 1;
-            transform->samd_aead_done = 0;
-            transform->samd_aead_success = 0;
-            if (samd_mbedtls_aead_encrypt_start(
-                    transform->samd_aead_algorithm,
-                    transform->samd_aead_key_enc,
-                    transform->samd_aead_key_len,
+        if (use_async_hardware_aead) {
+            transform->async_hardware_aead_pending = 1;
+            transform->async_hardware_aead_done = 0;
+            transform->async_hardware_aead_success = 0;
+            if (mbedtls_async_hardware_aead_encrypt_start(
+                    transform->async_hardware_aead_algorithm,
+                    transform->async_hardware_aead_key_enc,
+                    transform->async_hardware_aead_key_len,
                     iv, transform->ivlen, add_data, add_data_len,
                     data, data, rec->data_len,
                     data + rec->data_len, transform->taglen,
-                    samd_mbedtls_ssl_aead_callback,
+                    mbedtls_async_hardware_ssl_aead_callback,
                     transform) == 0) {
-                transform->samd_aead_pending = 0;
+                transform->async_hardware_aead_pending = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
@@ -1251,7 +1251,7 @@ hmac_failed_etm_disabled:
 
         auth_done++;
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-samd_aead_encrypt_done:
+async_hardware_aead_encrypt_done:
         (void) 0;
 #endif
     } else
@@ -1523,25 +1523,25 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
         unsigned char *dynamic_iv;
         size_t dynamic_iv_len;
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        int use_samd_aead =
-            samd_mbedtls_ssl_transform_has_aead(transform);
+        int use_async_hardware_aead =
+            mbedtls_async_hardware_ssl_transform_has_aead(transform);
 #endif
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_samd_aead && transform->samd_aead_pending != 0) {
-            if (transform->samd_aead_done == 0) {
+        if (use_async_hardware_aead && transform->async_hardware_aead_pending != 0) {
+            if (transform->async_hardware_aead_done == 0) {
                 return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
-            transform->samd_aead_pending = 0;
-            transform->samd_aead_done = 0;
-            if (transform->samd_aead_success == 0) {
-                transform->samd_aead_success = 0;
+            transform->async_hardware_aead_pending = 0;
+            transform->async_hardware_aead_done = 0;
+            if (transform->async_hardware_aead_success == 0) {
+                transform->async_hardware_aead_success = 0;
                 return MBEDTLS_ERR_SSL_INVALID_MAC;
             }
-            transform->samd_aead_success = 0;
+            transform->async_hardware_aead_success = 0;
             auth_done++;
-            goto samd_aead_decrypt_done;
+            goto async_hardware_aead_decrypt_done;
         }
 #endif
 
@@ -1614,20 +1614,20 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
          * Decrypt and authenticate
          */
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_samd_aead) {
-            transform->samd_aead_pending = 1;
-            transform->samd_aead_done = 0;
-            transform->samd_aead_success = 0;
-            if (samd_mbedtls_aead_decrypt_start(
-                    transform->samd_aead_algorithm,
-                    transform->samd_aead_key_dec,
-                    transform->samd_aead_key_len,
+        if (use_async_hardware_aead) {
+            transform->async_hardware_aead_pending = 1;
+            transform->async_hardware_aead_done = 0;
+            transform->async_hardware_aead_success = 0;
+            if (mbedtls_async_hardware_aead_decrypt_start(
+                    transform->async_hardware_aead_algorithm,
+                    transform->async_hardware_aead_key_dec,
+                    transform->async_hardware_aead_key_len,
                     iv, transform->ivlen, add_data, add_data_len,
                     data, data, rec->data_len,
                     data + rec->data_len, transform->taglen,
-                    samd_mbedtls_ssl_aead_callback,
+                    mbedtls_async_hardware_ssl_aead_callback,
                     transform) == 0) {
-                transform->samd_aead_pending = 0;
+                transform->async_hardware_aead_pending = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
@@ -1657,7 +1657,7 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-samd_aead_decrypt_done:
+async_hardware_aead_decrypt_done:
         (void) 0;
 #endif
     } else
@@ -4934,7 +4934,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
     if (ssl->transform_in != NULL &&
-        ssl->transform_in->samd_aead_pending != 0) {
+        ssl->transform_in->async_hardware_aead_pending != 0) {
         const size_t header_len = mbedtls_ssl_in_hdr_len(ssl);
         const size_t explicit_iv_len =
             ssl_transform_aead_dynamic_iv_is_explicit(ssl->transform_in) ?
@@ -4958,7 +4958,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
             return ret;
         }
 
-        goto samd_aead_record_content_ready;
+        goto async_hardware_aead_record_content_ready;
     }
 #endif
 
@@ -5148,7 +5148,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
 
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-samd_aead_record_content_ready:
+async_hardware_aead_record_content_ready:
 #endif
 
     /* Reset in pointers to default state for TLS/DTLS records,
@@ -6149,7 +6149,7 @@ static int ssl_write_real(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
     if (ssl->transform_out != NULL &&
-        ssl->transform_out->samd_aead_pending != 0) {
+        ssl->transform_out->async_hardware_aead_pending != 0) {
         if ((ret = mbedtls_ssl_write_record(ssl, SSL_FORCE_FLUSH)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_record", ret);
             return ret;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -43,6 +43,63 @@ static int local_err_translation(psa_status_t status)
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+
+int samd_mbedtls_aes_gcm128_encrypt_start(
+    const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
+    size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
+    size_t length, uint8_t tag[16], samd_mbedtls_async_callback_t callback,
+    void *context);
+int samd_mbedtls_aes_gcm128_decrypt_start(
+    const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
+    size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
+    size_t length, const uint8_t tag[16],
+    samd_mbedtls_async_callback_t callback, void *context);
+int samd_mbedtls_aead_encrypt_start(
+    int algorithm, const uint8_t *key, size_t keyLength,
+    const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
+    size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
+    size_t length, uint8_t *tag, size_t tagLength,
+    samd_mbedtls_async_callback_t callback, void *context);
+int samd_mbedtls_aead_decrypt_start(
+    int algorithm, const uint8_t *key, size_t keyLength,
+    const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
+    size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
+    size_t length, const uint8_t *tag, size_t tagLength,
+    samd_mbedtls_async_callback_t callback, void *context);
+
+static void samd_mbedtls_ssl_aead_callback(int success, void *context)
+{
+    mbedtls_ssl_transform *transform = (mbedtls_ssl_transform *) context;
+    if (transform == NULL) {
+        return;
+    }
+
+    transform->samd_aead_success = success ? 1 : 0;
+    transform->samd_aead_done = 1;
+}
+
+/**
+ * @brief Return whether the transform has explicit SAMD AEAD metadata.
+ *
+ * @todo Extend the provider dispatch behind this metadata for AES-256-GCM,
+ * AES-CCM, AES-CCM-8, and ChaCha20-Poly1305. Until then those algorithms are
+ * intentional fail-closed stubs instead of PSA/software fallbacks.
+ */
+static int samd_mbedtls_ssl_transform_has_aead(
+    const mbedtls_ssl_transform *transform)
+{
+    return transform != NULL &&
+           transform->samd_aead_keys_configured != 0 &&
+           transform->samd_aead_algorithm != 0 &&
+           transform->samd_aead_key_len != 0 &&
+           transform->samd_aead_key_len <=
+               sizeof(transform->samd_aead_key_enc) &&
+           transform->ivlen == 12;
+}
+#endif
+
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
 
 
@@ -988,6 +1045,10 @@ hmac_failed_etm_disabled:
         size_t dynamic_iv_len;
         int dynamic_iv_is_explicit =
             ssl_transform_aead_dynamic_iv_is_explicit(transform);
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        int use_samd_aead =
+            samd_mbedtls_ssl_transform_has_aead(transform);
+#endif
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
@@ -1011,6 +1072,43 @@ hmac_failed_etm_disabled:
          */
         dynamic_iv     = rec->ctr;
         dynamic_iv_len = sizeof(rec->ctr);
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        if (use_samd_aead && transform->samd_aead_pending != 0) {
+            if (transform->samd_aead_done == 0) {
+                return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            }
+            transform->samd_aead_pending = 0;
+            transform->samd_aead_done = 0;
+            if (transform->samd_aead_success == 0) {
+                transform->samd_aead_success = 0;
+                return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            }
+            transform->samd_aead_success = 0;
+
+            MBEDTLS_SSL_DEBUG_BUF(4, "after encrypt: tag",
+                                  data + rec->data_len,
+                                  transform->taglen);
+            post_avail -= transform->taglen;
+            rec->data_len += transform->taglen;
+
+            if (dynamic_iv_is_explicit != 0) {
+                if (rec->data_offset < dynamic_iv_len) {
+                    MBEDTLS_SSL_DEBUG_MSG(
+                        1,
+                        ("Buffer provided for encrypted record not large enough"));
+                    return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
+                }
+
+                memcpy(data - dynamic_iv_len, dynamic_iv, dynamic_iv_len);
+                rec->data_offset -= dynamic_iv_len;
+                rec->data_len    += dynamic_iv_len;
+            }
+
+            auth_done++;
+            goto samd_aead_encrypt_done;
+        }
+#endif
 
         ssl_build_record_nonce(iv, sizeof(iv),
                                transform->iv_enc,
@@ -1040,6 +1138,28 @@ hmac_failed_etm_disabled:
         /*
          * Encrypt and authenticate
          */
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        if (use_samd_aead) {
+            transform->samd_aead_pending = 1;
+            transform->samd_aead_done = 0;
+            transform->samd_aead_success = 0;
+            if (samd_mbedtls_aead_encrypt_start(
+                    transform->samd_aead_algorithm,
+                    transform->samd_aead_key_enc,
+                    transform->samd_aead_key_len,
+                    iv, transform->ivlen, add_data, add_data_len,
+                    data, data, rec->data_len,
+                    data + rec->data_len, transform->taglen,
+                    samd_mbedtls_ssl_aead_callback,
+                    transform) == 0) {
+                transform->samd_aead_pending = 0;
+                return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            }
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+#endif
         status = psa_aead_encrypt(transform->psa_key_enc,
                                   transform->psa_alg,
                                   iv, transform->ivlen,
@@ -1075,6 +1195,10 @@ hmac_failed_etm_disabled:
         }
 
         auth_done++;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+samd_aead_encrypt_done:
+        (void) 0;
+#endif
     } else
 #endif /* MBEDTLS_SSL_HAVE_AEAD */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
@@ -1121,7 +1245,11 @@ hmac_failed_etm_disabled:
         /*
          * Generate IV
          */
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+        ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+#else
         ret = psa_generate_random(transform->iv_enc, transform->ivlen);
+#endif
         if (ret != 0) {
             return ret;
         }
@@ -1339,7 +1467,28 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
         unsigned char iv[12];
         unsigned char *dynamic_iv;
         size_t dynamic_iv_len;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        int use_samd_aead =
+            samd_mbedtls_ssl_transform_has_aead(transform);
+#endif
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        if (use_samd_aead && transform->samd_aead_pending != 0) {
+            if (transform->samd_aead_done == 0) {
+                return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            }
+            transform->samd_aead_pending = 0;
+            transform->samd_aead_done = 0;
+            if (transform->samd_aead_success == 0) {
+                transform->samd_aead_success = 0;
+                return MBEDTLS_ERR_SSL_INVALID_MAC;
+            }
+            transform->samd_aead_success = 0;
+            auth_done++;
+            goto samd_aead_decrypt_done;
+        }
+#endif
 
         /*
          * Extract dynamic part of nonce for AEAD decryption.
@@ -1409,6 +1558,28 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
         /*
          * Decrypt and authenticate
          */
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        if (use_samd_aead) {
+            transform->samd_aead_pending = 1;
+            transform->samd_aead_done = 0;
+            transform->samd_aead_success = 0;
+            if (samd_mbedtls_aead_decrypt_start(
+                    transform->samd_aead_algorithm,
+                    transform->samd_aead_key_dec,
+                    transform->samd_aead_key_len,
+                    iv, transform->ivlen, add_data, add_data_len,
+                    data, data, rec->data_len,
+                    data + rec->data_len, transform->taglen,
+                    samd_mbedtls_ssl_aead_callback,
+                    transform) == 0) {
+                transform->samd_aead_pending = 0;
+                return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            }
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+#endif
         status = psa_aead_decrypt(transform->psa_key_dec,
                                   transform->psa_alg,
                                   iv, transform->ivlen,
@@ -1430,6 +1601,10 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+samd_aead_decrypt_done:
+        (void) 0;
+#endif
     } else
 #endif /* MBEDTLS_SSL_HAVE_AEAD */
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_CBC)
@@ -4702,6 +4877,34 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_record rec;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    if (ssl->transform_in != NULL &&
+        ssl->transform_in->samd_aead_pending != 0) {
+        const size_t header_len = mbedtls_ssl_in_hdr_len(ssl);
+        const size_t explicit_iv_len = sizeof(rec.ctr);
+        const size_t record_len = MBEDTLS_GET_UINT16_BE(ssl->in_len, 0);
+
+        if (record_len < explicit_iv_len + ssl->transform_in->taglen) {
+            return MBEDTLS_ERR_SSL_INVALID_MAC;
+        }
+
+        memset(&rec, 0, sizeof(rec));
+        rec.buf = ssl->in_hdr;
+        rec.buf_len = header_len + record_len;
+        rec.data_offset = header_len + explicit_iv_len;
+        rec.data_len = record_len - explicit_iv_len - ssl->transform_in->taglen;
+        memcpy(rec.ctr, ssl->in_ctr, sizeof(rec.ctr));
+        memcpy(rec.ver, ssl->in_hdr + 1, sizeof(rec.ver));
+        rec.type = ssl->in_hdr[0];
+
+        if ((ret = ssl_prepare_record_content(ssl, &rec)) != 0) {
+            return ret;
+        }
+
+        goto samd_aead_record_content_ready;
+    }
+#endif
+
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     /* We might have buffered a future record; if so,
      * and if the epoch matches now, load it.
@@ -4886,6 +5089,10 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
         }
     }
 
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+samd_aead_record_content_ready:
+#endif
 
     /* Reset in pointers to default state for TLS/DTLS records,
      * assuming no CID and no offset between record content and
@@ -5882,6 +6089,18 @@ static int ssl_write_real(mbedtls_ssl_context *ssl,
 #endif
         len = max_len;
     }
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    if (ssl->transform_out != NULL &&
+        ssl->transform_out->samd_aead_pending != 0) {
+        if ((ret = mbedtls_ssl_write_record(ssl, SSL_FORCE_FLUSH)) != 0) {
+            MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_record", ret);
+            return ret;
+        }
+
+        return (int) len;
+    }
+#endif
 
     if (ssl->out_left != 0) {
         /*

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -98,6 +98,61 @@ static int samd_mbedtls_ssl_transform_has_aead(
                sizeof(transform->samd_aead_key_enc) &&
            transform->ivlen == 12;
 }
+
+int mbedtls_ssl_configure_async_aead_transform(
+    mbedtls_ssl_transform *transform,
+    psa_key_type_t key_type,
+    psa_algorithm_t alg,
+    const unsigned char *key_enc,
+    const unsigned char *key_dec,
+    size_t key_len)
+{
+    unsigned char async_algorithm = 0;
+
+    if (transform == NULL || key_enc == NULL || key_dec == NULL ||
+        key_len == 0 || key_len > sizeof(transform->samd_aead_key_enc) ||
+        transform->ivlen != 12 || transform->taglen != 16) {
+        return 0;
+    }
+
+    if (key_type == PSA_KEY_TYPE_AES && alg == PSA_ALG_GCM) {
+        if (key_len == 16) {
+            async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM;
+        } else if (key_len == 32) {
+            async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM;
+        }
+    } else if (key_type == PSA_KEY_TYPE_CHACHA20 &&
+               alg == PSA_ALG_CHACHA20_POLY1305 && key_len == 32) {
+        async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305;
+    }
+
+    if (async_algorithm == 0) {
+        return 0;
+    }
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+    if (transform->tls_version == MBEDTLS_SSL_VERSION_TLS1_3) {
+        if (transform->fixed_ivlen != 12) {
+            return 0;
+        }
+    } else
+#endif
+    {
+        if (transform->fixed_ivlen != 4 &&
+            !(key_type == PSA_KEY_TYPE_CHACHA20 &&
+              alg == PSA_ALG_CHACHA20_POLY1305 &&
+              transform->fixed_ivlen == 12)) {
+            return 0;
+        }
+    }
+
+    memcpy(transform->samd_aead_key_enc, key_enc, key_len);
+    memcpy(transform->samd_aead_key_dec, key_dec, key_len);
+    transform->samd_aead_key_len = key_len;
+    transform->samd_aead_algorithm = async_algorithm;
+    transform->samd_aead_keys_configured = 1;
+    return 1;
+}
 #endif
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_MAC)
@@ -4881,7 +4936,9 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
     if (ssl->transform_in != NULL &&
         ssl->transform_in->samd_aead_pending != 0) {
         const size_t header_len = mbedtls_ssl_in_hdr_len(ssl);
-        const size_t explicit_iv_len = sizeof(rec.ctr);
+        const size_t explicit_iv_len =
+            ssl_transform_aead_dynamic_iv_is_explicit(ssl->transform_in) ?
+            sizeof(rec.ctr) : 0;
         const size_t record_len = MBEDTLS_GET_UINT16_BE(ssl->in_len, 0);
 
         if (record_len < explicit_iv_len + ssl->transform_in->taglen) {

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -970,12 +970,22 @@ int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
         size_t padding =
             ssl_compute_padding_length(rec->data_len,
                                        MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY);
-        if (ssl_build_inner_plaintext(data,
-                                      &rec->data_len,
-                                      post_avail,
-                                      rec->type,
-                                      padding) != 0) {
-            return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+        if (transform->async_hardware_aead_pending != 0) {
+            if (post_avail < padding + 1) {
+                return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
+            }
+            rec->data_len += padding + 1;
+        } else
+#endif
+        {
+            if (ssl_build_inner_plaintext(data,
+                                          &rec->data_len,
+                                          post_avail,
+                                          rec->type,
+                                          padding) != 0) {
+                return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
+            }
         }
 
         rec->type = MBEDTLS_SSL_MSG_APPLICATION_DATA;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -43,41 +43,18 @@ static int local_err_translation(psa_status_t status)
 }
 #define PSA_TO_MBEDTLS_ERR(status) local_err_translation(status)
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+#include "mbedtls/psa_crypto_async_tls.h"
 
-int mbedtls_async_hardware_aes_gcm128_encrypt_start(
-    const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
-    size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
-    size_t length, uint8_t tag[16], mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_aes_gcm128_decrypt_start(
-    const uint8_t key[16], const uint8_t nonce[12], const uint8_t *aad,
-    size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
-    size_t length, const uint8_t tag[16],
-    mbedtls_async_hardware_callback_t callback, void *context);
-int mbedtls_async_hardware_aead_encrypt_start(
-    int algorithm, const uint8_t *key, size_t keyLength,
-    const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
-    size_t aadLength, const uint8_t *plaintext, uint8_t *ciphertext,
-    size_t length, uint8_t *tag, size_t tagLength,
-    mbedtls_async_hardware_callback_t callback, void *context);
-int mbedtls_async_hardware_aead_decrypt_start(
-    int algorithm, const uint8_t *key, size_t keyLength,
-    const uint8_t *nonce, size_t nonceLength, const uint8_t *aad,
-    size_t aadLength, const uint8_t *ciphertext, uint8_t *plaintext,
-    size_t length, const uint8_t *tag, size_t tagLength,
-    mbedtls_async_hardware_callback_t callback, void *context);
-
-static void mbedtls_async_hardware_ssl_aead_callback(int success, void *context)
+static void mbedtls_psa_async_tls_ssl_aead_callback(int success, void *context)
 {
     mbedtls_ssl_transform *transform = (mbedtls_ssl_transform *) context;
     if (transform == NULL) {
         return;
     }
 
-    transform->async_hardware_aead_success = success ? 1 : 0;
-    transform->async_hardware_aead_done = 1;
+    transform->async_psa_aead_success = success ? 1 : 0;
+    transform->async_psa_aead_done = 1;
 }
 
 /**
@@ -90,15 +67,15 @@ static void mbedtls_async_hardware_ssl_aead_callback(int success, void *context)
  * @todo Extend this direct transform configuration path for AES-CCM and
  * AES-CCM-8 once those suites are wired through this helper.
  */
-static int mbedtls_async_hardware_ssl_transform_has_aead(
+static int mbedtls_psa_async_tls_ssl_transform_has_aead(
     const mbedtls_ssl_transform *transform)
 {
     return transform != NULL &&
-           transform->async_hardware_aead_keys_configured != 0 &&
-           transform->async_hardware_aead_algorithm != 0 &&
-           transform->async_hardware_aead_key_len != 0 &&
-           transform->async_hardware_aead_key_len <=
-               sizeof(transform->async_hardware_aead_key_enc) &&
+           transform->async_psa_aead_keys_configured != 0 &&
+           transform->async_psa_aead_algorithm != 0 &&
+           transform->async_psa_aead_key_len != 0 &&
+           transform->async_psa_aead_key_len <=
+               sizeof(transform->async_psa_aead_key_enc) &&
            transform->ivlen == 12;
 }
 
@@ -113,20 +90,20 @@ int mbedtls_ssl_configure_async_aead_transform(
     unsigned char async_algorithm = 0;
 
     if (transform == NULL || key_enc == NULL || key_dec == NULL ||
-        key_len == 0 || key_len > sizeof(transform->async_hardware_aead_key_enc) ||
+        key_len == 0 || key_len > sizeof(transform->async_psa_aead_key_enc) ||
         transform->ivlen != 12 || transform->taglen != 16) {
         return 0;
     }
 
     if (key_type == PSA_KEY_TYPE_AES && alg == PSA_ALG_GCM) {
         if (key_len == 16) {
-            async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM;
+            async_algorithm = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_GCM;
         } else if (key_len == 32) {
-            async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM;
+            async_algorithm = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_GCM;
         }
     } else if (key_type == PSA_KEY_TYPE_CHACHA20 &&
                alg == PSA_ALG_CHACHA20_POLY1305 && key_len == 32) {
-        async_algorithm = MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305;
+        async_algorithm = MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_CHACHA20_POLY1305;
     }
 
     if (async_algorithm == 0) {
@@ -149,11 +126,11 @@ int mbedtls_ssl_configure_async_aead_transform(
         }
     }
 
-    memcpy(transform->async_hardware_aead_key_enc, key_enc, key_len);
-    memcpy(transform->async_hardware_aead_key_dec, key_dec, key_len);
-    transform->async_hardware_aead_key_len = key_len;
-    transform->async_hardware_aead_algorithm = async_algorithm;
-    transform->async_hardware_aead_keys_configured = 1;
+    memcpy(transform->async_psa_aead_key_enc, key_enc, key_len);
+    memcpy(transform->async_psa_aead_key_dec, key_dec, key_len);
+    transform->async_psa_aead_key_len = key_len;
+    transform->async_psa_aead_algorithm = async_algorithm;
+    transform->async_psa_aead_keys_configured = 1;
     return 1;
 }
 #endif
@@ -970,8 +947,8 @@ int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
         size_t padding =
             ssl_compute_padding_length(rec->data_len,
                                        MBEDTLS_SSL_CID_TLS1_3_PADDING_GRANULARITY);
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (transform->async_hardware_aead_pending != 0) {
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        if (transform->async_psa_aead_pending != 0) {
             if (post_avail < padding + 1) {
                 return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
             }
@@ -1113,12 +1090,10 @@ hmac_failed_etm_disabled:
         size_t dynamic_iv_len;
         int dynamic_iv_is_explicit =
             ssl_transform_aead_dynamic_iv_is_explicit(transform);
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        int use_async_hardware_aead =
-            mbedtls_async_hardware_ssl_transform_has_aead(transform);
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        int use_async_psa_aead =
+            mbedtls_psa_async_tls_ssl_transform_has_aead(transform);
 #endif
-        psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
-        int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
         /* Check that there's space for the authentication tag. */
         if (post_avail < transform->taglen) {
@@ -1141,18 +1116,18 @@ hmac_failed_etm_disabled:
         dynamic_iv     = rec->ctr;
         dynamic_iv_len = sizeof(rec->ctr);
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_async_hardware_aead && transform->async_hardware_aead_pending != 0) {
-            if (transform->async_hardware_aead_done == 0) {
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        if (use_async_psa_aead && transform->async_psa_aead_pending != 0) {
+            if (transform->async_psa_aead_done == 0) {
                 return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
-            transform->async_hardware_aead_pending = 0;
-            transform->async_hardware_aead_done = 0;
-            if (transform->async_hardware_aead_success == 0) {
-                transform->async_hardware_aead_success = 0;
+            transform->async_psa_aead_pending = 0;
+            transform->async_psa_aead_done = 0;
+            if (transform->async_psa_aead_success == 0) {
+                transform->async_psa_aead_success = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
-            transform->async_hardware_aead_success = 0;
+            transform->async_psa_aead_success = 0;
 
             MBEDTLS_SSL_DEBUG_BUF(4, "after encrypt: tag",
                                   data + rec->data_len,
@@ -1174,7 +1149,7 @@ hmac_failed_etm_disabled:
             }
 
             auth_done++;
-            goto async_hardware_aead_encrypt_done;
+            goto async_psa_aead_encrypt_done;
         }
 #endif
 
@@ -1206,28 +1181,31 @@ hmac_failed_etm_disabled:
         /*
          * Encrypt and authenticate
          */
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_async_hardware_aead) {
-            transform->async_hardware_aead_pending = 1;
-            transform->async_hardware_aead_done = 0;
-            transform->async_hardware_aead_success = 0;
-            if (mbedtls_async_hardware_aead_encrypt_start(
-                    transform->async_hardware_aead_algorithm,
-                    transform->async_hardware_aead_key_enc,
-                    transform->async_hardware_aead_key_len,
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        if (use_async_psa_aead) {
+            transform->async_psa_aead_pending = 1;
+            transform->async_psa_aead_done = 0;
+            transform->async_psa_aead_success = 0;
+            if (mbedtls_psa_async_tls_aead_encrypt_start(
+                    transform->async_psa_aead_algorithm,
+                    transform->async_psa_aead_key_enc,
+                    transform->async_psa_aead_key_len,
                     iv, transform->ivlen, add_data, add_data_len,
                     data, data, rec->data_len,
                     data + rec->data_len, transform->taglen,
-                    mbedtls_async_hardware_ssl_aead_callback,
+                    mbedtls_psa_async_tls_ssl_aead_callback,
                     transform) == 0) {
-                transform->async_hardware_aead_pending = 0;
+                transform->async_psa_aead_pending = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-#endif
+#else
+        psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+        int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+
         status = psa_aead_encrypt(transform->psa_key_enc,
                                   transform->psa_alg,
                                   iv, transform->ivlen,
@@ -1241,7 +1219,6 @@ hmac_failed_etm_disabled:
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_encrypt_buf", ret);
             return ret;
         }
-
         MBEDTLS_SSL_DEBUG_BUF(4, "after encrypt: tag",
                               data + rec->data_len - transform->taglen,
                               transform->taglen);
@@ -1263,8 +1240,9 @@ hmac_failed_etm_disabled:
         }
 
         auth_done++;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-async_hardware_aead_encrypt_done:
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+async_psa_aead_encrypt_done:
         (void) 0;
 #endif
     } else
@@ -1313,7 +1291,7 @@ async_hardware_aead_encrypt_done:
         /*
          * Generate IV
          */
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
         ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
 #else
         ret = psa_generate_random(transform->iv_enc, transform->ivlen);
@@ -1535,26 +1513,25 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
         unsigned char iv[12];
         unsigned char *dynamic_iv;
         size_t dynamic_iv_len;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        int use_async_hardware_aead =
-            mbedtls_async_hardware_ssl_transform_has_aead(transform);
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        int use_async_psa_aead =
+            mbedtls_psa_async_tls_ssl_transform_has_aead(transform);
 #endif
-        psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_async_hardware_aead && transform->async_hardware_aead_pending != 0) {
-            if (transform->async_hardware_aead_done == 0) {
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        if (use_async_psa_aead && transform->async_psa_aead_pending != 0) {
+            if (transform->async_psa_aead_done == 0) {
                 return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
-            transform->async_hardware_aead_pending = 0;
-            transform->async_hardware_aead_done = 0;
-            if (transform->async_hardware_aead_success == 0) {
-                transform->async_hardware_aead_success = 0;
+            transform->async_psa_aead_pending = 0;
+            transform->async_psa_aead_done = 0;
+            if (transform->async_psa_aead_success == 0) {
+                transform->async_psa_aead_success = 0;
                 return MBEDTLS_ERR_SSL_INVALID_MAC;
             }
-            transform->async_hardware_aead_success = 0;
+            transform->async_psa_aead_success = 0;
             auth_done++;
-            goto async_hardware_aead_decrypt_done;
+            goto async_psa_aead_decrypt_done;
         }
 #endif
 
@@ -1626,28 +1603,30 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
         /*
          * Decrypt and authenticate
          */
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-        if (use_async_hardware_aead) {
-            transform->async_hardware_aead_pending = 1;
-            transform->async_hardware_aead_done = 0;
-            transform->async_hardware_aead_success = 0;
-            if (mbedtls_async_hardware_aead_decrypt_start(
-                    transform->async_hardware_aead_algorithm,
-                    transform->async_hardware_aead_key_dec,
-                    transform->async_hardware_aead_key_len,
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+        if (use_async_psa_aead) {
+            transform->async_psa_aead_pending = 1;
+            transform->async_psa_aead_done = 0;
+            transform->async_psa_aead_success = 0;
+            if (mbedtls_psa_async_tls_aead_decrypt_start(
+                    transform->async_psa_aead_algorithm,
+                    transform->async_psa_aead_key_dec,
+                    transform->async_psa_aead_key_len,
                     iv, transform->ivlen, add_data, add_data_len,
                     data, data, rec->data_len,
                     data + rec->data_len, transform->taglen,
-                    mbedtls_async_hardware_ssl_aead_callback,
+                    mbedtls_psa_async_tls_ssl_aead_callback,
                     transform) == 0) {
-                transform->async_hardware_aead_pending = 0;
+                transform->async_psa_aead_pending = 0;
                 return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
             }
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
-#endif
+#else
+        psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
         status = psa_aead_decrypt(transform->psa_key_dec,
                                   transform->psa_alg,
                                   iv, transform->ivlen,
@@ -1661,7 +1640,6 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             MBEDTLS_SSL_DEBUG_RET(1, "psa_aead_decrypt", ret);
             return ret;
         }
-
         auth_done++;
 
         /* Double-check that AEAD decryption doesn't change content length. */
@@ -1669,8 +1647,9 @@ int mbedtls_ssl_decrypt_buf(mbedtls_ssl_context const *ssl,
             MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-async_hardware_aead_decrypt_done:
+#endif
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+async_psa_aead_decrypt_done:
         (void) 0;
 #endif
     } else
@@ -4945,9 +4924,9 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_record rec;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     if (ssl->transform_in != NULL &&
-        ssl->transform_in->async_hardware_aead_pending != 0) {
+        ssl->transform_in->async_psa_aead_pending != 0) {
         const size_t header_len = mbedtls_ssl_in_hdr_len(ssl);
         const size_t explicit_iv_len =
             ssl_transform_aead_dynamic_iv_is_explicit(ssl->transform_in) ?
@@ -4971,7 +4950,7 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
             return ret;
         }
 
-        goto async_hardware_aead_record_content_ready;
+        goto async_psa_aead_record_content_ready;
     }
 #endif
 
@@ -5160,8 +5139,8 @@ static int ssl_get_next_record(mbedtls_ssl_context *ssl)
     }
 
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-async_hardware_aead_record_content_ready:
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+async_psa_aead_record_content_ready:
 #endif
 
     /* Reset in pointers to default state for TLS/DTLS records,
@@ -6160,9 +6139,9 @@ static int ssl_write_real(mbedtls_ssl_context *ssl,
         len = max_len;
     }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     if (ssl->transform_out != NULL &&
-        ssl->transform_out->async_hardware_aead_pending != 0) {
+        ssl->transform_out->async_psa_aead_pending != 0) {
         if ((ret = mbedtls_ssl_write_record(ssl, SSL_FORCE_FLUSH)) != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_record", ret);
             return ret;

--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -83,9 +83,12 @@ static void mbedtls_async_hardware_ssl_aead_callback(int success, void *context)
 /**
  * @brief Return whether the transform has explicit async hardware AEAD metadata.
  *
- * @todo Extend the provider dispatch behind this metadata for AES-256-GCM,
- * AES-CCM, AES-CCM-8, and ChaCha20-Poly1305. Until then those algorithms are
- * intentional fail-closed stubs instead of PSA/software fallbacks.
+ * AES-GCM and ChaCha20-Poly1305 transforms are represented through the
+ * generic async AEAD boundary. Providers that do not implement a classified
+ * algorithm fail closed instead of falling back to PSA/software.
+ *
+ * @todo Extend this direct transform configuration path for AES-CCM and
+ * AES-CCM-8 once those suites are wired through this helper.
  */
 static int mbedtls_async_hardware_ssl_transform_has_aead(
     const mbedtls_ssl_transform *transform)

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -446,6 +446,10 @@ static int ssl_calc_verify_tls_sha384(const mbedtls_ssl_context *, unsigned char
 static int ssl_calc_finished_tls_sha384(mbedtls_ssl_context *, unsigned char *, int);
 #endif /* PSA_WANT_ALG_SHA_384*/
 
+#if defined(PSA_WANT_ALG_SHA_512)
+static int ssl_calc_verify_tls_sha512(const mbedtls_ssl_context *, unsigned char *, size_t *);
+#endif /* PSA_WANT_ALG_SHA_512 */
+
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls12_session_load(mbedtls_ssl_session *session,
                                   const unsigned char *buf,
@@ -461,6 +465,10 @@ static int ssl_update_checksum_sha256(mbedtls_ssl_context *, const unsigned char
 #if defined(PSA_WANT_ALG_SHA_384)
 static int ssl_update_checksum_sha384(mbedtls_ssl_context *, const unsigned char *, size_t);
 #endif /* PSA_WANT_ALG_SHA_384*/
+
+#if defined(PSA_WANT_ALG_SHA_512)
+static int ssl_update_checksum_sha512(mbedtls_ssl_context *, const unsigned char *, size_t);
+#endif /* PSA_WANT_ALG_SHA_512 */
 
 int  mbedtls_ssl_tls_prf(const mbedtls_tls_prf_types prf,
                          const unsigned char *secret, size_t slen,
@@ -791,6 +799,10 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
 {
     ((void) ciphersuite_info);
 
+#if defined(PSA_WANT_ALG_SHA_512)
+    ((void) ssl);
+    return;
+#else
 #if defined(PSA_WANT_ALG_SHA_384)
     if (ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
         ssl->handshake->update_checksum = ssl_update_checksum_sha384;
@@ -805,6 +817,7 @@ void mbedtls_ssl_optimize_checksum(mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
         return;
     }
+#endif
 }
 
 int mbedtls_ssl_add_hs_hdr_to_checksum(mbedtls_ssl_context *ssl,
@@ -838,11 +851,12 @@ int mbedtls_ssl_add_hs_msg_to_checksum(mbedtls_ssl_context *ssl,
 int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
 {
 #if defined(PSA_WANT_ALG_SHA_256) || \
-    defined(PSA_WANT_ALG_SHA_384)
+    defined(PSA_WANT_ALG_SHA_384) || \
+    defined(PSA_WANT_ALG_SHA_512)
     psa_status_t status;
-#else /* SHA-256 or SHA-384 */
+#else /* SHA-256, SHA-384 or SHA-512 */
     ((void) ssl);
-#endif /* SHA-256 or SHA-384 */
+#endif /* SHA-256, SHA-384 or SHA-512 */
 #if defined(PSA_WANT_ALG_SHA_256)
     status = psa_hash_abort(&ssl->handshake->fin_sha256_psa);
     if (status != PSA_SUCCESS) {
@@ -863,6 +877,16 @@ int mbedtls_ssl_reset_checksum(mbedtls_ssl_context *ssl)
         return mbedtls_md_error_from_psa(status);
     }
 #endif
+#if defined(PSA_WANT_ALG_SHA_512)
+    status = psa_hash_abort(&ssl->handshake->fin_sha512_psa);
+    if (status != PSA_SUCCESS) {
+        return mbedtls_md_error_from_psa(status);
+    }
+    status = psa_hash_setup(&ssl->handshake->fin_sha512_psa, PSA_ALG_SHA_512);
+    if (status != PSA_SUCCESS) {
+        return mbedtls_md_error_from_psa(status);
+    }
+#endif
     return 0;
 }
 
@@ -870,13 +894,14 @@ static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
                                      const unsigned char *buf, size_t len)
 {
 #if defined(PSA_WANT_ALG_SHA_256) || \
-    defined(PSA_WANT_ALG_SHA_384)
+    defined(PSA_WANT_ALG_SHA_384) || \
+    defined(PSA_WANT_ALG_SHA_512)
     psa_status_t status;
-#else /* SHA-256 or SHA-384 */
+#else /* SHA-256, SHA-384 or SHA-512 */
     ((void) ssl);
     (void) buf;
     (void) len;
-#endif /* SHA-256 or SHA-384 */
+#endif /* SHA-256, SHA-384 or SHA-512 */
 #if defined(PSA_WANT_ALG_SHA_256)
     status = psa_hash_update(&ssl->handshake->fin_sha256_psa, buf, len);
     if (status != PSA_SUCCESS) {
@@ -885,6 +910,12 @@ static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
 #endif
 #if defined(PSA_WANT_ALG_SHA_384)
     status = psa_hash_update(&ssl->handshake->fin_sha384_psa, buf, len);
+    if (status != PSA_SUCCESS) {
+        return mbedtls_md_error_from_psa(status);
+    }
+#endif
+#if defined(PSA_WANT_ALG_SHA_512)
+    status = psa_hash_update(&ssl->handshake->fin_sha512_psa, buf, len);
     if (status != PSA_SUCCESS) {
         return mbedtls_md_error_from_psa(status);
     }
@@ -910,6 +941,15 @@ static int ssl_update_checksum_sha384(mbedtls_ssl_context *ssl,
 }
 #endif
 
+#if defined(PSA_WANT_ALG_SHA_512)
+static int ssl_update_checksum_sha512(mbedtls_ssl_context *ssl,
+                                      const unsigned char *buf, size_t len)
+{
+    return mbedtls_md_error_from_psa(psa_hash_update(
+                                         &ssl->handshake->fin_sha512_psa, buf, len));
+}
+#endif
+
 static void ssl_handshake_params_init(mbedtls_ssl_handshake_params *handshake)
 {
     memset(handshake, 0, sizeof(mbedtls_ssl_handshake_params));
@@ -919,6 +959,9 @@ static void ssl_handshake_params_init(mbedtls_ssl_handshake_params *handshake)
 #endif
 #if defined(PSA_WANT_ALG_SHA_384)
     handshake->fin_sha384_psa = psa_hash_operation_init();
+#endif
+#if defined(PSA_WANT_ALG_SHA_512)
+    handshake->fin_sha512_psa = psa_hash_operation_init();
 #endif
 
     handshake->update_checksum = ssl_update_checksum_start;
@@ -4462,6 +4505,9 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #if defined(PSA_WANT_ALG_SHA_384)
     psa_hash_abort(&handshake->fin_sha384_psa);
 #endif
+#if defined(PSA_WANT_ALG_SHA_512)
+    psa_hash_abort(&handshake->fin_sha512_psa);
+#endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
     psa_pake_abort(&handshake->psa_pake_ctx);
@@ -5913,6 +5959,12 @@ int mbedtls_ssl_get_handshake_transcript(mbedtls_ssl_context *ssl,
     *olen = 0;
 
     switch (md) {
+#if defined(PSA_WANT_ALG_SHA_512)
+        case MBEDTLS_MD_SHA512:
+            hash_operation_to_clone = &ssl->handshake->fin_sha512_psa;
+            break;
+#endif
+
 #if defined(PSA_WANT_ALG_SHA_384)
         case MBEDTLS_MD_SHA384:
             hash_operation_to_clone = &ssl->handshake->fin_sha384_psa;
@@ -6542,6 +6594,11 @@ int mbedtls_ssl_derive_keys(mbedtls_ssl_context *ssl)
 int mbedtls_ssl_set_calc_verify_md(mbedtls_ssl_context *ssl, int md)
 {
     switch (md) {
+#if defined(PSA_WANT_ALG_SHA_512)
+        case MBEDTLS_SSL_HASH_SHA512:
+            ssl->handshake->calc_verify = ssl_calc_verify_tls_sha512;
+            break;
+#endif
 #if defined(PSA_WANT_ALG_SHA_384)
         case MBEDTLS_SSL_HASH_SHA384:
             ssl->handshake->calc_verify = ssl_calc_verify_tls_sha384;
@@ -6612,6 +6669,16 @@ int ssl_calc_verify_tls_sha384(const mbedtls_ssl_context *ssl,
                                    hash, hlen);
 }
 #endif /* PSA_WANT_ALG_SHA_384 */
+
+#if defined(PSA_WANT_ALG_SHA_512)
+int ssl_calc_verify_tls_sha512(const mbedtls_ssl_context *ssl,
+                               unsigned char *hash,
+                               size_t *hlen)
+{
+    return ssl_calc_verify_tls_psa(ssl, &ssl->handshake->fin_sha512_psa, 64,
+                                   hash, hlen);
+}
+#endif /* PSA_WANT_ALG_SHA_512 */
 
 #if defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_RENEGOTIATION)
 MBEDTLS_CHECK_RETURN_CRITICAL

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7455,16 +7455,16 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     int ret;
     int next_state = -1;
     unsigned int hash_len;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    int async_hardware_resume_pending_finished = 0;
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+    int async_psa_resume_pending_finished = 0;
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write finished"));
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     if (ssl->transform_negotiate != NULL &&
-        ssl->transform_negotiate->async_hardware_aead_pending != 0) {
-        async_hardware_resume_pending_finished = 1;
+        ssl->transform_negotiate->async_psa_aead_pending != 0) {
+        async_psa_resume_pending_finished = 1;
         if (ssl->handshake->resume != 0) {
 #if defined(MBEDTLS_SSL_CLI_C)
             if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
@@ -7479,7 +7479,7 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
         } else {
             next_state = ssl->state + 1;
         }
-        goto async_hardware_resume_pending_finished_write;
+        goto async_psa_resume_pending_finished_write;
     }
 #endif
 
@@ -7533,8 +7533,8 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
      */
     MBEDTLS_SSL_DEBUG_MSG(3, ("switching to new transform spec for outbound data"));
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-async_hardware_resume_pending_finished_write:
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+async_psa_resume_pending_finished_write:
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -7575,8 +7575,8 @@ async_hardware_resume_pending_finished_write:
     }
 #endif
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    if (async_hardware_resume_pending_finished) {
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+    if (async_psa_resume_pending_finished) {
         ret = mbedtls_ssl_write_record(ssl, 1);
     } else
 #endif
@@ -7585,8 +7585,8 @@ async_hardware_resume_pending_finished_write:
     }
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1,
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-                              async_hardware_resume_pending_finished
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+                              async_psa_resume_pending_finished
                                   ? "mbedtls_ssl_write_record"
                                   :
 #endif
@@ -7744,7 +7744,7 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
     return MBEDTLS_SSL_TLS_PRF_NONE;
 }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 /**
  * @brief Map Mbed TLS/PSA record parameters to async hardware TLS AEAD capabilities.
  *
@@ -7753,7 +7753,7 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
  * algorithm fail closed through the generic AEAD boundary instead of silently
  * falling back to PSA/software.
  */
-static int mbedtls_async_hardware_tls_aead_from_transform(psa_key_type_t key_type,
+static int mbedtls_psa_async_tls_aead_from_transform(psa_key_type_t key_type,
                                                  size_t keylen,
                                                  psa_algorithm_t alg,
                                                  size_t ivlen,
@@ -7767,10 +7767,10 @@ static int mbedtls_async_hardware_tls_aead_from_transform(psa_key_type_t key_typ
     if (key_type == PSA_KEY_TYPE_AES && alg == PSA_ALG_GCM &&
         fixed_ivlen == 4 && taglen == 16) {
         if (keylen == 16) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_GCM;
         }
         if (keylen == 32) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_GCM;
         }
     }
 
@@ -7779,23 +7779,23 @@ static int mbedtls_async_hardware_tls_aead_from_transform(psa_key_type_t key_typ
          alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 8)) &&
         fixed_ivlen == 4 && (taglen == 16 || taglen == 8)) {
         if (keylen == 16 && taglen == 16) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_CCM;
         }
         if (keylen == 32 && taglen == 16) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_CCM;
         }
         if (keylen == 16 && taglen == 8) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM_8;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_128_CCM_8;
         }
         if (keylen == 32 && taglen == 8) {
-            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM_8;
+            return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_AES_256_CCM_8;
         }
     }
 
     if (key_type == PSA_KEY_TYPE_CHACHA20 &&
         alg == PSA_ALG_CHACHA20_POLY1305 && keylen == 32 &&
         fixed_ivlen == 12 && taglen == 16) {
-        return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305;
+        return MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD_CHACHA20_POLY1305;
     }
 
     return 0;
@@ -8089,18 +8089,18 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
 
     transform->psa_alg = alg;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    int async_hardware_aead_algorithm = mbedtls_async_hardware_tls_aead_from_transform(
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
+    int async_psa_aead_algorithm = mbedtls_psa_async_tls_aead_from_transform(
         key_type, keylen, alg, transform->ivlen, transform->fixed_ivlen,
         transform->taglen);
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD &&
-        async_hardware_aead_algorithm != 0 &&
-        keylen <= sizeof(transform->async_hardware_aead_key_enc)) {
-        memcpy(transform->async_hardware_aead_key_enc, key1, keylen);
-        memcpy(transform->async_hardware_aead_key_dec, key2, keylen);
-        transform->async_hardware_aead_key_len = keylen;
-        transform->async_hardware_aead_algorithm = (unsigned char) async_hardware_aead_algorithm;
-        transform->async_hardware_aead_keys_configured = 1;
+        async_psa_aead_algorithm != 0 &&
+        keylen <= sizeof(transform->async_psa_aead_key_enc)) {
+        memcpy(transform->async_psa_aead_key_enc, key1, keylen);
+        memcpy(transform->async_psa_aead_key_dec, key2, keylen);
+        transform->async_psa_aead_key_len = keylen;
+        transform->async_psa_aead_algorithm = (unsigned char) async_psa_aead_algorithm;
+        transform->async_psa_aead_keys_configured = 1;
     }
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -458,17 +458,13 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 
 static int ssl_update_checksum_start(mbedtls_ssl_context *, const unsigned char *, size_t);
 
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(PSA_WANT_ALG_SHA_256) && !defined(PSA_WANT_ALG_SHA_512)
 static int ssl_update_checksum_sha256(mbedtls_ssl_context *, const unsigned char *, size_t);
 #endif /* PSA_WANT_ALG_SHA_256*/
 
-#if defined(PSA_WANT_ALG_SHA_384)
+#if defined(PSA_WANT_ALG_SHA_384) && !defined(PSA_WANT_ALG_SHA_512)
 static int ssl_update_checksum_sha384(mbedtls_ssl_context *, const unsigned char *, size_t);
 #endif /* PSA_WANT_ALG_SHA_384*/
-
-#if defined(PSA_WANT_ALG_SHA_512)
-static int ssl_update_checksum_sha512(mbedtls_ssl_context *, const unsigned char *, size_t);
-#endif /* PSA_WANT_ALG_SHA_512 */
 
 int  mbedtls_ssl_tls_prf(const mbedtls_tls_prf_types prf,
                          const unsigned char *secret, size_t slen,
@@ -923,7 +919,7 @@ static int ssl_update_checksum_start(mbedtls_ssl_context *ssl,
     return 0;
 }
 
-#if defined(PSA_WANT_ALG_SHA_256)
+#if defined(PSA_WANT_ALG_SHA_256) && !defined(PSA_WANT_ALG_SHA_512)
 static int ssl_update_checksum_sha256(mbedtls_ssl_context *ssl,
                                       const unsigned char *buf, size_t len)
 {
@@ -932,21 +928,12 @@ static int ssl_update_checksum_sha256(mbedtls_ssl_context *ssl,
 }
 #endif
 
-#if defined(PSA_WANT_ALG_SHA_384)
+#if defined(PSA_WANT_ALG_SHA_384) && !defined(PSA_WANT_ALG_SHA_512)
 static int ssl_update_checksum_sha384(mbedtls_ssl_context *ssl,
                                       const unsigned char *buf, size_t len)
 {
     return mbedtls_md_error_from_psa(psa_hash_update(
                                          &ssl->handshake->fin_sha384_psa, buf, len));
-}
-#endif
-
-#if defined(PSA_WANT_ALG_SHA_512)
-static int ssl_update_checksum_sha512(mbedtls_ssl_context *ssl,
-                                      const unsigned char *buf, size_t len)
-{
-    return mbedtls_md_error_from_psa(psa_hash_update(
-                                         &ssl->handshake->fin_sha512_psa, buf, len));
 }
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7469,15 +7469,15 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     int next_state = -1;
     unsigned int hash_len;
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    int samd_resume_pending_finished = 0;
+    int async_hardware_resume_pending_finished = 0;
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write finished"));
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
     if (ssl->transform_negotiate != NULL &&
-        ssl->transform_negotiate->samd_aead_pending != 0) {
-        samd_resume_pending_finished = 1;
+        ssl->transform_negotiate->async_hardware_aead_pending != 0) {
+        async_hardware_resume_pending_finished = 1;
         if (ssl->handshake->resume != 0) {
 #if defined(MBEDTLS_SSL_CLI_C)
             if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
@@ -7492,7 +7492,7 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
         } else {
             next_state = ssl->state + 1;
         }
-        goto samd_resume_pending_finished_write;
+        goto async_hardware_resume_pending_finished_write;
     }
 #endif
 
@@ -7547,7 +7547,7 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_DEBUG_MSG(3, ("switching to new transform spec for outbound data"));
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-samd_resume_pending_finished_write:
+async_hardware_resume_pending_finished_write:
 #endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
@@ -7589,7 +7589,7 @@ samd_resume_pending_finished_write:
 #endif
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    if (samd_resume_pending_finished) {
+    if (async_hardware_resume_pending_finished) {
         ret = mbedtls_ssl_write_record(ssl, 1);
     } else
 #endif
@@ -7599,7 +7599,7 @@ samd_resume_pending_finished_write:
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1,
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-                              samd_resume_pending_finished
+                              async_hardware_resume_pending_finished
                                   ? "mbedtls_ssl_write_record"
                                   :
 #endif
@@ -7759,14 +7759,14 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
 /**
- * @brief Map Mbed TLS/PSA record parameters to SAMD TLS AEAD capabilities.
+ * @brief Map Mbed TLS/PSA record parameters to async hardware TLS AEAD capabilities.
  *
  * @todo Wire AES-256-GCM, AES-CCM, AES-CCM-8, and ChaCha20-Poly1305 to
  * hardware-backed provider operations. They are classified here so production
  * hardware builds fail closed through the generic AEAD boundary instead of
  * silently falling back to PSA/software.
  */
-static int samd_mbedtls_tls_aead_from_transform(psa_key_type_t key_type,
+static int mbedtls_async_hardware_tls_aead_from_transform(psa_key_type_t key_type,
                                                  size_t keylen,
                                                  psa_algorithm_t alg,
                                                  size_t ivlen,
@@ -8103,17 +8103,17 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     transform->psa_alg = alg;
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
-    int samd_aead_algorithm = samd_mbedtls_tls_aead_from_transform(
+    int async_hardware_aead_algorithm = mbedtls_async_hardware_tls_aead_from_transform(
         key_type, keylen, alg, transform->ivlen, transform->fixed_ivlen,
         transform->taglen);
     if (ssl_mode == MBEDTLS_SSL_MODE_AEAD &&
-        samd_aead_algorithm != 0 &&
-        keylen <= sizeof(transform->samd_aead_key_enc)) {
-        memcpy(transform->samd_aead_key_enc, key1, keylen);
-        memcpy(transform->samd_aead_key_dec, key2, keylen);
-        transform->samd_aead_key_len = keylen;
-        transform->samd_aead_algorithm = (unsigned char) samd_aead_algorithm;
-        transform->samd_aead_keys_configured = 1;
+        async_hardware_aead_algorithm != 0 &&
+        keylen <= sizeof(transform->async_hardware_aead_key_enc)) {
+        memcpy(transform->async_hardware_aead_key_enc, key1, keylen);
+        memcpy(transform->async_hardware_aead_key_dec, key2, keylen);
+        transform->async_hardware_aead_key_len = keylen;
+        transform->async_hardware_aead_algorithm = (unsigned char) async_hardware_aead_algorithm;
+        transform->async_hardware_aead_keys_configured = 1;
     }
 #endif
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4534,6 +4534,9 @@ void mbedtls_ssl_handshake_free(mbedtls_ssl_context *ssl)
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_XXDH_PSA_ANY_ENABLED)
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    psa_key_agreement_iop_abort(&handshake->xxdh_psa_iop);
+#endif
     if (handshake->xxdh_psa_privkey_is_external == 0) {
         psa_destroy_key(handshake->xxdh_psa_privkey);
     }
@@ -7396,9 +7399,35 @@ void mbedtls_ssl_handshake_wrapup(mbedtls_ssl_context *ssl)
 int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
 {
     int ret;
+    int next_state = -1;
     unsigned int hash_len;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    int samd_resume_pending_finished = 0;
+#endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write finished"));
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    if (ssl->transform_negotiate != NULL &&
+        ssl->transform_negotiate->samd_aead_pending != 0) {
+        samd_resume_pending_finished = 1;
+        if (ssl->handshake->resume != 0) {
+#if defined(MBEDTLS_SSL_CLI_C)
+            if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
+                next_state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
+            }
+#endif
+#if defined(MBEDTLS_SSL_SRV_C)
+            if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) {
+                next_state = MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC;
+            }
+#endif
+        } else {
+            next_state = ssl->state + 1;
+        }
+        goto samd_resume_pending_finished_write;
+    }
+#endif
 
     mbedtls_ssl_update_out_pointers(ssl, ssl->transform_negotiate);
 
@@ -7432,16 +7461,16 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     if (ssl->handshake->resume != 0) {
 #if defined(MBEDTLS_SSL_CLI_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_CLIENT) {
-            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_HANDSHAKE_WRAPUP);
+            next_state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
         }
 #endif
 #if defined(MBEDTLS_SSL_SRV_C)
         if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) {
-            mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC);
+            next_state = MBEDTLS_SSL_CLIENT_CHANGE_CIPHER_SPEC;
         }
 #endif
     } else {
-        mbedtls_ssl_handshake_increment_state(ssl);
+        next_state = ssl->state + 1;
     }
 
     /*
@@ -7449,6 +7478,10 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
      * data.
      */
     MBEDTLS_SSL_DEBUG_MSG(3, ("switching to new transform spec for outbound data"));
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+samd_resume_pending_finished_write:
+#endif
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
@@ -7488,8 +7521,23 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
     }
 #endif
 
-    if ((ret = mbedtls_ssl_write_handshake_msg_ext(ssl, 1, 1)) != 0) {
-        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_write_handshake_msg_ext", ret);
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    if (samd_resume_pending_finished) {
+        ret = mbedtls_ssl_write_record(ssl, 1);
+    } else
+#endif
+    {
+        ret = mbedtls_ssl_write_handshake_msg_ext(ssl, 1, 1);
+    }
+    if (ret != 0) {
+        MBEDTLS_SSL_DEBUG_RET(1,
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+                              samd_resume_pending_finished
+                                  ? "mbedtls_ssl_write_record"
+                                  :
+#endif
+                                    "mbedtls_ssl_write_handshake_msg_ext",
+                              ret);
         return ret;
     }
 
@@ -7500,6 +7548,10 @@ int mbedtls_ssl_write_finished(mbedtls_ssl_context *ssl)
         return ret;
     }
 #endif
+
+    if (next_state >= 0) {
+        mbedtls_ssl_handshake_set_state(ssl, (mbedtls_ssl_states) next_state);
+    }
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("<= write finished"));
 
@@ -7637,6 +7689,64 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
 #endif
     return MBEDTLS_SSL_TLS_PRF_NONE;
 }
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+/**
+ * @brief Map Mbed TLS/PSA record parameters to SAMD TLS AEAD capabilities.
+ *
+ * @todo Wire AES-256-GCM, AES-CCM, AES-CCM-8, and ChaCha20-Poly1305 to
+ * hardware-backed provider operations. They are classified here so production
+ * hardware builds fail closed through the generic AEAD boundary instead of
+ * silently falling back to PSA/software.
+ */
+static int samd_mbedtls_tls_aead_from_transform(psa_key_type_t key_type,
+                                                 size_t keylen,
+                                                 psa_algorithm_t alg,
+                                                 size_t ivlen,
+                                                 size_t fixed_ivlen,
+                                                 size_t taglen)
+{
+    if (ivlen != 12) {
+        return 0;
+    }
+
+    if (key_type == PSA_KEY_TYPE_AES && alg == PSA_ALG_GCM &&
+        fixed_ivlen == 4 && taglen == 16) {
+        if (keylen == 16) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_GCM;
+        }
+        if (keylen == 32) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_GCM;
+        }
+    }
+
+    if (key_type == PSA_KEY_TYPE_AES &&
+        (alg == PSA_ALG_CCM ||
+         alg == PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, 8)) &&
+        fixed_ivlen == 4 && (taglen == 16 || taglen == 8)) {
+        if (keylen == 16 && taglen == 16) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM;
+        }
+        if (keylen == 32 && taglen == 16) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM;
+        }
+        if (keylen == 16 && taglen == 8) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_128_CCM_8;
+        }
+        if (keylen == 32 && taglen == 8) {
+            return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_AES_256_CCM_8;
+        }
+    }
+
+    if (key_type == PSA_KEY_TYPE_CHACHA20 &&
+        alg == PSA_ALG_CHACHA20_POLY1305 && keylen == 32 &&
+        fixed_ivlen == 12 && taglen == 16) {
+        return MBEDTLS_ASYNC_HARDWARE_TLS_AEAD_CHACHA20_POLY1305;
+    }
+
+    return 0;
+}
+#endif
 
 /*
  * Populate a transform structure with session keys and all the other
@@ -7924,6 +8034,21 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     }
 
     transform->psa_alg = alg;
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    int samd_aead_algorithm = samd_mbedtls_tls_aead_from_transform(
+        key_type, keylen, alg, transform->ivlen, transform->fixed_ivlen,
+        transform->taglen);
+    if (ssl_mode == MBEDTLS_SSL_MODE_AEAD &&
+        samd_aead_algorithm != 0 &&
+        keylen <= sizeof(transform->samd_aead_key_enc)) {
+        memcpy(transform->samd_aead_key_enc, key1, keylen);
+        memcpy(transform->samd_aead_key_dec, key2, keylen);
+        transform->samd_aead_key_len = keylen;
+        transform->samd_aead_algorithm = (unsigned char) samd_aead_algorithm;
+        transform->samd_aead_keys_configured = 1;
+    }
+#endif
 
     if (alg != MBEDTLS_SSL_NULL_CIPHER) {
         psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT);

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -7761,10 +7761,10 @@ static mbedtls_tls_prf_types tls_prf_get_type(mbedtls_ssl_tls_prf_cb *tls_prf)
 /**
  * @brief Map Mbed TLS/PSA record parameters to async hardware TLS AEAD capabilities.
  *
- * @todo Wire AES-256-GCM, AES-CCM, AES-CCM-8, and ChaCha20-Poly1305 to
- * hardware-backed provider operations. They are classified here so production
- * hardware builds fail closed through the generic AEAD boundary instead of
- * silently falling back to PSA/software.
+ * TLS 1.2 AEAD transforms are classified into the generic async hardware
+ * provider algorithm IDs. Providers that do not implement a classified
+ * algorithm fail closed through the generic AEAD boundary instead of silently
+ * falling back to PSA/software.
  */
 static int mbedtls_async_hardware_tls_aead_from_transform(psa_key_type_t key_type,
                                                  size_t keylen,

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -61,6 +61,11 @@ int samd_mbedtls_ecdh_p384_public_key_start(
     uint8_t public_key[97],
     samd_mbedtls_async_callback_t callback,
     void *context);
+int samd_mbedtls_ecdh_p521_public_key_start(
+    const uint8_t private_scalar[66],
+    uint8_t public_key[133],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
 int samd_mbedtls_ecdh_p256_start(
     const uint8_t private_scalar[32],
     const uint8_t peer_public_key[65],
@@ -71,6 +76,12 @@ int samd_mbedtls_ecdh_p384_start(
     const uint8_t private_scalar[48],
     const uint8_t peer_public_key[97],
     uint8_t shared_secret[48],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
+int samd_mbedtls_ecdh_p521_start(
+    const uint8_t private_scalar[66],
+    const uint8_t peer_public_key[133],
+    uint8_t shared_secret[66],
     samd_mbedtls_async_callback_t callback,
     void *context);
 
@@ -177,7 +188,7 @@ static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
     handshake->samd_ecdh_public_done = 0;
     handshake->samd_ecdh_public_success = 0;
     handshake->samd_ecdh_public_ready = 0;
-    coordinate_len = handshake->xxdh_psa_bits / 8u;
+    coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
          samd_mbedtls_ecdh_p256_public_key_start(
@@ -187,6 +198,12 @@ static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
              handshake) :
          coordinate_len == 48 ?
          samd_mbedtls_ecdh_p384_public_key_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->samd_ecdh_public_key,
+             samd_mbedtls_ssl_ecdh_public_key_callback,
+             handshake) :
+         coordinate_len == 66 ?
+         samd_mbedtls_ecdh_p521_public_key_start(
              handshake->samd_ecdh_private_scalar,
              handshake->samd_ecdh_public_key,
              samd_mbedtls_ssl_ecdh_public_key_callback,
@@ -238,7 +255,7 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
         }
         handshake->samd_ecdh_secret_success = 0;
         handshake->samd_ecdh_secret_ready = 1;
-        ssl->handshake->pmslen = handshake->xxdh_psa_bits / 8u;
+        ssl->handshake->pmslen = (handshake->xxdh_psa_bits + 7u) / 8u;
         return 0;
     }
 
@@ -246,7 +263,7 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
     handshake->samd_ecdh_secret_done = 0;
     handshake->samd_ecdh_secret_success = 0;
     handshake->samd_ecdh_secret_ready = 0;
-    coordinate_len = handshake->xxdh_psa_bits / 8u;
+    coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
          samd_mbedtls_ecdh_p256_start(
@@ -257,6 +274,13 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
              handshake) :
          coordinate_len == 48 ?
          samd_mbedtls_ecdh_p384_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->xxdh_psa_peerkey,
+             ssl->handshake->premaster,
+             samd_mbedtls_ssl_ecdh_secret_callback,
+             handshake) :
+         coordinate_len == 66 ?
+         samd_mbedtls_ecdh_p521_start(
              handshake->samd_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
@@ -2311,13 +2335,14 @@ start_processing:
         }
 #endif
 
-#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT)
-        if (pk_alg == MBEDTLS_PK_SIGALG_RSA_PSS) {
+#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+        if (pk_alg == MBEDTLS_PK_SIGALG_RSA_PSS ||
+            pk_alg == MBEDTLS_PK_SIGALG_RSA_PKCS1V15) {
             ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) pk_alg, peer_pk,
                                         md_alg, hash, hashlen,
                                         p, sig_len);
         } else
-#endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT */
+#endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT || MBEDTLS_ASYNC_HARDWARE_RSA */
         ret = mbedtls_pk_verify_restartable(peer_pk,
                                             md_alg, hash, hashlen, p, sig_len, rs_ctx);
 
@@ -2389,8 +2414,8 @@ static int ssl_parse_certificate_request(mbedtls_ssl_context *ssl)
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info =
         ssl->handshake->ciphersuite_info;
     size_t sig_alg_len;
-#if defined(MBEDTLS_DEBUG_C)
     unsigned char *sig_alg;
+#if defined(MBEDTLS_DEBUG_C)
     unsigned char *dn;
 #endif
 
@@ -2506,14 +2531,20 @@ static int ssl_parse_certificate_request(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
-#if defined(MBEDTLS_DEBUG_C)
     sig_alg = buf + mbedtls_ssl_hs_hdr_len(ssl) + 3 + n;
+#if defined(MBEDTLS_DEBUG_C)
     for (size_t i = 0; i < sig_alg_len; i += 2) {
         MBEDTLS_SSL_DEBUG_MSG(3,
                               ("Supported Signature Algorithm found: %02x %02x",
                                sig_alg[i], sig_alg[i + 1]));
     }
 #endif
+
+    if ((ret = mbedtls_ssl_parse_sig_alg_ext(
+             ssl, sig_alg - 2, sig_alg + sig_alg_len)) != 0) {
+        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_ssl_parse_sig_alg_ext", ret);
+        return ret;
+    }
 
     n += 2 + sig_alg_len;
 
@@ -2665,11 +2696,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         size_t samd_coordinate_len;
         size_t samd_public_key_len;
 
-        if (handshake->xxdh_psa_bits !=
-                256u && handshake->xxdh_psa_bits != 384u) {
+        if (handshake->xxdh_psa_bits != 256u &&
+            handshake->xxdh_psa_bits != 384u &&
+            handshake->xxdh_psa_bits != 521u) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        samd_coordinate_len = handshake->xxdh_psa_bits / 8u;
+        samd_coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
         samd_public_key_len = samd_coordinate_len * 2u + 1u;
 
         if (handshake->samd_ecdh_private_ready == 0) {
@@ -3065,9 +3097,11 @@ static int ssl_write_certificate_verify(mbedtls_ssl_context *ssl)
     const mbedtls_ssl_ciphersuite_t *ciphersuite_info =
         ssl->handshake->ciphersuite_info;
     size_t n = 0, offset = 0;
-    unsigned char hash[48];
+    unsigned char hash[64];
     unsigned char *hash_start = hash;
     mbedtls_md_type_t md_alg = MBEDTLS_MD_NONE;
+    mbedtls_pk_sigalg_t pk_alg = MBEDTLS_PK_SIGALG_NONE;
+    uint16_t selected_sig_alg = MBEDTLS_TLS_SIG_NONE;
     size_t hashlen;
     void *rs_ctx = NULL;
 #if defined(MBEDTLS_SSL_VARIABLE_BUFFER_LENGTH)
@@ -3125,30 +3159,43 @@ sign:
         return ret;
     }
 
-    /*
-     * digitally-signed struct {
-     *     opaque handshake_messages[handshake_messages_length];
-     * };
-     *
-     * Taking shortcut here. We assume that the server always allows the
-     * PRF Hash function and has sent it in the allowed signature
-     * algorithms list received in the Certificate Request message.
-     *
-     * Until we encounter a server that does not, we will take this
-     * shortcut.
-     *
-     * Reason: Otherwise we should have running hashes for SHA512 and
-     *         SHA224 in order to satisfy 'weird' needs from the server
-     *         side.
-     */
-    if (ssl->handshake->ciphersuite_info->mac == MBEDTLS_MD_SHA384) {
-        md_alg = MBEDTLS_MD_SHA384;
-        ssl->out_msg[4] = MBEDTLS_SSL_HASH_SHA384;
-    } else {
-        md_alg = MBEDTLS_MD_SHA256;
-        ssl->out_msg[4] = MBEDTLS_SSL_HASH_SHA256;
+    const uint16_t *received_sig_alg = ssl->handshake->received_sig_algs;
+    for (; *received_sig_alg != MBEDTLS_TLS_SIG_NONE; received_sig_alg++) {
+        psa_algorithm_t psa_hash_alg = PSA_ALG_NONE;
+        psa_algorithm_t psa_sig_alg = PSA_ALG_NONE;
+        mbedtls_pk_sigalg_t candidate_pk_alg = MBEDTLS_PK_SIGALG_NONE;
+        mbedtls_md_type_t candidate_md_alg = MBEDTLS_MD_NONE;
+
+        if (mbedtls_ssl_get_pk_sigalg_and_md_alg_from_sig_alg(
+                *received_sig_alg, &candidate_pk_alg, &candidate_md_alg) != 0) {
+            continue;
+        }
+
+        psa_hash_alg = mbedtls_md_psa_alg_from_type(candidate_md_alg);
+        psa_sig_alg = mbedtls_psa_alg_from_pk_sigalg(candidate_pk_alg,
+                                                     psa_hash_alg);
+        if (!mbedtls_pk_can_do_psa(mbedtls_ssl_own_key(ssl), psa_sig_alg,
+                                   PSA_KEY_USAGE_SIGN_HASH)) {
+            continue;
+        }
+
+        if (mbedtls_ssl_set_calc_verify_md(
+                ssl, mbedtls_ssl_hash_from_md_alg(candidate_md_alg)) != 0) {
+            continue;
+        }
+
+        selected_sig_alg = *received_sig_alg;
+        pk_alg = candidate_pk_alg;
+        md_alg = candidate_md_alg;
+        break;
     }
-    ssl->out_msg[5] = mbedtls_ssl_sig_from_pk(mbedtls_ssl_own_key(ssl));
+
+    if (selected_sig_alg == MBEDTLS_TLS_SIG_NONE) {
+        MBEDTLS_SSL_DEBUG_MSG(1, ("no suitable client signature algorithm"));
+        return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+    }
+
+    MBEDTLS_PUT_UINT16_BE(selected_sig_alg, ssl->out_msg, 4);
 
     /* Info from md_alg will be used instead */
     hashlen = 0;
@@ -3160,14 +3207,24 @@ sign:
     }
 #endif
 
-    if ((ret = mbedtls_pk_sign_restartable(mbedtls_ssl_own_key(ssl),
-                                           md_alg, hash_start, hashlen,
-                                           ssl->out_msg + 6 + offset,
-                                           out_buf_len - 6 - offset,
-                                           &n,
-                                           rs_ctx)) != 0) {
-        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_sign_restartable", ret);
-#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (pk_alg == MBEDTLS_PK_SIGALG_RSA_PSS ||
+        pk_alg == MBEDTLS_PK_SIGALG_RSA_PKCS1V15) {
+        ret = mbedtls_pk_sign_ext(pk_alg, mbedtls_ssl_own_key(ssl),
+                                  md_alg, hash_start, hashlen,
+                                  ssl->out_msg + 6 + offset,
+                                  out_buf_len - 6 - offset, &n);
+    } else {
+        ret = mbedtls_pk_sign_restartable(mbedtls_ssl_own_key(ssl),
+                                          md_alg, hash_start, hashlen,
+                                          ssl->out_msg + 6 + offset,
+                                          out_buf_len - 6 - offset,
+                                          &n,
+                                          rs_ctx);
+    }
+    if (ret != 0) {
+        MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_sign", ret);
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
+    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
         if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
             ret = MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -41,51 +41,14 @@ static int local_err_translation(psa_status_t status)
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) || \
-    defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
 #include "mbedtls/platform_util.h"
 #endif
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+#include "mbedtls/psa_crypto_async_tls.h"
 
-int mbedtls_async_hardware_random_start(uint8_t *buffer, size_t length,
-                               mbedtls_async_hardware_callback_t callback,
-                               void *context);
-int mbedtls_async_hardware_ecdh_p256_public_key_start(
-    const uint8_t private_scalar[32],
-    uint8_t public_key[65],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_ecdh_p384_public_key_start(
-    const uint8_t private_scalar[48],
-    uint8_t public_key[97],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_ecdh_p521_public_key_start(
-    const uint8_t private_scalar[66],
-    uint8_t public_key[133],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_ecdh_p256_start(
-    const uint8_t private_scalar[32],
-    const uint8_t peer_public_key[65],
-    uint8_t shared_secret[32],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_ecdh_p384_start(
-    const uint8_t private_scalar[48],
-    const uint8_t peer_public_key[97],
-    uint8_t shared_secret[48],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-int mbedtls_async_hardware_ecdh_p521_start(
-    const uint8_t private_scalar[66],
-    const uint8_t peer_public_key[133],
-    uint8_t shared_secret[66],
-    mbedtls_async_hardware_callback_t callback,
-    void *context);
-
-static void mbedtls_async_hardware_ssl_random_callback(int success, void *context)
+static void mbedtls_psa_async_tls_ssl_random_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -93,11 +56,11 @@ static void mbedtls_async_hardware_ssl_random_callback(int success, void *contex
         return;
     }
 
-    handshake->async_hardware_random_success = success ? 1 : 0;
-    handshake->async_hardware_random_done = 1;
+    handshake->async_psa_random_success = success ? 1 : 0;
+    handshake->async_psa_random_done = 1;
 }
 
-static int mbedtls_async_hardware_ssl_random_fill(
+static int mbedtls_psa_async_tls_ssl_random_fill(
     mbedtls_ssl_context *ssl,
     unsigned char *buffer,
     size_t length)
@@ -111,36 +74,36 @@ static int mbedtls_async_hardware_ssl_random_fill(
 
     handshake = ssl->handshake;
 
-    if (handshake->async_hardware_random_pending != 0) {
-        if (handshake->async_hardware_random_done == 0) {
+    if (handshake->async_psa_random_pending != 0) {
+        if (handshake->async_psa_random_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->async_hardware_random_pending = 0;
-        handshake->async_hardware_random_done = 0;
-        if (handshake->async_hardware_random_success == 0) {
-            handshake->async_hardware_random_success = 0;
+        handshake->async_psa_random_pending = 0;
+        handshake->async_psa_random_done = 0;
+        if (handshake->async_psa_random_success == 0) {
+            handshake->async_psa_random_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->async_hardware_random_success = 0;
+        handshake->async_psa_random_success = 0;
         return 0;
     }
 
-    handshake->async_hardware_random_pending = 1;
-    handshake->async_hardware_random_done = 0;
-    handshake->async_hardware_random_success = 0;
+    handshake->async_psa_random_pending = 1;
+    handshake->async_psa_random_done = 0;
+    handshake->async_psa_random_success = 0;
 
-    if (mbedtls_async_hardware_random_start(
-            buffer, length, mbedtls_async_hardware_ssl_random_callback,
+    if (mbedtls_psa_async_tls_random_start(
+            buffer, length, mbedtls_psa_async_tls_ssl_random_callback,
             handshake) == 0) {
-        handshake->async_hardware_random_pending = 0;
+        handshake->async_psa_random_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void mbedtls_async_hardware_ssl_ecdh_public_key_callback(int success,
+static void mbedtls_psa_async_tls_ssl_ecdh_public_key_callback(int success,
                                                        void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
@@ -149,11 +112,11 @@ static void mbedtls_async_hardware_ssl_ecdh_public_key_callback(int success,
         return;
     }
 
-    handshake->async_hardware_ecdh_public_success = success ? 1 : 0;
-    handshake->async_hardware_ecdh_public_done = 1;
+    handshake->async_psa_ecdh_public_success = success ? 1 : 0;
+    handshake->async_psa_ecdh_public_done = 1;
 }
 
-static int mbedtls_async_hardware_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
+static int mbedtls_psa_async_tls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
     size_t coordinate_len;
@@ -164,58 +127,58 @@ static int mbedtls_async_hardware_ssl_ecdh_public_key_fill(mbedtls_ssl_context *
 
     handshake = ssl->handshake;
 
-    if (handshake->async_hardware_ecdh_public_ready != 0) {
+    if (handshake->async_psa_ecdh_public_ready != 0) {
         return 0;
     }
 
-    if (handshake->async_hardware_ecdh_public_pending != 0) {
-        if (handshake->async_hardware_ecdh_public_done == 0) {
+    if (handshake->async_psa_ecdh_public_pending != 0) {
+        if (handshake->async_psa_ecdh_public_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->async_hardware_ecdh_public_pending = 0;
-        handshake->async_hardware_ecdh_public_done = 0;
-        if (handshake->async_hardware_ecdh_public_success == 0) {
-            handshake->async_hardware_ecdh_public_success = 0;
+        handshake->async_psa_ecdh_public_pending = 0;
+        handshake->async_psa_ecdh_public_done = 0;
+        if (handshake->async_psa_ecdh_public_success == 0) {
+            handshake->async_psa_ecdh_public_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->async_hardware_ecdh_public_success = 0;
-        handshake->async_hardware_ecdh_public_ready = 1;
+        handshake->async_psa_ecdh_public_success = 0;
+        handshake->async_psa_ecdh_public_ready = 1;
         return 0;
     }
 
-    handshake->async_hardware_ecdh_public_pending = 1;
-    handshake->async_hardware_ecdh_public_done = 0;
-    handshake->async_hardware_ecdh_public_success = 0;
-    handshake->async_hardware_ecdh_public_ready = 0;
+    handshake->async_psa_ecdh_public_pending = 1;
+    handshake->async_psa_ecdh_public_done = 0;
+    handshake->async_psa_ecdh_public_success = 0;
+    handshake->async_psa_ecdh_public_ready = 0;
     coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
-         mbedtls_async_hardware_ecdh_p256_public_key_start(
-             handshake->async_hardware_ecdh_private_scalar,
-             handshake->async_hardware_ecdh_public_key,
-             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
+         mbedtls_psa_async_tls_ecdh_p256_public_key_start(
+             handshake->async_psa_ecdh_private_scalar,
+             handshake->async_psa_ecdh_public_key,
+             mbedtls_psa_async_tls_ssl_ecdh_public_key_callback,
              handshake) :
          coordinate_len == 48 ?
-         mbedtls_async_hardware_ecdh_p384_public_key_start(
-             handshake->async_hardware_ecdh_private_scalar,
-             handshake->async_hardware_ecdh_public_key,
-             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
+         mbedtls_psa_async_tls_ecdh_p384_public_key_start(
+             handshake->async_psa_ecdh_private_scalar,
+             handshake->async_psa_ecdh_public_key,
+             mbedtls_psa_async_tls_ssl_ecdh_public_key_callback,
              handshake) :
          coordinate_len == 66 ?
-         mbedtls_async_hardware_ecdh_p521_public_key_start(
-             handshake->async_hardware_ecdh_private_scalar,
-             handshake->async_hardware_ecdh_public_key,
-             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
+         mbedtls_psa_async_tls_ecdh_p521_public_key_start(
+             handshake->async_psa_ecdh_private_scalar,
+             handshake->async_psa_ecdh_public_key,
+             mbedtls_psa_async_tls_ssl_ecdh_public_key_callback,
              handshake) :
          0) == 0) {
-        handshake->async_hardware_ecdh_public_pending = 0;
+        handshake->async_psa_ecdh_public_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void mbedtls_async_hardware_ssl_ecdh_secret_callback(int success, void *context)
+static void mbedtls_psa_async_tls_ssl_ecdh_secret_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -223,11 +186,11 @@ static void mbedtls_async_hardware_ssl_ecdh_secret_callback(int success, void *c
         return;
     }
 
-    handshake->async_hardware_ecdh_secret_success = success ? 1 : 0;
-    handshake->async_hardware_ecdh_secret_done = 1;
+    handshake->async_psa_ecdh_secret_success = success ? 1 : 0;
+    handshake->async_psa_ecdh_secret_done = 1;
 }
 
-static int mbedtls_async_hardware_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
+static int mbedtls_psa_async_tls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
     size_t coordinate_len;
@@ -238,71 +201,71 @@ static int mbedtls_async_hardware_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
 
     handshake = ssl->handshake;
 
-    if (handshake->async_hardware_ecdh_secret_ready != 0) {
+    if (handshake->async_psa_ecdh_secret_ready != 0) {
         return 0;
     }
 
-    if (handshake->async_hardware_ecdh_secret_pending != 0) {
-        if (handshake->async_hardware_ecdh_secret_done == 0) {
+    if (handshake->async_psa_ecdh_secret_pending != 0) {
+        if (handshake->async_psa_ecdh_secret_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->async_hardware_ecdh_secret_pending = 0;
-        handshake->async_hardware_ecdh_secret_done = 0;
-        if (handshake->async_hardware_ecdh_secret_success == 0) {
-            handshake->async_hardware_ecdh_secret_success = 0;
+        handshake->async_psa_ecdh_secret_pending = 0;
+        handshake->async_psa_ecdh_secret_done = 0;
+        if (handshake->async_psa_ecdh_secret_success == 0) {
+            handshake->async_psa_ecdh_secret_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->async_hardware_ecdh_secret_success = 0;
-        handshake->async_hardware_ecdh_secret_ready = 1;
+        handshake->async_psa_ecdh_secret_success = 0;
+        handshake->async_psa_ecdh_secret_ready = 1;
         ssl->handshake->pmslen = (handshake->xxdh_psa_bits + 7u) / 8u;
         return 0;
     }
 
-    handshake->async_hardware_ecdh_secret_pending = 1;
-    handshake->async_hardware_ecdh_secret_done = 0;
-    handshake->async_hardware_ecdh_secret_success = 0;
-    handshake->async_hardware_ecdh_secret_ready = 0;
+    handshake->async_psa_ecdh_secret_pending = 1;
+    handshake->async_psa_ecdh_secret_done = 0;
+    handshake->async_psa_ecdh_secret_success = 0;
+    handshake->async_psa_ecdh_secret_ready = 0;
     coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
-         mbedtls_async_hardware_ecdh_p256_start(
-             handshake->async_hardware_ecdh_private_scalar,
+         mbedtls_psa_async_tls_ecdh_p256_start(
+             handshake->async_psa_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             mbedtls_async_hardware_ssl_ecdh_secret_callback,
+             mbedtls_psa_async_tls_ssl_ecdh_secret_callback,
              handshake) :
          coordinate_len == 48 ?
-         mbedtls_async_hardware_ecdh_p384_start(
-             handshake->async_hardware_ecdh_private_scalar,
+         mbedtls_psa_async_tls_ecdh_p384_start(
+             handshake->async_psa_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             mbedtls_async_hardware_ssl_ecdh_secret_callback,
+             mbedtls_psa_async_tls_ssl_ecdh_secret_callback,
              handshake) :
          coordinate_len == 66 ?
-         mbedtls_async_hardware_ecdh_p521_start(
-             handshake->async_hardware_ecdh_private_scalar,
+         mbedtls_psa_async_tls_ecdh_p521_start(
+             handshake->async_psa_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             mbedtls_async_hardware_ssl_ecdh_secret_callback,
+             mbedtls_psa_async_tls_ssl_ecdh_secret_callback,
              handshake) :
          0) == 0) {
-        handshake->async_hardware_ecdh_secret_pending = 0;
+        handshake->async_psa_ecdh_secret_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void mbedtls_async_hardware_clear_ecdh_scalar(
+static void mbedtls_async_psa_clear_ecdh_scalar(
     mbedtls_ssl_handshake_params *handshake)
 {
     if (handshake == NULL) {
         return;
     }
 
-    mbedtls_platform_zeroize(handshake->async_hardware_ecdh_private_scalar,
-                             sizeof(handshake->async_hardware_ecdh_private_scalar));
+    mbedtls_platform_zeroize(handshake->async_psa_ecdh_private_scalar,
+                             sizeof(handshake->async_psa_ecdh_private_scalar));
 }
 #endif
 
@@ -2335,21 +2298,21 @@ start_processing:
         }
 #endif
 
-#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) || defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA)
         if (pk_alg == MBEDTLS_PK_SIGALG_RSA_PSS ||
             pk_alg == MBEDTLS_PK_SIGALG_RSA_PKCS1V15) {
             ret = mbedtls_pk_verify_ext((mbedtls_pk_sigalg_t) pk_alg, peer_pk,
                                         md_alg, hash, hashlen,
                                         p, sig_len);
         } else
-#endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT || MBEDTLS_ASYNC_HARDWARE_RSA */
+#endif /* MBEDTLS_X509_RSASSA_PSS_SUPPORT || MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA */
         ret = mbedtls_pk_verify_restartable(peer_pk,
                                             md_alg, hash, hashlen, p, sig_len, rs_ctx);
 
         if (ret != 0) {
             int send_alert_msg = 1;
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
-    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+    defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA) || defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA)
             send_alert_msg = (ret != MBEDTLS_ERR_ECP_IN_PROGRESS);
 #endif
             if (send_alert_msg) {
@@ -2360,7 +2323,7 @@ start_processing:
             }
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_restartable", ret);
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
-    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+    defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA) || defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA)
             if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
                 ret = MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
@@ -2647,13 +2610,13 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
     defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     if (ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_RSA ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA) {
-#if !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+#if !defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
         psa_status_t destruction_status = PSA_ERROR_CORRUPTION_DETECTED;
 #endif
         psa_key_attributes_t key_attributes;
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) && \
-    !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    !defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
         psa_key_attributes_t secret_attributes;
         mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
         psa_status_t shared_secret_destruction_status = PSA_SUCCESS;
@@ -2666,7 +2629,7 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         MBEDTLS_SSL_DEBUG_MSG(3, ("Perform PSA-based ECDH computation."));
 
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) && \
-    !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+    !defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
         secret_attributes = psa_key_attributes_init();
         if (handshake->ecrs_enabled &&
             handshake->ecrs_state == ssl_ecrs_cke_ecdh_calc_secret) {
@@ -2692,67 +2655,67 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
         psa_set_key_bits(&key_attributes, handshake->xxdh_psa_bits);
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-        size_t async_hardware_coordinate_len;
-        size_t async_hardware_public_key_len;
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+        size_t async_psa_coordinate_len;
+        size_t async_psa_public_key_len;
 
         if (handshake->xxdh_psa_bits != 256u &&
             handshake->xxdh_psa_bits != 384u &&
             handshake->xxdh_psa_bits != 521u) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        async_hardware_coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
-        async_hardware_public_key_len = async_hardware_coordinate_len * 2u + 1u;
+        async_psa_coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
+        async_psa_public_key_len = async_psa_coordinate_len * 2u + 1u;
 
-        if (handshake->async_hardware_ecdh_private_ready == 0) {
-            ret = mbedtls_async_hardware_ssl_random_fill(
-                ssl, handshake->async_hardware_ecdh_private_scalar,
-                async_hardware_coordinate_len);
+        if (handshake->async_psa_ecdh_private_ready == 0) {
+            ret = mbedtls_psa_async_tls_ssl_random_fill(
+                ssl, handshake->async_psa_ecdh_private_scalar,
+                async_psa_coordinate_len);
             if (ret != 0) {
                 return ret;
             }
-            handshake->async_hardware_ecdh_private_ready = 1;
+            handshake->async_psa_ecdh_private_ready = 1;
         }
 
-        ret = mbedtls_async_hardware_ssl_ecdh_public_key_fill(ssl);
+        ret = mbedtls_psa_async_tls_ssl_ecdh_public_key_fill(ssl);
         if (ret != 0) {
             return ret;
         }
 
-        unsigned char *async_hardware_own_pubkey = ssl->out_msg + header_len + 1;
-        unsigned char *async_hardware_end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
-        size_t async_hardware_own_pubkey_max_len =
-            (size_t) (async_hardware_end - async_hardware_own_pubkey);
+        unsigned char *async_psa_own_pubkey = ssl->out_msg + header_len + 1;
+        unsigned char *async_psa_end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
+        size_t async_psa_own_pubkey_max_len =
+            (size_t) (async_psa_end - async_psa_own_pubkey);
 
-        if (async_hardware_own_pubkey_max_len <
-            async_hardware_public_key_len) {
+        if (async_psa_own_pubkey_max_len <
+            async_psa_public_key_len) {
             return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
         }
 
-        memcpy(async_hardware_own_pubkey, handshake->async_hardware_ecdh_public_key,
-               async_hardware_public_key_len);
+        memcpy(async_psa_own_pubkey, handshake->async_psa_ecdh_public_key,
+               async_psa_public_key_len);
         ssl->out_msg[header_len] =
-            (unsigned char) async_hardware_public_key_len;
-        content_len = async_hardware_public_key_len + 1;
+            (unsigned char) async_psa_public_key_len;
+        content_len = async_psa_public_key_len + 1;
 
-        ret = mbedtls_async_hardware_ssl_ecdh_secret_fill(ssl);
+        ret = mbedtls_psa_async_tls_ssl_ecdh_secret_fill(ssl);
         if (ret != 0) {
             return ret;
         }
 
-        mbedtls_async_hardware_clear_ecdh_scalar(handshake);
-        handshake->async_hardware_ecdh_private_ready = 0;
-        handshake->async_hardware_ecdh_public_ready = 0;
-        handshake->async_hardware_ecdh_secret_ready = 0;
-        mbedtls_platform_zeroize(handshake->async_hardware_ecdh_public_key,
-                                 sizeof(handshake->async_hardware_ecdh_public_key));
-        goto async_hardware_ecdh_done;
+        mbedtls_async_psa_clear_ecdh_scalar(handshake);
+        handshake->async_psa_ecdh_private_ready = 0;
+        handshake->async_psa_ecdh_public_ready = 0;
+        handshake->async_psa_ecdh_secret_ready = 0;
+        mbedtls_platform_zeroize(handshake->async_psa_ecdh_public_key,
+                                 sizeof(handshake->async_psa_ecdh_public_key));
+        goto async_psa_ecdh_done;
 #else
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
                                   &handshake->xxdh_psa_privkey);
 #endif
-#if !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+#if !defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
         if (status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
@@ -2853,8 +2816,8 @@ complete_interruptible_ecdh:
         }
         }
 #endif
-#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-async_hardware_ecdh_done:
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RANDOM)
+async_psa_ecdh_done:
         (void) 0;
 #endif
     } else
@@ -3230,7 +3193,7 @@ sign:
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_sign", ret);
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
-    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+    defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA) || defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA)
         if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
             ret = MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -3195,6 +3195,12 @@ sign:
         return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
     }
 
+    ret = ssl->handshake->calc_verify(ssl, hash, &hashlen);
+    if (0 != ret) {
+        MBEDTLS_SSL_DEBUG_RET(1, ("calc_verify"), ret);
+        return ret;
+    }
+
     MBEDTLS_PUT_UINT16_BE(selected_sig_alg, ssl->out_msg, 4);
 
     /* Info from md_alg will be used instead */

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -46,46 +46,46 @@ static int local_err_translation(psa_status_t status)
 #endif
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+typedef void (*mbedtls_async_hardware_callback_t)(int success, void *context);
 
-int samd_mbedtls_random_start(uint8_t *buffer, size_t length,
-                               samd_mbedtls_async_callback_t callback,
+int mbedtls_async_hardware_random_start(uint8_t *buffer, size_t length,
+                               mbedtls_async_hardware_callback_t callback,
                                void *context);
-int samd_mbedtls_ecdh_p256_public_key_start(
+int mbedtls_async_hardware_ecdh_p256_public_key_start(
     const uint8_t private_scalar[32],
     uint8_t public_key[65],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_ecdh_p384_public_key_start(
+int mbedtls_async_hardware_ecdh_p384_public_key_start(
     const uint8_t private_scalar[48],
     uint8_t public_key[97],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_ecdh_p521_public_key_start(
+int mbedtls_async_hardware_ecdh_p521_public_key_start(
     const uint8_t private_scalar[66],
     uint8_t public_key[133],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_ecdh_p256_start(
+int mbedtls_async_hardware_ecdh_p256_start(
     const uint8_t private_scalar[32],
     const uint8_t peer_public_key[65],
     uint8_t shared_secret[32],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_ecdh_p384_start(
+int mbedtls_async_hardware_ecdh_p384_start(
     const uint8_t private_scalar[48],
     const uint8_t peer_public_key[97],
     uint8_t shared_secret[48],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
-int samd_mbedtls_ecdh_p521_start(
+int mbedtls_async_hardware_ecdh_p521_start(
     const uint8_t private_scalar[66],
     const uint8_t peer_public_key[133],
     uint8_t shared_secret[66],
-    samd_mbedtls_async_callback_t callback,
+    mbedtls_async_hardware_callback_t callback,
     void *context);
 
-static void samd_mbedtls_ssl_random_callback(int success, void *context)
+static void mbedtls_async_hardware_ssl_random_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -93,11 +93,11 @@ static void samd_mbedtls_ssl_random_callback(int success, void *context)
         return;
     }
 
-    handshake->samd_random_success = success ? 1 : 0;
-    handshake->samd_random_done = 1;
+    handshake->async_hardware_random_success = success ? 1 : 0;
+    handshake->async_hardware_random_done = 1;
 }
 
-static int samd_mbedtls_ssl_random_fill(
+static int mbedtls_async_hardware_ssl_random_fill(
     mbedtls_ssl_context *ssl,
     unsigned char *buffer,
     size_t length)
@@ -111,36 +111,36 @@ static int samd_mbedtls_ssl_random_fill(
 
     handshake = ssl->handshake;
 
-    if (handshake->samd_random_pending != 0) {
-        if (handshake->samd_random_done == 0) {
+    if (handshake->async_hardware_random_pending != 0) {
+        if (handshake->async_hardware_random_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->samd_random_pending = 0;
-        handshake->samd_random_done = 0;
-        if (handshake->samd_random_success == 0) {
-            handshake->samd_random_success = 0;
+        handshake->async_hardware_random_pending = 0;
+        handshake->async_hardware_random_done = 0;
+        if (handshake->async_hardware_random_success == 0) {
+            handshake->async_hardware_random_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->samd_random_success = 0;
+        handshake->async_hardware_random_success = 0;
         return 0;
     }
 
-    handshake->samd_random_pending = 1;
-    handshake->samd_random_done = 0;
-    handshake->samd_random_success = 0;
+    handshake->async_hardware_random_pending = 1;
+    handshake->async_hardware_random_done = 0;
+    handshake->async_hardware_random_success = 0;
 
-    if (samd_mbedtls_random_start(
-            buffer, length, samd_mbedtls_ssl_random_callback,
+    if (mbedtls_async_hardware_random_start(
+            buffer, length, mbedtls_async_hardware_ssl_random_callback,
             handshake) == 0) {
-        handshake->samd_random_pending = 0;
+        handshake->async_hardware_random_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void samd_mbedtls_ssl_ecdh_public_key_callback(int success,
+static void mbedtls_async_hardware_ssl_ecdh_public_key_callback(int success,
                                                        void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
@@ -149,11 +149,11 @@ static void samd_mbedtls_ssl_ecdh_public_key_callback(int success,
         return;
     }
 
-    handshake->samd_ecdh_public_success = success ? 1 : 0;
-    handshake->samd_ecdh_public_done = 1;
+    handshake->async_hardware_ecdh_public_success = success ? 1 : 0;
+    handshake->async_hardware_ecdh_public_done = 1;
 }
 
-static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
+static int mbedtls_async_hardware_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
     size_t coordinate_len;
@@ -164,58 +164,58 @@ static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
 
     handshake = ssl->handshake;
 
-    if (handshake->samd_ecdh_public_ready != 0) {
+    if (handshake->async_hardware_ecdh_public_ready != 0) {
         return 0;
     }
 
-    if (handshake->samd_ecdh_public_pending != 0) {
-        if (handshake->samd_ecdh_public_done == 0) {
+    if (handshake->async_hardware_ecdh_public_pending != 0) {
+        if (handshake->async_hardware_ecdh_public_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->samd_ecdh_public_pending = 0;
-        handshake->samd_ecdh_public_done = 0;
-        if (handshake->samd_ecdh_public_success == 0) {
-            handshake->samd_ecdh_public_success = 0;
+        handshake->async_hardware_ecdh_public_pending = 0;
+        handshake->async_hardware_ecdh_public_done = 0;
+        if (handshake->async_hardware_ecdh_public_success == 0) {
+            handshake->async_hardware_ecdh_public_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->samd_ecdh_public_success = 0;
-        handshake->samd_ecdh_public_ready = 1;
+        handshake->async_hardware_ecdh_public_success = 0;
+        handshake->async_hardware_ecdh_public_ready = 1;
         return 0;
     }
 
-    handshake->samd_ecdh_public_pending = 1;
-    handshake->samd_ecdh_public_done = 0;
-    handshake->samd_ecdh_public_success = 0;
-    handshake->samd_ecdh_public_ready = 0;
+    handshake->async_hardware_ecdh_public_pending = 1;
+    handshake->async_hardware_ecdh_public_done = 0;
+    handshake->async_hardware_ecdh_public_success = 0;
+    handshake->async_hardware_ecdh_public_ready = 0;
     coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
-         samd_mbedtls_ecdh_p256_public_key_start(
-             handshake->samd_ecdh_private_scalar,
-             handshake->samd_ecdh_public_key,
-             samd_mbedtls_ssl_ecdh_public_key_callback,
+         mbedtls_async_hardware_ecdh_p256_public_key_start(
+             handshake->async_hardware_ecdh_private_scalar,
+             handshake->async_hardware_ecdh_public_key,
+             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
              handshake) :
          coordinate_len == 48 ?
-         samd_mbedtls_ecdh_p384_public_key_start(
-             handshake->samd_ecdh_private_scalar,
-             handshake->samd_ecdh_public_key,
-             samd_mbedtls_ssl_ecdh_public_key_callback,
+         mbedtls_async_hardware_ecdh_p384_public_key_start(
+             handshake->async_hardware_ecdh_private_scalar,
+             handshake->async_hardware_ecdh_public_key,
+             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
              handshake) :
          coordinate_len == 66 ?
-         samd_mbedtls_ecdh_p521_public_key_start(
-             handshake->samd_ecdh_private_scalar,
-             handshake->samd_ecdh_public_key,
-             samd_mbedtls_ssl_ecdh_public_key_callback,
+         mbedtls_async_hardware_ecdh_p521_public_key_start(
+             handshake->async_hardware_ecdh_private_scalar,
+             handshake->async_hardware_ecdh_public_key,
+             mbedtls_async_hardware_ssl_ecdh_public_key_callback,
              handshake) :
          0) == 0) {
-        handshake->samd_ecdh_public_pending = 0;
+        handshake->async_hardware_ecdh_public_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void samd_mbedtls_ssl_ecdh_secret_callback(int success, void *context)
+static void mbedtls_async_hardware_ssl_ecdh_secret_callback(int success, void *context)
 {
     mbedtls_ssl_handshake_params *handshake =
         (mbedtls_ssl_handshake_params *) context;
@@ -223,11 +223,11 @@ static void samd_mbedtls_ssl_ecdh_secret_callback(int success, void *context)
         return;
     }
 
-    handshake->samd_ecdh_secret_success = success ? 1 : 0;
-    handshake->samd_ecdh_secret_done = 1;
+    handshake->async_hardware_ecdh_secret_success = success ? 1 : 0;
+    handshake->async_hardware_ecdh_secret_done = 1;
 }
 
-static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
+static int mbedtls_async_hardware_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
     size_t coordinate_len;
@@ -238,71 +238,71 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
 
     handshake = ssl->handshake;
 
-    if (handshake->samd_ecdh_secret_ready != 0) {
+    if (handshake->async_hardware_ecdh_secret_ready != 0) {
         return 0;
     }
 
-    if (handshake->samd_ecdh_secret_pending != 0) {
-        if (handshake->samd_ecdh_secret_done == 0) {
+    if (handshake->async_hardware_ecdh_secret_pending != 0) {
+        if (handshake->async_hardware_ecdh_secret_done == 0) {
             return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
         }
 
-        handshake->samd_ecdh_secret_pending = 0;
-        handshake->samd_ecdh_secret_done = 0;
-        if (handshake->samd_ecdh_secret_success == 0) {
-            handshake->samd_ecdh_secret_success = 0;
+        handshake->async_hardware_ecdh_secret_pending = 0;
+        handshake->async_hardware_ecdh_secret_done = 0;
+        if (handshake->async_hardware_ecdh_secret_success == 0) {
+            handshake->async_hardware_ecdh_secret_success = 0;
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        handshake->samd_ecdh_secret_success = 0;
-        handshake->samd_ecdh_secret_ready = 1;
+        handshake->async_hardware_ecdh_secret_success = 0;
+        handshake->async_hardware_ecdh_secret_ready = 1;
         ssl->handshake->pmslen = (handshake->xxdh_psa_bits + 7u) / 8u;
         return 0;
     }
 
-    handshake->samd_ecdh_secret_pending = 1;
-    handshake->samd_ecdh_secret_done = 0;
-    handshake->samd_ecdh_secret_success = 0;
-    handshake->samd_ecdh_secret_ready = 0;
+    handshake->async_hardware_ecdh_secret_pending = 1;
+    handshake->async_hardware_ecdh_secret_done = 0;
+    handshake->async_hardware_ecdh_secret_success = 0;
+    handshake->async_hardware_ecdh_secret_ready = 0;
     coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
 
     if ((coordinate_len == 32 ?
-         samd_mbedtls_ecdh_p256_start(
-             handshake->samd_ecdh_private_scalar,
+         mbedtls_async_hardware_ecdh_p256_start(
+             handshake->async_hardware_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             samd_mbedtls_ssl_ecdh_secret_callback,
+             mbedtls_async_hardware_ssl_ecdh_secret_callback,
              handshake) :
          coordinate_len == 48 ?
-         samd_mbedtls_ecdh_p384_start(
-             handshake->samd_ecdh_private_scalar,
+         mbedtls_async_hardware_ecdh_p384_start(
+             handshake->async_hardware_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             samd_mbedtls_ssl_ecdh_secret_callback,
+             mbedtls_async_hardware_ssl_ecdh_secret_callback,
              handshake) :
          coordinate_len == 66 ?
-         samd_mbedtls_ecdh_p521_start(
-             handshake->samd_ecdh_private_scalar,
+         mbedtls_async_hardware_ecdh_p521_start(
+             handshake->async_hardware_ecdh_private_scalar,
              handshake->xxdh_psa_peerkey,
              ssl->handshake->premaster,
-             samd_mbedtls_ssl_ecdh_secret_callback,
+             mbedtls_async_hardware_ssl_ecdh_secret_callback,
              handshake) :
          0) == 0) {
-        handshake->samd_ecdh_secret_pending = 0;
+        handshake->async_hardware_ecdh_secret_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
 
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
-static void samd_mbedtls_clear_ecdh_scalar(
+static void mbedtls_async_hardware_clear_ecdh_scalar(
     mbedtls_ssl_handshake_params *handshake)
 {
     if (handshake == NULL) {
         return;
     }
 
-    mbedtls_platform_zeroize(handshake->samd_ecdh_private_scalar,
-                             sizeof(handshake->samd_ecdh_private_scalar));
+    mbedtls_platform_zeroize(handshake->async_hardware_ecdh_private_scalar,
+                             sizeof(handshake->async_hardware_ecdh_private_scalar));
 }
 #endif
 
@@ -2693,60 +2693,60 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         psa_set_key_bits(&key_attributes, handshake->xxdh_psa_bits);
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-        size_t samd_coordinate_len;
-        size_t samd_public_key_len;
+        size_t async_hardware_coordinate_len;
+        size_t async_hardware_public_key_len;
 
         if (handshake->xxdh_psa_bits != 256u &&
             handshake->xxdh_psa_bits != 384u &&
             handshake->xxdh_psa_bits != 521u) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
-        samd_coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
-        samd_public_key_len = samd_coordinate_len * 2u + 1u;
+        async_hardware_coordinate_len = (handshake->xxdh_psa_bits + 7u) / 8u;
+        async_hardware_public_key_len = async_hardware_coordinate_len * 2u + 1u;
 
-        if (handshake->samd_ecdh_private_ready == 0) {
-            ret = samd_mbedtls_ssl_random_fill(
-                ssl, handshake->samd_ecdh_private_scalar,
-                samd_coordinate_len);
+        if (handshake->async_hardware_ecdh_private_ready == 0) {
+            ret = mbedtls_async_hardware_ssl_random_fill(
+                ssl, handshake->async_hardware_ecdh_private_scalar,
+                async_hardware_coordinate_len);
             if (ret != 0) {
                 return ret;
             }
-            handshake->samd_ecdh_private_ready = 1;
+            handshake->async_hardware_ecdh_private_ready = 1;
         }
 
-        ret = samd_mbedtls_ssl_ecdh_public_key_fill(ssl);
+        ret = mbedtls_async_hardware_ssl_ecdh_public_key_fill(ssl);
         if (ret != 0) {
             return ret;
         }
 
-        unsigned char *samd_own_pubkey = ssl->out_msg + header_len + 1;
-        unsigned char *samd_end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
-        size_t samd_own_pubkey_max_len =
-            (size_t) (samd_end - samd_own_pubkey);
+        unsigned char *async_hardware_own_pubkey = ssl->out_msg + header_len + 1;
+        unsigned char *async_hardware_end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
+        size_t async_hardware_own_pubkey_max_len =
+            (size_t) (async_hardware_end - async_hardware_own_pubkey);
 
-        if (samd_own_pubkey_max_len <
-            samd_public_key_len) {
+        if (async_hardware_own_pubkey_max_len <
+            async_hardware_public_key_len) {
             return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
         }
 
-        memcpy(samd_own_pubkey, handshake->samd_ecdh_public_key,
-               samd_public_key_len);
+        memcpy(async_hardware_own_pubkey, handshake->async_hardware_ecdh_public_key,
+               async_hardware_public_key_len);
         ssl->out_msg[header_len] =
-            (unsigned char) samd_public_key_len;
-        content_len = samd_public_key_len + 1;
+            (unsigned char) async_hardware_public_key_len;
+        content_len = async_hardware_public_key_len + 1;
 
-        ret = samd_mbedtls_ssl_ecdh_secret_fill(ssl);
+        ret = mbedtls_async_hardware_ssl_ecdh_secret_fill(ssl);
         if (ret != 0) {
             return ret;
         }
 
-        samd_mbedtls_clear_ecdh_scalar(handshake);
-        handshake->samd_ecdh_private_ready = 0;
-        handshake->samd_ecdh_public_ready = 0;
-        handshake->samd_ecdh_secret_ready = 0;
-        mbedtls_platform_zeroize(handshake->samd_ecdh_public_key,
-                                 sizeof(handshake->samd_ecdh_public_key));
-        goto samd_ecdh_done;
+        mbedtls_async_hardware_clear_ecdh_scalar(handshake);
+        handshake->async_hardware_ecdh_private_ready = 0;
+        handshake->async_hardware_ecdh_public_ready = 0;
+        handshake->async_hardware_ecdh_secret_ready = 0;
+        mbedtls_platform_zeroize(handshake->async_hardware_ecdh_public_key,
+                                 sizeof(handshake->async_hardware_ecdh_public_key));
+        goto async_hardware_ecdh_done;
 #else
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
@@ -2854,7 +2854,7 @@ complete_interruptible_ecdh:
         }
 #endif
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
-samd_ecdh_done:
+async_hardware_ecdh_done:
         (void) 0;
 #endif
     } else

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -40,8 +40,215 @@ static int local_err_translation(psa_status_t status)
 #include "mbedtls/platform_time.h"
 #endif
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) || \
+    defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
 #include "mbedtls/platform_util.h"
+#endif
+
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+typedef void (*samd_mbedtls_async_callback_t)(int success, void *context);
+
+int samd_mbedtls_random_start(uint8_t *buffer, size_t length,
+                               samd_mbedtls_async_callback_t callback,
+                               void *context);
+int samd_mbedtls_ecdh_p256_public_key_start(
+    const uint8_t private_scalar[32],
+    uint8_t public_key[65],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
+int samd_mbedtls_ecdh_p256_start(
+    const uint8_t private_scalar[32],
+    const uint8_t peer_public_key[65],
+    uint8_t shared_secret[32],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
+
+static void samd_mbedtls_ssl_random_callback(int success, void *context)
+{
+    mbedtls_ssl_handshake_params *handshake =
+        (mbedtls_ssl_handshake_params *) context;
+    if (handshake == NULL) {
+        return;
+    }
+
+    handshake->samd_random_success = success ? 1 : 0;
+    handshake->samd_random_done = 1;
+}
+
+static int samd_mbedtls_ssl_random_fill(
+    mbedtls_ssl_context *ssl,
+    unsigned char *buffer,
+    size_t length)
+{
+    mbedtls_ssl_handshake_params *handshake;
+
+    if (ssl == NULL || ssl->handshake == NULL ||
+        buffer == NULL || length == 0) {
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    handshake = ssl->handshake;
+
+    if (handshake->samd_random_pending != 0) {
+        if (handshake->samd_random_done == 0) {
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        handshake->samd_random_pending = 0;
+        handshake->samd_random_done = 0;
+        if (handshake->samd_random_success == 0) {
+            handshake->samd_random_success = 0;
+            return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        }
+        handshake->samd_random_success = 0;
+        return 0;
+    }
+
+    handshake->samd_random_pending = 1;
+    handshake->samd_random_done = 0;
+    handshake->samd_random_success = 0;
+
+    if (samd_mbedtls_random_start(
+            buffer, length, samd_mbedtls_ssl_random_callback,
+            handshake) == 0) {
+        handshake->samd_random_pending = 0;
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+    }
+
+    return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+}
+
+static void samd_mbedtls_ssl_ecdh_public_key_callback(int success,
+                                                       void *context)
+{
+    mbedtls_ssl_handshake_params *handshake =
+        (mbedtls_ssl_handshake_params *) context;
+    if (handshake == NULL) {
+        return;
+    }
+
+    handshake->samd_ecdh_public_success = success ? 1 : 0;
+    handshake->samd_ecdh_public_done = 1;
+}
+
+static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_handshake_params *handshake;
+
+    if (ssl == NULL || ssl->handshake == NULL) {
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    handshake = ssl->handshake;
+
+    if (handshake->samd_ecdh_public_ready != 0) {
+        return 0;
+    }
+
+    if (handshake->samd_ecdh_public_pending != 0) {
+        if (handshake->samd_ecdh_public_done == 0) {
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        handshake->samd_ecdh_public_pending = 0;
+        handshake->samd_ecdh_public_done = 0;
+        if (handshake->samd_ecdh_public_success == 0) {
+            handshake->samd_ecdh_public_success = 0;
+            return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        }
+        handshake->samd_ecdh_public_success = 0;
+        handshake->samd_ecdh_public_ready = 1;
+        return 0;
+    }
+
+    handshake->samd_ecdh_public_pending = 1;
+    handshake->samd_ecdh_public_done = 0;
+    handshake->samd_ecdh_public_success = 0;
+    handshake->samd_ecdh_public_ready = 0;
+
+    if (samd_mbedtls_ecdh_p256_public_key_start(
+            handshake->samd_ecdh_private_scalar,
+            handshake->samd_ecdh_public_key,
+            samd_mbedtls_ssl_ecdh_public_key_callback,
+            handshake) == 0) {
+        handshake->samd_ecdh_public_pending = 0;
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+    }
+
+    return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+}
+
+static void samd_mbedtls_ssl_ecdh_secret_callback(int success, void *context)
+{
+    mbedtls_ssl_handshake_params *handshake =
+        (mbedtls_ssl_handshake_params *) context;
+    if (handshake == NULL) {
+        return;
+    }
+
+    handshake->samd_ecdh_secret_success = success ? 1 : 0;
+    handshake->samd_ecdh_secret_done = 1;
+}
+
+static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
+{
+    mbedtls_ssl_handshake_params *handshake;
+
+    if (ssl == NULL || ssl->handshake == NULL) {
+        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    }
+
+    handshake = ssl->handshake;
+
+    if (handshake->samd_ecdh_secret_ready != 0) {
+        return 0;
+    }
+
+    if (handshake->samd_ecdh_secret_pending != 0) {
+        if (handshake->samd_ecdh_secret_done == 0) {
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+
+        handshake->samd_ecdh_secret_pending = 0;
+        handshake->samd_ecdh_secret_done = 0;
+        if (handshake->samd_ecdh_secret_success == 0) {
+            handshake->samd_ecdh_secret_success = 0;
+            return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        }
+        handshake->samd_ecdh_secret_success = 0;
+        handshake->samd_ecdh_secret_ready = 1;
+        ssl->handshake->pmslen = 32;
+        return 0;
+    }
+
+    handshake->samd_ecdh_secret_pending = 1;
+    handshake->samd_ecdh_secret_done = 0;
+    handshake->samd_ecdh_secret_success = 0;
+    handshake->samd_ecdh_secret_ready = 0;
+
+    if (samd_mbedtls_ecdh_p256_start(
+            handshake->samd_ecdh_private_scalar,
+            handshake->xxdh_psa_peerkey,
+            ssl->handshake->premaster,
+            samd_mbedtls_ssl_ecdh_secret_callback,
+            handshake) == 0) {
+        handshake->samd_ecdh_secret_pending = 0;
+        return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+    }
+
+    return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+}
+
+static void samd_mbedtls_clear_ecdh_scalar(
+    mbedtls_ssl_handshake_params *handshake)
+{
+    if (handshake == NULL) {
+        return;
+    }
+
+    mbedtls_platform_zeroize(handshake->samd_ecdh_private_scalar,
+                             sizeof(handshake->samd_ecdh_private_scalar));
+}
 #endif
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
@@ -2376,15 +2583,33 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
     defined(MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED)
     if (ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_RSA ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA) {
+#if !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
         psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
         psa_status_t destruction_status = PSA_ERROR_CORRUPTION_DETECTED;
+#endif
         psa_key_attributes_t key_attributes;
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) && \
+    !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+        psa_key_attributes_t secret_attributes;
+        mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
+        psa_status_t shared_secret_destruction_status = PSA_SUCCESS;
+#endif
 
         mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
         header_len = 4;
 
         MBEDTLS_SSL_DEBUG_MSG(3, ("Perform PSA-based ECDH computation."));
+
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) && \
+    !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+        secret_attributes = psa_key_attributes_init();
+        if (handshake->ecrs_enabled &&
+            handshake->ecrs_state == ssl_ecrs_cke_ecdh_calc_secret) {
+            content_len = handshake->ecrs_n;
+            goto complete_interruptible_ecdh;
+        }
+#endif
 
         /*
          * Generate EC private key for ECDHE exchange.
@@ -2403,9 +2628,61 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         psa_set_key_type(&key_attributes, handshake->xxdh_psa_type);
         psa_set_key_bits(&key_attributes, handshake->xxdh_psa_bits);
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+        if (handshake->xxdh_psa_bits !=
+            sizeof(handshake->samd_ecdh_private_scalar) * 8u) {
+            return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+        }
+
+        if (handshake->samd_ecdh_private_ready == 0) {
+            ret = samd_mbedtls_ssl_random_fill(
+                ssl, handshake->samd_ecdh_private_scalar,
+                sizeof(handshake->samd_ecdh_private_scalar));
+            if (ret != 0) {
+                return ret;
+            }
+            handshake->samd_ecdh_private_ready = 1;
+        }
+
+        ret = samd_mbedtls_ssl_ecdh_public_key_fill(ssl);
+        if (ret != 0) {
+            return ret;
+        }
+
+        unsigned char *samd_own_pubkey = ssl->out_msg + header_len + 1;
+        unsigned char *samd_end = ssl->out_msg + MBEDTLS_SSL_OUT_CONTENT_LEN;
+        size_t samd_own_pubkey_max_len =
+            (size_t) (samd_end - samd_own_pubkey);
+
+        if (samd_own_pubkey_max_len <
+            sizeof(handshake->samd_ecdh_public_key)) {
+            return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
+        }
+
+        memcpy(samd_own_pubkey, handshake->samd_ecdh_public_key,
+               sizeof(handshake->samd_ecdh_public_key));
+        ssl->out_msg[header_len] =
+            (unsigned char) sizeof(handshake->samd_ecdh_public_key);
+        content_len = sizeof(handshake->samd_ecdh_public_key) + 1;
+
+        ret = samd_mbedtls_ssl_ecdh_secret_fill(ssl);
+        if (ret != 0) {
+            return ret;
+        }
+
+        samd_mbedtls_clear_ecdh_scalar(handshake);
+        handshake->samd_ecdh_private_ready = 0;
+        handshake->samd_ecdh_public_ready = 0;
+        handshake->samd_ecdh_secret_ready = 0;
+        mbedtls_platform_zeroize(handshake->samd_ecdh_public_key,
+                                 sizeof(handshake->samd_ecdh_public_key));
+        goto samd_ecdh_done;
+#else
         /* Generate ECDH private key. */
         status = psa_generate_key(&key_attributes,
                                   &handshake->xxdh_psa_privkey);
+#endif
+#if !defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
         if (status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
@@ -2432,6 +2709,63 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
 
         /* The ECDH secret is the premaster secret used for key derivation. */
 
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+        if (handshake->ecrs_enabled) {
+            secret_attributes = psa_key_attributes_init();
+            psa_set_key_usage_flags(&secret_attributes, PSA_KEY_USAGE_EXPORT);
+            psa_set_key_type(&secret_attributes, PSA_KEY_TYPE_RAW_DATA);
+            psa_set_key_bits(&secret_attributes, handshake->xxdh_psa_bits);
+
+            status = psa_key_agreement_iop_setup(&handshake->xxdh_psa_iop,
+                                                 handshake->xxdh_psa_privkey,
+                                                 handshake->xxdh_psa_peerkey,
+                                                 handshake->xxdh_psa_peerkey_len,
+                                                 PSA_ALG_ECDH,
+                                                 &secret_attributes);
+            if (status != PSA_SUCCESS) {
+                (void) psa_key_agreement_iop_abort(&handshake->xxdh_psa_iop);
+                destruction_status = psa_destroy_key(handshake->xxdh_psa_privkey);
+                handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+                if (destruction_status != PSA_SUCCESS) {
+                    return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+                }
+                return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            }
+
+            handshake->ecrs_state = ssl_ecrs_cke_ecdh_calc_secret;
+            handshake->ecrs_n = content_len;
+
+complete_interruptible_ecdh:
+            status = psa_key_agreement_iop_complete(&handshake->xxdh_psa_iop,
+                                                    &shared_secret_key);
+            if (status == PSA_OPERATION_INCOMPLETE) {
+                return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            }
+            (void) psa_key_agreement_iop_abort(&handshake->xxdh_psa_iop);
+            handshake->ecrs_state = ssl_ecrs_none;
+
+            if (status == PSA_SUCCESS) {
+                status = psa_export_key(shared_secret_key,
+                                        ssl->handshake->premaster,
+                                        sizeof(ssl->handshake->premaster),
+                                        &ssl->handshake->pmslen);
+                shared_secret_destruction_status =
+                    psa_destroy_key(shared_secret_key);
+            }
+
+            psa_reset_key_attributes(&secret_attributes);
+
+            destruction_status = psa_destroy_key(handshake->xxdh_psa_privkey);
+            handshake->xxdh_psa_privkey = MBEDTLS_SVC_KEY_ID_INIT;
+
+            if (status != PSA_SUCCESS ||
+                shared_secret_destruction_status != PSA_SUCCESS ||
+                destruction_status != PSA_SUCCESS) {
+                return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
+            }
+        } else
+#endif
+        {
         /* Compute ECDH shared secret. */
         status = psa_raw_key_agreement(PSA_ALG_ECDH,
                                        handshake->xxdh_psa_privkey,
@@ -2447,6 +2781,12 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         if (status != PSA_SUCCESS || destruction_status != PSA_SUCCESS) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
+        }
+#endif
+#if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+samd_ecdh_done:
+        (void) 0;
+#endif
     } else
 #endif /* MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
           MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED */

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -56,10 +56,21 @@ int samd_mbedtls_ecdh_p256_public_key_start(
     uint8_t public_key[65],
     samd_mbedtls_async_callback_t callback,
     void *context);
+int samd_mbedtls_ecdh_p384_public_key_start(
+    const uint8_t private_scalar[48],
+    uint8_t public_key[97],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
 int samd_mbedtls_ecdh_p256_start(
     const uint8_t private_scalar[32],
     const uint8_t peer_public_key[65],
     uint8_t shared_secret[32],
+    samd_mbedtls_async_callback_t callback,
+    void *context);
+int samd_mbedtls_ecdh_p384_start(
+    const uint8_t private_scalar[48],
+    const uint8_t peer_public_key[97],
+    uint8_t shared_secret[48],
     samd_mbedtls_async_callback_t callback,
     void *context);
 
@@ -134,6 +145,7 @@ static void samd_mbedtls_ssl_ecdh_public_key_callback(int success,
 static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
+    size_t coordinate_len;
 
     if (ssl == NULL || ssl->handshake == NULL) {
         return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
@@ -165,16 +177,24 @@ static int samd_mbedtls_ssl_ecdh_public_key_fill(mbedtls_ssl_context *ssl)
     handshake->samd_ecdh_public_done = 0;
     handshake->samd_ecdh_public_success = 0;
     handshake->samd_ecdh_public_ready = 0;
+    coordinate_len = handshake->xxdh_psa_bits / 8u;
 
-    if (samd_mbedtls_ecdh_p256_public_key_start(
-            handshake->samd_ecdh_private_scalar,
-            handshake->samd_ecdh_public_key,
-            samd_mbedtls_ssl_ecdh_public_key_callback,
-            handshake) == 0) {
+    if ((coordinate_len == 32 ?
+         samd_mbedtls_ecdh_p256_public_key_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->samd_ecdh_public_key,
+             samd_mbedtls_ssl_ecdh_public_key_callback,
+             handshake) :
+         coordinate_len == 48 ?
+         samd_mbedtls_ecdh_p384_public_key_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->samd_ecdh_public_key,
+             samd_mbedtls_ssl_ecdh_public_key_callback,
+             handshake) :
+         0) == 0) {
         handshake->samd_ecdh_public_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
-
     return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
 }
 
@@ -193,6 +213,7 @@ static void samd_mbedtls_ssl_ecdh_secret_callback(int success, void *context)
 static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
 {
     mbedtls_ssl_handshake_params *handshake;
+    size_t coordinate_len;
 
     if (ssl == NULL || ssl->handshake == NULL) {
         return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
@@ -217,7 +238,7 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
         }
         handshake->samd_ecdh_secret_success = 0;
         handshake->samd_ecdh_secret_ready = 1;
-        ssl->handshake->pmslen = 32;
+        ssl->handshake->pmslen = handshake->xxdh_psa_bits / 8u;
         return 0;
     }
 
@@ -225,13 +246,23 @@ static int samd_mbedtls_ssl_ecdh_secret_fill(mbedtls_ssl_context *ssl)
     handshake->samd_ecdh_secret_done = 0;
     handshake->samd_ecdh_secret_success = 0;
     handshake->samd_ecdh_secret_ready = 0;
+    coordinate_len = handshake->xxdh_psa_bits / 8u;
 
-    if (samd_mbedtls_ecdh_p256_start(
-            handshake->samd_ecdh_private_scalar,
-            handshake->xxdh_psa_peerkey,
-            ssl->handshake->premaster,
-            samd_mbedtls_ssl_ecdh_secret_callback,
-            handshake) == 0) {
+    if ((coordinate_len == 32 ?
+         samd_mbedtls_ecdh_p256_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->xxdh_psa_peerkey,
+             ssl->handshake->premaster,
+             samd_mbedtls_ssl_ecdh_secret_callback,
+             handshake) :
+         coordinate_len == 48 ?
+         samd_mbedtls_ecdh_p384_start(
+             handshake->samd_ecdh_private_scalar,
+             handshake->xxdh_psa_peerkey,
+             ssl->handshake->premaster,
+             samd_mbedtls_ssl_ecdh_secret_callback,
+             handshake) :
+         0) == 0) {
         handshake->samd_ecdh_secret_pending = 0;
         return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
     }
@@ -2629,15 +2660,20 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
         psa_set_key_bits(&key_attributes, handshake->xxdh_psa_bits);
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_RANDOM)
+        size_t samd_coordinate_len;
+        size_t samd_public_key_len;
+
         if (handshake->xxdh_psa_bits !=
-            sizeof(handshake->samd_ecdh_private_scalar) * 8u) {
+                256u && handshake->xxdh_psa_bits != 384u) {
             return MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;
         }
+        samd_coordinate_len = handshake->xxdh_psa_bits / 8u;
+        samd_public_key_len = samd_coordinate_len * 2u + 1u;
 
         if (handshake->samd_ecdh_private_ready == 0) {
             ret = samd_mbedtls_ssl_random_fill(
                 ssl, handshake->samd_ecdh_private_scalar,
-                sizeof(handshake->samd_ecdh_private_scalar));
+                samd_coordinate_len);
             if (ret != 0) {
                 return ret;
             }
@@ -2655,15 +2691,15 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
             (size_t) (samd_end - samd_own_pubkey);
 
         if (samd_own_pubkey_max_len <
-            sizeof(handshake->samd_ecdh_public_key)) {
+            samd_public_key_len) {
             return MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
         }
 
         memcpy(samd_own_pubkey, handshake->samd_ecdh_public_key,
-               sizeof(handshake->samd_ecdh_public_key));
+               samd_public_key_len);
         ssl->out_msg[header_len] =
-            (unsigned char) sizeof(handshake->samd_ecdh_public_key);
-        content_len = sizeof(handshake->samd_ecdh_public_key) + 1;
+            (unsigned char) samd_public_key_len;
+        content_len = samd_public_key_len + 1;
 
         ret = samd_mbedtls_ssl_ecdh_secret_fill(ssl);
         if (ret != 0) {

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2323,7 +2323,8 @@ start_processing:
 
         if (ret != 0) {
             int send_alert_msg = 1;
-#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
+    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
             send_alert_msg = (ret != MBEDTLS_ERR_ECP_IN_PROGRESS);
 #endif
             if (send_alert_msg) {
@@ -2333,7 +2334,8 @@ start_processing:
                     MBEDTLS_SSL_ALERT_MSG_DECRYPT_ERROR);
             }
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_restartable", ret);
-#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
+    defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
             if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
                 ret = MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3206,7 +3206,7 @@ static int ssl_parse_certificate_verify(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
     size_t i, sig_len;
-    unsigned char hash[48];
+    unsigned char hash[64];
     unsigned char *hash_start = hash;
     size_t hashlen;
     mbedtls_pk_sigalg_t pk_alg;

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -2437,6 +2437,9 @@ static int ssl_prepare_server_key_exchange(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_KEY_EXCHANGE_SOME_PFS_ENABLED)
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED)
     unsigned char *dig_signed = NULL;
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    int restart_sign = 0;
+#endif
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED */
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PFS_ENABLED */
 
@@ -2451,6 +2454,15 @@ static int ssl_prepare_server_key_exchange(mbedtls_ssl_context *ssl,
 #else
     size_t out_buf_len = MBEDTLS_SSL_OUT_BUFFER_LEN - (size_t) (ssl->out_msg - ssl->out_buf);
 #endif
+#endif
+
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) && \
+    defined(MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED)
+    if (ssl->handshake->ecrs_state == ssl_ecrs_ske_sign) {
+        restart_sign = 1;
+        dig_signed = ssl->out_msg + ssl->handshake->ecrs_n;
+        goto sign_server_key_exchange;
+    }
 #endif
 
     ssl->out_msglen = 4; /* header (type:1, length:3) to be written later */
@@ -2656,12 +2668,20 @@ curve_matching_done:
      */
 #if defined(MBEDTLS_KEY_EXCHANGE_WITH_SERVER_SIGNATURE_ENABLED)
     if (mbedtls_ssl_ciphersuite_uses_server_signature(ciphersuite_info)) {
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+sign_server_key_exchange:
+#endif
         if (dig_signed == NULL) {
             MBEDTLS_SSL_DEBUG_MSG(1, ("should never happen"));
             return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
         }
 
         size_t dig_signed_len = (size_t) (ssl->out_msg + ssl->out_msglen - dig_signed);
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+        if (restart_sign != 0) {
+            dig_signed_len -= 2;
+        }
+#endif
         size_t hashlen = 0;
         unsigned char hash[MBEDTLS_MD_MAX_SIZE];
 
@@ -2730,8 +2750,13 @@ curve_matching_done:
          *
          */
 
-        ssl->out_msg[ssl->out_msglen++] = mbedtls_ssl_hash_from_md_alg(md_alg);
-        ssl->out_msg[ssl->out_msglen++] = mbedtls_ssl_sig_from_pk_alg(sig_alg);
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+        if (restart_sign == 0)
+#endif
+        {
+            ssl->out_msg[ssl->out_msglen++] = mbedtls_ssl_hash_from_md_alg(md_alg);
+            ssl->out_msg[ssl->out_msglen++] = mbedtls_ssl_sig_from_pk_alg(sig_alg);
+        }
 
 #if defined(MBEDTLS_SSL_ASYNC_PRIVATE)
         if (ssl->conf->f_async_sign_start != NULL) {
@@ -2765,11 +2790,37 @@ curve_matching_done:
          * after the call to ssl_prepare_server_key_exchange.
          * ssl_write_server_key_exchange also takes care of incrementing
          * ssl->out_msglen. */
-        if ((ret = mbedtls_pk_sign_ext(sig_alg, mbedtls_ssl_own_key(ssl),
-                                       md_alg, hash, hashlen,
-                                       ssl->out_msg + ssl->out_msglen + 2,
-                                       out_buf_len - ssl->out_msglen - 2,
-                                       signature_len)) != 0) {
+        if (sig_alg == MBEDTLS_PK_SIGALG_ECDSA) {
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+            ret = mbedtls_pk_sign_restartable(mbedtls_ssl_own_key(ssl),
+                                               md_alg, hash, hashlen,
+                                               ssl->out_msg + ssl->out_msglen + 2,
+                                               out_buf_len - ssl->out_msglen - 2,
+                                               signature_len,
+                                               &ssl->handshake->ecrs_ctx.pk);
+#else
+            ret = mbedtls_pk_sign(mbedtls_ssl_own_key(ssl),
+                                  md_alg, hash, hashlen,
+                                  ssl->out_msg + ssl->out_msglen + 2,
+                                  out_buf_len - ssl->out_msglen - 2,
+                                  signature_len);
+#endif
+        } else {
+            ret = mbedtls_pk_sign_ext(sig_alg, mbedtls_ssl_own_key(ssl),
+                                      md_alg, hash, hashlen,
+                                      ssl->out_msg + ssl->out_msglen + 2,
+                                      out_buf_len - ssl->out_msglen - 2,
+                                      signature_len);
+        }
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+        if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
+            ssl->handshake->ecrs_state = ssl_ecrs_ske_sign;
+            ssl->handshake->ecrs_n = (size_t) (dig_signed - ssl->out_msg);
+            return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+        }
+        ssl->handshake->ecrs_state = ssl_ecrs_none;
+#endif
+        if (ret != 0) {
             MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_sign_ext", ret);
             return ret;
         }
@@ -2825,7 +2876,8 @@ static int ssl_write_server_key_exchange(mbedtls_ssl_context *ssl)
          * to 0. But if we're resuming after an asynchronous message,
          * out_msglen is the amount of data written so far and mst be
          * preserved. */
-        if (ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS) {
+        if (ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
+            ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
             MBEDTLS_SSL_DEBUG_MSG(2, ("<= write server key exchange (pending)"));
         } else {
             ssl->out_msglen = 0;

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1859,6 +1859,13 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ssl_handshake_params *handshake = ssl->handshake;
 
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (handshake->ecrs_state ==
+        ssl_ecrs_tls13_server_hello_postprocess) {
+        goto compute_handshake_transform;
+    }
+#endif
+
     /* Determine the key exchange mode:
      * 1) If both the pre_shared_key and key_share extensions were received
      *    then the key exchange mode is PSK with EPHEMERAL.
@@ -1932,7 +1939,16 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
         }
     }
 
+compute_handshake_transform:
     ret = mbedtls_ssl_tls13_compute_handshake_transform(ssl);
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
+        ssl->handshake->ecrs_state =
+            ssl_ecrs_tls13_server_hello_postprocess;
+        goto cleanup;
+    }
+    ssl->handshake->ecrs_state = ssl_ecrs_none;
+#endif
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(1,
                               "mbedtls_ssl_tls13_compute_handshake_transform",
@@ -1945,7 +1961,7 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
     ssl->session_in = ssl->session_negotiate;
 
 cleanup:
-    if (ret != 0) {
+    if (ret != 0 && ret != MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
         MBEDTLS_SSL_PEND_FATAL_ALERT(
             MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE,
             MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE);
@@ -1996,6 +2012,18 @@ static int ssl_tls13_process_server_hello(mbedtls_ssl_context *ssl)
     int is_hrr = 0;
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> %s", __func__));
+
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (ssl->handshake->ecrs_state ==
+        ssl_ecrs_tls13_server_hello_postprocess) {
+        ret = ssl_tls13_postprocess_server_hello(ssl);
+        if (ret == 0) {
+            mbedtls_ssl_handshake_set_state(
+                ssl, MBEDTLS_SSL_ENCRYPTED_EXTENSIONS);
+        }
+        goto cleanup;
+    }
+#endif
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_tls13_fetch_handshake_msg(
                              ssl, MBEDTLS_SSL_HS_SERVER_HELLO, &buf, &buf_len));
@@ -2628,18 +2656,46 @@ static int ssl_tls13_process_server_finished(mbedtls_ssl_context *ssl)
 /*
  * Handler for MBEDTLS_SSL_CLIENT_CERTIFICATE
  */
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+static int ssl_tls13_resume_pending_record(mbedtls_ssl_context *ssl)
+{
+    if (ssl->transform_out == NULL ||
+        ssl->transform_out->async_hardware_aead_pending == 0) {
+        return 0;
+    }
+
+    int ret = mbedtls_ssl_write_record(ssl, 1);
+    return ret == 0 ? 1 : ret;
+}
+#endif
+
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
 {
     int non_empty_certificate_msg = 0;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD) || \
+    defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
+    int ret;
+#endif
 
     MBEDTLS_SSL_DEBUG_MSG(1,
                           ("Switch to handshake traffic keys for outbound traffic"));
     mbedtls_ssl_set_outbound_transform(ssl, ssl->handshake->transform_handshake);
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        non_empty_certificate_msg = mbedtls_ssl_own_cert(ssl) != NULL;
+        goto client_certificate_written;
+    }
+#endif
+
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     if (ssl->handshake->client_auth) {
-        int ret = mbedtls_ssl_tls13_write_certificate(ssl);
+        ret = mbedtls_ssl_tls13_write_certificate(ssl);
         if (ret != 0) {
             return ret;
         }
@@ -2652,6 +2708,9 @@ static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
     }
 #endif
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+client_certificate_written:
+#endif
     if (non_empty_certificate_msg) {
         mbedtls_ssl_handshake_set_state(ssl,
                                         MBEDTLS_SSL_CLIENT_CERTIFICATE_VERIFY);
@@ -2670,8 +2729,22 @@ static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_client_certificate_verify(mbedtls_ssl_context *ssl)
 {
-    int ret = mbedtls_ssl_tls13_write_certificate_verify(ssl);
+    int ret;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto client_certificate_verify_written;
+    }
+#endif
+    ret = mbedtls_ssl_tls13_write_certificate_verify(ssl);
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+client_certificate_verify_written:
+#endif
     if (ret == 0) {
         mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CLIENT_FINISHED);
     }
@@ -2688,11 +2761,25 @@ static int ssl_tls13_write_client_finished(mbedtls_ssl_context *ssl)
 {
     int ret;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto client_finished_written;
+    }
+#endif
+
     ret = mbedtls_ssl_tls13_write_finished_message(ssl);
     if (ret != 0) {
         return ret;
     }
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+client_finished_written:
+#endif
     ret = mbedtls_ssl_tls13_compute_resumption_master_secret(ssl);
     if (ret != 0) {
         MBEDTLS_SSL_DEBUG_RET(

--- a/library/ssl_tls13_client.c
+++ b/library/ssl_tls13_client.c
@@ -1939,7 +1939,9 @@ static int ssl_tls13_postprocess_server_hello(mbedtls_ssl_context *ssl)
         }
     }
 
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
 compute_handshake_transform:
+#endif
     ret = mbedtls_ssl_tls13_compute_handshake_transform(ssl);
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
     if (ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
@@ -2656,11 +2658,11 @@ static int ssl_tls13_process_server_finished(mbedtls_ssl_context *ssl)
 /*
  * Handler for MBEDTLS_SSL_CLIENT_CERTIFICATE
  */
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 static int ssl_tls13_resume_pending_record(mbedtls_ssl_context *ssl)
 {
     if (ssl->transform_out == NULL ||
-        ssl->transform_out->async_hardware_aead_pending == 0) {
+        ssl->transform_out->async_psa_aead_pending == 0) {
         return 0;
     }
 
@@ -2673,7 +2675,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
 {
     int non_empty_certificate_msg = 0;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD) || \
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD) || \
     defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     int ret;
 #endif
@@ -2682,7 +2684,7 @@ static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
                           ("Switch to handshake traffic keys for outbound traffic"));
     mbedtls_ssl_set_outbound_transform(ssl, ssl->handshake->transform_handshake);
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2708,7 +2710,7 @@ static int ssl_tls13_write_client_certificate(mbedtls_ssl_context *ssl)
     }
 #endif
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 client_certificate_written:
 #endif
     if (non_empty_certificate_msg) {
@@ -2730,7 +2732,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_client_certificate_verify(mbedtls_ssl_context *ssl)
 {
     int ret;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2742,7 +2744,7 @@ static int ssl_tls13_write_client_certificate_verify(mbedtls_ssl_context *ssl)
 #endif
     ret = mbedtls_ssl_tls13_write_certificate_verify(ssl);
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 client_certificate_verify_written:
 #endif
     if (ret == 0) {
@@ -2761,7 +2763,7 @@ static int ssl_tls13_write_client_finished(mbedtls_ssl_context *ssl)
 {
     int ret;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2777,7 +2779,7 @@ static int ssl_tls13_write_client_finished(mbedtls_ssl_context *ssl)
         return ret;
     }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 client_finished_written:
 #endif
     ret = mbedtls_ssl_tls13_compute_resumption_master_secret(ssl);

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -898,7 +898,6 @@ static int ssl_tls13_write_certificate_verify_body(mbedtls_ssl_context *ssl,
 
     uint16_t *sig_alg = ssl->handshake->received_sig_algs;
     size_t signature_len = 0;
-
     *out_len = 0;
 
     own_key = mbedtls_ssl_own_key(ssl);
@@ -971,14 +970,37 @@ static int ssl_tls13_write_certificate_verify_body(mbedtls_ssl_context *ssl,
 
         MBEDTLS_SSL_DEBUG_BUF(3, "verify hash", verify_hash, verify_hash_len);
 
-        if ((ret = mbedtls_pk_sign_ext((mbedtls_pk_sigalg_t) pk_type, own_key,
-                                       md_alg, verify_hash, verify_hash_len,
-                                       p + 4, (size_t) (end - (p + 4)), &signature_len)) != 0) {
+        if (pk_type == MBEDTLS_PK_SIGALG_ECDSA) {
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+            ret = mbedtls_pk_sign_restartable(own_key, md_alg,
+                                               verify_hash, verify_hash_len,
+                                               p + 4, (size_t) (end - (p + 4)),
+                                               &signature_len,
+                                               &ssl->handshake->ecrs_ctx.pk);
+#else
+            ret = mbedtls_pk_sign(own_key, md_alg,
+                                  verify_hash, verify_hash_len,
+                                  p + 4, (size_t) (end - (p + 4)),
+                                  &signature_len);
+#endif
+        } else {
+            ret = mbedtls_pk_sign_ext(pk_type, own_key, md_alg,
+                                      verify_hash, verify_hash_len,
+                                      p + 4, (size_t) (end - (p + 4)),
+                                      &signature_len);
+        }
+        if (ret != 0) {
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
             defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
             if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+                ssl->handshake->ecrs_state = ssl_ecrs_crt_vrfy_sign;
+#endif
                 return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
             }
+#endif
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+            ssl->handshake->ecrs_state = ssl_ecrs_none;
 #endif
             MBEDTLS_SSL_DEBUG_MSG(2, ("CertificateVerify signature failed with %s",
                                       mbedtls_ssl_sig_alg_to_str(*sig_alg)));
@@ -991,6 +1013,10 @@ static int ssl_tls13_write_certificate_verify_body(mbedtls_ssl_context *ssl,
              */
             continue;
         }
+
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+        ssl->handshake->ecrs_state = ssl_ecrs_none;
+#endif
 
         MBEDTLS_SSL_DEBUG_MSG(2, ("CertificateVerify signature with %s",
                                   mbedtls_ssl_sig_alg_to_str(*sig_alg)));

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -974,6 +974,12 @@ static int ssl_tls13_write_certificate_verify_body(mbedtls_ssl_context *ssl,
         if ((ret = mbedtls_pk_sign_ext((mbedtls_pk_sigalg_t) pk_type, own_key,
                                        md_alg, verify_hash, verify_hash_len,
                                        p + 4, (size_t) (end - (p + 4)), &signature_len)) != 0) {
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
+            defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+            if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
+                return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            }
+#endif
             MBEDTLS_SSL_DEBUG_MSG(2, ("CertificateVerify signature failed with %s",
                                       mbedtls_ssl_sig_alg_to_str(*sig_alg)));
             MBEDTLS_SSL_DEBUG_RET(2, "mbedtls_pk_sign_ext", ret);

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -991,7 +991,7 @@ static int ssl_tls13_write_certificate_verify_body(mbedtls_ssl_context *ssl,
         }
         if (ret != 0) {
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED) || \
-            defined(MBEDTLS_ASYNC_HARDWARE_ECDSA) || defined(MBEDTLS_ASYNC_HARDWARE_RSA)
+            defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDSA) || defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_RSA)
             if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
 #if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
                 ssl->handshake->ecrs_state = ssl_ecrs_crt_vrfy_sign;

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -309,6 +309,11 @@ static int ssl_tls13_parse_certificate_verify(mbedtls_ssl_context *ssl,
     if (ret == 0) {
         return ret;
     }
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (ret == MBEDTLS_ERR_ECP_IN_PROGRESS) {
+        return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+    }
+#endif
     MBEDTLS_SSL_DEBUG_RET(1, "mbedtls_pk_verify_ext", ret);
 
 error:

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1446,9 +1446,6 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             /* Compute ECDH shared secret. */
             psa_status_t status = PSA_ERROR_GENERIC_ERROR;
             psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
-            mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
-            psa_status_t shared_secret_key_destruction_status =
-                PSA_ERROR_GENERIC_ERROR;
 
             status = psa_get_key_attributes(handshake->xxdh_psa_privkey,
                                             &key_attributes);
@@ -1467,6 +1464,10 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
 
 #if defined(MBEDTLS_ASYNC_HARDWARE_ECDH) && \
     defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+            mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_status_t shared_secret_key_destruction_status =
+                PSA_ERROR_GENERIC_ERROR;
+
             if (handshake->xxdh_psa_iop_active == 0) {
                 psa_key_attributes_t secret_attributes =
                     psa_key_attributes_init();

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1012,7 +1012,7 @@ int mbedtls_ssl_tls13_populate_transform(
 
     transform->psa_alg = alg;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     int async_aead_configured = mbedtls_ssl_configure_async_aead_transform(
         transform, key_type, alg, key_enc, key_dec, PSA_BITS_TO_BYTES(key_bits));
     (void) async_aead_configured;
@@ -1462,7 +1462,7 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
                 return MBEDTLS_ERR_SSL_ALLOC_FAILED;
             }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_ECDH) && \
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_ECDH) && \
     defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
             mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
             psa_status_t shared_secret_key_destruction_status =

--- a/library/ssl_tls13_keys.c
+++ b/library/ssl_tls13_keys.c
@@ -1012,6 +1012,12 @@ int mbedtls_ssl_tls13_populate_transform(
 
     transform->psa_alg = alg;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    int async_aead_configured = mbedtls_ssl_configure_async_aead_transform(
+        transform, key_type, alg, key_enc, key_dec, PSA_BITS_TO_BYTES(key_bits));
+    (void) async_aead_configured;
+#endif
+
     if (alg != MBEDTLS_SSL_NULL_CIPHER) {
         psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT);
         psa_set_key_algorithm(&attributes, alg);
@@ -1440,11 +1446,16 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
             /* Compute ECDH shared secret. */
             psa_status_t status = PSA_ERROR_GENERIC_ERROR;
             psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
+            mbedtls_svc_key_id_t shared_secret_key = MBEDTLS_SVC_KEY_ID_INIT;
+            psa_status_t shared_secret_key_destruction_status =
+                PSA_ERROR_GENERIC_ERROR;
 
             status = psa_get_key_attributes(handshake->xxdh_psa_privkey,
                                             &key_attributes);
             if (status != PSA_SUCCESS) {
                 ret = PSA_TO_MBEDTLS_ERR(status);
+                MBEDTLS_SSL_DEBUG_RET(1, "psa_get_key_attributes", ret);
+                goto cleanup;
             }
 
             shared_secret_len = PSA_BITS_TO_BYTES(
@@ -1454,6 +1465,70 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
                 return MBEDTLS_ERR_SSL_ALLOC_FAILED;
             }
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_ECDH) && \
+    defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+            if (handshake->xxdh_psa_iop_active == 0) {
+                psa_key_attributes_t secret_attributes =
+                    psa_key_attributes_init();
+                psa_set_key_usage_flags(&secret_attributes,
+                                        PSA_KEY_USAGE_EXPORT);
+                psa_set_key_type(&secret_attributes, PSA_KEY_TYPE_RAW_DATA);
+                psa_set_key_bits(&secret_attributes,
+                                 PSA_BYTES_TO_BITS(shared_secret_len));
+
+                status = psa_key_agreement_iop_setup(
+                    &handshake->xxdh_psa_iop,
+                    handshake->xxdh_psa_privkey,
+                    handshake->xxdh_psa_peerkey,
+                    handshake->xxdh_psa_peerkey_len,
+                    alg,
+                    &secret_attributes);
+                if (status != PSA_SUCCESS) {
+                    (void) psa_key_agreement_iop_abort(
+                        &handshake->xxdh_psa_iop);
+                    ret = PSA_TO_MBEDTLS_ERR(status);
+                    MBEDTLS_SSL_DEBUG_RET(1, "psa_key_agreement_iop_setup",
+                                          ret);
+                    goto cleanup;
+                }
+                handshake->xxdh_psa_iop_active = 1;
+            }
+
+            status = psa_key_agreement_iop_complete(
+                &handshake->xxdh_psa_iop,
+                &shared_secret_key);
+            if (status == PSA_OPERATION_INCOMPLETE) {
+                mbedtls_free(shared_secret);
+                return MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+            }
+
+            (void) psa_key_agreement_iop_abort(&handshake->xxdh_psa_iop);
+            handshake->xxdh_psa_iop_active = 0;
+
+            if (status != PSA_SUCCESS) {
+                ret = PSA_TO_MBEDTLS_ERR(status);
+                MBEDTLS_SSL_DEBUG_RET(1, "psa_key_agreement_iop_complete",
+                                      ret);
+                goto cleanup;
+            }
+
+            status = psa_export_key(shared_secret_key,
+                                    shared_secret,
+                                    shared_secret_len,
+                                    &shared_secret_len);
+            shared_secret_key_destruction_status =
+                psa_destroy_key(shared_secret_key);
+            if (status != PSA_SUCCESS) {
+                ret = PSA_TO_MBEDTLS_ERR(status);
+                MBEDTLS_SSL_DEBUG_RET(1, "psa_export_key", ret);
+                goto cleanup;
+            }
+            if (shared_secret_key_destruction_status != PSA_SUCCESS) {
+                ret = PSA_TO_MBEDTLS_ERR(shared_secret_key_destruction_status);
+                MBEDTLS_SSL_DEBUG_RET(1, "psa_destroy_key", ret);
+                goto cleanup;
+            }
+#else
             status = psa_raw_key_agreement(
                 alg, handshake->xxdh_psa_privkey,
                 handshake->xxdh_psa_peerkey, handshake->xxdh_psa_peerkey_len,
@@ -1463,6 +1538,7 @@ static int ssl_tls13_key_schedule_stage_handshake(mbedtls_ssl_context *ssl)
                 MBEDTLS_SSL_DEBUG_RET(1, "psa_raw_key_agreement", ret);
                 goto cleanup;
             }
+#endif
 
             status = psa_destroy_key(handshake->xxdh_psa_privkey);
             if (status != PSA_SUCCESS) {

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2410,6 +2410,12 @@ static int ssl_tls13_write_server_hello(mbedtls_ssl_context *ssl)
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write server hello"));
 
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (ssl->handshake->ecrs_state == ssl_ecrs_tls13_server_hello_finalize) {
+        goto finalize_server_hello;
+    }
+#endif
+
     MBEDTLS_SSL_PROC_CHK(ssl_tls13_prepare_server_hello(ssl));
 
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_start_handshake_msg(
@@ -2426,7 +2432,20 @@ static int ssl_tls13_write_server_hello(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
 
-    MBEDTLS_SSL_PROC_CHK(ssl_tls13_finalize_server_hello(ssl));
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+finalize_server_hello:
+#endif
+    ret = ssl_tls13_finalize_server_hello(ssl);
+#if defined(MBEDTLS_SSL_ECP_RESTARTABLE_ENABLED)
+    if (ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
+        ssl->handshake->ecrs_state = ssl_ecrs_tls13_server_hello_finalize;
+        goto cleanup;
+    }
+    ssl->handshake->ecrs_state = ssl_ecrs_none;
+#endif
+    if (ret != 0) {
+        goto cleanup;
+    }
 
 #if defined(MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE)
     /* The server sends a dummy change_cipher_spec record immediately
@@ -2522,6 +2541,19 @@ cleanup:
  * Handler for MBEDTLS_SSL_ENCRYPTED_EXTENSIONS
  */
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+static int ssl_tls13_resume_pending_record(mbedtls_ssl_context *ssl)
+{
+    if (ssl->transform_out == NULL ||
+        ssl->transform_out->async_hardware_aead_pending == 0) {
+        return 0;
+    }
+
+    int ret = mbedtls_ssl_write_record(ssl, 1);
+    return ret == 0 ? 1 : ret;
+}
+#endif
+
 /*
  * struct {
  *    Extension extensions<0..2 ^ 16 - 1>;
@@ -2607,6 +2639,17 @@ static int ssl_tls13_write_encrypted_extensions(mbedtls_ssl_context *ssl)
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write encrypted extensions"));
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        goto cleanup;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto encrypted_extensions_written;
+    }
+#endif
+
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_start_handshake_msg(
                              ssl, MBEDTLS_SSL_HS_ENCRYPTED_EXTENSIONS,
                              &buf, &buf_len));
@@ -2621,6 +2664,9 @@ static int ssl_tls13_write_encrypted_extensions(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+encrypted_extensions_written:
+#endif
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
     if (mbedtls_ssl_tls13_key_exchange_mode_with_psk(ssl)) {
         mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_FINISHED);
@@ -2781,6 +2827,17 @@ static int ssl_tls13_write_server_certificate(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto server_certificate_written;
+    }
+#endif
+
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
     if ((ssl_tls13_pick_key_cert(ssl) != 0) ||
         mbedtls_ssl_own_cert(ssl) == NULL) {
@@ -2795,6 +2852,9 @@ static int ssl_tls13_write_server_certificate(mbedtls_ssl_context *ssl)
     if (ret != 0) {
         return ret;
     }
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+server_certificate_written:
+#endif
     mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CERTIFICATE_VERIFY);
     return 0;
 }
@@ -2805,10 +2865,24 @@ static int ssl_tls13_write_server_certificate(mbedtls_ssl_context *ssl)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl)
 {
-    int ret = mbedtls_ssl_tls13_write_certificate_verify(ssl);
+    int ret;
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto certificate_verify_written;
+    }
+#endif
+    ret = mbedtls_ssl_tls13_write_certificate_verify(ssl);
     if (ret != 0) {
         return ret;
     }
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+certificate_verify_written:
+#endif
     mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_FINISHED);
     return 0;
 }
@@ -2875,11 +2949,25 @@ static int ssl_tls13_write_server_finished(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+    ret = ssl_tls13_resume_pending_record(ssl);
+    if (ret < 0) {
+        return ret;
+    }
+    if (ret > 0) {
+        ret = 0;
+        goto server_finished_written;
+    }
+#endif
+
     ret = mbedtls_ssl_tls13_write_finished_message(ssl);
     if (ret != 0) {
         return ret;
     }
 
+#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+server_finished_written:
+#endif
     ret = mbedtls_ssl_tls13_compute_application_transform(ssl);
     if (ret != 0) {
         MBEDTLS_SSL_PEND_FATAL_ALERT(

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -2541,11 +2541,11 @@ cleanup:
  * Handler for MBEDTLS_SSL_ENCRYPTED_EXTENSIONS
  */
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 static int ssl_tls13_resume_pending_record(mbedtls_ssl_context *ssl)
 {
     if (ssl->transform_out == NULL ||
-        ssl->transform_out->async_hardware_aead_pending == 0) {
+        ssl->transform_out->async_psa_aead_pending == 0) {
         return 0;
     }
 
@@ -2639,7 +2639,7 @@ static int ssl_tls13_write_encrypted_extensions(mbedtls_ssl_context *ssl)
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write encrypted extensions"));
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         goto cleanup;
@@ -2664,7 +2664,7 @@ static int ssl_tls13_write_encrypted_extensions(mbedtls_ssl_context *ssl)
     MBEDTLS_SSL_PROC_CHK(mbedtls_ssl_finish_handshake_msg(
                              ssl, buf_len, msg_len));
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 encrypted_extensions_written:
 #endif
 #if defined(MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_EPHEMERAL_ENABLED)
@@ -2827,7 +2827,7 @@ static int ssl_tls13_write_server_certificate(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2852,7 +2852,7 @@ static int ssl_tls13_write_server_certificate(mbedtls_ssl_context *ssl)
     if (ret != 0) {
         return ret;
     }
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 server_certificate_written:
 #endif
     mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_CERTIFICATE_VERIFY);
@@ -2866,7 +2866,7 @@ MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl)
 {
     int ret;
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2880,7 +2880,7 @@ static int ssl_tls13_write_certificate_verify(mbedtls_ssl_context *ssl)
     if (ret != 0) {
         return ret;
     }
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 certificate_verify_written:
 #endif
     mbedtls_ssl_handshake_set_state(ssl, MBEDTLS_SSL_SERVER_FINISHED);
@@ -2949,7 +2949,7 @@ static int ssl_tls13_write_server_finished(mbedtls_ssl_context *ssl)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
     ret = ssl_tls13_resume_pending_record(ssl);
     if (ret < 0) {
         return ret;
@@ -2965,7 +2965,7 @@ static int ssl_tls13_write_server_finished(mbedtls_ssl_context *ssl)
         return ret;
     }
 
-#if defined(MBEDTLS_ASYNC_HARDWARE_AEAD)
+#if defined(MBEDTLS_PSA_CRYPTO_ASYNC_TLS_AEAD)
 server_finished_written:
 #endif
     ret = mbedtls_ssl_tls13_compute_application_transform(ssl);

--- a/library/x509write_csr.c
+++ b/library/x509write_csr.c
@@ -226,7 +226,7 @@ static int x509write_csr_der_internal(mbedtls_x509write_csr *ctx,
         return MBEDTLS_ERR_X509_INVALID_ALG;
     }
 
-    if ((ret = mbedtls_pk_sign_ext(pk_alg, ctx->key, ctx->md_alg, hash, 0,
+    if ((ret = mbedtls_pk_sign_ext(pk_alg, ctx->key, ctx->md_alg, hash, hash_len,
                                    sig, sig_size, &sig_len)) != 0) {
         return ret;
     }

--- a/tests/suites/test_suite_psa_crypto_async_tls.data
+++ b/tests/suites/test_suite_psa_crypto_async_tls.data
@@ -1,0 +1,26 @@
+Async TLS bind, unbind and busy state
+bind_unbind_and_busy:
+
+Async TLS owner and abort control
+owner_and_abort_control:
+
+Async TLS trusted time surface
+trusted_time_surface:
+
+Async TLS random and effective capacity
+random_and_capacity:
+
+Async TLS ECDH public key and shared secret requests
+ecdh_public_and_shared:
+
+Async TLS ECDSA sign and verify requests
+ecdsa_sign_and_verify:
+
+Async TLS AEAD generic and AES-GCM wrapper requests
+aead_generic_and_gcm_wrappers:
+
+Async TLS RSA sign and verify requests
+rsa_sign_and_verify_requests:
+
+Async TLS invalid argument rejection
+api_rejects_invalid_arguments:

--- a/tests/suites/test_suite_psa_crypto_async_tls.function
+++ b/tests/suites/test_suite_psa_crypto_async_tls.function
@@ -1,0 +1,645 @@
+/* BEGIN_HEADER */
+
+#include "mbedtls/psa_crypto_async_tls.h"
+
+#include "test/certs.h"
+
+#include <mbedtls/psa_crypto_async_curves.h>
+#include <mbedtls/psa_crypto_async_provider.h>
+#include <psa/crypto.h>
+#include <psa/crypto_extra.h>
+#include <string.h>
+
+typedef struct {
+    int calls;
+    int callback_calls;
+    psa_status_t start_status;
+    mbedtls_psa_async_crypto_capability_t capabilities;
+    mbedtls_psa_async_crypto_request_t last_request;
+    mbedtls_psa_async_crypto_hardware_completion_t completion;
+    mbedtls_psa_async_crypto_hardware_completion_t completions[
+        MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS];
+} async_tls_test_context_t;
+
+typedef struct {
+    int called;
+    int success;
+} async_tls_test_completion_t;
+
+static mbedtls_psa_async_crypto_capability_t
+async_tls_test_get_capabilities(void *context)
+{
+    async_tls_test_context_t *test_context = context;
+    return test_context->capabilities;
+}
+
+static psa_status_t async_tls_test_operation(
+    void *context,
+    const mbedtls_psa_async_crypto_request_t *request,
+    mbedtls_psa_async_crypto_hardware_completion_t *completion)
+{
+    async_tls_test_context_t *test_context = context;
+
+    test_context->calls++;
+    test_context->last_request = *request;
+    test_context->completion = *completion;
+    if (test_context->calls <=
+        MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS) {
+        test_context->completions[test_context->calls - 1] = *completion;
+    }
+
+    if (request->output.data != NULL) {
+        memset(request->output.data, 0x5a, request->output.length);
+    }
+    if (request->output_tag.data != NULL) {
+        memset(request->output_tag.data, 0xa5, request->output_tag.length);
+    }
+    if (request->signature.data != NULL) {
+        memset(request->signature.data, 0x3c, request->signature.length);
+    }
+    if (request->shared_secret.data != NULL) {
+        memset(request->shared_secret.data, 0xc3,
+               request->shared_secret.length);
+    }
+    if (request->public_key_output.data != NULL) {
+        memset(request->public_key_output.data, 0x42,
+               request->public_key_output.length);
+        request->public_key_output.data[0] = 0x04;
+    }
+
+    return test_context->start_status;
+}
+
+static const mbedtls_psa_async_crypto_hardware_functions_t
+    async_tls_test_functions = {
+    async_tls_test_get_capabilities,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+    async_tls_test_operation,
+};
+
+static void async_tls_test_callback(int success, void *context)
+{
+    async_tls_test_completion_t *completion = context;
+    completion->called++;
+    completion->success = success;
+}
+
+static void async_tls_test_complete(async_tls_test_context_t *context,
+                                    psa_status_t status)
+{
+    if (context->completion.callback == NULL) {
+        return;
+    }
+    context->callback_calls++;
+    context->completion.callback(status, context->completion.context);
+    mbedtls_psa_async_tls_service();
+}
+
+static void async_tls_test_init(async_tls_test_context_t *context,
+                                mbedtls_psa_async_crypto_provider_t *provider,
+                                mbedtls_psa_async_crypto_hardware_t *hardware)
+{
+    memset(context, 0, sizeof(*context));
+    context->start_status = PSA_OPERATION_INCOMPLETE;
+    context->capabilities =
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_RANDOM |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_AES_GCM |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_AES_CCM |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_ECDH |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_ECDSA |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_EXPORT_PUBLIC_KEY |
+        MBEDTLS_PSA_ASYNC_CRYPTO_CAPABILITY_RSA;
+    hardware->functions = &async_tls_test_functions;
+    hardware->context = context;
+    mbedtls_psa_async_crypto_provider_init(provider, hardware);
+}
+
+static void async_tls_test_cleanup(mbedtls_psa_async_crypto_provider_t *provider)
+{
+    mbedtls_psa_async_tls_abort();
+    while (mbedtls_psa_async_tls_unbind(provider)) {
+    }
+    mbedtls_psa_async_tls_clear_trusted_time();
+}
+
+static void async_tls_test_expect_bound(
+    async_tls_test_context_t *context,
+    mbedtls_psa_async_crypto_provider_t *provider,
+    mbedtls_psa_async_crypto_hardware_t *hardware)
+{
+    async_tls_test_init(context, provider, hardware);
+    (void) mbedtls_psa_async_tls_bind(provider);
+}
+
+static size_t async_tls_test_make_rsa_public_key(uint8_t output[269])
+{
+    output[0] = 0x30;
+    output[1] = 0x82;
+    output[2] = 0x01;
+    output[3] = 0x09;
+    output[4] = 0x02;
+    output[5] = 0x82;
+    output[6] = 0x01;
+    output[7] = 0x00;
+    memset(output + 8, 0x11, 256);
+    output[8] = 0x7f;
+    output[264] = 0x02;
+    output[265] = 0x03;
+    output[266] = 0x01;
+    output[267] = 0x00;
+    output[268] = 0x01;
+    return 269;
+}
+
+/* END_HEADER */
+
+/* BEGIN_DEPENDENCIES
+ * depends_on:MBEDTLS_PSA_CRYPTO_C
+ * END_DEPENDENCIES */
+
+/* BEGIN_CASE */
+void bind_unbind_and_busy(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_provider_t other_provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t output[16] = { 0 };
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_init(&context, &provider, &hardware);
+    mbedtls_psa_async_crypto_provider_init(&other_provider, NULL);
+
+    TEST_EQUAL(mbedtls_psa_async_tls_bind(NULL), 0);
+    TEST_ASSERT(mbedtls_psa_async_tls_bind(&provider));
+    TEST_ASSERT(mbedtls_psa_async_tls_bind(&provider));
+    TEST_EQUAL(mbedtls_psa_async_tls_bind(&other_provider), 0);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_random_start(
+                    output, sizeof(output), async_tls_test_callback, &completion));
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 1);
+    TEST_EQUAL(mbedtls_psa_async_tls_unbind(&provider), 1);
+    TEST_EQUAL(mbedtls_psa_async_tls_unbind(&provider), 0);
+
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(completion.called, 1);
+    TEST_EQUAL(completion.success, 1);
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 0);
+    TEST_ASSERT(mbedtls_psa_async_tls_unbind(&provider));
+    TEST_EQUAL(mbedtls_psa_async_tls_unbind(&provider), 0);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void owner_and_abort_control(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t first_output[16] = { 0 };
+    uint8_t second_output[16] = { 0 };
+    async_tls_test_completion_t first = { 0, 0 };
+    async_tls_test_completion_t second = { 0, 0 };
+    int first_owner;
+    int second_owner;
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    PSA_ASSERT(psa_crypto_init());
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    TEST_EQUAL(mbedtls_psa_async_tls_begin_call(NULL), 0);
+    TEST_ASSERT(mbedtls_psa_async_tls_begin_call(&first_owner));
+    TEST_EQUAL(mbedtls_psa_async_tls_begin_call(&second_owner), 0);
+    TEST_ASSERT(mbedtls_psa_async_tls_random_start(
+                    first_output, sizeof(first_output), async_tls_test_callback, &first));
+    mbedtls_psa_async_tls_end_call(&first_owner);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_begin_call(&second_owner));
+    TEST_ASSERT(mbedtls_psa_async_tls_random_start(
+                    second_output, sizeof(second_output), async_tls_test_callback,
+                    &second));
+    mbedtls_psa_async_tls_end_call(&second_owner);
+
+    mbedtls_psa_async_tls_abort_owner(&first_owner);
+    TEST_EQUAL(first.called, 0);
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 1);
+
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(second.called, 1);
+    TEST_EQUAL(second.success, 1);
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 0);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void trusted_time_surface(void)
+{
+    time_t now = 0;
+
+    mbedtls_psa_async_tls_clear_trusted_time();
+    TEST_EQUAL(mbedtls_psa_async_tls_get_trusted_time(), 0);
+    TEST_EQUAL(mbedtls_platform_time(NULL), 0);
+
+    mbedtls_psa_async_tls_set_trusted_time(1700000000u);
+    TEST_EQUAL(mbedtls_psa_async_tls_get_trusted_time(), 1700000000u);
+    TEST_EQUAL(mbedtls_platform_time(&now), 1700000000u);
+    TEST_EQUAL(now, 1700000000u);
+
+    mbedtls_psa_async_tls_clear_trusted_time();
+    TEST_EQUAL(mbedtls_platform_time(NULL), 0);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void random_and_capacity(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t output[MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS + 1][8];
+    async_tls_test_completion_t completion[
+        MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS + 1];
+    size_t index;
+
+    memset(output, 0, sizeof(output));
+    memset(completion, 0, sizeof(completion));
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    for (index = 0; index < MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS;
+         index++) {
+        TEST_ASSERT(mbedtls_psa_async_tls_random_start(
+                        output[index], sizeof(output[index]), async_tls_test_callback,
+                        &completion[index]));
+        TEST_EQUAL(context.last_request.operation,
+                   MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM);
+        TEST_EQUAL(context.last_request.output.data, output[index]);
+        TEST_EQUAL(context.last_request.output.length, sizeof(output[index]));
+    }
+
+    TEST_EQUAL(mbedtls_psa_async_tls_random_start(
+                   output[index], sizeof(output[index]),
+                   async_tls_test_callback, &completion[index]),
+               0);
+
+    for (index = 0; index < MBEDTLS_PSA_ASYNC_CRYPTO_MAX_CONCURRENT_OPERATIONS;
+         index++) {
+        TEST_ASSERT(context.completions[index].callback != NULL);
+        context.completions[index].callback(
+            PSA_SUCCESS, context.completions[index].context);
+        mbedtls_psa_async_tls_service();
+    }
+
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 0);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ecdh_public_and_shared(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t private_key[66] = { 1 };
+    uint8_t public_key[133] = { 0x04 };
+    uint8_t shared_secret[66] = { 0 };
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p256_public_key_start(
+                    private_key, public_key, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_EXPORT_PUBLIC_KEY);
+    TEST_EQUAL(context.last_request.key_bits, 256);
+    TEST_EQUAL(context.last_request.private_key.length, 32);
+    TEST_EQUAL(context.last_request.public_key_output.length, 65);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p384_public_key_start(
+                    private_key, public_key, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.key_bits, 384);
+    TEST_EQUAL(context.last_request.private_key.length, 48);
+    TEST_EQUAL(context.last_request.public_key_output.length, 97);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p521_public_key_start(
+                    private_key, public_key, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.key_bits, 521);
+    TEST_EQUAL(context.last_request.private_key.length, 66);
+    TEST_EQUAL(context.last_request.public_key_output.length, 133);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p256_start(
+                    private_key, public_key, shared_secret, async_tls_test_callback,
+                    &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_KEY_AGREEMENT);
+    TEST_EQUAL(context.last_request.key_bits, 256);
+    TEST_EQUAL(context.last_request.peer_key.length, 65);
+    TEST_EQUAL(context.last_request.shared_secret.length, 32);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p384_start(
+                    private_key, public_key, shared_secret, async_tls_test_callback,
+                    &completion));
+    TEST_EQUAL(context.last_request.key_bits, 384);
+    TEST_EQUAL(context.last_request.peer_key.length, 97);
+    TEST_EQUAL(context.last_request.shared_secret.length, 48);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdh_p521_start(
+                    private_key, public_key, shared_secret, async_tls_test_callback,
+                    &completion));
+    TEST_EQUAL(context.last_request.key_bits, 521);
+    TEST_EQUAL(context.last_request.peer_key.length, 133);
+    TEST_EQUAL(context.last_request.shared_secret.length, 66);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void ecdsa_sign_and_verify(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t private_key[66] = { 1 };
+    uint8_t public_key[133] = { 0x04 };
+    uint8_t hash[64] = { 2 };
+    uint8_t signature[132] = { 0 };
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p256_sign_start(
+                    private_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM);
+    TEST_EQUAL(context.last_request.output.length, 32);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_SIGN_HASH);
+    TEST_EQUAL(context.last_request.key_bits, 256);
+    TEST_EQUAL(context.last_request.hash.length, 32);
+    TEST_EQUAL(context.last_request.signature.length, 64);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p384_sign_start(
+                    private_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.output.length, 48);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(context.last_request.key_bits, 384);
+    TEST_EQUAL(context.last_request.hash.length, 48);
+    TEST_EQUAL(context.last_request.signature.length, 96);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p521_sign_start(
+                    private_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.output.length, 66);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(context.last_request.key_bits, 521);
+    TEST_EQUAL(context.last_request.hash.length, 64);
+    TEST_EQUAL(context.last_request.signature.length, 132);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p256_verify_start(
+                    public_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_VERIFY_HASH);
+    TEST_EQUAL(context.last_request.key_bits, 256);
+    TEST_EQUAL(context.last_request.public_key.length, 65);
+    TEST_EQUAL(context.last_request.signature.length, 64);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p384_verify_start(
+                    public_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.key_bits, 384);
+    TEST_EQUAL(context.last_request.public_key.length, 97);
+    TEST_EQUAL(context.last_request.signature.length, 96);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_ecdsa_p521_verify_start(
+                    public_key, hash, signature, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.key_bits, 521);
+    TEST_EQUAL(context.last_request.public_key.length, 133);
+    TEST_EQUAL(context.last_request.signature.length, 132);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void aead_generic_and_gcm_wrappers(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t key[32] = { 1 };
+    uint8_t nonce[13] = { 2 };
+    uint8_t aad[8] = { 3 };
+    uint8_t input[32] = { 4 };
+    uint8_t output[32] = { 0 };
+    uint8_t tag[16] = { 0 };
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_aead_encrypt_start(
+                    1, key, 16, nonce, 12, aad, sizeof(aad), input, output,
+                    sizeof(input), tag, sizeof(tag), async_tls_test_callback,
+                    &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_AEAD);
+    TEST_EQUAL(context.last_request.alg, PSA_ALG_GCM);
+    TEST_EQUAL(context.last_request.direction,
+               MBEDTLS_PSA_ASYNC_CRYPTO_ENCRYPT);
+    TEST_EQUAL(context.last_request.key_bits, 128);
+    TEST_EQUAL(context.last_request.output_tag.length, sizeof(tag));
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_aead_decrypt_start(
+                    3, key, 32, nonce, 13, aad, sizeof(aad), input, output,
+                    sizeof(input), tag, 8, async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.alg, PSA_ALG_CCM);
+    TEST_EQUAL(context.last_request.direction,
+               MBEDTLS_PSA_ASYNC_CRYPTO_DECRYPT);
+    TEST_EQUAL(context.last_request.key_bits, 256);
+    TEST_EQUAL(context.last_request.input_tag.length, 8);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_aes_gcm128_encrypt_start(
+                    key, nonce, aad, sizeof(aad), input, output, sizeof(input), tag,
+                    async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.alg, PSA_ALG_GCM);
+    TEST_EQUAL(context.last_request.key.length, 16);
+    TEST_EQUAL(context.last_request.nonce.length, 12);
+    TEST_EQUAL(context.last_request.output_tag.length, 16);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_aes_gcm128_decrypt_start(
+                    key, nonce, aad, sizeof(aad), input, output, sizeof(input), tag,
+                    async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.alg, PSA_ALG_GCM);
+    TEST_EQUAL(context.last_request.key.length, 16);
+    TEST_EQUAL(context.last_request.nonce.length, 12);
+    TEST_EQUAL(context.last_request.input_tag.length, 16);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void rsa_sign_and_verify_requests(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t public_key[269] = { 0 };
+    uint8_t hash[32] = { 1 };
+    uint8_t signature[256] = { 0 };
+    size_t public_key_length;
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_ASSUME(MBEDTLS_PSA_ASYNC_CRYPTO_HARDWARE_ENABLED);
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+    public_key_length = async_tls_test_make_rsa_public_key(public_key);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_rsa_pkcs1_sign_start(
+                    256, mbedtls_test_srv_key_rsa_der, mbedtls_test_srv_key_rsa_der_len,
+                    hash, sizeof(hash), signature,
+                    sizeof(signature), async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA);
+    TEST_EQUAL(context.last_request.modulus.length, sizeof(signature));
+    TEST_EQUAL(context.last_request.output.data, signature);
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(completion.called, 1);
+    TEST_EQUAL(completion.success, 1);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_rsa_pss_sign_start(
+                    256, mbedtls_test_srv_key_rsa_der, mbedtls_test_srv_key_rsa_der_len,
+                    hash, sizeof(hash), signature,
+                    sizeof(signature), async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RANDOM);
+    TEST_EQUAL(context.last_request.output.length, sizeof(hash));
+    async_tls_test_complete(&context, PSA_SUCCESS);
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA);
+    TEST_EQUAL(context.last_request.modulus.length, sizeof(signature));
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_rsa_pkcs1_verify_start(
+                    256, public_key, (size_t) public_key_length, hash, sizeof(hash),
+                    signature, sizeof(signature), async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA);
+    TEST_EQUAL(context.last_request.modulus.length, sizeof(signature));
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+    TEST_ASSERT(mbedtls_psa_async_tls_rsa_pss_verify_start(
+                    256, public_key, (size_t) public_key_length, hash, sizeof(hash),
+                    signature, sizeof(signature), async_tls_test_callback, &completion));
+    TEST_EQUAL(context.last_request.operation,
+               MBEDTLS_PSA_ASYNC_CRYPTO_OPERATION_RAW_RSA);
+    TEST_EQUAL(context.last_request.modulus.length, sizeof(signature));
+    async_tls_test_complete(&context, PSA_SUCCESS);
+
+exit:
+    mbedtls_psa_crypto_free();
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
+void api_rejects_invalid_arguments(void)
+{
+    async_tls_test_context_t context;
+    mbedtls_psa_async_crypto_provider_t provider;
+    mbedtls_psa_async_crypto_hardware_t hardware;
+    uint8_t key[32] = { 1 };
+    uint8_t nonce[12] = { 2 };
+    uint8_t input[16] = { 3 };
+    uint8_t output[16] = { 0 };
+    uint8_t tag[16] = { 0 };
+    async_tls_test_completion_t completion = { 0, 0 };
+
+    TEST_EQUAL(mbedtls_psa_async_tls_random_start(
+                   output, sizeof(output), async_tls_test_callback,
+                   &completion),
+               0);
+
+    async_tls_test_expect_bound(&context, &provider, &hardware);
+
+    TEST_EQUAL(mbedtls_psa_async_tls_random_start(
+                   NULL, sizeof(output), async_tls_test_callback,
+                   &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_random_start(
+                   output, 0, async_tls_test_callback, &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_random_start(
+                   output, sizeof(output), NULL, &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_ecdh_p256_start(
+                   NULL, input, output, async_tls_test_callback,
+                   &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_ecdsa_p256_verify_start(
+                   NULL, input, tag, async_tls_test_callback, &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_aead_encrypt_start(
+                   0, key, 16, nonce, sizeof(nonce), NULL, 0, input, output,
+                   sizeof(input), tag, sizeof(tag), async_tls_test_callback,
+                   &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_aead_encrypt_start(
+                   1, key, 24, nonce, sizeof(nonce), NULL, 0, input, output,
+                   sizeof(input), tag, sizeof(tag), async_tls_test_callback,
+                   &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_rsa_pkcs1_sign_start(
+                   256, NULL, 0, input, 32, output, sizeof(output),
+                   async_tls_test_callback, &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_rsa_pss_verify_start(
+                   256, NULL, 0, input, 32, tag, sizeof(tag),
+                   async_tls_test_callback, &completion),
+               0);
+    TEST_EQUAL(mbedtls_psa_async_tls_busy(), 0);
+
+exit:
+    async_tls_test_cleanup(&provider);
+}
+/* END_CASE */


### PR DESCRIPTION
## Description

This PR adds generic async hardware crypto hook points for TLS handshakes and
TLS record protection. The goal is to allow platforms with interrupt-driven or
DMA-backed crypto peripherals to keep TLS progress non-blocking while still
failing closed when a required hardware-backed operation cannot be started or
completed.

The TLS integration covers async random generation, ECDHE key generation/shared
secret operations, ECDSA/RSA signature operations through PSA, and AEAD record
protection for the TLS cipher suites wired through the async hardware metadata.
TLS 1.2 and TLS 1.3 paths are both covered so hardware-backed TLS behavior is
consistent across protocol versions.

The hook surface is intentionally hardware-agnostic. Public-facing and vendored
symbols use generic `MBEDTLS_ASYNC_HARDWARE_*` /
`mbedtls_async_hardware_*` naming rather than platform-specific names. The
platform-specific implementation lives outside this repo and provides the hook
functions. Unsupported or unavailable hardware paths return failure instead of
silently falling back to synchronous software behavior.

This was developed against SAMD/SAME class hardware with async AES, TRNG, and
public-key crypto peripherals, and hardware-tested primarily on a SAME54
Xplained Pro end-to-end TLS setup. The downstream integration also exercised
SAMD51/SAME54 build and peripheral boundaries while keeping the mbedTLS changes
generic enough for other hardware providers.

## What changed

- Adds TLS async hardware metadata and hook routing for selected TLS 1.2 and
  TLS 1.3 handshake operations.
- Adds TLS 1.2 and TLS 1.3 AEAD record-protection routing for supported
  hardware-backed record shapes.
- Preserves upstream TLS/PK behavior while integrating async hardware paths,
  including SHA-512 CertificateVerify handling and existing PK signing
  hash-length semantics.
- Uses generic async hardware naming throughout the mbedTLS integration so the
  hook surface is not tied to one platform family.
- Adds a changelog fragment for the new async hardware TLS hook points.

## Validation

- mbedTLS upstream CMake build: passed.
- mbedTLS upstream CTest: `147/147` passed.
- TF-PSA-Crypto upstream CMake build: passed.
- TF-PSA-Crypto upstream CTest: `129/129` passed.
- Downstream native TLS/transport tests: `265` passed.
- Downstream SAME54 embedded Ethernet/TLS/crypto/RTC tests: `80` passed.
- Downstream SAMD51 embedded RTC/crypto tests: `68` passed.

## PR checklist

- [x] **changelog** provided
- [x] **framework PR** not required
- [x] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto#829
- [ ] **TF-PSA-Crypto 1.1 PR** not required because this is new async hardware
      feature work targeting development.
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10807
- [ ] **mbedtls 4.1 PR** not required because this is new feature work targeting
      development first.
- [ ] **mbedtls 3.6 PR** not required because this is new feature work and is not
      suitable for LTS backport without maintainer direction.
- [x] **tests** provided: upstream mbedTLS and TF-PSA-Crypto CTest, downstream
      native TLS/transport tests, and downstream hardware TLS validation on
      SAME54 Xplained Pro and SAMD51 hardware.