### PR TITLE
Reject empty ALPN protocol list in mbedtls_ssl_conf_alpn_protocols()

### DIFF
--- a/ChangeLog.d/fix-alpn-empty-list.txt
+++ b/ChangeLog.d/fix-alpn-empty-list.txt
@@ -1,0 +1,7 @@
+Bugfix
+   * Fix mbedtls_ssl_conf_alpn_protocols() silently accepting an empty
+     protocol list, which caused an invalid ALPN extension with a
+     zero-length protocol_name_list to be sent during the handshake,
+     violating RFC 7301 and causing conforming peers to reject the
+     connection with a fatal decode error. mbedtls_ssl_conf_alpn_protocols()
+     now returns MBEDTLS_ERR_SSL_BAD_INPUT_DATA for an empty list.

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2527,6 +2527,16 @@ int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf,
     const char *const *p;
 
     /*
+     * RFC 7301 3.1: the ALPN extension's protocol_name_list must contain
+     * at least one entry - an empty list is not a valid ProtocolNameList
+     * and must not be sent. Reject it here rather than silently sending
+     * an ALPN extension with a zero-length list later.
+     */
+    if (*protos == NULL) {
+        return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+    }
+
+    /*
      * RFC 7301 3.1: "Empty strings MUST NOT be included and byte strings
      * MUST NOT be truncated."
      * We check lengths now rather than later.


### PR DESCRIPTION
## Summary

Fixes #10461.

`mbedtls_ssl_conf_alpn_protocols()` validates that no individual protocol name is empty or too long, but never checked that the list itself has at least one entry:

```c
tot_len = 0;
for (p = protos; *p != NULL; p++) {
    ...
}
conf->alpn_list = protos;
return 0;
```

Configuring an empty list (a `NULL`-terminated array whose first element is already `NULL`) makes the loop body never execute, so it's silently accepted. The list is later used as-is by `ssl_write_alpn_ext()` to build the ALPN extension, producing a `protocol_name_list` of length 0.

RFC 7301 §3.1 requires the ALPN extension's `protocol_name_list` to contain at least one entry — a zero-length list isn't a valid encoding. Peers that correctly validate the extension respond with a fatal `decode_error` alert, breaking the handshake, as described in the issue.

## Fix

Following the direction from @davidhorstmann-arm on the issue, reject an empty list up front with `MBEDTLS_ERR_SSL_BAD_INPUT_DATA`, matching how this function already rejects other invalid inputs (empty individual protocol names, names or total length exceeding the configured maximums) rather than silently unsetting the list later.

## Testing

I don't have the test suite building locally right now (this repo's ASN.1/crypto internals now live in the `tf-psa-crypto` submodule, and I didn't want to stand up the full CMake build just for this), so I can't provide a `test_suite_ssl` run. What I did instead: extracted the exact validation logic into a standalone host-C reproduction and confirmed:

- **Before fix**: an empty list (`{NULL}`) returns `0` (accepted).
- **After fix**: the same empty list returns `MBEDTLS_ERR_SSL_BAD_INPUT_DATA`; a real, non-empty list (`{"h2", NULL}`) is unaffected and still returns `0`.

Added a `ChangeLog.d` entry per `CONTRIBUTING.md`. Happy to add a proper `test_suite_ssl` case calling `mbedtls_ssl_conf_alpn_protocols()` directly with an empty list if that's wanted before merge — I didn't see an existing direct unit test for this function to model one on, so wanted to check the preferred style first rather than guess.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.