### PR TITLE
Fix generate_errors.pl

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -188,7 +188,7 @@ foreach my $match (@matches)
             $first = 0;
             foreach my $dep (split(/,/, ${$old_define_name}))
             {
-                ${$code_check} .= " || \n          " if ($first++);
+                ${$code_check} .= " ||\n          " if ($first++);
                 ${$code_check} .= "${$old_define_prefix}${dep}${$old_define_suffix}";
             }
             ${$code_check} .= " */\n\n";
@@ -229,7 +229,7 @@ if ($ll_old_define[0] ne "")
     my $first = 0;
     foreach my $dep (split(/,/, $ll_old_define[0]))
     {
-        $ll_code_check .= " || \n          " if ($first++);
+        $ll_code_check .= " ||\n          " if ($first++);
         $ll_code_check .= "${ll_old_define[1]}${dep}${ll_old_define[2]}";
     }
     $ll_code_check .= " */\n";
@@ -240,7 +240,7 @@ if ($hl_old_define[0] ne "")
     my $first = 0;
     foreach my $dep (split(/,/, $hl_old_define[0]))
     {
-        $hl_code_check .= " || \n          " if ($first++);
+        $hl_code_check .= " ||\n          " if ($first++);
         $hl_code_check .= "${hl_old_define[1]}${dep}${hl_old_define[2]}";
     }
     $hl_code_check .= " */\n";


### PR DESCRIPTION
## Description

As part of the post release activities, fixing minor inconveniences of the tooling required to build a release.

Minor fix in the perl template that is adding a trailing space in error.c when auto-generating files

Adds to framework Mbed-TLS/mbedtls-framework#313 but not rely on it.

Needs to be tested locally with `scripts/generate_errors.pl`, `./framework/scripts/make_generated_files.py`, `./framework/scripts/make_generated_files.py`, `./framework/scripts/code_style.py`, `./framework/scripts/code_style.py` and `./framework/scripts/check_files.py`

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [x] **changelog** not required because: No user-facing change
- [x] **framework PR** provided Mbed-TLS/mbedtls-framework#313
- [x] **TF-PSA-Crypto development PR** not required because: Script not in crypto
- [x] **TF-PSA-Crypto 1.1 PR** not required because: Script not in crypto
- [x] **mbedtls development PR** here
- [x] **mbedtls 4.1 PR** provided #10822 
- [x] **mbedtls 3.6 PR** not required, bug not in 3.6
- **tests**  not required because: Minor script fix only

