### PR TITLE
[3.6 Backport]Fix generate_errors.pl

### DIFF
--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -168,7 +168,7 @@ foreach my $match (@matches)
             $first = 0;
             foreach my $dep (split(/,/, ${$old_define}))
             {
-                ${$code_check} .= " || " if ($first++);
+                ${$code_check} .= " ||\n " if ($first++);
                 ${$code_check} .= "MBEDTLS_${dep}_C";
             }
             ${$code_check} .= " */\n\n";
@@ -202,7 +202,7 @@ if ($ll_old_define ne "")
     my $first = 0;
     foreach my $dep (split(/,/, $ll_old_define))
     {
-        $ll_code_check .= " || " if ($first++);
+        $ll_code_check .= " ||\n " if ($first++);
         $ll_code_check .= "MBEDTLS_${dep}_C";
     }
     $ll_code_check .= " */\n";
@@ -213,7 +213,7 @@ if ($hl_old_define ne "")
     my $first = 0;
     foreach my $dep (split(/,/, $hl_old_define))
     {
-        $hl_code_check .= " || " if ($first++);
+        $hl_code_check .= " ||\n " if ($first++);
         $hl_code_check .= "MBEDTLS_${dep}_C";
     }
     $hl_code_check .= " */\n";


### PR DESCRIPTION
## Description

Backport of #10820



## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** provided | not required because:
- [ ] **framework PR** provided Mbed-TLS/mbedtls-framework# | not required
- [ ] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **TF-PSA-Crypto 1.1 PR** provided Mbed-TLS/TF-PSA-Crypto# | not required because:
- [ ] **mbedtls development PR** provided #10820
- [ ] **mbedtls 4.1 PR** provided # | not required because:
- [ ] **mbedtls 3.6 PR** provided # | not required because:
- **tests**  provided | not required because:


## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
