### PR TITLE
Fix x509_get_uid() accepting constructed [1]/[2] tags

### DIFF
--- a/ChangeLog.d/fix-x509-uid-tag-constructed.txt
+++ b/ChangeLog.d/fix-x509-uid-tag-constructed.txt
@@ -1,0 +1,13 @@
+Security
+   * Fix mbedtls_x509_crt_parse() accepting a certificate whose
+     extensions field (context tag [3]) has been relabeled as
+     issuerUniqueID (tag [1]) or subjectUniqueID (tag [2]). Previously
+     x509_get_uid() matched context-specific tags [1]/[2] in either
+     primitive or constructed form, but a genuine, correctly
+     DER-encoded issuerUniqueID/subjectUniqueID (an IMPLICIT-tagged
+     BIT STRING) is always primitive, while a real extensions block is
+     always constructed (EXPLICIT tagging). A relabeled extensions
+     block was therefore silently consumed as a unique identifier,
+     causing all certificate extensions - including basicConstraints
+     and keyUsage - to be dropped without any parse error. Reported by
+     an anonymous researcher.

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -469,8 +469,7 @@ static int x509_get_uid(unsigned char **p,
     uid->tag = **p;
 
     if ((ret = mbedtls_asn1_get_tag(p, end, &uid->len,
-                                    MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED |
-                                    n)) != 0) {
+                                    MBEDTLS_ASN1_CONTEXT_SPECIFIC | n)) != 0) {
         if (ret == MBEDTLS_ERR_ASN1_UNEXPECTED_TAG) {
             return 0;
         }


### PR DESCRIPTION
## Summary

Fixes #10774.

`x509_get_uid()` (parses the optional `issuerUniqueID [1]` and `subjectUniqueID [2]` fields of a TBSCertificate) matched context-specific tags `[1]`/`[2]` **requiring** the constructed bit:

```c
mbedtls_asn1_get_tag(p, end, &uid->len,
                     MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED | n)
```

`issuerUniqueID`/`subjectUniqueID` are IMPLICIT-tagged `BIT STRING`s, and DER requires `BIT STRING` to be encoded in primitive form — so a genuinely well-formed field here has tag byte `0x81`/`0x82` (primitive), not `0xa1`/`0xa2` (constructed). The `extensions` field, by contrast, uses `EXPLICIT [3]` tagging, which is always constructed (`0xa3`).

Because the code required `CONSTRUCTED`, a certificate whose extensions wrapper tag has been changed from `[3]` to `[1]` or `[2]` (a single-byte mutation, as described in #10774) matches this check and gets silently consumed as a unique identifier instead — the certificate parses successfully but every extension (`basicConstraints`, `keyUsage`, etc.) disappears with no error.

### Note on the current vs. originally-reported code path

#10774 was filed against mbedTLS 2.28 and shows the vulnerable logic living directly in `x509_get_crt_ext()`'s own tag check. On current `development`, that logic has been refactored into `mbedtls_x509_get_ext()` (`library/x509.c`), which I checked does **not** have this problem — it propagates a tag mismatch as `MBEDTLS_ERR_X509_INVALID_EXTENSIONS`-wrapped error rather than treating it as "extensions absent". The vulnerability is still fully present on `development`, but via `x509_get_uid()` specifically: it runs *before* `x509_get_crt_ext()`/`mbedtls_x509_get_ext()` ever sees the relabeled tag, silently consuming it first.

## Fix

Require `PRIMITIVE` encoding instead of `CONSTRUCTED`, matching correct DER encoding of an IMPLICIT-tagged `BIT STRING`. A relabeled extensions block (always constructed) then no longer matches `issuerUniqueID`/`subjectUniqueID`, falls through to `mbedtls_x509_get_ext()` with its tag intact, and is correctly rejected there as a tag mismatch — failing the whole certificate parse instead of silently dropping extensions.

## Testing

I don't have a full build of the test suite running locally right now (this repo vendors ASN.1 parsing into the `tf-psa-crypto` submodule and building `test_suite_x509parse` needs the full CMake/build setup), so I can't provide a `test_suite_x509parse` run. What I did instead: pulled the real tag-matching logic (`mbedtls_asn1_get_tag()`, verbatim from `tf-psa-crypto/utilities/asn1parse.c`) into a standalone host-C reproduction and tested both tag bytes directly:

- A genuine, DER-correct primitive `[1]` tag (`0x81`): **rejected before this fix**, **accepted after**.
- A forged/relabeled constructed `[1]` tag (`0xa1` — what a mutated `[3]` extensions wrapper looks like): **accepted before this fix** (the vulnerability), **rejected after**.

Added a `ChangeLog.d` entry under `Security` per `CONTRIBUTING.md`. Happy to add a proper `test_suite_x509parse` case (a hand-crafted DER TBSCertificate with the extensions tag mutated to `0xa1`/`0xa2`) if that's wanted before merge — I described the exact construction needed in the testing note above and can build it out if useful.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.