### PR TITLE
ssl_tls13_server: validate supported_versions extension length

### DIFF
--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -782,6 +782,12 @@ static int ssl_tls13_parse_supported_versions_ext(mbedtls_ssl_context *ssl,
 
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, 1);
     versions_len = p[0];
+
+    /* RFC 8446, Section 4.2.1 (versions<2..254>) and Section 3.4
+    * (vector length must be a multiple of the element size). */
+    if ( (versions_len < 2) || (versions_len > 254) || (versions_len % 2 != 0))
+        return MBEDTLS_ERR_SSL_DECODE_ERROR;
+
     p += 1;
 
     MBEDTLS_SSL_CHK_BUF_READ_PTR(p, end, versions_len);


### PR DESCRIPTION
Reject versions_len outside [2,254] or not a multiple of 2, per RFC 8446 §4.2.1 (versions<2..254>) and §3.4 (vector length must be a multiple of element size). Prevents malformed/truncated version lists from being parsed as if well-formed.

Fixes #10739

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because:
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **mbedtls development PR** provided # | not required because:
- [ ] **mbedtls 4.1 PR** provided # | not required because:
- [ ] **mbedtls 3.6 PR** provided # | not required because:
- **tests**  provided | not required because:


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
