### PR TITLE
fix issue with sprintf's unguarded by MBEDTLS_X509_REMOVE_INFO

### DIFF
--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -265,7 +265,7 @@
  *   ecdsa-with-SHA2(3) 4 } */
 #define MBEDTLS_OID_ECDSA_SHA512            MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
 
-#if defined(MBEDTLS_X509_USE_C)
+#if defined(MBEDTLS_X509_USE_C) && !defined(MBEDTLS_X509_REMOVE_INFO)
 /**
  * \brief           Translate an ASN.1 OID into its numeric representation
  *                  (e.g. "\x2A\x86\x48\x86\xF7\x0D" into "1.2.840.113549")
@@ -278,7 +278,7 @@
  *                  PSA_ERROR_BUFFER_TOO_SMALL in case of error
  */
 int mbedtls_oid_get_numeric_string(char *buf, size_t size, const mbedtls_asn1_buf *oid);
-#endif /* MBEDTLS_X509_USE_C */
+#endif /* MBEDTLS_X509_USE_C && !MBEDTLS_X509_REMOVE_INFO */
 
 #if defined(MBEDTLS_X509_CREATE_C)
 /**

--- a/include/mbedtls/x509.h
+++ b/include/mbedtls/x509.h
@@ -302,6 +302,7 @@ mbedtls_x509_san_list;
 /** \} name Structures for parsing X.509 certificates, CRLs and CSRs */
 /** \} addtogroup x509_module */
 
+#if !defined(MBEDTLS_X509_REMOVE_INFO)
 /**
  * \brief          Store the certificate DN in printable form into buf;
  *                 no more than size characters will be written.
@@ -314,6 +315,7 @@ mbedtls_x509_san_list;
  *                 terminated nul byte), or a negative error code.
  */
 int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn);
+#endif /* !MBEDTLS_X509_REMOVE_INFO */
 
 
 /**
@@ -363,6 +365,7 @@ static inline mbedtls_x509_name *mbedtls_x509_dn_get_next(
     return dn->next;
 }
 
+#if !defined(MBEDTLS_X509_REMOVE_INFO)
 /**
  * \brief          Store the certificate serial in printable form into buf;
  *                 no more than size characters will be written.
@@ -375,6 +378,7 @@ static inline mbedtls_x509_name *mbedtls_x509_dn_get_next(
  *                 terminated nul byte), or a negative error code.
  */
 int mbedtls_x509_serial_gets(char *buf, size_t size, const mbedtls_x509_buf *serial);
+#endif /* !MBEDTLS_X509_REMOVE_INFO */
 
 /**
  * \brief          Compare pair of mbedtls_x509_time.

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2153,7 +2153,6 @@ static int ssl_parse_certificate_request(mbedtls_ssl_context *ssl)
     size_t sig_alg_len;
 #if defined(MBEDTLS_DEBUG_C)
     unsigned char *sig_alg;
-    unsigned char *dn;
 #endif
 
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> parse certificate request"));
@@ -2290,8 +2289,8 @@ static int ssl_parse_certificate_request(mbedtls_ssl_context *ssl)
         return MBEDTLS_ERR_SSL_DECODE_ERROR;
     }
 
-#if defined(MBEDTLS_DEBUG_C)
-    dn = buf + mbedtls_ssl_hs_hdr_len(ssl) + 3 + n - dn_len;
+#if defined(MBEDTLS_DEBUG_C) && !defined(MBEDTLS_X509_REMOVE_INFO)
+    unsigned char *dn = buf + mbedtls_ssl_hs_hdr_len(ssl) + 3 + n - dn_len;
     for (size_t i = 0, dni_len = 0; i < dn_len; i += 2 + dni_len) {
         unsigned char *p = dn + i + 2;
         mbedtls_x509_name name;

--- a/library/x509.c
+++ b/library/x509.c
@@ -810,6 +810,8 @@ int mbedtls_x509_get_ext(unsigned char **p, const unsigned char *end,
     return 0;
 }
 
+#if !defined(MBEDTLS_X509_REMOVE_INFO)
+
 static char nibble_to_hex_digit(int i)
 {
     return (i < 10) ? (i + '0') : (i - 10 + 'A');
@@ -1051,7 +1053,6 @@ int mbedtls_x509_serial_gets(char *buf, size_t size, const mbedtls_x509_buf *ser
     return (int) (size - n);
 }
 
-#if !defined(MBEDTLS_X509_REMOVE_INFO)
 /*
  * Helper for writing signature algorithms
  */
@@ -1088,8 +1089,6 @@ int mbedtls_x509_sig_alg_gets(char *buf, size_t size, const mbedtls_x509_buf *si
 
     return (int) (size - n);
 }
-#endif /* MBEDTLS_X509_REMOVE_INFO */
-
 /*
  * Helper for writing "RSA key size", "EC key size", etc
  */
@@ -1104,6 +1103,8 @@ int mbedtls_x509_key_size_helper(char *buf, size_t buf_size, const char *name)
 
     return 0;
 }
+
+#endif /* MBEDTLS_X509_REMOVE_INFO */
 
 int mbedtls_x509_time_cmp(const mbedtls_x509_time *t1,
                           const mbedtls_x509_time *t2)

--- a/library/x509_internal.h
+++ b/library/x509_internal.h
@@ -43,8 +43,8 @@ int mbedtls_x509_get_ext(unsigned char **p, const unsigned char *end,
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
 int mbedtls_x509_sig_alg_gets(char *buf, size_t size, const mbedtls_x509_buf *sig_oid,
                               mbedtls_pk_sigalg_t pk_alg, mbedtls_md_type_t md_alg);
-#endif
 int mbedtls_x509_key_size_helper(char *buf, size_t buf_size, const char *name);
+#endif
 int mbedtls_x509_set_extension(mbedtls_asn1_named_data **head, const char *oid, size_t oid_len,
                                int critical, const unsigned char *val,
                                size_t val_len);

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1150,6 +1150,7 @@ static int ssl_async_start(mbedtls_ssl_context *ssl,
     ssl_async_operation_context_t *ctx = NULL;
     const char *op_name = ssl_async_operation_names[op_type];
 
+#if !defined(MBEDTLS_X509_REMOVE_INFO)
     {
         char dn[100];
         if (mbedtls_x509_dn_gets(dn, sizeof(dn), &cert->subject) > 0) {
@@ -1157,6 +1158,7 @@ static int ssl_async_start(mbedtls_ssl_context *ssl,
                            op_name, dn);
         }
     }
+#endif /* !MBEDTLS_X509_REMOVE_INFO */
 
     /* Look for a private key that matches the public key in cert.
      * Since this test code has the private key inside Mbed TLS,

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -24,13 +24,15 @@
 
 #if !defined(MBEDTLS_X509_CRT_WRITE_C) || \
     !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_FS_IO) || \
+    defined(MBEDTLS_X509_REMOVE_INFO) || \
     !defined(MBEDTLS_ERROR_C) || !defined(PSA_WANT_ALG_SHA_256) || \
     !defined(MBEDTLS_PEM_WRITE_C) || !defined(MBEDTLS_MD_C)
 int main(void)
 {
     mbedtls_printf("MBEDTLS_X509_CRT_WRITE_C and/or MBEDTLS_X509_CRT_PARSE_C and/or "
                    "MBEDTLS_FS_IO and/or PSA_WANT_ALG_SHA_256 and/or "
-                   "MBEDTLS_ERROR_C not defined.\n");
+                   "MBEDTLS_ERROR_C not defined and/or "
+                   "MBEDTLS_X509_REMOVE_INFO defined.\n");
     mbedtls_exit(0);
 }
 #else

--- a/tests/ssl-opt.sh
+++ b/tests/ssl-opt.sh
@@ -6369,6 +6369,7 @@ run_test    "Authentication: send CA list in CertificateRequest, client self sig
             -s "X509 - Certificate verification failed"
 
 requires_any_configs_enabled $TLS1_2_KEY_EXCHANGES_WITH_CERT
+requires_config_disabled MBEDTLS_X509_REMOVE_INFO
 run_test    "Authentication: send alt conf DN hints in CertificateRequest" \
             "$P_SRV debug_level=3 auth_mode=optional cert_req_ca_list=2 \
              crt_file2=$DATA_FILES_PATH/server1.crt \
@@ -6380,6 +6381,7 @@ run_test    "Authentication: send alt conf DN hints in CertificateRequest" \
             -c "DN hint: C=NL, O=PolarSSL, CN=PolarSSL Server 1"
 
 requires_any_configs_enabled $TLS1_2_KEY_EXCHANGES_WITH_CERT
+requires_config_disabled MBEDTLS_X509_REMOVE_INFO
 run_test    "Authentication: send alt conf DN hints in CertificateRequest (2)" \
             "$P_SRV debug_level=3 auth_mode=optional cert_req_ca_list=2 \
              crt_file2=$DATA_FILES_PATH/server2.crt \
@@ -6391,6 +6393,7 @@ run_test    "Authentication: send alt conf DN hints in CertificateRequest (2)" \
             -c "DN hint: C=NL, O=PolarSSL, CN=localhost"
 
 requires_any_configs_enabled $TLS1_2_KEY_EXCHANGES_WITH_CERT
+requires_config_disabled MBEDTLS_X509_REMOVE_INFO
 run_test    "Authentication: send alt hs DN hints in CertificateRequest" \
             "$P_SRV debug_level=3 auth_mode=optional cert_req_ca_list=3 \
              crt_file2=$DATA_FILES_PATH/server1.crt \

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -196,6 +196,7 @@ done:
     return ret;
 }
 
+#if !defined(MBEDTLS_X509_REMOVE_INFO)
 typedef struct {
     char buf[512];
     char *p;
@@ -325,6 +326,7 @@ static int verify_parse_san(mbedtls_x509_subject_alternative_name *san,
 
     return 0;
 }
+#endif /* !MBEDTLS_X509_REMOVE_INFO */
 #endif /* MBEDTLS_FS_IO */
 
 static int parse_crt_ext_cb(void *p_ctx, mbedtls_x509_crt const *crt, mbedtls_x509_buf const *oid,
@@ -507,7 +509,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:!MBEDTLS_X509_REMOVE_INFO */
 void x509_parse_san(char *crt_file, char *result_str, int parse_result)
 {
     int ret;
@@ -846,7 +848,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_FS_IO:MBEDTLS_X509_CRT_PARSE_C:!MBEDTLS_X509_REMOVE_INFO */
 void x509_verify_callback(char *crt_file, char *ca_file, char *name,
                           int exp_ret, char *exp_vrfy_out)
 {
@@ -1552,7 +1554,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C:!MBEDTLS_X509_REMOVE_INFO */
 void x509_oid_numstr(data_t *oid_buf, char *numstr, int blen, int ret)
 {
     mbedtls_x509_buf oid;
@@ -1709,7 +1711,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_FS_IO */
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CRT_PARSE_C:MBEDTLS_FS_IO:!MBEDTLS_X509_REMOVE_INFO */
 void x509_crt_parse_authoritykeyid(char *file,
                                    data_t *keyId,
                                    char *authorityKeyId_issuer,
@@ -1779,7 +1781,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_X509_USE_C:!MBEDTLS_X509_REMOVE_INFO */
 void oid_get_numeric_string(data_t *oid, int error_ret, char *result_str)
 {
     char buf[256];

--- a/tests/suites/test_suite_x509write.function
+++ b/tests/suites/test_suite_x509write.function
@@ -579,7 +579,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE depends_on:MBEDTLS_X509_CREATE_C:MBEDTLS_X509_USE_C */
+/* BEGIN_CASE depends_on:MBEDTLS_X509_CREATE_C:MBEDTLS_X509_USE_C:!MBEDTLS_X509_REMOVE_INFO */
 void mbedtls_x509_string_to_names(char *name, char *parsed_name,
                                   int result, int may_fail)
 {


### PR DESCRIPTION
• ## Description

  This PR makes `MBEDTLS_X509_REMOVE_INFO` consistently remove X.509 information-formatting helpers that depend on `mbedtls_snprintf`. It moves the guard in `library/x509.c` to cover DN, serial, OID numeric string, signature algorithm, and key-size formatting helpers, and updates matching declarations and call sites so the remove-info configuration builds cleanly. resolves https://github.com/Mbed-TLS/mbedtls/issues/10818

  This avoids requiring embedded platforms without `snprintf` support to provide unused stubs when X.509 info output has been disabled.

  ## PR checklist

  - [ ] **changelog** not required because: this is a build/configuration fix for an existing option.
  - [ ] **framework PR** not required
  - [ ] **TF-PSA-Crypto development PR** not required because: no TF-PSA-Crypto changes are needed.
  - [ ] **TF-PSA-Crypto 1.1 PR** not required because: no TF-PSA-Crypto changes are needed.
  - [ ] **mbedtls development PR** provided #
  - [ ] **mbedtls 4.1 PR** not required because: not yet assessed/applicable for this PR.
  - [ ] **mbedtls 3.6 PR** not required because: not yet assessed/applicable for this PR.
  - **tests** provided: built with `MBEDTLS_X509_REMOVE_INFO` enabled and verified the affected X.509 helpers are not emitted or referenced.