### PR TITLE
PKCS5 simplify deps on MBEDTLS_CIPHER_PADDING_PKCS7 + PKCS12 remove test exceptions

### DIFF
--- a/tests/scripts/analyze_outcomes.py
+++ b/tests/scripts/analyze_outcomes.py
@@ -147,21 +147,6 @@ class CoverageTask(outcome_analysis.CoverageTask):
             # https://github.com/Mbed-TLS/mbedtls/issues/9592
             'Config: PSA_WANT_ALG_DETERMINSTIC_ECDSA without PSA_WANT_ALG_ECDSA',
         ],
-        'test_suite_pkcs12': [
-            # We never test with CBC/PKCS5/PKCS12 enabled but
-            # PKCS7 padding disabled.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9580
-            'PBE Decrypt, (Invalid padding & PKCS7 padding disabled)',
-            'PBE Encrypt, pad = 8 (PKCS7 padding disabled)',
-        ],
-        'test_suite_pkcs5': [
-            # We never test with CBC/PKCS5/PKCS12 enabled but
-            # PKCS7 padding disabled.
-            # https://github.com/Mbed-TLS/mbedtls/issues/9580
-            'PBES2 Decrypt (Invalid padding & PKCS7 padding disabled)',
-            'PBES2 Encrypt, pad=6 (PKCS7 padding disabled)',
-            'PBES2 Encrypt, pad=8 (PKCS7 padding disabled)',
-        ],
         'test_suite_psa_crypto': [
             # We don't test this unusual, but sensible configuration.
             # https://github.com/Mbed-TLS/mbedtls/issues/9592


### PR DESCRIPTION
## Description

Resolves #9580
Depends on https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/864

## PR checklist

- [ ] **changelog** not required because: just updating tests
- [ ] **framework PR** not required
- [ ] **TF-PSA-Crypto development PR provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/864
- [ ] **TF-PSA-Crypto 1.1 PR** provided: TODO
- [ ] **mbedtls development PR** provided: this one
- [ ] **mbedtls 4.1 PR** provided: todo
- [ ] **mbedtls 3.6 PR** provided: I need to check
- **tests**  provided