### PR TITLE
x509_crt: Add initialization to time `now`

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -2530,7 +2530,7 @@ static int x509_crt_verify_chain(
     int signature_is_good;
     unsigned self_cnt;
     mbedtls_x509_crt *cur_trust_ca = NULL;
-    mbedtls_x509_time now;
+    mbedtls_x509_time now = {};
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
     if (mbedtls_x509_time_gmtime(mbedtls_time(NULL), &now) != 0) {


### PR DESCRIPTION
## Description

When `-Werror` is set on the compiler together with `-Wuninitialized-const-pointer`, we get an error on *library/x509_crt.c:2631:37*.

This patch fixes this issue.

If MBEDTLS_HAVE_TIME_DATE is defined, then it is initialized. Otherwise, having an initialized structure can be helpful for error checking.

This should also be ported into 4.1 and development branches

## PR checklist

Please remove the segment/s on either side of the | symbol as appropriate, and add any relevant link/s to the end of the line.
If the provided content is part of the present PR remove the # symbol.

- [ ] **changelog** not required because: trivial change
- [ ] **framework PR** not required: does not change
- [ ] **TF-PSA-Crypto development PR** not required because: does not change
- [ ] **TF-PSA-Crypto 1.1 PR** not required because: does not change
- [ ] **mbedtls development PR** not required because: trivial change
- [ ] **mbedtls 4.1 PR** not required because: trivial change
- [ ] **mbedtls 3.6 PR** not required because: trivial change
- **tests**  not required because: nothing new was added

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
